### PR TITLE
Sketch a simd128 optimized q4k vecdot.

### DIFF
--- a/candle-core/src/quantized/k_quants.rs
+++ b/candle-core/src/quantized/k_quants.rs
@@ -1132,6 +1132,9 @@ impl GgmlType for BlockQ4K {
         #[cfg(target_feature = "neon")]
         return super::neon::vec_dot_q4k_q8k(n, xs, ys);
 
+        #[cfg(target_feature = "simd128")]
+        return super::simd128::vec_dot_q4k_q8k(n, xs, ys);
+
         if n % QK_K != 0 {
             crate::bail!("vec_dot_q4k_q8k: {n} is not divisible by {QK_K}")
         }

--- a/candle-core/src/quantized/simd128.rs
+++ b/candle-core/src/quantized/simd128.rs
@@ -1,5 +1,6 @@
-use super::k_quants::{BlockQ4_0, BlockQ8_0, QK8_0};
+use super::k_quants::{BlockQ4K, BlockQ4_0, BlockQ8K, BlockQ8_0, QK8_0, QK_K};
 use crate::Result;
+use byteorder::{ByteOrder, LittleEndian};
 use half::f16;
 
 use core::arch::wasm32::*;
@@ -96,4 +97,86 @@ pub(crate) fn vec_dot_q8_0_q8_0(n: usize, xs: &[BlockQ8_0], ys: &[BlockQ8_0]) ->
             + f32x4_extract_lane::<3>(acc);
         Ok(res)
     }
+}
+
+#[inline(always)]
+pub(crate) fn vec_dot_q4k_q8k(n: usize, xs: &[BlockQ4K], ys: &[BlockQ8K]) -> Result<f32> {
+    if n % QK_K != 0 {
+        crate::bail!("vec_dot_q4k_q8k: {n} is not divisible by {QK_K}")
+    }
+
+    const KMASK1: u32 = 0x3f3f3f3f;
+    const KMASK2: u32 = 0x0f0f0f0f;
+    const KMASK3: u32 = 0x03030303;
+
+    let mut utmp: [u32; 4] = [0; 4];
+    let mut scales: [u8; 8] = [0; 8];
+    let mut mins: [u8; 8] = [0; 8];
+
+    let mut aux8: [i8; QK_K] = [0; QK_K];
+    let mut aux16: [i16; 8] = [0; 8];
+    let mut sums: [f32; 8] = [0.0; 8];
+    let mut aux32: [i32; 8] = [0; 8];
+
+    let mut sumf = 0.0;
+    for (y, x) in ys.iter().zip(xs.iter()) {
+        let q4 = &x.qs;
+        let q8 = &y.qs;
+        aux32.fill(0);
+
+        let mut a = &mut aux8[..];
+        let mut q4 = &q4[..];
+        for _ in 0..QK_K / 64 {
+            for l in 0..32 {
+                a[l] = (q4[l] & 0xF) as i8;
+            }
+            a = &mut a[32..];
+            for l in 0..32 {
+                a[l] = (q4[l] >> 4) as i8;
+            }
+            a = &mut a[32..];
+            q4 = &q4[32..];
+        }
+
+        LittleEndian::read_u32_into(&x.scales, &mut utmp[0..3]);
+
+        utmp[3] = ((utmp[2] >> 4) & KMASK2) | (((utmp[1] >> 6) & KMASK3) << 4);
+        let uaux = utmp[1] & KMASK1;
+        utmp[1] = (utmp[2] & KMASK2) | (((utmp[0] >> 6) & KMASK3) << 4);
+        utmp[2] = uaux;
+        utmp[0] &= KMASK1;
+
+        //extract scales and mins
+        LittleEndian::write_u32_into(&utmp[0..2], &mut scales);
+        LittleEndian::write_u32_into(&utmp[2..4], &mut mins);
+
+        let mut sumi = 0;
+        for j in 0..QK_K / 16 {
+            sumi += y.bsums[j] as i32 * mins[j / 2] as i32;
+        }
+
+        let mut a = &mut aux8[..];
+        let mut q8 = &q8[..];
+
+        for scale in scales {
+            let scale = scale as i32;
+            for _ in 0..4 {
+                for l in 0..8 {
+                    aux16[l] = q8[l] as i16 * a[l] as i16;
+                }
+                for l in 0..8 {
+                    aux32[l] += scale * aux16[l] as i32;
+                }
+                q8 = &q8[8..];
+                a = &mut a[8..];
+            }
+        }
+        let d = x.d.to_f32() * y.d;
+        for l in 0..8 {
+            sums[l] += d * aux32[l] as f32;
+        }
+        let dmin = x.dmin.to_f32() * y.d;
+        sumf -= dmin * sumi as f32;
+    }
+    Ok(sumf + sums.iter().sum::<f32>())
 }

--- a/candle-wasm-tests/tests/quantized_tests.rs
+++ b/candle-wasm-tests/tests/quantized_tests.rs
@@ -134,6 +134,12 @@ fn quantized_matmul_q40() -> Result<()> {
 }
 
 #[wasm_bindgen_test]
+fn quantized_matmul_q4k() -> Result<()> {
+    ggml_matmul_error_test::<candle::quantized::k_quants::BlockQ4K>()?;
+    Ok(())
+}
+
+#[wasm_bindgen_test]
 fn quantized_matmul_q80() -> Result<()> {
     ggml_matmul_error_test::<candle::quantized::k_quants::BlockQ8_0>()?;
     Ok(())


### PR DESCRIPTION
This also adds some testing.
For the phi1.5 example in a chrome or a ryzen 2600x, inference for the small model goes from 0.85 token/s to ~4 token/s.