### PR TITLE
[do-not-merge] Transpose the rhs in linear.

### DIFF
--- a/candle-nn/src/linear.rs
+++ b/candle-nn/src/linear.rs
@@ -27,13 +27,14 @@ pub struct Linear {
 
 impl Linear {
     pub fn new(weight: Tensor, bias: Option<Tensor>) -> Self {
+        let weight = weight.t().unwrap().contiguous().unwrap();
         Self { weight, bias }
     }
 
     pub fn forward(&self, x: &Tensor) -> candle::Result<Tensor> {
         let w = match x.dims() {
-            &[bsize, _, _] => self.weight.broadcast_left(bsize)?.t()?,
-            _ => self.weight.t()?,
+            &[bsize, _, _] => self.weight.broadcast_left(bsize)?,
+            _ => self.weight.clone(),
         };
         let x = x.matmul(&w)?;
         match &self.bias {


### PR DESCRIPTION
This results in a speed up of > 6x when running llama2 inference as the `pack_generic_inner_loop` bits from `gemm-f16` can use the vectorized instructions. With this the time per token is ~1.98s vs ~1.3s for mkl.