### PR TITLE
PyO3: Add `equal` and `__richcmp__` to `candle.Tensor` 

### DIFF
--- a/candle-pyo3/py_src/candle/__init__.pyi
+++ b/candle-pyo3/py_src/candle/__init__.pyi
@@ -191,6 +191,11 @@ class Tensor:
         Gets the tensor's dtype.
         """
         pass
+    def equal(self, rhs: Tensor) -> bool:
+        """
+        True if two tensors have the same size and elements, False otherwise.
+        """
+        pass
     def exp(self) -> Tensor:
         """
         Performs the `exp` operation on the tensor.

--- a/candle-pyo3/src/lib.rs
+++ b/candle-pyo3/src/lib.rs
@@ -592,6 +592,27 @@ impl PyTensor {
         Ok(Self(tensor))
     }
 
+    #[pyo3(text_signature = "(self, rhs:Tensor)")]
+    /// True if two tensors have the same size and elements, False otherwise.
+    /// &RETURNS&: bool
+    fn equal(&self, rhs: &Self) -> PyResult<bool> {
+        if self.0.shape() != rhs.0.shape() {
+            return Ok(false);
+        }
+        let result = self
+            .0
+            .eq(&rhs.0)
+            .map_err(wrap_err)?
+            .to_dtype(DType::I64)
+            .map_err(wrap_err)?;
+        Ok(result
+            .sum_all()
+            .map_err(wrap_err)?
+            .to_scalar::<i64>()
+            .map_err(wrap_err)?
+            == self.0.elem_count() as i64)
+    }
+
     #[pyo3(text_signature = "(self, shape:Sequence[int])")]
     /// Reshapes the tensor to the given shape.
     /// &RETURNS&: Tensor

--- a/candle-pyo3/src/utils.rs
+++ b/candle-pyo3/src/utils.rs
@@ -1,0 +1,40 @@
+use ::candle::{Error as CandleError, Result as CandleResult};
+use candle::Shape;
+
+/// Tries to broadcast the `rhs` shape into the `lhs` shape.
+pub fn broadcast_shapes(lhs: &::candle::Tensor, rhs: &::candle::Tensor) -> CandleResult<Shape> {
+    // see `Shape.broadcast_shape_binary_op`
+    let lhs_dims = lhs.dims();
+    let rhs_dims = rhs.dims();
+    let lhs_ndims = lhs_dims.len();
+    let rhs_ndims = rhs_dims.len();
+    let bcast_ndims = usize::max(lhs_ndims, rhs_ndims);
+    let mut bcast_dims = vec![0; bcast_ndims];
+    for (idx, bcast_value) in bcast_dims.iter_mut().enumerate() {
+        let rev_idx = bcast_ndims - idx;
+        let l_value = if lhs_ndims < rev_idx {
+            1
+        } else {
+            lhs_dims[lhs_ndims - rev_idx]
+        };
+        let r_value = if rhs_ndims < rev_idx {
+            1
+        } else {
+            rhs_dims[rhs_ndims - rev_idx]
+        };
+        *bcast_value = if l_value == r_value {
+            l_value
+        } else if l_value == 1 {
+            r_value
+        } else if r_value == 1 {
+            l_value
+        } else {
+            return Err(CandleError::BroadcastIncompatibleShapes {
+                src_shape: lhs.shape().clone(),
+                dst_shape: rhs.shape().clone(),
+            }
+            .bt());
+        }
+    }
+    Ok(Shape::from(bcast_dims))
+}

--- a/candle-pyo3/tests/native/test_tensor.py
+++ b/candle-pyo3/tests/native/test_tensor.py
@@ -84,3 +84,68 @@ def test_tensors_can_be_compared_with_equal():
     t = Tensor(42.0)
     other = Tensor([42.0, 42.0])
     assert not t.equal(other)
