### PR TITLE
General interpolation op

### DIFF
--- a/candle-core/src/cpu_backend.rs
+++ b/candle-core/src/cpu_backend.rs
@@ -727,7 +727,7 @@ impl Map1 for UpsampleNearest2D {
         let scale_w = dst_w as f64 / src_w as f64;
         let mut dst = vec![T::zero(); b_sz * c * dst_h * dst_w];
 
-        for idx in 0..(b_sz * c * dst_h * dst_w) {
+        for (idx, dst_val) in dst.iter_mut().enumerate() {
             let b_idx = idx / (c * dst_h * dst_w);
             let c_idx = (idx / (dst_h * dst_w)) % c;
             let h_idx = (idx / dst_w) % dst_h;
@@ -738,8 +738,8 @@ impl Map1 for UpsampleNearest2D {
                 + b_idx * stride[0]
                 + c_idx * stride[1]
                 + src_h_idx * stride[2]
-                + src_w_idx * stride[3];
-            dst[idx] = src[src_index];
+                + src_w_idx * stride[3] ;
+            *dst_val = src[src_index];
         }
         Ok(dst)
     }

--- a/candle-core/tests/pool_tests.rs
+++ b/candle-core/tests/pool_tests.rs
@@ -79,3 +79,15 @@ fn upsample_nearest2d() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn downsample_nearest2d() -> anyhow::Result<()> {
+    let t = Tensor::arange(0f32, 6f32, &Device::Cpu)?.reshape((1, 1, 2, 3))?;
+    let upsampled = t.upsample_nearest2d(4, 6)?;
+    let downsampled = upsampled.upsample_nearest2d(2, 3)?;
+    assert_eq!(
+        downsampled.i(0)?.i(0)?.to_vec2::<f32>()?,
+        [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
+    );
+    Ok(())
+}


### PR DESCRIPTION
Here is a more general implementation that supports both up/down-sampling with a test. I want to implement other interpolation methods like bilinear, lanczos, etc. Should they each be their own thing or do we put them in one struct and use ```match```? Also still need to rename UpsampleNearest2D. 