### PR TITLE
Delete invalid comment in T5 code

### DIFF
--- a/candle-transformers/src/models/quantized_t5.rs
+++ b/candle-transformers/src/models/quantized_t5.rs
@@ -775,8 +775,6 @@ impl T5ForConditionalGeneration {
                 Some(ref lm_head) => lm_head.forward(&sequence_output)?,
             }
         };
-
-        // TODO: Rescale output before projecting on vocab? * (self.model_dim**-0.5)
         Ok(output)
     }
 

--- a/candle-transformers/src/models/t5.rs
+++ b/candle-transformers/src/models/t5.rs
@@ -779,8 +779,6 @@ impl T5ForConditionalGeneration {
                 Some(ref lm_head) => lm_head.forward(&sequence_output)?,
             }
         };
-
-        // TODO: Rescale output before projecting on vocab? * (self.model_dim**-0.5)
         Ok(output)
     }
 


### PR DESCRIPTION
I should have deleted this comment in https://github.com/huggingface/candle/commit/05626ef492300a4f99c87555304ec863071722d5 . We do take the sqrt when necessary.