### PR TITLE
Add small customization to the build 

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,17 @@ authentication token. See issue
 git submodule update --init
 ```
 
+#### Compiling with flash-attention fails
+
+```
+/usr/include/c++/11/bits/std_function.h:530:146: error: parameter packs not expanded with ‘...’:
+```
+
+This is a bug in gcc-11 triggered by the Cuda compiler. To fix this, install a different, supported gcc version - for example gcc-10, and specify the path to the compiler in the CANDLE_NVCC_CCBIN environment variable.
+```
+env CANDLE_NVCC_CCBIN=/usr/lib/gcc/x86_64-linux-gnu/10 cargo ...
+```
+
 #### Tracking down errors
 
 You can set `RUST_BACKTRACE=1` to be provided with backtraces when a candle

--- a/candle-flash-attn/build.rs
+++ b/candle-flash-attn/build.rs
@@ -60,6 +60,10 @@ fn main() -> Result<()> {
         Ok(build_dir) => PathBuf::from(build_dir),
     };
     set_cuda_include_dir()?;
+
+    let ccbin_env = std::env::var("CANDLE_NVCC_CCBIN");
+    println!("cargo:rerun-if-env-changed=CANDLE_NVCC_CCBIN");
+
     let compute_cap = compute_cap()?;
 
     let out_file = build_dir.join("libflashattention.a");
@@ -95,14 +99,21 @@ fn main() -> Result<()> {
                     .args(["--default-stream", "per-thread"])
                     .arg("-Icutlass/include")
                     .arg("--expt-relaxed-constexpr")
-                    .arg(cu_file);
+                    .arg("--verbose");
+                if let Ok(ccbin_path) = &ccbin_env {
+                    command
+                        .arg("-allow-unsupported-compiler")
+                        .args(["-ccbin", ccbin_path]);
+                }
+                command.arg(cu_file);
                 let output = command
                     .spawn()
                     .context("failed spawning nvcc")?
                     .wait_with_output()?;
                 if !output.status.success() {
                     anyhow::bail!(
-                        "nvcc error while compiling:\n\n# stdout\n{:#}\n\n# stderr\n{:#}",
+                        "nvcc error while executing compiling: {:?}\n\n# stdout\n{:#}\n\n# stderr\n{:#}",
+                        &command,
                         String::from_utf8_lossy(&output.stdout),
                         String::from_utf8_lossy(&output.stderr)
                     )
@@ -122,7 +133,8 @@ fn main() -> Result<()> {
             .wait_with_output()?;
         if !output.status.success() {
             anyhow::bail!(
-                "nvcc error while linking:\n\n# stdout\n{:#}\n\n# stderr\n{:#}",
+                "nvcc error while linking: {:?}\n\n# stdout\n{:#}\n\n# stderr\n{:#}",
+                &command,
                 String::from_utf8_lossy(&output.stdout),
                 String::from_utf8_lossy(&output.stderr)
             )

--- a/candle-flash-attn/build.rs
+++ b/candle-flash-attn/build.rs
@@ -57,7 +57,16 @@ fn main() -> Result<()> {
             #[allow(clippy::redundant_clone)]
             out_dir.clone()
         }
-        Ok(build_dir) => PathBuf::from(build_dir),
+        Ok(build_dir) =>
+        {
+            let path = PathBuf::from(build_dir);
+            let path = if path.is_relative() {
+                let mut cur = std::env::current_dir()?;
+                cur.push(&path);
+                cur
+            } else { path };
+            path.canonicalize().expect(&format!("Directory doesn't exists: {}", &path.display()))
+        }
     };
     set_cuda_include_dir()?;
 


### PR DESCRIPTION
I tried to build locally with flash-attention, but I run into a couple of problems.
First, Cuda 11.x doesn't work well with the gcc 11, which is the default on Ubuntu 22, but the current build script didn't provide any knob to control the used compiler, so I've added support for a new environment variable.
Second,  when I specified a relative path as CANDLE_FLASH_ATTN_BUILD_DIR, the build failed again - so I've fixed that too.