### PR TITLE
Allow retrieving and setting prefix of VarBuilder

### DIFF
--- a/candle-nn/src/var_builder.rs
+++ b/candle-nn/src/var_builder.rs
@@ -102,6 +102,20 @@ impl<'a, B: Backend> VarBuilderArgs<'a, B> {
         }
     }
 
+    /// Returns the prefix of the `VarBuilder`.
+    pub fn prefix(&self) -> String {
+        self.path.join(".")
+    }
+
+    /// Returns a new `VarBuilder` with the prefix set to `prefix`.
+    pub fn set_prefix(&self, prefix: impl ToString) -> Self {
+        Self {
+            data: self.data.clone(),
+            path: vec![prefix.to_string()],
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
     /// Return a new `VarBuilder` adding `s` to the current prefix. This can be think of as `cd`
     /// into a directory.
     pub fn push_prefix<S: ToString>(&self, s: S) -> Self {


### PR DESCRIPTION
Since a recent change `VarBuilder::get` doesn't panic anymore when a tensor couldn't be found and instead initializes it silently. `VarBuilder::contains_tensor` allows for manually checking wether the tensor exists, but I didn't find any way to figure out what the prefix of the current `VarBuilder` is, which is why I need `VarBuilder::prefix`.
`VarBuilder::set_prefix` is useful when some tensor that isn't on the current path needs to be retrieved, for example when weights are tied.