### PR TITLE
Fix typo in the nll function document

### DIFF
--- a/candle-nn/src/loss.rs
+++ b/candle-nn/src/loss.rs
@@ -1,6 +1,6 @@
 use candle::{Result, Tensor};
 
-/// The negative loss likelihodd loss.
+/// The negative log likelihood loss.
 ///
 /// Arguments
 ///


### PR DESCRIPTION
Fix typo in the `nll` function document