### PR TITLE
Fuse the rel-pos additions via a custom-op.

### DIFF
--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -24,6 +24,7 @@ intel-mkl-src = { workspace = true, optional = true }
 cudarc = { workspace = true, optional = true }
 half = { workspace = true, optional = true }
 image = { workspace = true }
+rayon = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/candle-examples/examples/segment-anything/model_image_encoder.rs
+++ b/candle-examples/examples/segment-anything/model_image_encoder.rs
@@ -34,6 +34,64 @@ impl Module for PatchEmbed {
     }
 }
 
+// A custom op to make add_decomposed_rel_pos faster. Most of the time is spent on the final
+// addition in the case where b = 12, q_h = q_w = 4096, k_h = k_w = 4096
+//   (attn.reshape((b, q_h, q_w, k_h, k_w))?
+//       + rel_h.unsqueeze(4)?.broadcast_add(&rel_w.unsqueeze(3)?)?)?
+//   .reshape((b, q_h * q_w, k_h * k_w))
+// Ideally we would perform this operation in place but this is not supported in candle at the
+// moment. We should also investigate using f16 rather than f32.
+struct Add3(usize, usize, usize, usize, usize);
+impl candle::CustomOp3 for Add3 {
+    fn name(&self) -> &'static str {
+        "add3"
+    }
+
+    fn cpu_fwd(
+        &self,
+        s1: &candle::CpuStorage,
+        l1: &candle::Layout,
+        s2: &candle::CpuStorage,
+        l2: &candle::Layout,
+        s3: &candle::CpuStorage,
+        l3: &candle::Layout,
+    ) -> Result<(candle::CpuStorage, candle::Shape)> {
+        let Add3(b, q_h, q_w, k_h, k_w) = *self;
+        let s1 = s1.as_slice::<f32>()?;
+        let s1 = match l1.contiguous_offsets() {
+            None => candle::bail!("input1 has to be contiguous"),
+            Some((o1, o2)) => &s1[o1..o2],
+        };
+        let s2 = s2.as_slice::<f32>()?;
+        let s2 = match l2.contiguous_offsets() {
+            None => candle::bail!("input2 has to be contiguous"),
+            Some((o1, o2)) => &s2[o1..o2],
+        };
+        let s3 = s3.as_slice::<f32>()?;
+        let s3 = match l3.contiguous_offsets() {
+            None => candle::bail!("input3 has to be contiguous"),
+            Some((o1, o2)) => &s3[o1..o2],
+        };
+        let mut dst = vec![0f32; b * q_h * q_w * k_h * k_w];
+        for b_idx in 0..(b * q_h * q_w) {
+            let s1_idx = b_idx * k_h * k_w;
+            let s2_idx = b_idx * k_h;
+            let s3_idx = b_idx * k_w;
+            for h_idx in 0..k_h {
+                let s1_idx = s1_idx + h_idx * k_w;
+                let s2_idx = s2_idx + h_idx;
+                for w_idx in 0..k_w {
+                    let s1_idx = s1_idx + w_idx;
+                    let s3_idx = s3_idx + w_idx;
+                    dst[s1_idx] = s1[s1_idx] + s2[s2_idx] + s3[s3_idx]
+                }
+            }
+        }
+        let dst = candle::WithDType::to_cpu_storage_owned(dst);
+        Ok((dst, (b, q_h * q_w, k_h * k_w).into()))
+    }
+}
+
 #[derive(Debug)]
 struct Attention {
     qkv: crate::Linear,
@@ -101,10 +159,16 @@ impl Attention {
                     .transpose(1, 2)? // -> bwhc
                     .contiguous()?
                     .matmul(&r_w.broadcast_left(b)?.t()?.contiguous()?)? // bwhc,bwck -> bwhk
-                    .transpose(1, 2)?;
-                (attn.reshape((b, q_h, q_w, k_h, k_w))?
-                    + rel_h.unsqueeze(4)?.broadcast_add(&rel_w.unsqueeze(3)?)?)?
-                .reshape((b, q_h * q_w, k_h * k_w))
+                    .transpose(1, 2)?
+                    .contiguous()?;
+                if attn.device().is_cpu() {
+                    let op = Add3(b, q_h, q_w, k_h, k_w);
+                    attn.apply_op3_no_bwd(&rel_h, &rel_w, &op)
+                } else {
+                    (attn.reshape((b, q_h, q_w, k_h, k_w))?
+                        + rel_h.unsqueeze(4)?.broadcast_add(&rel_w.unsqueeze(3)?)?)?
+                    .reshape((b, q_h * q_w, k_h * k_w))
+                }
             }
             None => Ok(attn),
         }


