### PR TITLE
Improve installation section and "get started"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-`cargo run` should display a tensor of shape `Tensor[[2, 4], f32]`
+`cargo run` should display a tensor of shape `Tensor[[2, 4], f32]`.
 
 
 Having installed `candle` with Cuda support, simply define the `device` to be on GPU:

--- a/README.md
+++ b/README.md
@@ -10,13 +10,99 @@ and ease of use. Try our online demos:
 [LLaMA2](https://huggingface.co/spaces/lmz/candle-llama2),
 [yolo](https://huggingface.co/spaces/lmz/candle-yolo).
 
-```rust
-let a = Tensor::randn(0f32, 1., (2, 3), &Device::Cpu)?;
-let b = Tensor::randn(0f32, 1., (3, 4), &Device::Cpu)?;
+## Installation
 
-let c = a.matmul(&b)?;
-println!("{c}");
+- *With Cuda support*:
+
+1. To install candle with Cuda support, first make sure that Cuda is correctly installed.
+- `nvcc --version` should print your information about your Cuda compiler driver.
+- `nvidia-smi --query-gpu=compute_cap --format=csv` should print your GPUs compute capability, e.g. something
+like:
 ```
+compute_cap
+8.9
+```
+
+If any of the above commands errors out, please make sure to update your CUDA version.
+
+2. Create a new app and add [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) with Cuda support
+
+```bash
+cargo new myapp
+cd myapp
+```
+
+Next make sure to add the `candle-core` crate with the cuda feature:
+
+```
+cargo add --git https://github.com/huggingface/candle.git candle-core --features "cuda"
+```
+
+Finally, run `cargo build` to make sure everything can be correctly built.
+
+```
+cargo run
+```
+
+Now you can run the example as shown in the next section!
+
+- *Without Cuda support*:
+
+Create a new app and add [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) as follows:
+
+```
+cargo new myapp
+cd myapp
+cargo add --git https://github.com/huggingface/candle.git candle-core
+```
+
+Finally, run `cargo build` to make sure everything can be correctly built.
+
+```
+cargo run
+```
+
+## Get started
+
+Having installed `candle-core` as described in [Installation](#Installation), we can now 
+run a simple matrix multiplication.
+
+First, let's add the [`anyhow`](https://docs.rs/anyhow/latest/anyhow/) package to our app.
+
+```
+cd myapp
+cargo add anyhow
+```
+
+Next, write the following to your `myapp/src/main.rs` file:
+
+```rust
+use anyhow::Result;
+use candle_core::{Device, Tensor};
+
+fn main() -> Result<()> {
+    let a = Tensor::randn(0f32, 1., (2, 3), &Device::Cpu)?;
+    let b = Tensor::randn(0f32, 1., (3, 4), &Device::Cpu)?;
+
+    let c = a.matmul(&b)?;
+    println!("{c}");
+    Ok(())
+}
+```
+
+`cargo run` should display a tensor of shape `Tensor[[2, 4], f32]`
+
+
+Having installed `candle` with Cuda support, you can create the tensors on GPU instead as follows:
+
+```diff
+- let a = Tensor::randn(0f32, 1., (2, 3), &Device::Cpu)?;
+- let b = Tensor::randn(0f32, 1., (3, 4), &Device::Cpu)?;
++ let a = Tensor::randn(0f32, 1., (2, 3), &Device::new_cuda(0)?)?;
++ let b = Tensor::randn(0f32, 1., (3, 4), &Device::new_cuda(0)?)?;
+```
+
+For more advanced examples, please have a look at the following sections.
 
 ## Check out our examples
 

--- a/README.md
+++ b/README.md
@@ -15,21 +15,11 @@ and ease of use. Try our online demos:
 Make sure that you have [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) correctly installed as described in [**Installation**](https://huggingface.github.io/candle/guide/installation.html).
 
 Let's see how to run a simple matrix multiplication.
-
-We will need the [`anyhow`](https://docs.rs/anyhow/latest/anyhow/) package for our example, so let's also add it to our app.
-
-```bash
-cd myapp
-cargo add anyhow
-```
-
-Next, write the following to your `myapp/src/main.rs` file:
-
+Write the following to your `myapp/src/main.rs` file:
 ```rust
-use anyhow::Result;
 use candle_core::{Device, Tensor};
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let device = Device::Cpu;
 
     let a = Tensor::randn(0f32, 1., (2, 3), &device)?;

--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ use anyhow::Result;
 use candle_core::{Device, Tensor};
 
 fn main() -> Result<()> {
-    let a = Tensor::randn(0f32, 1., (2, 3), &Device::Cpu)?;
-    let b = Tensor::randn(0f32, 1., (3, 4), &Device::Cpu)?;
+    let device = Device::Cpu;
+
+    let a = Tensor::randn(0f32, 1., (2, 3), &device)?;
+    let b = Tensor::randn(0f32, 1., (3, 4), &device)?;
 
     let c = a.matmul(&b)?;
     println!("{c}");
@@ -94,14 +96,11 @@ fn main() -> Result<()> {
 `cargo run` should display a tensor of shape `Tensor[[2, 4], f32]`
 
 
-Having installed `candle` with Cuda support, you can create the tensors on GPU instead as follows:
+Having installed `candle` with Cuda support, simply define the `device` to be on GPU:
 
 ```diff
-- let a = Tensor::randn(0f32, 1., (2, 3), &Device::Cpu)?;
-- let b = Tensor::randn(0f32, 1., (3, 4), &Device::Cpu)?;
+- let device = Device::Cpu;
 + let device = Device::new_cuda(0)?;
-+ let a = Tensor::randn(0f32, 1., (2, 3), &device)?;
-+ let b = Tensor::randn(0f32, 1., (3, 4), &device)?;
 ```
 
 For more advanced examples, please have a look at the following sections.

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ Having installed `candle` with Cuda support, you can create the tensors on GPU i
 ```diff
 - let a = Tensor::randn(0f32, 1., (2, 3), &Device::Cpu)?;
 - let b = Tensor::randn(0f32, 1., (3, 4), &Device::Cpu)?;
-+ let a = Tensor::randn(0f32, 1., (2, 3), &Device::new_cuda(0)?)?;
-+ let b = Tensor::randn(0f32, 1., (3, 4), &Device::new_cuda(0)?)?;
++ let device = Device::new_cuda(0)?;
++ let a = Tensor::randn(0f32, 1., (2, 3), &device)?;
++ let b = Tensor::randn(0f32, 1., (3, 4), &device)?;
 ```
 
 For more advanced examples, please have a look at the following sections.

--- a/README.md
+++ b/README.md
@@ -10,65 +10,13 @@ and ease of use. Try our online demos:
 [LLaMA2](https://huggingface.co/spaces/lmz/candle-llama2),
 [yolo](https://huggingface.co/spaces/lmz/candle-yolo).
 
-## Installation
-
-- **With Cuda support**:
-
-1. First, make sure that Cuda is correctly installed.
-- `nvcc --version` should print your information about your Cuda compiler driver.
-- `nvidia-smi --query-gpu=compute_cap --format=csv` should print your GPUs compute capability, e.g. something
-like:
-```
-compute_cap
-8.9
-```
-
-If any of the above commands errors out, please make sure to update your Cuda version.
-
-2. Create a new app and add [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) with Cuda support
-
-Start by creating a new cargo:
-
-```bash
-cargo new myapp
-cd myapp
-```
-
-Make sure to add the `candle-core` crate with the cuda feature:
-
-```
-cargo add --git https://github.com/huggingface/candle.git candle-core --features "cuda"
-```
-
-Run `cargo build` to make sure everything can be correctly built.
-
-```
-cargo run
-```
-
-**Without Cuda support**:
-
-Create a new app and add [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) as follows:
-
-```
-cargo new myapp
-cd myapp
-cargo add --git https://github.com/huggingface/candle.git candle-core
-```
-
-Run `cargo build` to make sure everything can be correctly built.
-
-```
-cargo run
-```
-
 ## Get started
 
-Having installed `candle-core` as described in [Installation](#Installation), we can now 
-run a simple matrix multiplication.
+Make sure that you have [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) correctly installed as described in [**Installation**](https://huggingface.github.io/candle/guide/installation.html).
 
-We will need the [`anyhow`](https://docs.rs/anyhow/latest/anyhow/) package for our example,
-so let's add it to our app.
+Let's see how to run a simple matrix multiplication.
+
+We will need the [`anyhow`](https://docs.rs/anyhow/latest/anyhow/) package for our example, so let's also add it to our app.
 
 ```
 cd myapp
@@ -103,7 +51,7 @@ Having installed `candle` with Cuda support, simply define the `device` to be on
 + let device = Device::new_cuda(0)?;
 ```
 
-For more advanced examples, please have a look at the following sections.
+For more advanced examples, please have a look at the following section.
 
 ## Check out our examples
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Let's see how to run a simple matrix multiplication.
 
 We will need the [`anyhow`](https://docs.rs/anyhow/latest/anyhow/) package for our example, so let's also add it to our app.
 
-```
+```bash
 cd myapp
 cargo add anyhow
 ```

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ and ease of use. Try our online demos:
 
 ## Installation
 
-- *With Cuda support*:
+- **With Cuda support**:
 
-1. To install candle with Cuda support, first make sure that Cuda is correctly installed.
+1. First, make sure that Cuda is correctly installed.
 - `nvcc --version` should print your information about your Cuda compiler driver.
 - `nvidia-smi --query-gpu=compute_cap --format=csv` should print your GPUs compute capability, e.g. something
 like:
@@ -23,30 +23,30 @@ compute_cap
 8.9
 ```
 
-If any of the above commands errors out, please make sure to update your CUDA version.
+If any of the above commands errors out, please make sure to update your Cuda version.
 
 2. Create a new app and add [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) with Cuda support
+
+Start by creating a new cargo:
 
 ```bash
 cargo new myapp
 cd myapp
 ```
 
-Next make sure to add the `candle-core` crate with the cuda feature:
+Make sure to add the `candle-core` crate with the cuda feature:
 
 ```
 cargo add --git https://github.com/huggingface/candle.git candle-core --features "cuda"
 ```
 
-Finally, run `cargo build` to make sure everything can be correctly built.
+Run `cargo build` to make sure everything can be correctly built.
 
 ```
 cargo run
 ```
 
-Now you can run the example as shown in the next section!
-
-- *Without Cuda support*:
+**Without Cuda support**:
 
 Create a new app and add [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) as follows:
 
@@ -56,7 +56,7 @@ cd myapp
 cargo add --git https://github.com/huggingface/candle.git candle-core
 ```
 
-Finally, run `cargo build` to make sure everything can be correctly built.
+Run `cargo build` to make sure everything can be correctly built.
 
 ```
 cargo run
@@ -67,7 +67,8 @@ cargo run
 Having installed `candle-core` as described in [Installation](#Installation), we can now 
 run a simple matrix multiplication.
 
-First, let's add the [`anyhow`](https://docs.rs/anyhow/latest/anyhow/) package to our app.
+We will need the [`anyhow`](https://docs.rs/anyhow/latest/anyhow/) package for our example,
+so let's add it to our app.
 
 ```
 cd myapp

--- a/candle-book/src/guide/installation.md
+++ b/candle-book/src/guide/installation.md
@@ -25,7 +25,7 @@ cd myapp
 
 Make sure to add the `candle-core` crate with the cuda feature:
 
-```
+```bash
 cargo add --git https://github.com/huggingface/candle.git candle-core --features "cuda"
 ```
 
@@ -47,7 +47,7 @@ cargo add --git https://github.com/huggingface/candle.git candle-core
 
 Finally, run `cargo build` to make sure everything can be correctly built.
 
-```
+```bash
 cargo run
 ```
 

--- a/candle-book/src/guide/installation.md
+++ b/candle-book/src/guide/installation.md
@@ -38,25 +38,16 @@ cargo run
 
 Create a new app and add [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) as follows:
 
-
-Start by creating a new app:
-
-```bash
+```
 cargo new myapp
 cd myapp
 cargo add --git https://github.com/huggingface/candle.git candle-core
 ```
 
-At this point, candle will be built **without** CUDA support.
-To get CUDA support use the `cuda` feature
-```bash
-cargo add --git https://github.com/huggingface/candle.git candle-core --features cuda
+Finally, run `cargo build` to make sure everything can be correctly built.
+
 ```
-
-You can check everything works properly:
-
-```bash
-cargo build
+cargo run
 ```
 
 **With mkl support**

--- a/candle-book/src/guide/installation.md
+++ b/candle-book/src/guide/installation.md
@@ -6,7 +6,8 @@
 - `nvcc --version` should print your information about your Cuda compiler driver.
 - `nvidia-smi --query-gpu=compute_cap --format=csv` should print your GPUs compute capability, e.g. something
 like:
-```
+
+```bash
 compute_cap
 8.9
 ```
@@ -30,7 +31,7 @@ cargo add --git https://github.com/huggingface/candle.git candle-core --features
 
 Run `cargo build` to make sure everything can be correctly built.
 
-```
+```bash
 cargo run
 ```
 
@@ -38,7 +39,7 @@ cargo run
 
 Create a new app and add [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) as follows:
 
-```
+```bash
 cargo new myapp
 cd myapp
 cargo add --git https://github.com/huggingface/candle.git candle-core

--- a/candle-book/src/guide/installation.md
+++ b/candle-book/src/guide/installation.md
@@ -45,7 +45,7 @@ cd myapp
 cargo add --git https://github.com/huggingface/candle.git candle-core
 ```
 
-Finally, run `cargo build` to make sure everything can be correctly built.
+Finally, run `cargo run` to make sure everything can be correctly built.
 
 ```bash
 cargo run

--- a/candle-book/src/guide/installation.md
+++ b/candle-book/src/guide/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-- **With Cuda support**:
+**With Cuda support**:
 
 1. First, make sure that Cuda is correctly installed.
 - `nvcc --version` should print your information about your Cuda compiler driver.

--- a/candle-book/src/guide/installation.md
+++ b/candle-book/src/guide/installation.md
@@ -32,7 +32,7 @@ cargo add --git https://github.com/huggingface/candle.git candle-core --features
 Run `cargo build` to make sure everything can be correctly built.
 
 ```bash
-cargo run
+cargo build
 ```
 
 **Without Cuda support**:
@@ -45,10 +45,10 @@ cd myapp
 cargo add --git https://github.com/huggingface/candle.git candle-core
 ```
 
-Finally, run `cargo run` to make sure everything can be correctly built.
+Finally, run `cargo build` to make sure everything can be correctly built.
 
 ```bash
-cargo run
+cargo build
 ```
 
 **With mkl support**

--- a/candle-book/src/guide/installation.md
+++ b/candle-book/src/guide/installation.md
@@ -1,5 +1,44 @@
 # Installation
 
+- **With Cuda support**:
+
+1. First, make sure that Cuda is correctly installed.
+- `nvcc --version` should print your information about your Cuda compiler driver.
+- `nvidia-smi --query-gpu=compute_cap --format=csv` should print your GPUs compute capability, e.g. something
+like:
+```
+compute_cap
+8.9
+```
+
+If any of the above commands errors out, please make sure to update your Cuda version.
+
+2. Create a new app and add [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) with Cuda support
+
+Start by creating a new cargo:
+
+```bash
+cargo new myapp
+cd myapp
+```
+
+Make sure to add the `candle-core` crate with the cuda feature:
+
+```
+cargo add --git https://github.com/huggingface/candle.git candle-core --features "cuda"
+```
+
+Run `cargo build` to make sure everything can be correctly built.
+
+```
+cargo run
+```
+
+**Without Cuda support**:
+
+Create a new app and add [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) as follows:
+
+
 Start by creating a new app:
 
 ```bash
@@ -20,5 +59,6 @@ You can check everything works properly:
 cargo build
 ```
 
+**With mkl support**
 
 You can also see the `mkl` feature which could be interesting to get faster inference on CPU. [Using mkl](./advanced/mkl.md)

--- a/candle-book/src/guide/installation.md
+++ b/candle-book/src/guide/installation.md
@@ -3,7 +3,7 @@
 **With Cuda support**:
 
 1. First, make sure that Cuda is correctly installed.
-- `nvcc --version` should print your information about your Cuda compiler driver.
+- `nvcc --version` should print information about your Cuda compiler driver.
 - `nvidia-smi --query-gpu=compute_cap --format=csv` should print your GPUs compute capability, e.g. something
 like:
 
@@ -14,7 +14,7 @@ compute_cap
 
 If any of the above commands errors out, please make sure to update your Cuda version.
 
-2. Create a new app and add [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) with Cuda support
+2. Create a new app and add [`candle-core`](https://github.com/huggingface/candle/tree/main/candle-core) with Cuda support.
 
 Start by creating a new cargo:
 


### PR DESCRIPTION
This PR improves the "Installation" section slightly by:
- Making the reader aware that `nvcc` has to be correctly installed and linked
- Making sure that when installing with cuda, one adds: `--features "cuda"` instead of `--features cuda` as `--features cuda` doesn't work in all shells (e.g. it fails in `zsh`)
- Shows the reader how to run the example on GPU