### PR TITLE
Quant t5: Add coedit model to wasm demo and readme

### DIFF
--- a/candle-examples/examples/quantized-t5/README.md
+++ b/candle-examples/examples/quantized-t5/README.md
@@ -13,5 +13,30 @@ generate quantized weight files from the original safetensors file by using the
 `tensor-tools` command line utility via:
 
 ```bash
-cargo run --example tensor-tools --release -- quantize --quantization q6k PATH/TO/T5/model.safetensors /tmp/model.gguf
+$ cargo run --example tensor-tools --release -- quantize --quantization q6k PATH/TO/T5/model.safetensors /tmp/model.gguf
+```
+
+To use a different model, specify the `model-id`. For example, you can use
+quantized [CoEdit models](https://huggingface.co/jbochi/candle-coedit-quantized).
+
+```bash
+$ cargo run --example quantized-t5 --release  -- \
+  --model-id "jbochi/candle-coedit-quantized" \
+  --prompt "Make this text coherent: Their flight is weak. They run quickly through the tree canopy." \
+  --temperature 0
+...
+ Although their flight is weak, they run quickly through the tree canopy.
+
+By default, it will look for `model.gguf` and `config.json`, but you can specify
+custom local or remote `weight-file` and `config-file`s:
+
+```bash
+cargo run --example quantized-t5 --release  -- \
+  --model-id "jbochi/candle-coedit-quantized" \
+  --weight-file "model-xl.gguf" \
+  --config-file "config-xl.json" \
+  --prompt "Rewrite to make this easier to understand: Note that a storm surge is what forecasters consider a hurricane's most treacherous aspect." \
+  --temperature 0
+...
+ Note that a storm surge is what forecasters consider a hurricane's most dangerous part.
 ```

--- a/candle-wasm-examples/t5/index.html
+++ b/candle-wasm-examples/t5/index.html
@@ -166,13 +166,19 @@
             target="_blank"
             class="link"
             >flan-t5-small</a
-          >
-          and several t5
+          >,
+          several
           <a
             href="https://huggingface.co/lmz/candle-quantized-t5/tree/main"
             target="_blank"
             class="link">
-            t5 quantized gguf</a
+            t5 quantized gguf models</a
+          >, and also a quantized
+          <a
+            href="https://huggingface.co/jbochi/candle-coedit-quantized/tree/main"
+            target="_blank"
+            class="link">
+            CoEdIT model for text rewrite</a
           >.
         </p>
       </div>

--- a/candle-wasm-examples/t5/utils.js
+++ b/candle-wasm-examples/t5/utils.js
@@ -65,6 +65,7 @@ export async function generateText(
     worker.addEventListener("message", messageHandler);
   });
 }
+
 export const MODELS = {
   t5_small_quantized: {
     size: "64.4 MB",
@@ -133,7 +134,6 @@ export const MODELS = {
       summarization: { prefix: "summarize: ", max_length: 200 },
     },
   },
-
   flan_t5_base_quantized: {
     size: "263 MB",
     base_url: "https://huggingface.co/lmz/candle-quantized-t5/resolve/main/",
@@ -156,7 +156,41 @@ export const MODELS = {
       summarization: { prefix: "summarize: ", max_length: 200 },
     },
   },
+  coedit_large_quantized: {
+    size: "643 MB",
+    base_url: "https://huggingface.co/jbochi/candle-coedit-quantized/resolve/main/",
+    model: "model.gguf",
+    tokenizer: "tokenizer.json",
+    config: "config.json",
+    tasks: {
+      fluency: {
+        prefix: "Fix the grammar: ",
+        max_length: 300,
+      },
+      coherence: {
+        prefix: "Rewrite to make this easier to understand: ",
+        max_length: 300,
+      },
+      simplification: {
+        prefix: "translate English to Romanian: ",
+        max_length: 300,
+      },
+      simplification: {
+        prefix: "Paraphrase this: ",
+        max_length: 300,
+      },
+      formalization: {
+        prefix: "Write this more formally: ",
+        max_length: 300,
+      },
+      neutralize: {
+        prefix: "Write in a more neutral way: ",
+        max_length: 300,
+      },
+    },
+  },
 };
+
 export function getModelInfo(id, taskID) {
   const model = MODELS[id];
   return {


### PR DESCRIPTION
Hey @LaurentMazare . Thanks for reviewing and merging https://github.com/huggingface/candle/pull/1029 so quickly.

As you [suggested](https://github.com/huggingface/candle/pull/1029#issuecomment-1747213867), this updates the [readme of the example](https://github.com/huggingface/candle/tree/main/candle-examples/examples/quantized-t5) and also the wasm demo.

I tested it locally:

![image](https://github.com/huggingface/candle/assets/292712/eb2e6033-dc62-47b8-9434-4077017518ee)

I'll see what I can do about advertising this. Creating a quantized model and running it in the browser with Candle was surprisingly easy!
