### PR TITLE
Get the comparison operation to work on scalar values.

### DIFF
--- a/candle-core/src/lib.rs
+++ b/candle-core/src/lib.rs
@@ -59,6 +59,7 @@ mod op;
 pub mod pickle;
 pub mod quantized;
 pub mod safetensors;
+pub mod scalar;
 pub mod shape;
 mod storage;
 mod strided_index;

--- a/candle-core/src/scalar.rs
+++ b/candle-core/src/scalar.rs
@@ -1,0 +1,23 @@
+use crate::{Result, Tensor, WithDType};
+
+pub enum TensorScalar {
+    Tensor(Tensor),
+    Scalar(Tensor),
+}
+
+pub trait TensorOrScalar {
+    fn to_tensor_scalar(self) -> Result<TensorScalar>;
+}
+
+impl TensorOrScalar for &Tensor {
+    fn to_tensor_scalar(self) -> Result<TensorScalar> {
+        Ok(TensorScalar::Tensor(self.clone()))
+    }
+}
+
+impl<T: WithDType> TensorOrScalar for T {
+    fn to_tensor_scalar(self) -> Result<TensorScalar> {
+        let scalar = Tensor::new(self, &crate::Device::Cpu)?;
+        Ok(TensorScalar::Scalar(scalar))
+    }
+}

--- a/candle-examples/examples/segment-anything/main.rs
+++ b/candle-examples/examples/segment-anything/main.rs
@@ -214,7 +214,7 @@ pub fn main() -> anyhow::Result<()> {
         println!("iou_predictions: {iou_predictions:?}");
 
         // Save the mask as an image.
-        let mask = (mask.ge(&mask.zeros_like()?)? * 255.)?;
+        let mask = (mask.ge(0f32)? * 255.)?;
         let (_one, h, w) = mask.dims3()?;
         let mask = mask.expand((3, h, w))?;
         candle_examples::save_image_resize(&mask, "sam_mask.png", initial_h, initial_w)?;

--- a/candle-examples/examples/segment-anything/main.rs
+++ b/candle-examples/examples/segment-anything/main.rs
@@ -209,7 +209,12 @@ pub fn main() -> anyhow::Result<()> {
         }
     } else {
         let point = Some((args.point_x, args.point_y));
+        let start_time = std::time::Instant::now();
         let (mask, iou_predictions) = sam.forward(&image, point, false)?;
+        println!(
+            "mask generated in {:.2}s",
+            start_time.elapsed().as_secs_f32()
+        );
         println!("mask:\n{mask}");
         println!("iou_predictions: {iou_predictions:?}");
 

--- a/candle-examples/examples/segment-anything/model_prompt_encoder.rs
+++ b/candle-examples/examples/segment-anything/model_prompt_encoder.rs
@@ -161,21 +161,21 @@ impl PromptEncoder {
             .forward_with_coords(&points, self.input_image_size)?;
         let labels = labels.unsqueeze(2)?.broadcast_as(point_embedding.shape())?;
         let zeros = point_embedding.zeros_like()?;
-        let point_embedding = labels.lt(&labels.zeros_like()?)?.where_cond(
+        let point_embedding = labels.lt(0f32)?.where_cond(
             &self
                 .not_a_point_embed
                 .embeddings()
                 .broadcast_as(zeros.shape())?,
             &point_embedding,
         )?;
-        let labels0 = labels.eq(&labels.zeros_like()?)?.where_cond(
+        let labels0 = labels.eq(0f32)?.where_cond(
             &self.point_embeddings[0]
                 .embeddings()
                 .broadcast_as(zeros.shape())?,
             &zeros,
         )?;
         let point_embedding = (point_embedding + labels0)?;
-        let labels1 = labels.eq(&labels.ones_like()?)?.where_cond(
+        let labels1 = labels.eq(1f32)?.where_cond(
             &self.point_embeddings[1]
                 .embeddings()
                 .broadcast_as(zeros.shape())?,


### PR DESCRIPTION
This is not very efficient as we broadcast the values rather than having some dedicated kernels for these, that said it's rare for these ops to represent much computation.