### PR TITLE
[Request for comment (RFC)] Allow printing out keys and values of VarBuilder

### DIFF
--- a/candle-nn/src/var_builder.rs
+++ b/candle-nn/src/var_builder.rs
@@ -1,8 +1,6 @@
 //! A `VarBuilder` is used to retrieve variables used by a model. These variables can either come
 //! from a pre-trained checkpoint, e.g. using `VarBuilder::from_safetensors`, or initialized for
 //! training, e.g. using `VarBuilder::from_varmap`.
-//!
-#![feature(type_name_of_val)]
 use crate::VarMap;
 use candle::{safetensors::Load, DType, Device, Error, Result, Shape, Tensor};
 use safetensors::{slice::IndexOp, tensor::SafeTensors};
@@ -115,10 +113,8 @@ impl<'a, B: Backend> VarBuilderArgs<'a, B> {
         }
     }
 
-    pub fn hey(&self) -> String {
-        let keys = self.data.backend.keys();
-        println!("Type: {:?}", keys);
-        "hey".to_string()
+    pub fn keys(&self) -> Option<Vec<&str>> {
+        self.data.backend.keys()
     }
 
     /// Returns the prefix of the `VarBuilder`.


### PR DESCRIPTION
When translating models into PyTorch or other frameworks (JAX, TF), the crux is often to match the names and tensors of the checkpoint to the expected names and tensors of PyTorch's nn.Module

When playing with building models in candle, the `VarBuilder` is a very important object as it's expected by almost every candle-nn layer object.

It would be super helpful to be able to better debug the var builder.

A common use case (I guess) is the following. One loads a safetensors checkpoint and tries to build a candle model on top of it:

```rs
        let weights = unsafe { candle::safetensors::MmapedFile::new(filename)? };
        let weights = weights.deserialize()?;

        let vs_model = nn::VarBuilder::from_safetensors(vec![weights], dtype, device);
```

Having loading `vs_model`, I would now like to inspect the object for the structure it has **before** I pass it into a candle struct definition. In this PR I propose to add a `state_dict()` method to `VarBuilderArgs`:

```rs
println!("{:?}", vs_model.state_dict());
```

This would nicely display all the expected names along side it's tensor shape:
```
{"encoder.down.0.block.0.conv2.weight": Tensor[dims 128, 128, 3, 3; f32], "encoder.down.3.block.1.conv1.weight": Tensor[dims 512, 512, 3, 3; f32], "decoder.up.4.block.0.conv2.bias": Tensor[dims 768; f32], "encoder.down.2.block.1.conv2.weight": Tensor[dims 256, 256, 3, 3; 
f32], "decoder.up.2.block.2.conv2.bias": Tensor[dims 256; f32],  ...}
```
which would help a lot to know how one should implement the model in rust.

This PR is far from being complete, I'm mainly just seeing if there is interest for this function.

One way to implement this function is to the following:
- 1.) Make passing the shape argument to the backend's `get(...)` functions optional so that one get retrieve a tensor simply based on the name
- 2.) Add a `fn keys()` function to every backend which returns a list of all keys. Note that for now this is incomplete


cc @Narsil @LaurentMazare - curious to hear your thoughts :-)