### PR TITLE
Adding Mnist example to README + better error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Check out our [examples](./candle-examples/examples/):
 - [DINOv2](./candle-examples/examples/dinov2/): computer vision model trained
   using self-supervision (can be used for imagenet classification, depth
   evaluation, segmentation).
+- [MNIST Training](./candle-examples/examples/mnist-training/): simple vision training example.
 
 Run them using the following commands:
 ```
@@ -42,6 +43,7 @@ cargo run --example bert --release
 cargo run --example bigcode --release
 cargo run --example stable-diffusion --release -- --prompt "a rusty robot holding a fire torch"
 cargo run --example dinov2 --release -- --image path/to/myinput.jpg
+cargo run --example mnist-training --release
 ```
 
 In order to use **CUDA** add `--features cuda` to the example command line. If

--- a/candle-datasets/src/vision/mnist.rs
+++ b/candle-datasets/src/vision/mnist.rs
@@ -51,10 +51,19 @@ fn read_images(filename: &std::path::Path) -> Result<Tensor> {
 
 pub fn load_dir<T: AsRef<std::path::Path>>(dir: T) -> Result<crate::vision::Dataset> {
     let dir = dir.as_ref();
-    let train_images = read_images(&dir.join("train-images-idx3-ubyte"))?;
-    let train_labels = read_labels(&dir.join("train-labels-idx1-ubyte"))?;
-    let test_images = read_images(&dir.join("t10k-images-idx3-ubyte"))?;
-    let test_labels = read_labels(&dir.join("t10k-labels-idx1-ubyte"))?;
+
+    let train_images_path = &dir.join("train-images-idx3-ubyte");
+    let train_images = read_images(train_images_path).map_err(|e| e.with_path(train_images_path))?;
+
+    let train_labels_path = &dir.join("train-labels-idx1-ubyte");
+    let train_labels = read_labels(train_labels_path).map_err(|e| e.with_path(train_labels_path))?;
+
+    let test_images_path = &dir.join("t10k-images-idx3-ubyte");
+    let test_images = read_images(test_images_path).map_err(|e| e.with_path(test_images_path))?;
+
+    let test_labels_path = &dir.join("t10k-labels-idx1-ubyte");
+    let test_labels = read_labels(test_labels_path).map_err(|e| e.with_path(test_labels_path))?;
+
     Ok(crate::vision::Dataset {
         train_images,
         train_labels,


### PR DESCRIPTION
Hi, thank you for your work on this excellent library.

When first trying it out, I attempted to run the mnist example, and it kept giving me a very cryptic "No such file or directory (os error 2)" error. I've gone and updated the data loader so it's more obvious that the script is failing to find the dataset, e.g.

`Error: path: "data/train-images-idx3-ubyte" No such file or directory (os error 2)`. I think this would trip up someone not familiar with Rust errors.

Additionally, I've updated the README with instructions on how to run the example.

Thanks for looking!