### PR TITLE
align VarBuilder argument name across nn modules public apis

### DIFF
--- a/candle-nn/src/conv.rs
+++ b/candle-nn/src/conv.rs
@@ -103,16 +103,16 @@ pub fn conv1d(
     out_channels: usize,
     kernel_size: usize,
     cfg: Conv1dConfig,
-    vs: crate::VarBuilder,
+    vb: crate::VarBuilder,
 ) -> Result<Conv1d> {
     let init_ws = crate::init::DEFAULT_KAIMING_NORMAL;
-    let ws = vs.get_or_init((out_channels, in_channels, kernel_size), "weight", init_ws)?;
+    let ws = vb.get_or_init((out_channels, in_channels, kernel_size), "weight", init_ws)?;
     let bound = 1. / (in_channels as f64).sqrt();
     let init_bs = crate::Init::Uniform {
         lo: -bound,
         up: bound,
     };
-    let bs = vs.get_or_init(out_channels, "bias", init_bs)?;
+    let bs = vb.get_or_init(out_channels, "bias", init_bs)?;
     Ok(Conv1d::new(ws, Some(bs), cfg))
 }
 
@@ -121,7 +121,7 @@ pub fn conv2d(
     out_channels: usize,
     kernel_size: usize,
     cfg: Conv2dConfig,
-    vs: crate::VarBuilder,
+    vb: crate::VarBuilder,
 ) -> Result<Conv2d> {
     let init_ws = crate::init::DEFAULT_KAIMING_NORMAL;
     let ws = vs.get_or_init(

--- a/candle-nn/src/conv.rs
+++ b/candle-nn/src/conv.rs
@@ -124,7 +124,7 @@ pub fn conv2d(
     vb: crate::VarBuilder,
 ) -> Result<Conv2d> {
     let init_ws = crate::init::DEFAULT_KAIMING_NORMAL;
-    let ws = vs.get_or_init(
+    let ws = vb.get_or_init(
         (out_channels, in_channels, kernel_size, kernel_size),
         "weight",
         init_ws,
@@ -134,6 +134,6 @@ pub fn conv2d(
         lo: -bound,
         up: bound,
     };
-    let bs = vs.get_or_init(out_channels, "bias", init_bs)?;
+    let bs = vb.get_or_init(out_channels, "bias", init_bs)?;
     Ok(Conv2d::new(ws, Some(bs), cfg))
 }

--- a/candle-nn/src/linear.rs
+++ b/candle-nn/src/linear.rs
@@ -46,20 +46,20 @@ impl Linear {
 /// Create or initialize a new linear layer.
 ///
 /// This uses some default names for weight and biases, namely `"weight"` and `"bias"`.
-pub fn linear(in_dim: usize, out_dim: usize, vs: crate::VarBuilder) -> Result<Linear> {
+pub fn linear(in_dim: usize, out_dim: usize, vb: crate::VarBuilder) -> Result<Linear> {
     let init_ws = crate::init::DEFAULT_KAIMING_NORMAL;
-    let ws = vs.get_or_init((out_dim, in_dim), "weight", init_ws)?;
+    let ws = vb.get_or_init((out_dim, in_dim), "weight", init_ws)?;
     let bound = 1. / (in_dim as f64).sqrt();
     let init_bs = crate::Init::Uniform {
         lo: -bound,
         up: bound,
     };
-    let bs = vs.get_or_init(out_dim, "bias", init_bs)?;
+    let bs = vb.get_or_init(out_dim, "bias", init_bs)?;
     Ok(Linear::new(ws, Some(bs)))
 }
 
-pub fn linear_no_bias(in_dim: usize, out_dim: usize, vs: crate::VarBuilder) -> Result<Linear> {
+pub fn linear_no_bias(in_dim: usize, out_dim: usize, vb: crate::VarBuilder) -> Result<Linear> {
     let init_ws = crate::init::DEFAULT_KAIMING_NORMAL;
-    let ws = vs.get_or_init((out_dim, in_dim), "weight", init_ws)?;
+    let ws = vb.get_or_init((out_dim, in_dim), "weight", init_ws)?;
     Ok(Linear::new(ws, None))
 }


### PR DESCRIPTION
change `vs: crate::VarBuilder` to `vb: crate::VarBuilder` in candle-nn, align naming across nn modules public apis.