### PR TITLE
Add support to flan-t5

### DIFF
--- a/candle-nn/src/activation.rs
+++ b/candle-nn/src/activation.rs
@@ -6,6 +6,8 @@ use serde::Deserialize;
 pub enum Activation {
     #[default]
     Gelu,
+    #[serde(rename = "gated-gelu")]
+    NewGelu,
     Relu,
     Elu(f64),
 }
@@ -14,6 +16,10 @@ impl super::Module for Activation {
     fn forward(&self, xs: &Tensor) -> candle::Result<Tensor> {
         match self {
             Self::Gelu => xs.gelu(),
+            // TODO: This is "gelu_new", not the original "gelu".
+            // There's some small numerical difference:
+            // https://github.com/huggingface/transformers/blob/12f043eaeaabfef6f6efea411d98e6f6d3c094b7/src/transformers/activations.py#L49-L78
+            Self::NewGelu => xs.gelu(),
             Self::Relu => xs.relu(),
             &Self::Elu(alpha) => xs.elu(alpha),
         }


### PR DESCRIPTION
Hello,

I made some changes to make it possible to load `google/flan-t5-base` and `google/flan-t5-large` models.

Note that there's no actual support for NewGelu, so I'm using the old Gelu.

Output:

```
$ cargo run --example t5 -- --model-id t5-base
...
score: 0.92 'The new movie is awesome' 'The new movie is so great'
score: 0.77 'The cat sits outside' 'The cat plays in the garden'
score: 0.65 'A man is playing guitar' 'A woman watches TV'
score: 0.58 'I love pasta' 'Do you like pizza?'
score: 0.53 'A man is playing guitar' 'The cat plays in the garden'

$ cargo run --example t5 -- --model-id google/flan-t5-base
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/examples/t5 --model-id google/flan-t5-base`
...
score: 0.93 'The new movie is awesome' 'The new movie is so great'
score: 0.82 'The cat sits outside' 'The cat plays in the garden'
score: 0.74 'A man is playing guitar' 'A woman watches TV'
score: 0.66 'The cat sits outside' 'A woman watches TV'
score: 0.63 'The cat sits outside' 'A man is playing guitar'

$ cargo run --example t5 -- --model-id google/flan-t5-large
...
score: 0.87 'The new movie is awesome' 'The new movie is so great'
score: 0.77 'The cat sits outside' 'The cat plays in the garden'
score: 0.62 'I love pasta' 'Do you like pizza?'
score: 0.61 'The cat sits outside' 'A man is playing guitar'
score: 0.59 'A man is playing guitar' 'A woman watches TV'
```
