### PR TITLE
[WIP] Adding i32 and randint, randint_like Tensor methods only for CPU

### DIFF
--- a/candle-core/src/backend.rs
+++ b/candle-core/src/backend.rs
@@ -1,5 +1,5 @@
 use crate::op::{BinaryOpT, CmpOp, ReduceOp, UnaryOpT};
-use crate::{CpuStorage, DType, Layout, Result, Shape};
+use crate::{CpuStorage, DType, Layout, Result, Shape, IntDType, FloatDType};
 
 pub trait BackendStorage: Sized {
     type Device: BackendDevice;
@@ -97,7 +97,11 @@ pub trait BackendDevice: Sized + std::fmt::Debug + Clone {
 
     fn storage_from_cpu_storage(&self, _: &CpuStorage) -> Result<Self::Storage>;
 
-    fn rand_uniform(&self, _: &Shape, _: DType, _: f64, _: f64) -> Result<Self::Storage>;
+    fn rand_uniform_float<T: Copy + PartialOrd + FloatDType>(
+        &self, _shape: &Shape, _dtype: DType, _lo: T, _up: T) -> Result<Self::Storage>;
+
+    fn rand_uniform_int<T: Copy + PartialOrd + IntDType>(
+        &self, _shape: &Shape, _dtype: DType, _lo: T, _up: T) -> Result<Self::Storage>;
 
     fn rand_normal(&self, _: &Shape, _: DType, _: f64, _: f64) -> Result<Self::Storage>;
 }

--- a/candle-core/src/convert.rs
+++ b/candle-core/src/convert.rs
@@ -92,6 +92,7 @@ from_tensor!(f64);
 from_tensor!(f32);
 from_tensor!(f16);
 from_tensor!(bf16);
+from_tensor!(i32);
 from_tensor!(u32);
 from_tensor!(u8);
 
@@ -122,6 +123,11 @@ impl Tensor {
             DType::F64 => {
                 for v in vs.to_vec1::<f64>()? {
                     f.write_f64::<LittleEndian>(v)?
+                }
+            }
+            DType::I32 => {
+                for v in vs.to_vec1::<i32>()? {
+                    f.write_i32::<LittleEndian>(v)?
                 }
             }
             DType::U32 => {

--- a/candle-core/src/cpu_kernels.rs
+++ b/candle-core/src/cpu_kernels.rs
@@ -26,6 +26,7 @@ impl VecDot for half::bf16 {}
 impl VecDot for half::f16 {}
 impl VecDot for u8 {}
 impl VecDot for u32 {}
+impl VecDot for i32 {}
 
 #[inline(always)]
 pub fn par_for_each(n_threads: usize, func: impl Fn(usize) + Send + Sync) {

--- a/candle-core/src/device.rs
+++ b/candle-core/src/device.rs
@@ -123,6 +123,25 @@ impl Device {
         }
     }
 
+    pub(crate) fn rand_uniform_i32<T: crate::IntDType>(
+        &self,
+        lo: T,
+        up: T,
+        shape: &Shape,
+    ) -> Result<Storage> {
+        match self {
+            Device::Cpu => {
+                let storage = CpuDevice.rand_uniform_int(shape, T::DTYPE, lo.to_i32(), up.to_i32())?;
+
+                Ok(Storage::Cpu(storage))
+            }
+            Device::Cuda(device) => {
+                let storage = device.rand_uniform_int(shape, T::DTYPE, lo.to_i32(), up.to_i32())?;
+                Ok(Storage::Cuda(storage))
+            }
+        }
+    }
+
     pub(crate) fn rand_uniform_f64(
         &self,
         lo: f64,
@@ -132,11 +151,11 @@ impl Device {
     ) -> Result<Storage> {
         match self {
             Device::Cpu => {
-                let storage = CpuDevice.rand_uniform(shape, dtype, lo, up)?;
+                let storage = CpuDevice.rand_uniform_float(shape, dtype, lo, up)?;
                 Ok(Storage::Cpu(storage))
             }
             Device::Cuda(device) => {
-                let storage = device.rand_uniform(shape, dtype, lo, up)?;
+                let storage = device.rand_uniform_float(shape, dtype, lo, up)?;
                 Ok(Storage::Cuda(storage))
             }
         }

--- a/candle-core/src/display.rs
+++ b/candle-core/src/display.rs
@@ -49,6 +49,7 @@ impl std::fmt::Debug for Tensor {
         match self.dtype() {
             DType::U8 => self.fmt_dt::<u8>(f),
             DType::U32 => self.fmt_dt::<u32>(f),
+            DType::I32 => self.fmt_dt::<i32>(f),
             DType::BF16 => self.fmt_dt::<bf16>(f),
             DType::F16 => self.fmt_dt::<f16>(f),
             DType::F32 => self.fmt_dt::<f32>(f),
@@ -427,6 +428,12 @@ impl std::fmt::Display for Tensor {
             }
             DType::U32 => {
                 let tf: IntFormatter<u32> = IntFormatter::new();
+                let max_w = tf.max_width(&to_display);
+                tf.fmt_tensor(self, 1, max_w, summarize, &po, f)?;
+                writeln!(f)?;
+            }
+            DType::I32 => {
+                let tf: IntFormatter<i32> = IntFormatter::new();
                 let max_w = tf.max_width(&to_display);
                 tf.fmt_tensor(self, 1, max_w, summarize, &po, f)?;
                 writeln!(f)?;

--- a/candle-core/src/dtype.rs
+++ b/candle-core/src/dtype.rs
@@ -5,6 +5,7 @@ use crate::{CpuStorage, Error, Result};
 pub enum DType {
     U8,
     U32,
+    I32,
     BF16,
     F16,
     F32,
@@ -20,6 +21,7 @@ impl std::str::FromStr for DType {
         match s {
             "u8" => Ok(Self::U8),
             "u32" => Ok(Self::U32),
+            "i32" => Ok(Self::I32),
             "bf16" => Ok(Self::BF16),
             "f16" => Ok(Self::F16),
             "f32" => Ok(Self::F32),
@@ -34,6 +36,7 @@ impl DType {
         match self {
             Self::U8 => "u8",
             Self::U32 => "u32",
+            Self::I32 => "i32",
             Self::BF16 => "bf16",
             Self::F16 => "f16",
             Self::F32 => "f32",
@@ -45,6 +48,7 @@ impl DType {
         match self {
             Self::U8 => 1,
             Self::U32 => 4,
+            Self::I32 => 4,
             Self::BF16 => 2,
             Self::F16 => 2,
             Self::F32 => 4,
@@ -125,6 +129,7 @@ use half::{bf16, f16};
 
 with_dtype!(u8, U8, |v: f64| v as u8, |v: u8| v as f64);
 with_dtype!(u32, U32, |v: f64| v as u32, |v: u32| v as f64);
+with_dtype!(i32, I32, |v: f64| v as i32, |v: i32| v as f64);
 with_dtype!(f16, F16, f16::from_f64, f16::to_f64);
 with_dtype!(bf16, BF16, bf16::from_f64, bf16::to_f64);
 with_dtype!(f32, F32, |v: f64| v as f32, |v: f32| v as f64);
@@ -133,6 +138,7 @@ with_dtype!(f64, F64, |v: f64| v, |v: f64| v);
 pub trait IntDType: WithDType {
     fn is_true(&self) -> bool;
     fn as_usize(&self) -> usize;
+    fn to_i32(&self) -> i32;
 }
 
 impl IntDType for u32 {
@@ -141,6 +147,9 @@ impl IntDType for u32 {
     }
     fn as_usize(&self) -> usize {
         *self as usize
+    }
+    fn to_i32(&self) -> i32 {
+        *self as i32
     }
 }
 
@@ -151,7 +160,23 @@ impl IntDType for u8 {
     fn as_usize(&self) -> usize {
         *self as usize
     }
+    fn to_i32(&self) -> i32 {
+        *self as i32
+    }
 }
+
+impl IntDType for i32 {
+    fn is_true(&self) -> bool {
+        *self != 0
+    }
+    fn as_usize(&self) -> usize {
+        *self as usize
+    }
+    fn to_i32(&self) -> i32 {
+        *self
+    }
+}
+
 
 pub trait FloatDType: WithDType {}
 

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -169,7 +169,13 @@ impl crate::backend::BackendDevice for CudaDevice {
         Err(Error::NotCompiledWithCudaSupport)
     }
 
-    fn rand_uniform(&self, _: &Shape, _: DType, _: f64, _: f64) -> Result<Self::Storage> {
+    fn rand_uniform_float<T>(
+            &self, _shape: &Shape, _dtype: DType, _lo: T, _up: T) -> Result<Self::Storage> {
+        Err(Error::NotCompiledWithCudaSupport)
+    }
+
+    fn rand_uniform_int<T>(
+            &self, _shape: &Shape, _dtype: DType, _lo: T, _up: T) -> Result<Self::Storage> {
         Err(Error::NotCompiledWithCudaSupport)
     }
 

--- a/candle-core/src/error.rs
+++ b/candle-core/src/error.rs
@@ -132,6 +132,18 @@ pub enum Error {
     #[error("cannot set variable {msg}")]
     CannotSetVar { msg: &'static str },
 
+    #[error("the upper bound value {up:?} must be greater than the lower bound value {lo:?}")]
+    RandIntBoundsInvalid {
+        lo: i32,
+        up: i32,
+    },
+
+    #[error("the upper bound value {up:?} must be greater than the lower bound value {lo:?}")]
+    RandFloatBoundsInvalid {
+        lo: f64,
+        up: f64,
+    },
+
     // Box indirection to avoid large variant.
     #[error("{0:?}")]
     MatMulUnexpectedStriding(Box<MatMulUnexpectedStriding>),

--- a/candle-core/src/npy.rs
+++ b/candle-core/src/npy.rs
@@ -85,6 +85,7 @@ impl Header {
             DType::F16 => "f2",
             DType::F32 => "f4",
             DType::F64 => "f8",
+            DType::I32 => "i4",
             DType::U32 => "u4",
             DType::U8 => "u1",
         };
@@ -159,7 +160,7 @@ impl Header {
                     "e" | "f2" => DType::F16,
                     "f" | "f4" => DType::F32,
                     "d" | "f8" => DType::F64,
-                    // "i" | "i4" => DType::S32,
+                    "i" | "i4" => DType::I32,
                     // "q" | "i8" => DType::S64,
                     // "h" | "i2" => DType::S16,
                     // "b" | "i1" => DType::S8,
@@ -227,6 +228,11 @@ impl Tensor {
             DType::U32 => {
                 let mut data_t = vec![0u32; elem_count];
                 reader.read_u32_into::<LittleEndian>(&mut data_t)?;
+                Tensor::from_vec(data_t, shape, &Device::Cpu)
+            }
+            DType::I32 => {
+                let mut data_t = vec![0i32; elem_count];
+                reader.read_i32_into::<LittleEndian>(&mut data_t)?;
                 Tensor::from_vec(data_t, shape, &Device::Cpu)
             }
         }

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -239,6 +239,7 @@ pub trait UnaryOpT {
     fn f64(v1: f64) -> f64;
     fn u8(v1: u8) -> u8;
     fn u32(v1: u32) -> u32;
+    fn i32(v1: i32) -> i32;
 
     // There is no very good way to represent optional function in traits so we go for an explicit
     // boolean flag to mark the function as existing.
@@ -262,6 +263,7 @@ pub trait BinaryOpT {
     fn f64(v1: f64, v2: f64) -> f64;
     fn u8(v1: u8, v2: u8) -> u8;
     fn u32(v1: u32, v2: u32) -> u32;
+    fn i32(v1: i32, v2: i32) -> i32;
 
     const BF16_VEC: bool = false;
     fn bf16_vec(_xs1: &[bf16], _xs2: &[bf16], _ys: &mut [bf16]) {}
@@ -275,6 +277,8 @@ pub trait BinaryOpT {
     fn u8_vec(_xs1: &[u8], _xs2: &[u8], _ys: &mut [u8]) {}
     const U32_VEC: bool = false;
     fn u32_vec(_xs1: &[u32], _xs2: &[u32], _ys: &mut [u32]) {}
+    const I32_VEC: bool = false;
+    fn i32_vec(_xs1: &[i32], _xs2: &[i32], _ys: &mut [i32]) {}
 }
 
 pub(crate) struct Add;
@@ -321,6 +325,10 @@ macro_rules! bin_op {
             }
             #[inline(always)]
             fn u32(v1: u32, v2: u32) -> u32 {
+                $e(v1, v2)
+            }
+            #[inline(always)]
+            fn i32(v1: i32, v2: i32) -> i32 {
                 $e(v1, v2)
             }
 
@@ -392,6 +400,10 @@ macro_rules! unary_op {
             fn u32(_: u32) -> u32 {
                 todo!("no unary function for u32")
             }
+            #[inline(always)]
+            fn i32(_: i32) -> i32 {
+                todo!("no unary function for i32")
+            }
         }
     };
 
@@ -423,6 +435,10 @@ macro_rules! unary_op {
             #[inline(always)]
             fn u32(_: u32) -> u32 {
                 todo!("no unary function for u32")
+            }
+            #[inline(always)]
+            fn i32(_: i32) -> i32 {
+                todo!("no unary function for i32")
             }
 
             #[cfg(feature = "mkl")]
@@ -515,6 +531,10 @@ impl UnaryOpT for Gelu {
     fn u32(_: u32) -> u32 {
         0
     }
+    #[inline(always)]
+    fn i32(_: i32) -> i32 {
+        0
+    }
     const KERNEL: &'static str = "ugelu";
 
     #[cfg(feature = "mkl")]
@@ -562,6 +582,10 @@ impl UnaryOpT for Relu {
     }
     #[inline(always)]
     fn u32(v: u32) -> u32 {
+        v
+    }
+    #[inline(always)]
+    fn i32(v: i32) -> i32 {
         v
     }
 }

--- a/candle-core/src/safetensors.rs
+++ b/candle-core/src/safetensors.rs
@@ -10,6 +10,7 @@ impl From<DType> for st::Dtype {
         match value {
             DType::U8 => st::Dtype::U8,
             DType::U32 => st::Dtype::U32,
+            DType::I32 => st::Dtype::I32,
             DType::BF16 => st::Dtype::BF16,
             DType::F16 => st::Dtype::F16,
             DType::F32 => st::Dtype::F32,
@@ -24,6 +25,7 @@ impl TryFrom<st::Dtype> for DType {
         match value {
             st::Dtype::U8 => Ok(DType::U8),
             st::Dtype::U32 => Ok(DType::U32),
+            st::Dtype::I32 => Ok(DType::I32),
             st::Dtype::BF16 => Ok(DType::BF16),
             st::Dtype::F16 => Ok(DType::F16),
             st::Dtype::F32 => Ok(DType::F32),
@@ -189,6 +191,7 @@ impl Tensor {
         match dtype {
             DType::U8 => convert_slice::<u8>(data, shape, device),
             DType::U32 => convert_slice::<u32>(data, shape, device),
+            DType::I32 => convert_slice::<i32>(data, shape, device),
             DType::BF16 => convert_slice::<half::bf16>(data, shape, device),
             DType::F16 => convert_slice::<half::f16>(data, shape, device),
             DType::F32 => convert_slice::<f32>(data, shape, device),
@@ -233,6 +236,7 @@ fn convert_back(tensor: &Tensor) -> Result<Vec<u8>> {
     match tensor.dtype() {
         DType::U8 => Ok(convert_back_::<u8>(tensor.to_vec1()?)),
         DType::U32 => Ok(convert_back_::<u32>(tensor.to_vec1()?)),
+        DType::I32 => Ok(convert_back_::<i32>(tensor.to_vec1()?)),
         DType::F16 => Ok(convert_back_::<half::f16>(tensor.to_vec1()?)),
         DType::BF16 => Ok(convert_back_::<half::bf16>(tensor.to_vec1()?)),
         DType::F32 => Ok(convert_back_::<f32>(tensor.to_vec1()?)),

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -273,6 +273,33 @@ impl Tensor {
         Tensor::rand_f64_impl(lo, up, self.shape(), self.dtype(), self.device(), false)
     }
 
+    pub(crate) fn randint_impl<S: Into<Shape>, T: crate::IntDType>(
+        lo: T,
+        up: T,
+        s: S,
+        device: &Device,
+        is_variable: bool,
+    ) -> Result<Self> {
+        let s = s.into();
+        let storage = device.rand_uniform_i32(lo, up, &s)?;
+        let none = BackpropOp::none();
+        Ok(from_storage(storage, s, none, is_variable))
+    }
+
+    /// Creates a new tensor initialized with integer values sampled uniformly between `lo` and `up`.
+    pub fn randint<S: Into<Shape>, T: crate::IntDType>(
+        lo: T,
+        up: T,
+        s: S,
+        device: &Device,
+    ) -> Result<Self> {
+        Self::randint_impl(lo, up, s, device, false)
+    }
+
+    pub fn randint_like(&self, lo: i32, up: i32) -> Result<Self> {
+        Tensor::randint_impl(lo, up, self.shape(), self.device(), false)
+    }
+
     pub(crate) fn randn_impl<S: Into<Shape>, T: crate::FloatDType>(
         mean: T,
         std: T,

--- a/candle-pyo3/src/lib.rs
+++ b/candle-pyo3/src/lib.rs
@@ -136,6 +136,7 @@ macro_rules! pydtype {
 }
 pydtype!(u8, |v| v);
 pydtype!(u32, |v| v);
+pydtype!(i32, |v| v);
 pydtype!(f16, f32::from);
 pydtype!(bf16, f32::from);
 pydtype!(f32, |v| v);
@@ -150,6 +151,7 @@ trait MapDType {
         match t.dtype() {
             DType::U8 => self.f::<u8>(t),
             DType::U32 => self.f::<u32>(t),
+            DType::I32 => self.f::<i32>(t),
             DType::BF16 => self.f::<bf16>(t),
             DType::F16 => self.f::<f16>(t),
             DType::F32 => self.f::<f32>(t),


### PR DESCRIPTION
Firstly, **great** work on this library, I'm very interested to see it grow!

I was looking for a way to generate tensors with uniform random integers, including negative values.

Similar methods found in PyTorch

[torch.randint](https://pytorch.org/docs/stable/generated/torch.randint.html)
[torch.randint_like](https://pytorch.org/docs/stable/generated/torch.randint_like.html)

However I'm quite unsure if this is at all something you would like to support in your framework, since it required incorporating a new DType `i32`. (Unless there is some really basic conversion of tensors from the existing `rand` method I completely missed) 

Please note my Rust experience is minimal, so this is a work in progress. I just wanted to know if this is something that would be considered at some point to include since there are some use cases for generating these kind of Tensors. However if there is no obvious need please IGNORE & close this PR.

If you would consider this for inclusion, I will continue writing tests for all the cases and also implement the Cuda backend of this.

```
    let a = Tensor::randint(0u8, 255, (8,), &Device::Cpu)?;
    let b = Tensor::randint(0u32, 1000, (6,), &Device::Cpu)?;
    let c = Tensor::randint(-100i32, 100, (4,), &Device::Cpu)?;
    let d = Tensor::randint_like(&a, 0i32, 1000);
    let fl = Tensor::rand(0.0f32, 1., (4,), &Device::Cpu)?;
    let err = Tensor::randint(0i32, -10, (2,), &Device::Cpu);

```

Yields
```
a: CpuTensor[195, 206, 250, 167, 35, 109, 156, 66; u8]
b: CpuTensor[600, 151, 443, 678, 824, 474; u32]
c: CpuTensor[-49, -86, 84, 37; i32]
d: Ok(CpuTensor[453, 545, 42, 103, 757, 483, 198, 913; i32])
fl: CpuTensor[0.01507771, 0.58171165, 0.7638751, 0.83642375; f32]
err: Err(RandIntBoundsInvalid { lo: 0, up: -10 })
```

Error if `up` is less than `lo`

```
Error: the upper bound value -10 must be greater than the lower bound value 0
```

I am also in the process of looking into setting a manual seed for the **RNG** for CPU and Cuda. I would like to build on this for testing purposes to ensure the same "random" values are tested consistently.

I see the current Cuda backend has a fixed seed (at the speed of light) :)

```    
let curand = cudarc::curand::CudaRng::new(299792458, device.clone()).w()?;
```

Any comments / feedback would be appreciated, also no worries simply closing this if not needed.