### PR TITLE
[candle-core] Remove incorrect unwrap from Conv1d in cuda_backend

### DIFF
--- a/candle-core/src/cuda_backend.rs
+++ b/candle-core/src/cuda_backend.rs
@@ -904,7 +904,7 @@ impl<'a> Map2 for Conv1D<'a> {
         let dims = shape.dims();
         let el = shape.elem_count();
         let l_out = p.l_out();
-        let dst_el = p.c_out * l_out * p.b_size.unwrap_or(1);
+        let dst_el = p.c_out * l_out * p.b_size;
         let cfg = LaunchConfig::for_num_elems(dst_el as u32);
         let func = dev.get_or_load_func(&kernel_name::<T>("conv1d"), kernels::CONV)?;
         // SAFETY: Set later by running the kernel.


### PR DESCRIPTION
```
error[E0599]: no method named `unwrap_or` found for type `usize` in the current scope
   --> candle-core/src/cuda_backend.rs:907:49
    |
907 |         let dst_el = p.c_out * l_out * p.b_size.unwrap_or(1);
    |                                                 ^^^^^^^^^ method not found in `usize`
```

PR #377 changed a type of `ParamsConv1D::b_size` from `Option<usize>` to regular `usize`, but didn't remove the unwrap in `cuda_backend`. Error only appears when building with `--features cuda`

Fix tested on an AWS `g4s.xlarge` instance with Ubuntu 20.04, CUDA 11.8, NVIDIA driver version: 535.54.03, rust 1.71.0