### PR TITLE
Enable the image crate by default in examples

### DIFF
--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -23,7 +23,7 @@ num-traits = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
 cudarc = { workspace = true, optional = true }
 half = { workspace = true, optional = true }
-image = { workspace = true, optional = true }
+image = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -55,7 +55,3 @@ nccl = ["cuda", "cudarc/nccl", "dep:half"]
 [[example]]
 name = "llama_multiprocess"
 required-features = ["cuda", "nccl", "flash-attn"]
-
-[[example]]
-name = "stable-diffusion"
-required-features = ["image"]


### PR DESCRIPTION
This makes it easier to catch errors when running clippy or in the CI, also avoids users having to provide the `--features` flag.