+
+
+def test_tensor_supports_equality_opperations_with_scalars():
+    t = Tensor(42.0)
+    assert (t == 42.0).equal(Tensor(1).to_dtype(candle.u8))
+    assert (t == 43.0).equal(Tensor(0).to_dtype(candle.u8))
+
+    assert (t != 42.0).equal(Tensor(0).to_dtype(candle.u8))
+    assert (t != 43.0).equal(Tensor(1).to_dtype(candle.u8))
+
+    assert (t > 41.0).equal(Tensor(1).to_dtype(candle.u8))
+    assert (t > 42.0).equal(Tensor(0).to_dtype(candle.u8))
+
+    assert (t >= 42.0).equal(Tensor(1).to_dtype(candle.u8))
+    assert (t >= 43.0).equal(Tensor(0).to_dtype(candle.u8))
+
+    assert (t < 43.0).equal(Tensor(1).to_dtype(candle.u8))
+    assert (t < 42.0).equal(Tensor(0).to_dtype(candle.u8))
+
+    assert (t <= 42.0).equal(Tensor(1).to_dtype(candle.u8))
+    assert (t <= 41.0).equal(Tensor(0).to_dtype(candle.u8))
+
+
+def test_tensor_supports_equality_opperations_with_tensors():
+    t = Tensor(42.0)
+    same = Tensor(42.0)
+    other = Tensor(43.0)
+
+    assert (t == same).equal(Tensor(1).to_dtype(candle.u8))
+    assert (t == other).equal(Tensor(0).to_dtype(candle.u8))
+
+    assert (t != same).equal(Tensor(0).to_dtype(candle.u8))
+    assert (t != other).equal(Tensor(1).to_dtype(candle.u8))
+
+    assert (t > same).equal(Tensor(0).to_dtype(candle.u8))
+    assert (t > other).equal(Tensor(0).to_dtype(candle.u8))
+
+    assert (t >= same).equal(Tensor(1).to_dtype(candle.u8))
+    assert (t >= other).equal(Tensor(0).to_dtype(candle.u8))
+
+    assert (t < same).equal(Tensor(0).to_dtype(candle.u8))
+    assert (t < other).equal(Tensor(1).to_dtype(candle.u8))
+
+    assert (t <= same).equal(Tensor(1).to_dtype(candle.u8))
+    assert (t <= other).equal(Tensor(1).to_dtype(candle.u8))
+
+
+def test_tensor_equality_opperations_can_broadcast():
+    # Create a decoder attention mask as a test case
+    # e.g.
+    # [[1,0,0]
+    #  [1,1,0]
+    #  [1,1,1]]
+    mask_cond = candle.Tensor([0, 1, 2])
+    mask = mask_cond < (mask_cond + 1).reshape((3, 1))
+    assert mask.shape == (3, 3)
+    assert mask.equal(Tensor([[1, 0, 0], [1, 1, 0], [1, 1, 1]]).to_dtype(candle.u8))
+
+
+def test_tensor_can_be_hashed():
+    t = Tensor(42.0)
+    other = Tensor(42.0)
+    # Hash should represent the a unique tensor
+    assert hash(t) != hash(other)
+    assert hash(t) == hash(t)

--- a/candle-pyo3/tests/native/test_tensor.py
+++ b/candle-pyo3/tests/native/test_tensor.py
@@ -72,3 +72,15 @@ def test_tensor_can_be_scliced_3d():
     assert t[:, 0, 0].values() == [1, 9]
     assert t[..., 0].values() == [[1, 5], [9, 13]]
     assert t[..., 0:2].values() == [[[1, 2], [5, 6]], [[9, 10], [13, 14]]]
+
+
+def test_tensors_can_be_compared_with_equal():
+    t = Tensor(42.0)
+    other = Tensor(42.0)
+    assert t.equal(other)
+    t = Tensor([42.0, 42.1])
+    other = Tensor([42.0, 42.0])
+    assert not t.equal(other)
+    t = Tensor(42.0)
+    other = Tensor([42.0, 42.0])
+    assert not t.equal(other)

--- a/candle-pyo3/tests/native/test_tensor.py
+++ b/candle-pyo3/tests/native/test_tensor.py
@@ -146,6 +146,6 @@ def test_tensor_equality_opperations_can_broadcast():
 def test_tensor_can_be_hashed():
     t = Tensor(42.0)
     other = Tensor(42.0)
-    # Hash should represent the a unique tensor
+    # Hash should represent a unique tensor
     assert hash(t) != hash(other)
     assert hash(t) == hash(t)


### PR DESCRIPTION
This PR adds support for all equality operations between tensors and scalars/tensors. This also has the same broadcasting behavior as pytorch/numpy meaning the `rhs` and `lhs` will be automatically broadcasted into the right shapes for the comparison.  