### PR TITLE
Matmul slowness example

### DIFF
--- a/candle-core/src/dtype.rs
+++ b/candle-core/src/dtype.rs
@@ -67,6 +67,20 @@ impl DType {
             Self::F64 => 8,
         }
     }
+
+    pub fn is_int(&self) -> bool {
+        match self {
+            Self::U8 | Self::U32 | Self::I64 => true,
+            Self::BF16 | Self::F16 | Self::F32 | Self::F64 => false,
+        }
+    }
+
+    pub fn is_float(&self) -> bool {
+        match self {
+            Self::U8 | Self::U32 | Self::I64 => false,
+            Self::BF16 | Self::F16 | Self::F32 | Self::F64 => true,
+        }
+    }
 }
 
 pub trait WithDType:

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -177,14 +177,9 @@ impl Tensor {
         is_variable: bool,
     ) -> Result<Self> {
         let none = BackpropOp::none();
-        if is_variable {
-            let shape = shape.into();
-            let storage = device.ones(&shape, dtype)?;
-            Ok(from_storage(storage, shape, none, is_variable))
-        } else {
-            let storage = device.ones(&crate::shape::SCALAR, dtype)?;
-            from_storage(storage, crate::shape::SCALAR, none, is_variable).broadcast_as(shape)
-        }
+        let shape = shape.into();
+        let storage = device.ones(&shape, dtype)?;
+        Ok(from_storage(storage, shape, none, is_variable))
     }
 
     /// Creates a new tensor filled with ones.
@@ -222,14 +217,9 @@ impl Tensor {
         is_variable: bool,
     ) -> Result<Self> {
         let none = BackpropOp::none();
-        if is_variable {
-            let shape = shape.into();
-            let storage = device.zeros(&shape, dtype)?;
-            Ok(from_storage(storage, shape, none, is_variable))
-        } else {
-            let storage = device.zeros(&crate::shape::SCALAR, dtype)?;
-            from_storage(storage, crate::shape::SCALAR, none, is_variable).broadcast_as(shape)
-        }
+        let shape = shape.into();
+        let storage = device.zeros(&shape, dtype)?;
+        Ok(from_storage(storage, shape, none, is_variable))
     }
 
     /// Creates a new tensor filled with zeros.

--- a/candle-nn/examples/cpu_benchmarks.rs
+++ b/candle-nn/examples/cpu_benchmarks.rs
@@ -185,8 +185,8 @@ impl Benchmark for Matmul {
     type PreProcessData = (Tensor, Tensor);
     type RunResult = Tensor;
     fn preprocess() -> Result<Self::PreProcessData> {
-        let lhs = Tensor::randn(0f32, 1., (1024, 1024), &Device::Cpu)?;
-        let rhs = Tensor::randn(0f32, 1., (1024, 1024), &Device::Cpu)?;
+        let lhs = Tensor::randn(0f32, 1., (1024 * 4, 1024 * 4), &Device::Cpu)?;
+        let rhs = Tensor::randn(0f32, 1., (1024 * 4, 1), &Device::Cpu)?;
         Ok((lhs, rhs))
     }
 

--- a/candle-nn/src/optim.rs
+++ b/candle-nn/src/optim.rs
@@ -41,6 +41,10 @@ impl Optimizer for SGD {
     type Config = f64;
 
     fn new(vars: Vec<Var>, learning_rate: f64) -> Result<Self> {
+        let vars = vars
+            .into_iter()
+            .filter(|var| var.dtype().is_float())
+            .collect();
         Ok(Self {
             vars,
             learning_rate,
@@ -116,6 +120,7 @@ impl Optimizer for AdamW {
     fn new(vars: Vec<Var>, params: ParamsAdamW) -> Result<Self> {
         let vars = vars
             .into_iter()
+            .filter(|var| var.dtype().is_float())
             .map(|var| {
                 let dtype = var.dtype();
                 let shape = var.shape();


### PR DESCRIPTION
Discord discussion for some context:

We don't have much benchmarks yet (and it would be great to have some). When trying to optimize some ops, I usually add them to cpu_benchmarks.rs. E.g. there is a standard matmul there that is a lot faster on my mac with accelerate (so using apple optimized blas) than when using gemm (which is the default). On intel, one can compare with --features mkl to have the mkl blas.
```bash
[nix-shell:~/github/candle]$ cargo run --example cpu_benchmarks --release --features accelerate -- matmul
1.160985ms

[nix-shell:~/github/candle]$ cargo run --example cpu_benchmarks --release  -- matmul
6.399711ms
```

In this case, both matrixes are 1024x1024 but I vaguely remember that at least on intel, the case where one of the dimension is 1 ended up being much slower that with the mkl too.

**sarah (⊙﹏⊙✿) — Today at 3:28 PM**
that's interesting. i don't have a mac on me so that's not a platform i can optimize on my own
i have some optimizations in mind that i can put on a separate gemm branch
can you benchmark eigen (with -march=native) as well to see how it compares?
**Zermelo Fraenkel — Today at 3:48 PM**
Ah I don't have eigen locally but maybe we should propose it as an alternative backend for candle if it's efficient.
There is less of a difference on x86 but still it's quite better with mkl.
```
laurent:~/github/candle$ cargo run --example cpu_benchmarks --release  -- matmul
    Finished release [optimized] target(s) in 0.17s
     Running `target/release/examples/cpu_benchmarks matmul`
4.626267ms
laurent:~/github/candle$ cargo run --example cpu_benchmarks --release  --features mkl -- matmul
    Finished release [optimized] target(s) in 0.19s
     Running `target/release/examples/cpu_benchmarks matmul`
3.483979ms
```
This is on a large aws boxes with 48 cores, and parallelism set to 48. Interestingly, gemm is better than mkl with a single thread.
```
laurent:~/github/candle$ OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 cargo run --example cpu_benchmarks --release  -- matmul
23.154966ms
laurent:~/github/candle$ OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 cargo run --example cpu_benchmarks --release  --features mkl -- matmul
29.037578ms
```
What starts to be pretty interesting is when using a size of 1x4096 for the lhs and 4096x4096 for the rhs, the timings stay on par. But with a lhs of 4096x4096 and a rhs of 4096x1 then gemm is a lot slower (and sadly that's the common case in LLM inference).
```
laurent:~/github/candle$ OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 cargo run --example cpu_benchmarks --release  -- matmul
49.151945ms
laurent:~/github/candle$ OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 cargo run --example cpu_benchmarks --release  --features mkl -- matmul
2.849821ms
```
If it was possible to get the performance on gemm on this last case at the same level as mkl that would be amazing.