### PR TITLE
Use maturin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,4 @@
-pyo3-test:
-	cargo build --profile=release-with-debug --package candle-pyo3
-	cp -f ./target/release-with-debug/libcandle.so candle.so
-	PYTHONPATH=.:$PYTHONPATH python3 candle-pyo3/test.py
-
-pyo3-test-macos:
-	cargo build --profile=release-with-debug --package candle-pyo3
-	cp -f ./target/release-with-debug/libcandle.dylib candle.so
-	PYTHONPATH=.:$PYTHONPATH python3 candle-pyo3/test.py
-
-.PHONY: pyo3-test pyo3-test-macos clean-ptx clean test
+.PHONY: clean-ptx clean test
 
 clean-ptx:
 	find target -name "*.ptx" -type f -delete

--- a/candle-pyo3/README.md
+++ b/candle-pyo3/README.md
@@ -1,11 +1,7 @@
-From the top level directory run the following for linux.
-```
-cargo build --profile=release-with-debug --package candle-pyo3 && cp -f ./target/release-with-debug/libcandle.so candle.so
-PYTHONPATH=. python3 candle-pyo3/test.py
-```bash
+From the `candle-pyo3` directory, enable a virtual env where you will want the
+candle package to be installed then run.
 
-  Or for macOS users:
 ```bash
-cargo build --profile=release-with-debug --package candle-pyo3 && cp -f ./target/release-with-debug/libcandle.dylib candle.so
-PYTHONPATH=. python3 candle-pyo3/test.py
+maturin develop
+python test.py
 ```

--- a/candle-pyo3/quant-llama.py
+++ b/candle-pyo3/quant-llama.py
@@ -1,19 +1,5 @@
 # This example shows how the candle Python api can be used to replicate llama.cpp.
-import os
 import sys
-
-# The "import candle" statement below works if there is a "candle.so" file in sys.path.
-# Here we check for shared libraries that can be used in the build directory.
-BUILD_DIR = "./target/release-with-debug"
-so_file = BUILD_DIR + "/candle.so"
-if os.path.islink(so_file): os.remove(so_file)
-for lib_file in ["libcandle.dylib", "libcandle.so"]:
-    lib_file_ = BUILD_DIR + "/" + lib_file
-    if os.path.isfile(lib_file_):
-        os.symlink(lib_file, so_file)
-        sys.path.insert(0, BUILD_DIR)
-        break
-
 import candle
 
 MAX_SEQ_LEN = 4096

--- a/candle-pyo3/test.py
+++ b/candle-pyo3/test.py
@@ -1,18 +1,3 @@
-import os
-import sys
-
-# The "import candle" statement below works if there is a "candle.so" file in sys.path.
-# Here we check for shared libraries that can be used in the build directory.
-BUILD_DIR = "./target/release-with-debug"
-so_file = BUILD_DIR + "/candle.so"
-if os.path.islink(so_file): os.remove(so_file)
-for lib_file in ["libcandle.dylib", "libcandle.so"]:
-    lib_file_ = BUILD_DIR + "/" + lib_file
-    if os.path.isfile(lib_file_):
-        os.symlink(lib_file, so_file)
-        sys.path.insert(0, BUILD_DIR)
-        break
-
 import candle
 
 t = candle.Tensor(42.0)


### PR DESCRIPTION
As recommended by @Narsil , using maturin is likely to make things simpler when it comes to deploying potential pip packages and also when just building/testing the pyo3 layer. This PR just adds some very simple maturin setup in which the quantized llama example can be run.