### PR TITLE
Improve the mnist-training error message when dataset is not found

### DIFF
--- a/candle-examples/examples/mnist-training/main.rs
+++ b/candle-examples/examples/mnist-training/main.rs
@@ -143,7 +143,7 @@ struct Args {
 pub fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     // Load the dataset
-    let m = candle_datasets::vision::mnist::load_dir("data")?;
+    let m = candle_datasets::vision::mnist::load_dir("data").expect("Cannot find the dataset. Please download the MNIST dataset and place it in a the ./data/ directory in the root directory of this crate.");
     println!("train-images: {:?}", m.train_images.shape());
     println!("train-labels: {:?}", m.train_labels.shape());
     println!("test-images: {:?}", m.test_images.shape());


### PR DESCRIPTION
The user need to manually download the dataset and place it in the right location. In the current implementation, the user will only get a generic "No such file or directory" error and don't know what to do. Adding an error message to guide the user to download the dataset.