### PR TITLE
AVX version for the q8-0 multiplications.

### DIFF
--- a/candle-core/src/quantized/k_quants.rs
+++ b/candle-core/src/quantized/k_quants.rs
@@ -421,7 +421,11 @@ impl GgmlType for BlockQ8_0 {
         Ok(())
     }
 
+    #[allow(unreachable_code)]
     fn vec_dot(n: usize, xs: &[Self], ys: &[Self::VecDotType]) -> Result<f32> {
+        #[cfg(target_feature = "avx")]
+        return super::avx::vec_dot_q8_0_q8_0(n, xs, ys);
+
         let qk = QK8_0;
         if n % QK8_0 != 0 {
             crate::bail!("vec_dot_q8_0_q8_0: {n} is not divisible by {qk}")


### PR DESCRIPTION
Not a massive speedup but got the code-llama 7b q8-0 version from 2.8 token per second to 3.3.