### PR TITLE
Compat windows.

### DIFF
--- a/candle-kernels/src/compatibility.cuh
+++ b/candle-kernels/src/compatibility.cuh
@@ -6,6 +6,15 @@
 
 // FIXME: the minimum compute capabilities are just guesses since the table is not specific enough
 
+#if (__CUDACC_VER_MAJOR__ < 12 || __CUDACC_VER_MINOR__ < 2) && __CUDA_ARCH__ < 800
+__device__ __forceinline__ __half __hmax_nan(__half a, __half b) {
+    return __hisnan(a) ? a : (__hisnan(b) ? b : __hmax(a, b));
+}
+__device__ __forceinline__ __half __hmin_nan(__half a, __half b) {
+    return __hisnan(a) ? a : (__hisnan(b) ? b : __hmin(a, b));
+}
+#endif
+
 #if __CUDA_ARCH__ < 600
 // Copied from https://docs.nvidia.com/cuda/cuda-c-programming-guide/#atomic-functions
 __device__ double atomicAdd(double* address, double val) {


### PR DESCRIPTION
Checked on a real windows machine.

The CUDA docs says those functions were introduced in Cuda 12.0 (and absent in Cuda 11.8).
However I run a windows machine on cuda 12.0 which doesn't have these....

Cuda 12.0: https://docs.nvidia.com/cuda/archive/12.0.0/cuda-math-api/group__CUDA__MATH____HALF__COMPARISON.html#group__CUDA__MATH____HALF__COMPARISON
Cuda 11.8: https://docs.nvidia.com/cuda/archive/11.8.0/cuda-math-api/group__CUDA__MATH____HALF__COMPARISON.html#group__CUDA__MATH____HALF__COMPARISON