### PR TITLE
Basic `qmatmul` parallelization

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@ rustflags = ["-C", "target-cpu=native"]
 
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "target-feature=+simd128"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "target-feature=-avx,-avx2"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,4 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=native"]
-
-[target.aarch64-apple-darwin]
+[build]
 rustflags = ["-C", "target-cpu=native"]
 
 [target.wasm32-unknown-unknown]

--- a/candle-core/src/quantized/k_quants.rs
+++ b/candle-core/src/quantized/k_quants.rs
@@ -1,6 +1,7 @@
 use super::GgmlDType;
 use crate::Result;
 use half::f16;
+use rayon::prelude::*;
 
 // Default to QK_K 256 rather than 64.
 pub const QK_K: usize = 256;
@@ -13,7 +14,7 @@ pub const QK5_1: usize = 32;
 pub const QK8_0: usize = 32;
 pub const QK8_1: usize = 32;
 
-pub trait GgmlType: Sized + Clone {
+pub trait GgmlType: Sized + Clone + Send + Sync {
     const DTYPE: GgmlDType;
     const BLCK_SIZE: usize;
     type VecDotType: GgmlType;
@@ -821,10 +822,16 @@ pub fn matmul<T: GgmlType>(
     for row_idx in 0..m {
         let lhs_row = &lhs_b[row_idx * k_in_lhs_blocks..(row_idx + 1) * k_in_lhs_blocks];
         let dst_row = &mut dst[row_idx * n..(row_idx + 1) * n];
-        for (col_idx, dst) in dst_row.iter_mut().enumerate() {
-            let rhs_col = &rhs_t[col_idx * k_in_rhs_blocks..(col_idx + 1) * k_in_rhs_blocks];
-            *dst = T::vec_dot(k, rhs_col, lhs_row)?;
-        }
+
+        dst_row
+            .into_par_iter()
+            .enumerate()
+            .with_min_len(128)
+            .with_max_len(512)
+            .for_each(|(col_idx, dst)| {
+                let rhs_col = &rhs_t[col_idx * k_in_rhs_blocks..(col_idx + 1) * k_in_rhs_blocks];
+                *dst = T::vec_dot(k, rhs_col, lhs_row).unwrap();
+            });
     }
     Ok(())
 }


### PR DESCRIPTION
Uses `rayon`'s parallel iterator with size constraints to create reasonable batches for the quantized `vec_dot` function. Achieves ~80% of `llama.cpp`'s speed. 

Maybe this should be replaced by `kernel::par_for_each` or `kernel::par_range` for more fine grained control in the future. 


Also changes the cargo config to always build with `native` cpu features. 