### PR DESCRIPTION
Also tried using simd on top of this but it didn't help so most likely we're memory bound for this op at this stage. Fwiw the simd diff:
```diff
diff --git a/candle-core/src/cpu/mod.rs b/candle-core/src/cpu/mod.rs
index 9a8e631..8bc97e2 100644
--- a/candle-core/src/cpu/mod.rs
+++ b/candle-core/src/cpu/mod.rs
@@ -139,6 +139,45 @@ pub(crate) unsafe fn vec_sum(row: *const f32, b: *mut f32, k: usize) {
     }
 }
 
+#[cfg(any(
+    target_feature = "neon",
+    target_feature = "avx",
+    target_feature = "simd128"
+))]
+#[inline(always)]
+pub unsafe fn vec_add_cst(dst: *mut f32, src1: *const f32, src2: *const f32, c: f32, k: usize) {
+    let np = k & !(CurrentCpu::STEP - 1);
+
+    if np > 0 {
+        let c = CurrentCpu::from_f32(c);
+        for i in (0..np).step_by(CurrentCpu::STEP) {
+            for j in 0..CurrentCpu::n() {
+                let src1 = CurrentCpu::load(src1.add(i + j * CurrentCpu::EPR));
+                let src2 = CurrentCpu::load(src2.add(i + j * CurrentCpu::EPR));
+                let sum = CurrentCpu::vec_add(CurrentCpu::vec_add(src1, src2), c);
+                CurrentCpu::vec_store(dst.add(i + j * CurrentCpu::EPR), sum)
+            }
+        }
+    }
+
+    // leftovers
+    for i in np..k {
+        *dst.add(i) = *src1.add(i) + *src2.add(i) + c
+    }
+}
+
+#[cfg(not(any(
+    target_feature = "neon",
+    target_feature = "avx",
+    target_feature = "simd128"
+)))]
+#[inline(always)]
+pub unsafe fn vec_add_cst(dst: *mut f32, src1: *const f32, src2: *const f32, c: f32, k: usize) {
+    for i in 0..k {
+        *dst.add(i) = *src1.add(i) + *src2.add(i) + c
+    }
+}
 #[cfg(target_feature = "avx")]
 #[inline(always)]
 pub(crate) unsafe fn vec_dot_f16(a_row: *const f16, b_row: *const f16, c: *mut f32, k: usize) {
diff --git a/candle-examples/examples/segment-anything/model_image_encoder.rs b/candle-examples/examples/segment-anything/model_image_encoder.rs
index 76cd15d..5f14aa3 100644
--- a/candle-examples/examples/segment-anything/model_image_encoder.rs
+++ b/candle-examples/examples/segment-anything/model_image_encoder.rs
@@ -85,11 +85,14 @@ impl candle::CustomOp3 for Add3 {
                     let s1_idx = s1_idx + h_idx * k_w;
                     let s2_idx = s2_idx + h_idx;
                     let dst_idx = h_idx * k_w;
-                    for w_idx in 0..k_w {
-                        let s1_idx = s1_idx + w_idx;
-                        let s3_idx = s3_idx + w_idx;
-                        let dst_idx = dst_idx + w_idx;
-                        dst[dst_idx] = s1[s1_idx] + s2[s2_idx] + s3[s3_idx]
+                    unsafe {
+                        candle::cpu::vec_add_cst(
+                            dst.as_mut_ptr().add(dst_idx),
+                            s1.as_ptr().add(s1_idx),
+                            s3.as_ptr().add(s3_idx),
+                            s2[s2_idx],
+                            k_w,
+                        )
                     }
                 }
             });
```