### PR TITLE
Optimize the cpu conv2d kernel

### DIFF
--- a/candle-core/src/cpu_backend.rs
+++ b/candle-core/src/cpu_backend.rs
@@ -1089,16 +1089,16 @@ impl<'a> Map2 for Conv2D<'a> {
 
         // TODO: Avoid making this copy if `inp` already has the appropriate layout.
         let mut inp_cont = vec![T::zero(); p.b_size * p.c_in * p.i_h * p.i_w];
+        let cont_s0 = p.i_h * p.i_w * p.c_in;
+        let cont_s1 = p.i_w * p.c_in;
+        let cont_s2 = p.c_in;
         for b_idx in 0..p.b_size {
             for h_idx in 0..p.i_h {
                 for w_idx in 0..p.i_w {
                     for c_idx in 0..p.c_in {
                         let src_idx =
                             b_idx * inp_s0 + c_idx * inp_s1 + h_idx * inp_s2 + w_idx * inp_s3;
-                        let dst_idx = b_idx * p.c_in * p.i_h * p.i_w
-                            + c_idx * p.i_h * p.i_w
-                            + h_idx * p.i_w
-                            + w_idx;
+                        let dst_idx = b_idx * cont_s0 + h_idx * cont_s1 + w_idx * cont_s2 + c_idx;
                         inp_cont[dst_idx] = inp[src_idx]
                     }
                 }

--- a/candle-core/src/cpu_backend.rs
+++ b/candle-core/src/cpu_backend.rs
@@ -1129,9 +1129,8 @@ impl<'a> Map2 for Conv2D<'a> {
                                 let src_w = (p.stride * dst_w + offset_w)
                                     .saturating_sub(p.padding)
                                     .min(p.i_w - 1);
-                                let inp_cont = &inp_cont[b_idx * p.c_in * p.i_h * p.i_w
-                                    + src_h * p.c_in * p.i_w
-                                    + src_w * p.c_in..];
+                                let inp_cont = &inp_cont
+                                    [b_idx * cont_s0 + src_h * cont_s1 + src_w * cont_s2..];
                                 assert!(inp_cont.len() >= p.c_in);
                                 assert!(k_cont.len() >= p.c_in);
                                 let mut d = T::zero();


### PR DESCRIPTION
Same as conv1d: re-order the ops to end up doing a large dot product of two vectors and use ggblas to use simd for this portion. There is still no multi-threading and this increases the memory requirement.

Benchmarking on a macbook (m2pro 2022), the `conv2d` case of `cpu_benchmarks.rs` goes from 14.8s to 1.29s.