### PR TITLE
T5: Add option to override use_cache from config

### DIFF
--- a/candle-examples/examples/t5/main.rs
+++ b/candle-examples/examples/t5/main.rs
@@ -44,6 +44,10 @@ struct Args {
     #[arg(long)]
     decode: bool,
 
+    // Enable/disable decoding.
+    #[arg(long)]
+    use_cache: Option<bool>,
+
     /// Use this prompt, otherwise compute sentence similarities.
     #[arg(long)]
     prompt: Option<String>,
@@ -111,7 +115,10 @@ impl T5ModelBuilder {
             )
         };
         let config = std::fs::read_to_string(config_filename)?;
-        let config: t5::Config = serde_json::from_str(&config)?;
+        let mut config: t5::Config = serde_json::from_str(&config)?;
+        if args.use_cache.is_some() {
+            config.use_cache = args.use_cache.unwrap();
+        }
         let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
         Ok((
             Self {

--- a/candle-examples/examples/t5/main.rs
+++ b/candle-examples/examples/t5/main.rs
@@ -45,8 +45,8 @@ struct Args {
     decode: bool,
 
     // Enable/disable decoding.
-    #[arg(long)]
-    use_cache: Option<bool>,
+    #[arg(long, default_value = "false")]
+    use_cache: bool,
 
     /// Use this prompt, otherwise compute sentence similarities.
     #[arg(long)]
@@ -116,9 +116,7 @@ impl T5ModelBuilder {
         };
         let config = std::fs::read_to_string(config_filename)?;
         let mut config: t5::Config = serde_json::from_str(&config)?;
-        if args.use_cache.is_some() {
-            config.use_cache = args.use_cache.unwrap();
-        }
+        config.use_cache = args.use_cache;
         let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
         Ok((
             Self {


### PR DESCRIPTION
I believe there's a bug in the cache implementation for T5 because I don't get the same output with and without it.

For example, this is without caching:

```bash
% cargo run --release --example t5 -- --model-id "t5-base" --prompt "translate to German: long sentences are not decoded properly" --temperature 0 --decode --use-cache false
...
 Lange Sätze werden nicht richtig entschlüsselt
13 tokens generated (16.94 token/s)
```

I don't speak German, but Google translate " Lange Sätze werden nicht richtig entschlüsselt" back to "
Long sentences are not decoded properly".

With cache, I get this:

```bash
$ cargo run --release --example t5 -- --model-id "t5-base" --prompt "translate to German: long sentences are not decoded properly" --temperature 0 --decode --use-cache true
...
 Langsames Sätzchen werden nicht richtig entschlüsseltakzacktackt
13 tokens generated (9.56 token/s)
```

"Langsames" is not a word in German.
