### PR TITLE
Parallelise the CPU kernels for the conv ops.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ num_cpus = "1.15.0"
 num-traits = "0.2.15"
 rand = "0.8.5"
 rand_distr = "0.4.3"
+rayon = "1.7.0"
 safetensors = "0.3.1"
 serde = { version = "1.0.171", features = ["derive"] }
 serde_json = "1.0.99"

--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -24,6 +24,7 @@ num-traits = { workspace = true }
 num_cpus = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
+rayon = { workspace = true }
 safetensors = { workspace = true }
 thiserror = { workspace = true }
 zip = { workspace = true }

--- a/candle-core/src/cpu_backend.rs
+++ b/candle-core/src/cpu_backend.rs
@@ -1066,6 +1066,9 @@ impl<'a> Map2 for Conv1D<'a> {
                         let mut d = T::zero();
                         unsafe { T::vec_dot(inp_cont.as_ptr(), k_cont.as_ptr(), &mut d, p.c_in) }
                         let dst_p = dst.as_ptr();
+                        // Safety: dst_idx are uniques per dst_c_idx which is used to parallelise
+                        // the different tasks so no two threads can try to write at the same
+                        // location.
                         unsafe {
                             let ptr = dst_p.add(dst_idx) as *mut T;
                             *ptr += d
@@ -1146,6 +1149,9 @@ impl<'a> Map2 for Conv2D<'a> {
                                     T::vec_dot(inp_cont.as_ptr(), k_cont.as_ptr(), &mut d, p.c_in)
                                 }
                                 let dst_p = dst.as_ptr();
+                                // Safety: dst_idx are uniques per dst_c_idx which is used to parallelise
+                                // the different tasks so no two threads can try to write at the same
+                                // location.
                                 unsafe {
                                     let ptr = dst_p.add(dst_idx) as *mut T;
                                     *ptr += d

--- a/candle-core/src/cpu_kernels.rs
+++ b/candle-core/src/cpu_kernels.rs
@@ -26,3 +26,37 @@ impl VecDot for half::bf16 {}
 impl VecDot for half::f16 {}
 impl VecDot for u8 {}
 impl VecDot for u32 {}
+
+#[inline(always)]
+pub fn par_for_each(n_threads: usize, func: impl Fn(usize) + Send + Sync) {
+    if n_threads == 1 {
+        func(0)
+    } else {
+        rayon::scope(|s| {
+            for thread_idx in 0..n_threads {
+                let func = &func;
+                s.spawn(move |_| func(thread_idx));
+            }
+        })
+    }
+}
+
+#[inline(always)]
+pub fn par_range(lo: usize, up: usize, n_threads: usize, func: impl Fn(usize) + Send + Sync) {
+    if n_threads == 1 {
+        for i in lo..up {
+            func(i)
+        }
+    } else {
+        rayon::scope(|s| {
+            for thread_idx in 0..n_threads {
+                let func = &func;
+                s.spawn(move |_| {
+                    for i in (thread_idx..up).step_by(n_threads) {
+                        func(i)
+                    }
+                });
+            }
+        })
+    }
+}

--- a/candle-core/src/dtype.rs
+++ b/candle-core/src/dtype.rs
@@ -60,6 +60,8 @@ pub trait WithDType:
     + std::cmp::PartialOrd
     + std::fmt::Display
     + 'static
+    + Send
+    + Sync
     + crate::cpu_kernels::VecDot
 {
     const DTYPE: DType;


### PR DESCRIPTION
This PR parallelize the conv1d and conv2d ops using the rayon thread pool. They do not use par_iter but rather scoped threads as the amount of work for each task is the same. This gives tighter control on thtread allocation at the expense of using heap allocation.
Benchmarks on my macbook pro (m2pro 2022) from `cpu_benchmarks.rs`:
- conv2d benchmark: 1.29s to 271ms.
- conv1d benchmark: 101ms to 20ms.