### PR TITLE
fix: can directly save the loaded weights

### DIFF
--- a/candle-core/src/safetensors.rs
+++ b/candle-core/src/safetensors.rs
@@ -253,7 +253,10 @@ pub fn load_buffer(data: &[u8], device: &Device) -> Result<HashMap<String, Tenso
         .collect()
 }
 
-pub fn save<P: AsRef<Path>>(tensors: &HashMap<&str, Tensor>, filename: P) -> Result<()> {
+pub fn save<K: AsRef<str> + Ord + std::fmt::Display, P: AsRef<Path>>(
+    tensors: &HashMap<K, Tensor>,
+    filename: P,
+) -> Result<()> {
     Ok(st::serialize_to_file(tensors, &None, filename.as_ref())?)
 }
 


### PR DESCRIPTION
can directly save the loaded weights.
```rust
  let api = Api::new()?;
  let repo = api.model("bert-base-uncased".to_string());

  let weights = repo.get("model.safetensors")?;

  let weights = candle_core::safetensors::load(weights, &Device::Cpu)?;
  // do something like this
  // ...
  candle_core::safetensors::save(&weights, "new-model.safetensors")?;
```