### PR TITLE
Add version numbers for all the candle crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,8 @@ anyhow = { version = "1", features = ["backtrace"] }
 byteorder = "1.4.3"
 clap = { version = "4.2.4", features = ["derive"] }
 cudarc = { version = "0.9.13", features = ["f16"] }
-# TODO: Switch back to the official gemm implementation once the following are available.
-# https://github.com/sarah-ek/gemm/pull/8.
-# https://github.com/sarah-ek/gemm/pull/9.
-gemm = { git = "https://github.com/LaurentMazare/gemm.git" }
+# TODO: Switch back to the official gemm implementation once it has caught up.
+gemm = { version = "0.15.5", package = "candle-gemm" }
 hf-hub = "0.2.0"
 half = { version = "2.3.1", features = ["num-traits", "rand_distr"] }
 intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"] }

--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 byteorder = { workspace = true }
-candle-kernels = { path = "../candle-kernels", optional = true }
+candle-kernels = { path = "../candle-kernels", version = "0.1.0", optional = true }
 cudarc = { workspace = true, optional = true }
 gemm = { workspace = true }
 half = { workspace = true }

--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -11,10 +11,10 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-candle = { path = "../candle-core", package = "candle-core" }
-candle-nn = { path = "../candle-nn" }
-candle-transformers = { path = "../candle-transformers" }
-candle-flash-attn = { path = "../candle-flash-attn", optional = true }
+candle = { path = "../candle-core", version = "0.1.0", package = "candle-core" }
+candle-nn = { path = "../candle-nn", version = "0.1.0" }
+candle-transformers = { path = "../candle-transformers", version = "0.1.0" }
+candle-flash-attn = { path = "../candle-flash-attn", version = "0.1.0", optional = true }
 safetensors = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/candle-flash-attn/Cargo.toml
+++ b/candle-flash-attn/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-candle = { path = "../candle-core", features = ["cuda"], package = "candle-core" }
+candle = { path = "../candle-core", features = ["cuda"], version = "0.1.0", package = "candle-core" }
 half = { version = "2.3.1", features = ["num-traits"] }
 
 [build-dependencies]
@@ -21,4 +21,4 @@ rayon = "1.7.0"
 
 [dev-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
-candle-nn = { path = "../candle-nn", features = ["cuda"] }
+candle-nn = { path = "../candle-nn", version = "0.1.0", features = ["cuda"] }

--- a/candle-nn/Cargo.toml
+++ b/candle-nn/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-candle = { path = "../candle-core", package = "candle-core" }
+candle = { path = "../candle-core", version = "0.1.0", package = "candle-core" }
 thiserror = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
 safetensors = { workspace = true }

--- a/candle-pyo3/Cargo.toml
+++ b/candle-pyo3/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
-candle = { path = "../candle-core", package = "candle-core" }
+candle = { path = "../candle-core", version = "0.1.0", package = "candle-core" }
 pyo3 = { version = "0.19.0", features = ["extension-module"] }
 half = { workspace = true }
 

--- a/candle-transformers/Cargo.toml
+++ b/candle-transformers/Cargo.toml
@@ -11,9 +11,9 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-candle = { path = "../candle-core", package = "candle-core" }
+candle = { path = "../candle-core", version = "0.1.0", package = "candle-core" }
 hf-hub = { workspace = true}
-candle-nn = { path = "../candle-nn" }
+candle-nn = { path = "../candle-nn", version = "0.1.0" }
 intel-mkl-src = { workspace = true, optional = true }
 tokenizers = { workspace = true, features = ["onig"] }
 rand = { workspace = true }

--- a/candle-wasm-examples/llama2-c/Cargo.toml
+++ b/candle-wasm-examples/llama2-c/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-candle = { path = "../../candle-core", package = "candle-core" }
-candle-nn = { path = "../../candle-nn" }
+candle = { path = "../../candle-core", version = "0.1.0", package = "candle-core" }
+candle-nn = { path = "../../candle-nn", version = "0.1.0" }
 num-traits = { workspace = true }
 
 # App crates.

--- a/candle-wasm-examples/whisper/Cargo.toml
+++ b/candle-wasm-examples/whisper/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-candle = { path = "../../candle-core", package = "candle-core" }
-candle-nn = { path = "../../candle-nn" }
+candle = { path = "../../candle-core", version = "0.1.0", package = "candle-core" }
+candle-nn = { path = "../../candle-nn", version = "0.1.0" }
 num-traits = { workspace = true }
 tokenizers = { workspace = true, features = ["unstable_wasm"] }
 


### PR DESCRIPTION
It would be nice to find a way to inherit these from the main workspace config.