### PR TITLE
[build scripts] add c++17 flag

### DIFF
--- a/candle-flash-attn/build.rs
+++ b/candle-flash-attn/build.rs
@@ -88,6 +88,7 @@ fn main() -> Result<()> {
             .map(|(cu_file, obj_file)| {
                 let mut command = std::process::Command::new("nvcc");
                 command
+                    .arg("-std=c++17")
                     .arg(format!("--gpu-architecture=sm_{compute_cap}"))
                     .arg("-c")
                     .args(["-o", obj_file.to_str().unwrap()])


### PR DESCRIPTION
Hey guys, I noticed that the current flash attention building [script](https://github.com/huggingface/candle/blob/main/candle-flash-attn/build.rs#L89) could fail due to the absence of ```c++17``` flag (just as described in  #385). Adding the flag would solve the problem. Thanks.