### PR TITLE
Conv1d optimize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ clap = { version = "4.2.4", features = ["derive"] }
 cudarc = { version = "0.9.13", features = ["f16"] }
 # TODO: Switch back to the official gemm implementation once it has caught up.
 gemm = { version = "0.15.6", package = "candle-gemm" }
+ggblas = "0.1.2"
 hf-hub = "0.2.0"
 half = { version = "2.3.1", features = ["num-traits", "rand_distr"] }
 image = { version = "0.24.7", default-features = false, features = ["jpeg", "png"] }

--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -15,6 +15,7 @@ byteorder = { workspace = true }
 candle-kernels = { path = "../candle-kernels", version = "0.1.0", optional = true }
 cudarc = { workspace = true, optional = true }
 gemm = { workspace = true }
+ggblas = { workspace = true }
 half = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }

--- a/candle-core/src/cpu_backend.rs
+++ b/candle-core/src/cpu_backend.rs
@@ -1040,25 +1040,25 @@ impl<'a> Map2 for Conv1D<'a> {
         let dst_elems = p.c_out * l_out * p.b_size;
         let mut dst = vec![T::zero(); dst_elems];
         // The output shape is [b_size, c_out, l_out]
-        for b_idx in 0..p.b_size {
-            let inp_idx = b_idx * inp_s0;
-            let dst_idx = b_idx * p.c_out * l_out;
-            for dst_c_idx in 0..p.c_out {
-                let dst_idx = dst_idx + dst_c_idx * l_out;
+        for offset in 0..p.k_size {
+            for b_idx in 0..p.b_size {
+                let inp_idx = b_idx * inp_s0;
+                let dst_idx = b_idx * p.c_out * l_out;
                 for dst_l in 0..l_out {
                     let dst_idx = dst_idx + dst_l;
-                    let mut d = T::zero();
-                    for offset in 0..p.k_size {
+                    for dst_c_idx in 0..p.c_out {
+                        let dst_idx = dst_idx + dst_c_idx * l_out;
                         let src_l = (p.stride * dst_l + offset)
                             .saturating_sub(p.padding)
                             .min(p.l_in - 1);
+                        let mut d = T::zero();
                         for src_c_idx in 0..p.c_in {
                             let inp_idx = inp_idx + src_c_idx * inp_s1 + src_l * inp_s2;
                             let k_idx = dst_c_idx * k_s0 + src_c_idx * k_s1 + offset * k_s2;
                             d += inp[inp_idx] * k[k_idx]
                         }
+                        dst[dst_idx] += d
                     }
-                    dst[dst_idx] = d
                 }
             }
         }

--- a/candle-core/src/cpu_kernels.rs
+++ b/candle-core/src/cpu_kernels.rs
@@ -1,4 +1,10 @@
 pub trait VecDot: num_traits::NumAssign + Copy {
+    /// Dot-product of two vectors.
+    ///
+    /// # Safety
+    ///
+    /// The length of `lhs` and `rhs` have to be at least `len`. `res` has to point to a valid
+    /// element.
     #[inline(always)]
     unsafe fn vec_dot(lhs: *const Self, rhs: *const Self, res: *mut Self, len: usize) {
         *res = Self::zero();

--- a/candle-core/src/cpu_kernels.rs
+++ b/candle-core/src/cpu_kernels.rs
@@ -1,0 +1,22 @@
+pub trait VecDot: num_traits::NumAssign + Copy {
+    #[inline(always)]
+    unsafe fn vec_dot(lhs: *const Self, rhs: *const Self, res: *mut Self, len: usize) {
+        *res = Self::zero();
+        for i in 0..len {
+            *res += *lhs.add(i) * *rhs.add(i)
+        }
+    }
+}
+
+impl VecDot for f32 {
+    #[inline(always)]
+    unsafe fn vec_dot(lhs: *const Self, rhs: *const Self, res: *mut Self, len: usize) {
+        ggblas::ggml::vec_dot_f32(lhs, rhs, res, len)
+    }
+}
+
+impl VecDot for f64 {}
+impl VecDot for half::bf16 {}
+impl VecDot for half::f16 {}
+impl VecDot for u8 {}
+impl VecDot for u32 {}

--- a/candle-core/src/dtype.rs
+++ b/candle-core/src/dtype.rs
@@ -54,7 +54,13 @@ impl DType {
 }
 
 pub trait WithDType:
-    Sized + Copy + num_traits::NumAssign + std::cmp::PartialOrd + std::fmt::Display + 'static
+    Sized
+    + Copy
+    + num_traits::NumAssign
+    + std::cmp::PartialOrd
+    + std::fmt::Display
+    + 'static
+    + crate::cpu_kernels::VecDot
 {
     const DTYPE: DType;
 

--- a/candle-core/src/lib.rs
+++ b/candle-core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod backprop;
 mod conv;
 mod convert;
 pub mod cpu_backend;
+pub mod cpu_kernels;
 #[cfg(feature = "cuda")]
 pub mod cuda_backend;
 mod device;


### PR DESCRIPTION
This optimizes the cpu implementation for `conv1d`: it changes the loop order so that the operation result in a large dot product and `ggblas` is used to implement this in an efficient way using simd where available. This does not use multiple threads. It is less efficient memory-wise than the naive implementation as the input tensor is made contiguous.
Benchmarking results on my macbook (m2pro 2022).
- On the conv1d benchmark in `candle-core/examples`, the runtime goes from 1.1s to 101ms.
- On whisper, the two first convolutions go from 226ms + 568ms to 30ms + 65ms.