### PR TITLE
fix: use correct BLOCK_SIZE in matmul function for ggml type

### DIFF
--- a/candle-core/src/quantized/k_quants.rs
+++ b/candle-core/src/quantized/k_quants.rs
@@ -1764,8 +1764,8 @@ pub fn matmul<T: GgmlType>(
         crate::bail!("unexpected lhs length {} {mkn:?}", lhs.len());
     }
 
-    let k_in_lhs_blocks = (k + T::BLCK_SIZE - 1) / T::BLCK_SIZE;
-    let k_in_rhs_blocks = (k + T::VecDotType::BLCK_SIZE - 1) / T::VecDotType::BLCK_SIZE;
+    let k_in_lhs_blocks = (k + T::VecDotType::BLCK_SIZE - 1) / T::VecDotType::BLCK_SIZE;
+    let k_in_rhs_blocks = (k + T::BLCK_SIZE - 1) / T::BLCK_SIZE;
     // TODO: Do not make this copy if the DotType is f32.
     // TODO: Pre-allocate this.
     let mut lhs_b = vec![T::VecDotType::zeros(); m * k_in_lhs_blocks];


### PR DESCRIPTION
To compute `k_in_lhs_blocks`, we should use `T::VecDottype::BLOCK_SIZE` because we obtain `lhs_b` using `T::VecDotType::from_float`. Similarly, to calculate `k_in_rhs_blocks`, we need to use `T::BLOCK_SIZE` since `rhs_t` is a slice of `T` (I'm just starting to learn quantization, so I'm not sure if it's correct, but it seems intuitive to me)

![image](https://github.com/huggingface/candle/assets/30254428/b982ed34-2cd0-4bf4-8ddc-5f8f11a49a50)
