### PR TITLE
Add negative prompts to segment-anything.

### DIFF
--- a/candle-wasm-examples/segment-anything/src/bin/m.rs
+++ b/candle-wasm-examples/segment-anything/src/bin/m.rs
@@ -94,7 +94,7 @@ impl Model {
             &embeddings.data,
             embeddings.height as usize,
             embeddings.width as usize,
-            &[(x, y)],
+            &[(x, y, true)],
             false,
         )?;
         let iou = iou_predictions.flatten(0, 1)?.to_vec1::<f32>()?[0];


### PR DESCRIPTION
These additional points are required not to be part of the generated mask, they can be specified in the command line example via the `-neg-prompt 0.5,0.4` flag.