### PR TITLE
Add `CANDLE_NVCC_CCBIN` support for `candle-kernels`, and eliminate warnings.

### DIFF
--- a/candle-core/src/cuda_backend.rs
+++ b/candle-core/src/cuda_backend.rs
@@ -12,6 +12,7 @@ use half::{bf16, f16};
 use std::sync::{Arc, Mutex};
 
 const USE_IM2COL_CONV1D: bool = true;
+#[cfg(not(feature = "cudnn"))]
 const USE_IM2COL_CONV2D: bool = true;
 
 /// cudarc related errors


### PR DESCRIPTION
On windows, it seems currently `nvcc` will not auto detect `cl.exe` position, so this allows the compiler bindir be stored as an environment variables, for convenience.

This also eliminate a warning under conditional compilation.