### PR TITLE
PyO3: Add typehinting for magic/dunder methodes

### DIFF
--- a/candle-pyo3/_additional_typing/README.md
+++ b/candle-pyo3/_additional_typing/README.md
@@ -1,0 +1,3 @@
+This python module contains external typehinting for certain `candle` classes. This is only necessary for `magic` methodes e.g. `__add__` as their text signature cant be set via pyo3.
+
+The classes in this module will be parsed by the `stub.py` script and interleafed with the signatures of the actual pyo3 `candle.candle` module.

--- a/candle-pyo3/_additional_typing/__init__.py
+++ b/candle-pyo3/_additional_typing/__init__.py
@@ -1,0 +1,55 @@
+from typing import Union, Sequence
+
+
+class Tensor:
+    """
+    This contains the type hints for the magic methodes of the `candle.Tensor` class.
+    """
+
+    def __add__(self, rhs: Union["Tensor", "Scalar"]) -> "Tensor":
+        """
+        Add a scalar to a tensor or two tensors together.
+        """
+        pass
+
+    def __radd__(self, rhs: Union["Tensor", "Scalar"]) -> "Tensor":
+        """
+        Add a scalar to a tensor or two tensors together.
+        """
+        pass
+
+    def __sub__(self, rhs: Union["Tensor", "Scalar"]) -> "Tensor":
+        """
+        Subtract a scalar from a tensor or one tensor from another.
+        """
+        pass
+
+    def __truediv__(self, rhs: Union["Tensor", "Scalar"]) -> "Tensor":
+        """
+        Divide a tensor by a scalar or one tensor by another.
+        """
+        pass
+
+    def __mul__(self, rhs: Union["Tensor", "Scalar"]) -> "Tensor":
+        """
+        Multiply a tensor by a scalar or one tensor by another.
+        """
+        pass
+
+    def __rmul__(self, rhs: Union["Tensor", "Scalar"]) -> "Tensor":
+        """
+        Multiply a tensor by a scalar or one tensor by another.
+        """
+        pass
+
+    def __richcmp__(self, rhs: Union["Tensor", "Scalar"], op) -> "Tensor":
+        """
+        Compare a tensor with a scalar or one tensor with another.
+        """
+        pass
+
+    def __getitem__(self, index: Union["Index", "Tensor", Sequence["Index"]]) -> "Tensor":
+        """
+        Return a slice of a tensor.
+        """
+        pass

--- a/candle-pyo3/py_src/candle/__init__.pyi
+++ b/candle-pyo3/py_src/candle/__init__.pyi
@@ -1,7 +1,7 @@
 # Generated content DO NOT EDIT
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, Sequence
 from os import PathLike
-from candle.typing import _ArrayLike, Device
+from candle.typing import _ArrayLike, Device, Scalar, Index
 
 class bf16(DType):
     pass
@@ -118,6 +118,46 @@ class Tensor:
     """
 
     def __init__(self, data: _ArrayLike):
+        pass
+    def __add__(self, rhs: Union[Tensor, Scalar]) -> "Tensor":
+        """
+        Add a scalar to a tensor or two tensors together.
+        """
+        pass
+    def __getitem__(self, index: Union[Index, Tensor, Sequence[Index]]) -> "Tensor":
+        """
+        Return a slice of a tensor.
+        """
+        pass
+    def __mul__(self, rhs: Union[Tensor, Scalar]) -> "Tensor":
+        """
+        Multiply a tensor by a scalar or one tensor by another.
+        """
+        pass
+    def __radd__(self, rhs: Union[Tensor, Scalar]) -> "Tensor":
+        """
+        Add a scalar to a tensor or two tensors together.
+        """
+        pass
+    def __richcmp__(self, rhs: Union[Tensor, Scalar], op) -> "Tensor":
+        """
+        Compare a tensor with a scalar or one tensor with another.
+        """
+        pass
+    def __rmul__(self, rhs: Union[Tensor, Scalar]) -> "Tensor":
+        """
+        Multiply a tensor by a scalar or one tensor by another.
+        """
+        pass
+    def __sub__(self, rhs: Union[Tensor, Scalar]) -> "Tensor":
+        """
+        Subtract a scalar from a tensor or one tensor from another.
+        """
+        pass
+    def __truediv__(self, rhs: Union[Tensor, Scalar]) -> "Tensor":
+        """
+        Divide a tensor by a scalar or one tensor by another.
+        """
         pass
     def argmax_keepdim(self, dim: int) -> Tensor:
         """

--- a/candle-pyo3/py_src/candle/functional/__init__.pyi
+++ b/candle-pyo3/py_src/candle/functional/__init__.pyi
@@ -1,7 +1,7 @@
 # Generated content DO NOT EDIT
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, Sequence
 from os import PathLike
-from candle.typing import _ArrayLike, Device
+from candle.typing import _ArrayLike, Device, Scalar, Index
 from candle import Tensor, DType, QTensor
 
 @staticmethod

--- a/candle-pyo3/py_src/candle/typing/__init__.py
+++ b/candle-pyo3/py_src/candle/typing/__init__.py
@@ -14,3 +14,7 @@ CPU: str = "cpu"
 CUDA: str = "cuda"
 
 Device = TypeVar("Device", CPU, CUDA)
+
+Scalar = Union[int, float]
+
+Index = Union[int, slice, None, "Ellipsis"]

--- a/candle-pyo3/py_src/candle/utils/__init__.pyi
+++ b/candle-pyo3/py_src/candle/utils/__init__.pyi
@@ -1,7 +1,7 @@
 # Generated content DO NOT EDIT
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, Sequence
 from os import PathLike
-from candle.typing import _ArrayLike, Device
+from candle.typing import _ArrayLike, Device, Scalar, Index
 from candle import Tensor, DType, QTensor
 
 @staticmethod


### PR DESCRIPTION
This PR adds the missing typehints for magic methodes e.g. `__add__`. Meaning with this PR the candle  should now be completely typehinted. 
 

https://github.com/huggingface/candle/assets/65088241/68409e07-89a6-40e2-9f95-ec109a96989d

# How it works

Since `pyo3` doesn't allow us to set the text signature or even change the doc-string of a magic method the typing information have to be stored externally. For this reason the `candle-pyo3/_additional_typing/__init__.py`  module was created to enable the definition of additional functions for candle classes. The `stub.py` script will import this module and extract all classes from it and combine the function signatures of classes with the same name. 

## Drawbacks
This means the magic/dunder signatures have to be defined manually in an additional file, if they should be typehinted. Realistically this shouldn't be a problem as it's very unlikely, that the signature of these methods will ever change, but i still would like your opinion on this approach.