### PR TITLE
Fix T5 kv cache

### DIFF
--- a/candle-examples/examples/t5/main.rs
+++ b/candle-examples/examples/t5/main.rs
@@ -46,7 +46,7 @@ struct Args {
 
     // Enable/disable decoding.
     #[arg(long, default_value = "false")]
-    use_cache: bool,
+    disable_cache: bool,
 
     /// Use this prompt, otherwise compute sentence similarities.
     #[arg(long)]
@@ -116,7 +116,7 @@ impl T5ModelBuilder {
         };
         let config = std::fs::read_to_string(config_filename)?;
         let mut config: t5::Config = serde_json::from_str(&config)?;
-        config.use_cache = args.use_cache;
+        config.use_cache = !args.disable_cache;
         let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
         Ok((
             Self {

--- a/candle-examples/examples/t5/main.rs
+++ b/candle-examples/examples/t5/main.rs
@@ -52,6 +52,10 @@ struct Args {
     #[arg(long)]
     prompt: Option<String>,
 
+    /// If set along with --decode, will use this prompt to initialize the decoder.
+    #[arg(long)]
+    decoder_prompt: Option<String>,
+
     /// L2 normalization for embeddings.
     #[arg(long, default_value = "true")]
     normalize_embeddings: bool,
@@ -170,6 +174,16 @@ fn main() -> Result<()> {
             } else {
                 let mut model = builder.build_conditional_generation()?;
                 let mut output_token_ids = [builder.config.pad_token_id as u32].to_vec();
+                if let Some(decoder_prompt) = &args.decoder_prompt {
+                    print!("{decoder_prompt}");
+                    output_token_ids.extend(
+                        tokenizer
+                            .encode(decoder_prompt.to_string(), false)
+                            .map_err(E::msg)?
+                            .get_ids()
+                            .to_vec(),
+                    );
+                }
                 let temperature = if args.temperature <= 0. {
                     None
                 } else {
@@ -195,11 +209,11 @@ fn main() -> Result<()> {
                     let logits = if args.repeat_penalty == 1. {
                         logits
                     } else {
-                        let start_at = tokens.len().saturating_sub(args.repeat_last_n);
+                        let start_at = output_token_ids.len().saturating_sub(args.repeat_last_n);
                         candle_transformers::utils::apply_repeat_penalty(
                             &logits,
                             args.repeat_penalty,
-                            &tokens[start_at..],
+                            &output_token_ids[start_at..],
                         )?
                     };
 
@@ -217,8 +231,8 @@ fn main() -> Result<()> {
                 let dt = start.elapsed();
                 println!(
                     "\n{} tokens generated ({:.2} token/s)\n",
-                    tokens.len(),
-                    tokens.len() as f64 / dt.as_secs_f64(),
+                    output_token_ids.len(),
+                    output_token_ids.len() as f64 / dt.as_secs_f64(),
                 );
             }
         }

--- a/candle-transformers/src/models/t5.rs
+++ b/candle-transformers/src/models/t5.rs
@@ -350,7 +350,7 @@ impl T5Attention {
                     // This only handles the bidirectional case.
                     let kv_len = k.dim(2)?;
                     let (q_start, q_end) = match self.use_cache {
-                        true => ((kv_len - 1) as u32, kv_len as u32),
+                        true => ((kv_len - q_len) as u32, kv_len as u32),
                         false => (0_u32, kv_len as u32),
                     };
                     let num_buckets = self.relative_attention_num_buckets as u32 / 2;

--- a/candle-transformers/src/models/t5.rs
+++ b/candle-transformers/src/models/t5.rs
@@ -348,9 +348,14 @@ impl T5Attention {
                 None => (scores, None),
                 Some(relative_attention_bias) => {
                     // This only handles the bidirectional case.
+                    let kv_len = k.dim(2)?;
+                    let (q_start, q_end) = match self.use_cache {
+                        true => ((kv_len - 1) as u32, kv_len as u32),
+                        false => (0_u32, kv_len as u32),
+                    };
                     let num_buckets = self.relative_attention_num_buckets as u32 / 2;
                     let max_exact = num_buckets / 2;
-                    let relative_position = (0..q_len as u32)
+                    let relative_position = (q_start..q_end)
                         .map(|i| {
                             (0..kv_len as u32)
                                 .map(|j| {


### PR DESCRIPTION
This fixes the issue I mentioned in https://github.com/huggingface/candle/pull/892 and https://github.com/huggingface/candle/pull/864#issuecomment-1724176512

The position biases were not taking into account the cache.

I now get the same output with the two approaches, but somehow, it's slightly slower when the cache is on.  (I have a M2 Mac. I didn't try with a GPU, larger batches, or much larger outputs.)


```bash
$ cargo run --release --example t5 -- --model-id "t5-base" --prompt "summarize: state authorities dispatched emergency crews tuesday to survey the damage after an onslaught of severe weather in mississipi." --temperature 0 --decode
    Finished release [optimized] target(s) in 0.18s
     Running `target/release/examples/t5 --model-id t5-base --prompt 'summarize: state authorities dispatched emergency crews tuesday to survey the damage after an onslaught of severe weather in mississipi.' --temperature 0 --decode`
Running on CPU, to run on GPU, build this example with `--features cuda`
 mississippi authorities dispatch emergency crews to survey damage . severe weather in mississippi has caused extensive damage .
38 tokens generated (15.90 token/s)
```

```bash
$ cargo run --release --example t5 -- --model-id "t5-base" --prompt "summarize: state authorities dispatched emergency crews tuesday to survey the damage after an onslaught of severe weather in mississipi." --temperature 0 --decode --disable-cache
    Finished release [optimized] target(s) in 0.17s
     Running `target/release/examples/t5 --model-id t5-base --prompt 'summarize: state authorities dispatched emergency crews tuesday to survey the damage after an onslaught of severe weather in mississipi.' --temperature 0 --decode --disable-cache`
Running on CPU, to run on GPU, build this example with `--features cuda`
 mississippi authorities dispatch emergency crews to survey damage . severe weather in mississippi has caused extensive damage .
38 tokens generated (17.94 token/s)
```