### PR TITLE
Add step indexing

### DIFF
--- a/candle-core/src/lib.rs
+++ b/candle-core/src/lib.rs
@@ -72,7 +72,7 @@ pub use cpu_backend::CpuStorage;
 pub use device::{Device, DeviceLocation};
 pub use dtype::{DType, FloatDType, IntDType, WithDType};
 pub use error::{Error, Result};
-pub use indexer::IndexOp;
+pub use indexer::{IndexOp, StepRange};
 pub use layout::Layout;
 pub use op::{CustomOp1, CustomOp2, CustomOp3};
 pub use shape::{Shape, D};

--- a/candle-core/tests/indexing_tests.rs
+++ b/candle-core/tests/indexing_tests.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use candle_core::{Device, IndexOp, Tensor};
+use candle_core::{Device, IndexOp, StepRange, Tensor};
 
 #[test]
 fn integer_index() -> Result<()> {
@@ -89,5 +89,34 @@ fn index_3d() -> Result<()> {
         &[[3, 7, 11], [15, 19, 23]]
     );
     assert_eq!(tensor.i((1, .., 3))?.to_vec1::<u32>()?, &[15, 19, 23]);
+    Ok(())
+}
+
+#[test]
+fn step_index() -> Result<()> {
+    let tensor = Tensor::from_iter(0..=10u32, &Device::Cpu)?;
+    assert_eq!(
+        tensor.i(StepRange::new(.., 1))?.to_vec1::<u32>()?,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    );
+
+    assert_eq!(
+        tensor.i(StepRange::new(.., 2))?.to_vec1::<u32>()?,
+        &[0, 2, 4, 6, 8, 10]
+    );
+    assert_eq!(
+        tensor.i(StepRange::new(1.., 2))?.to_vec1::<u32>()?,
+        &[1, 3, 5, 7, 9]
+    );
+
+    assert_eq!(
+        tensor.i(StepRange::new(.., -1))?.to_vec1::<u32>()?,
+        &[10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+    );
+    assert_eq!(
+        tensor.i(StepRange::new(..5, -1))?.to_vec1::<u32>()?,
+        &[4, 3, 2, 1, 0]
+    );
+
     Ok(())
 }

--- a/candle-examples/examples/blip/README.md
+++ b/candle-examples/examples/blip/README.md
@@ -1,0 +1,19 @@
+# candle-blip
+
+The
+[blip-image-captioning](https://huggingface.co/Salesforce/blip-image-captioning-base)
+model can generate captions for an input image.
+
+## Running on an example
+
+```bash
+cargo run --example blip --release -- --image candle-examples/examples/yolo-v8/assets/bike.jpg
+```
+
+```
+Running on CPU, to run on GPU, build this example with `--features cuda`
+loaded image Tensor[dims 3, 384, 384; f32]
+model built
+several cyclists are riding down a road with cars behind them%
+```
+![Leading group, Giro d'Italia 2021](../yolo-v8/assets/bike.jpg)


### PR DESCRIPTION
Adds a new public type called `StepRange` which implements `Into<TensorIndexer>`, so it can be used to index tensors with a step size other than one. Supports negative step sizes, which index starting from the end instead of starting from the beginning.

Resolves #1133.