### PR TITLE
Add a naive conv2d cuda kernel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ clean-ptx:
 	find target -name "*.ptx" -type f -delete
 	echo "" > candle-kernels/src/lib.rs
 	touch candle-kernels/build.rs
+	touch candle-examples/build.rs
+	touch candle-flash-attn/build.rs
 
 clean:
 	cargo clean

--- a/candle-core/tests/conv_tests.rs
+++ b/candle-core/tests/conv_tests.rs
@@ -78,9 +78,7 @@ print(w.flatten())
 res = torch.nn.functional.conv2d(t, w)
 print(res.flatten())
 */
-#[test]
-fn conv2d() -> Result<()> {
-    let dev = &Device::Cpu;
+fn conv2d(dev: &Device) -> Result<()> {
     let t = Tensor::new(
         &[
             0.4056f32, -0.8689, -0.0773, -1.5630, -2.8012, -1.5059, 0.3972, 1.0852, 0.4997, 3.0616,
@@ -134,9 +132,7 @@ print(w.flatten())
 res = torch.nn.functional.conv2d(t, w)
 print(res.flatten())
 */
-#[test]
-fn conv2d_small() -> Result<()> {
-    let dev = &Device::Cpu;
+fn conv2d_small(dev: &Device) -> Result<()> {
     let t = Tensor::new(
         &[
             0.4056f32, -0.8689, 0.6843, 0.2395, 1.2279, -0.9287, -1.7030, 0.1370, 0.1866, 0.4145,
@@ -156,9 +152,7 @@ fn conv2d_small() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn conv2d_smaller() -> Result<()> {
-    let dev = &Device::Cpu;
+fn conv2d_smaller(dev: &Device) -> Result<()> {
     let t = Tensor::new(
         &[
             0.4056f32, -0.8689, 0.6843, 0.2395, 1.2279, -0.9287, -1.7030, 0.1370, 0.1866,
@@ -179,3 +173,6 @@ fn conv2d_smaller() -> Result<()> {
 
 test_device!(conv1d, conv1d_cpu, conv1d_gpu);
 test_device!(conv1d_small, conv1d_small_cpu, conv1d_small_gpu);
+test_device!(conv2d, conv2d_cpu, conv2d_gpu);
+test_device!(conv2d_small, conv2d_small_cpu, conv2d_small_gpu);
+test_device!(conv2d_smaller, conv2d_smaller_cpu, conv2d_smaller_gpu);

--- a/candle-core/tests/conv_tests.rs
+++ b/candle-core/tests/conv_tests.rs
@@ -15,9 +15,7 @@ print(res.flatten())
 res = torch.nn.functional.conv1d(t, w, padding=1)
 print(res.flatten())
 */
-#[test]
-fn conv1d() -> Result<()> {
-    let dev = &Device::Cpu;
+fn conv1d(dev: &Device) -> Result<()> {
     let t = Tensor::new(
         &[
             0.4056f32, -0.8689, -0.0773, -1.5630, 1.2279, -0.9287, -1.7030, 0.1370, 0.1866, 0.4145,
@@ -51,9 +49,7 @@ fn conv1d() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn conv1d_small() -> Result<()> {
-    let dev = &Device::Cpu;
+fn conv1d_small(dev: &Device) -> Result<()> {
     let t = Tensor::new(&[0.4056f32, -0.8689, -0.0773, -1.5630], dev)?.reshape((1, 1, 4))?;
     let w = Tensor::new(&[1f32, 0., 0.], dev)?.reshape((1, 1, 3))?;
     let res = t.conv1d(&w, 0, 1)?;
@@ -180,3 +176,6 @@ fn conv2d_smaller() -> Result<()> {
     );
     Ok(())
 }
+
+test_device!(conv1d, conv1d_cpu, conv1d_gpu);
+test_device!(conv1d_small, conv1d_small_cpu, conv1d_small_gpu);

--- a/candle-kernels/src/conv.cu
+++ b/candle-kernels/src/conv.cu
@@ -6,7 +6,8 @@ template <typename T, typename A>
 __device__ void conv1d(
     const size_t src_numel,
     const size_t l_out,
-    const size_t stride, 
+    const size_t stride,
+    const size_t padding,
     const size_t *info,
     const T *src,
     const T *kernel,
@@ -20,7 +21,6 @@ __device__ void conv1d(
   const size_t *k_s = info + 9;
   const size_t dst_i = blockIdx.x * blockDim.x + threadIdx.x;
   const size_t k_size = k_dims[2];
-  const size_t k_over_2 = k_size / 2;
   const size_t c_out = k_dims[0];
   const size_t c_in = src_dims[1];
   const size_t l_in = src_dims[2];
@@ -33,14 +33,15 @@ __device__ void conv1d(
   const size_t src_idx0 = b_idx * src_s[0];
   A d = 0;
   for (size_t offset = 0; offset < k_size; ++offset) {
-    const size_t src_l_plus = stride * dst_l + offset;
-    if (k_over_2 <= src_l_plus && src_l_plus < l_in + k_over_2) {
-      const size_t src_l = src_l_plus - k_over_2;
-      for (size_t src_c_idx = 0; src_c_idx < c_in; ++src_c_idx) {
-        const size_t src_idx = src_idx0 + src_c_idx * src_s[1] + src_l * src_s[2];
-        const size_t k_idx = dst_c_idx * k_s[0] + src_c_idx * k_s[1] + offset * k_s[2];
-        d += static_cast<A>(src[src_idx]) * static_cast<A>(kernel[k_idx]);
-      }
+    size_t src_l = stride * dst_l + offset;
+    if (src_l < padding || src_l >= padding + l_in) {
+      continue;
+    }
+    src_l -= padding;
+    for (size_t src_c_idx = 0; src_c_idx < c_in; ++src_c_idx) {
+      const size_t src_idx = src_idx0 + src_c_idx * src_s[1] + src_l * src_s[2];
+      const size_t k_idx = dst_c_idx * k_s[0] + src_c_idx * k_s[1] + offset * k_s[2];
+      d += static_cast<A>(src[src_idx]) * static_cast<A>(kernel[k_idx]);
     }
   }
   dst[dst_i] = static_cast<T>(d);
@@ -52,8 +53,8 @@ __device__ void conv2d(
     const size_t src_numel,
     const size_t w_out,
     const size_t h_out,
-    const size_t stride, 
-    const size_t padding, 
+    const size_t stride,
+    const size_t padding,
     const size_t *info,
     const T *src,
     const T *kernel,
@@ -112,12 +113,13 @@ extern "C" __global__ void FN_NAME(  \
     const size_t src_numel, \
     const size_t num_dims, \
     const size_t stride, \
+    const size_t padding, \
     const size_t *info, \
     const TYPENAME *src, \
     const TYPENAME *kernel, \
     TYPENAME *dst \
 ) {  \
-  conv1d<TYPENAME, TYPEACC>(src_numel, num_dims, stride, info, src, kernel, dst); \
+  conv1d<TYPENAME, TYPEACC>(src_numel, num_dims, stride, padding, info, src, kernel, dst); \
 } \
 
 #define CONV2D_OP(TYPENAME, TYPEACC, FN_NAME) \


### PR DESCRIPTION
This will be used when cudnn is not available, it's likely to be much less efficient.
Also use this PR as an opportunity to add padding support for conv1d and run the conv tests on both cpu and gpu when cuda is available.