### PR TITLE
Candle Optim: separate crate for optimisers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "candle-examples",
     "candle-book",
     "candle-nn",
+    "candle-optim",
     "candle-pyo3",
     "candle-transformers",
     "candle-wasm-examples/llama2-c",

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Documentation](https://docs.rs/candle-core/badge.svg)](https://docs.rs/candle-core)
 ![License](https://img.shields.io/crates/l/candle-core.svg)
 
-Candle is a minimalist ML framework for Rust with a focus on performance (including GPU support) 
-and ease of use. Try our online demos: 
+Candle is a minimalist ML framework for Rust with a focus on performance (including GPU support)
+and ease of use. Try our online demos:
 [whisper](https://huggingface.co/spaces/lmz/candle-whisper),
 [LLaMA2](https://huggingface.co/spaces/lmz/candle-llama2),
 [T5](https://huggingface.co/spaces/radames/Candle-T5-Generation-Wasm),
@@ -73,7 +73,7 @@ We also provide a some command line based examples using state of the art models
   [llama.cpp](https://github.com/ggerganov/llama.cpp).
 
 <img src="https://github.com/huggingface/candle/raw/main/candle-examples/examples/quantized/assets/aoc.gif" width="600">
-  
+
 - [Stable Diffusion](./candle-examples/examples/stable-diffusion/): text to
   image generative model, support for the 1.5, 2.1, and SDXL 1.0 versions.
 
@@ -210,6 +210,7 @@ Cheatsheet:
 - [candle-datasets](./candle-datasets/): Datasets and data loaders.
 - [candle-transformers](./candle-transformers): transformers-related utilities.
 - [candle-flash-attn](./candle-flash-attn): Flash attention v2 layer.
+- [candle-optim](./candle-optim): Optimizers (momentum SGD, AdaGrad ...).
 
 ## FAQ
 
@@ -237,7 +238,7 @@ Finally, Rust is cool! A lot of the HF ecosystem already has Rust crates, like [
 - [burn](https://github.com/burn-rs/burn) is a general crate that can leverage multiple backends so you can choose the best
   engine for your workload.
 
-- [tch-rs](https://github.com/LaurentMazare/tch-rs.git) Bindings to the torch library in Rust. Extremely versatile, but they 
+- [tch-rs](https://github.com/LaurentMazare/tch-rs.git) Bindings to the torch library in Rust. Extremely versatile, but they
   bring in the entire torch library into the runtime. The main contributor of `tch-rs` is also involved in the development
   of `candle`.
 

--- a/candle-optim/Cargo.toml
+++ b/candle-optim/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "candle-optim"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+candle = { path = "../candle-core", version = "0.3.0", package = "candle-core" }
+candle-nn = { path = "../candle-nn", version = "0.3.0" }
+intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"], optional = true }
+
+
+[dev-dependencies]
+anyhow = { version = "1", features = ["backtrace"] }
+
+[features]
+default = []
+cuda = ["candle/cuda", "candle-nn/cuda"]
+mkl = ["dep:intel-mkl-src", "candle/mkl"]

--- a/candle-optim/Cargo.toml
+++ b/candle-optim/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
 license.workspace = true
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/candle-optim/README.md
+++ b/candle-optim/README.md
@@ -1,9 +1,11 @@
 # Optimisers
 
-A crate for optimisers for use with candle, the minimalist ML framework
+A crate for optimisers for use with candle, the minimalist ML framework, similar to pytorch optim.
 
 * Momentum enhanced SGD
 
 * AdaGrad
 
 * AdaDelta
+
+All optimisers are currently tested against their implementation in 2.1.0+cu118

--- a/candle-optim/README.md
+++ b/candle-optim/README.md
@@ -1,0 +1,9 @@
+# Optimisers
+
+A crate for optimisers for use with candle, the minimalist ML framework
+
+* Momentum enhanced SGD
+
+* AdaGrad
+
+* AdaDelta

--- a/candle-optim/examples/adagrad.rs
+++ b/candle-optim/examples/adagrad.rs
@@ -1,0 +1,40 @@
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use candle::{DType, Device, Result, Tensor};
+use candle_nn::{linear, Linear, Module, Optimizer, VarBuilder, VarMap};
+use candle_optim::adagrad::{Adagrad, ParamsAdaGrad};
+
+fn gen_data() -> Result<(Tensor, Tensor)> {
+    // Generate some sample linear data.
+    let w_gen = Tensor::new(&[[3f32, 1.]], &Device::Cpu)?;
+    let b_gen = Tensor::new(-2f32, &Device::Cpu)?;
+    let gen = Linear::new(w_gen, Some(b_gen));
+    let sample_xs = Tensor::new(&[[2f32, 1.], [7., 4.], [-4., 12.], [5., 8.]], &Device::Cpu)?;
+    let sample_ys = gen.forward(&sample_xs)?;
+    Ok((sample_xs, sample_ys))
+}
+
+fn main() -> Result<()> {
+    let (sample_xs, sample_ys) = gen_data()?;
+
+    // Use backprop to run a linear regression between samples and get the coefficients back.
+    let varmap = VarMap::new();
+    let vb = VarBuilder::from_varmap(&varmap, DType::F32, &Device::Cpu);
+    let model = linear(2, 1, vb.pp("linear"))?;
+    let params = ParamsAdaGrad {
+        lr: 0.3,
+        ..Default::default()
+    };
+    let mut opt = Adagrad::new(varmap.all_vars(), params)?;
+    for step in 0..10000 {
+        let ys = model.forward(&sample_xs)?;
+        let loss = ys.sub(&sample_ys)?.sqr()?.sum_all()?;
+        opt.backward_step(&loss)?;
+        println!("{step} {}", loss.to_vec0::<f32>()?);
+    }
+    Ok(())
+}

--- a/candle-optim/src/adadelta.rs
+++ b/candle-optim/src/adadelta.rs
@@ -1,0 +1,125 @@
+use candle::{Result, Tensor, TensorId, Var};
+use candle_nn::optim::Optimizer;
+use std::collections::HashMap;
+
+/// Adadelta optimizer
+///
+/// Described in <https://arxiv.org/abs/1212.5701>
+///
+/// For pseudocde see <https://pytorch.org/docs/stable/generated/torch.optim.Adadelta.html>
+
+#[derive(Debug)]
+pub struct Adadelta {
+    vars: Vec<Var>,
+    params: ParamsAdaDelta,
+    avg_acc: HashMap<TensorId, (Tensor, Tensor)>,
+}
+
+#[derive(Debug)]
+pub struct ParamsAdaDelta {
+    pub lr: f64,
+    pub rho: f64,
+    pub eps: f64,
+    pub weight_decay: f64,
+}
+
+impl Default for ParamsAdaDelta {
+    fn default() -> Self {
+        Self {
+            lr: 1.0,
+            rho: 0.9,
+            weight_decay: 0.0,
+            eps: 1e-6,
+        }
+    }
+}
+
+impl Optimizer for Adadelta {
+    type Config = ParamsAdaDelta;
+
+    fn new(vars: Vec<Var>, params: ParamsAdaDelta) -> Result<Self> {
+        let vars = vars
+            .into_iter()
+            .filter(|var| var.dtype().is_float())
+            .collect();
+        // // Err(SGDError::NoMomentum)?;
+        // let mut params = params;
+        // params.t = 0;
+        Ok(Self {
+            vars,
+            params,
+            avg_acc: HashMap::new(),
+        })
+    }
+
+    fn learning_rate(&self) -> f64 {
+        self.params.lr
+    }
+
+    fn step(&mut self, grads: &candle::backprop::GradStore) -> Result<()> {
+        for var in &self.vars {
+            if let Some(grad) = grads.get(var) {
+                if self.params.weight_decay == 0. {
+                    if let Some((v, u)) = self.avg_acc.get(&var.id()) {
+                        let v =
+                            ((v * self.params.rho)? + (1. - self.params.rho) * grad.powf(2.)?)?;
+                        let delta_x = (((u + self.params.eps)?.powf(0.5)?)
+                            .div(&((&v + self.params.eps)?.powf(0.5)?))?
+                            * grad)?;
+                        let u = ((u * self.params.rho)?
+                            + (1. - self.params.rho) * delta_x.powf(2.)?)?;
+                        var.set(&var.sub(&(delta_x * self.params.lr)?)?)?;
+                        self.avg_acc.insert(var.id(), (v, u));
+                    } else {
+                        // start  u and v as 0 tensors
+                        let v = ((1. - self.params.rho) * grad.powf(2.)?)?;
+                        let delta_x = ((self.params.eps.powf(0.5))
+                            * (&((&v + self.params.eps)?.powf(-0.5)?))
+                            * grad)?;
+                        let u = ((1. - self.params.rho) * delta_x.powf(2.)?)?;
+                        var.set(&var.sub(&(delta_x * self.params.lr)?)?)?;
+                        self.avg_acc.insert(var.id(), (v, u));
+                    };
+                } else {
+                    let grad = &(grad + (self.params.weight_decay * var.as_tensor())?)?;
+                    if let Some((v, u)) = self.avg_acc.get(&var.id()) {
+                        let v =
+                            ((v * self.params.rho)? + (1. - self.params.rho) * grad.powf(2.)?)?;
+                        let delta_x = (((u + self.params.eps)?.powf(0.5)?)
+                            .div(&((&v + self.params.eps)?.powf(0.5)?))?
+                            * grad)?;
+                        let u = ((u * self.params.rho)?
+                            + (1. - self.params.rho) * delta_x.powf(2.)?)?;
+                        var.set(&var.sub(&(delta_x * self.params.lr)?)?)?;
+                        self.avg_acc.insert(var.id(), (v, u));
+                    } else {
+                        // start  u and v as 0 tensors
+                        let v = ((1. - self.params.rho) * grad.powf(2.)?)?;
+                        let delta_x = ((self.params.eps.powf(0.5))
+                            * (&((&v + self.params.eps)?.powf(-0.5)?))
+                            * grad)?;
+                        let u = ((1. - self.params.rho) * delta_x.powf(2.)?)?;
+                        var.set(&var.sub(&(delta_x * self.params.lr)?)?)?;
+                        self.avg_acc.insert(var.id(), (v, u));
+                    };
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn set_learning_rate(&mut self, lr: f64) {
+        self.params.lr = lr;
+    }
+}
+
+impl Adadelta {
+    #[must_use]
+    pub fn into_inner(self) -> Vec<Var> {
+        self.vars
+    }
+
+    pub fn push(&mut self, var: &Var) {
+        self.vars.push(var.clone());
+    }
+}

--- a/candle-optim/src/adagrad.rs
+++ b/candle-optim/src/adagrad.rs
@@ -1,0 +1,113 @@
+use candle::{Result, Tensor, TensorId, Var};
+use candle_nn::optim::Optimizer;
+use std::collections::HashMap;
+
+/// Adagrad optimizer
+///
+/// Described in <https://jmlr.org/papers/v12/duchi11a.html>
+///
+/// For pseudocde see <https://pytorch.org/docs/stable/generated/torch.optim.Adagrad.html>
+
+#[derive(Debug)]
+pub struct Adagrad {
+    vars: Vec<Var>,
+    params: ParamsAdaGrad,
+    t: usize,
+    state_sum: HashMap<TensorId, Tensor>,
+}
+
+#[derive(Debug)]
+pub struct ParamsAdaGrad {
+    pub lr: f64,
+    pub lr_decay: f64,
+    pub initial_acc: f64,
+    pub dampening: f64,
+    pub weight_decay: f64,
+    pub eps: f64,
+}
+
+impl Default for ParamsAdaGrad {
+    fn default() -> Self {
+        Self {
+            lr: 0.01,
+            lr_decay: 0.0,
+            initial_acc: 0.0,
+            dampening: 0.0,
+            weight_decay: 0.0,
+            eps: 1e-10,
+        }
+    }
+}
+
+impl Optimizer for Adagrad {
+    type Config = ParamsAdaGrad;
+
+    fn new(vars: Vec<Var>, params: ParamsAdaGrad) -> Result<Self> {
+        let vars = vars
+            .into_iter()
+            .filter(|var| var.dtype().is_float())
+            .collect();
+        // // Err(SGDError::NoMomentum)?;
+        // let mut params = params;
+        // params.t = 0;
+        Ok(Self {
+            vars,
+            t: 0,
+            params,
+            state_sum: HashMap::new(),
+        })
+    }
+
+    fn learning_rate(&self) -> f64 {
+        self.params.lr
+    }
+
+    fn step(&mut self, grads: &candle::backprop::GradStore) -> Result<()> {
+        for var in &self.vars {
+            if let Some(grad) = grads.get(var) {
+                #[allow(clippy::cast_precision_loss)]
+                let gamma_tilde = self.params.lr / (1. + (self.t as f64 * self.params.lr_decay));
+                if self.params.weight_decay == 0. {
+                    // let gt = (grad + (self.params.weight_decay * var.as_tensor())?)?;
+                    let current_sum = if let Some(sum) = self.state_sum.get(&var.id()) {
+                        (sum + grad.powf(2.)?)?
+                    } else {
+                        (self.params.initial_acc + grad.powf(2.)?)?
+                    };
+                    let change =
+                        (gamma_tilde * (grad.div(&(current_sum.powf(0.5)? + self.params.eps)?))?)?;
+                    self.state_sum.insert(var.id(), current_sum);
+                    var.set(&var.sub(&change)?)?;
+                } else {
+                    let grad = &(grad + (self.params.weight_decay * var.as_tensor())?)?;
+                    let current_sum = if let Some(sum) = self.state_sum.get(&var.id()) {
+                        (sum + grad.powf(2.)?)?
+                    } else {
+                        (self.params.initial_acc + grad.powf(2.)?)?
+                    };
+                    let change =
+                        (gamma_tilde * (grad.div(&(current_sum.powf(0.5)? + self.params.eps)?))?)?;
+                    self.state_sum.insert(var.id(), current_sum);
+                    var.set(&var.sub(&change)?)?;
+                }
+            }
+        }
+        self.t += 1;
+        Ok(())
+    }
+
+    fn set_learning_rate(&mut self, lr: f64) {
+        self.params.lr = lr;
+    }
+}
+
+impl Adagrad {
+    #[must_use]
+    pub fn into_inner(self) -> Vec<Var> {
+        self.vars
+    }
+
+    pub fn push(&mut self, var: &Var) {
+        self.vars.push(var.clone());
+    }
+}

--- a/candle-optim/src/esgd.rs
+++ b/candle-optim/src/esgd.rs
@@ -1,0 +1,151 @@
+use candle::{Result, Tensor, TensorId, Var};
+use candle_nn::optim::Optimizer;
+use std::collections::HashMap;
+
+/// Optimizer for Stochastic Gradient Descent with momentum.
+///
+/// Utilised same interface as pytorch but allows negative momenta and dampening with Nesterov
+///
+/// For pseudocde see <https://pytorch.org/docs/stable/generated/torch.optim.SGD.html>
+
+#[derive(Debug)]
+pub struct MomentumEnhancedSGD {
+    vars: Vec<Var>,
+    params: ParamsMESGD,
+    prev_step: HashMap<TensorId, Tensor>,
+}
+
+#[derive(Debug)]
+pub struct ParamsMESGD {
+    pub lr: f64,
+    pub weight_decay: f64,
+    pub momentum: f64,
+    pub dampening: f64,
+    pub nesterov: bool,
+}
+
+impl Default for ParamsMESGD {
+    fn default() -> Self {
+        Self {
+            lr: 0.1,
+            weight_decay: 0.,
+            momentum: 0.1,
+            dampening: 0.0,
+            nesterov: false,
+        }
+    }
+}
+
+impl Optimizer for MomentumEnhancedSGD {
+    type Config = ParamsMESGD;
+
+    fn new(vars: Vec<Var>, params: ParamsMESGD) -> Result<Self> {
+        let vars = vars
+            .into_iter()
+            .filter(|var| var.dtype().is_float())
+            .collect();
+        // Err(SGDError::NoMomentum)?;
+        Ok(Self {
+            vars,
+            params,
+            prev_step: HashMap::new(),
+        })
+    }
+
+    fn learning_rate(&self) -> f64 {
+        self.params.lr
+    }
+
+    fn step(&mut self, grads: &candle::backprop::GradStore) -> Result<()> {
+        for var in &self.vars {
+            if let Some(grad) = grads.get(var) {
+                if self.params.weight_decay == 0. {
+                    if let Some(prev_step) = self.prev_step.get(&var.id()) {
+                        // println!("Exists");
+                        // bt​←μbt−1​+(1−τ)gt
+                        let bt = ((prev_step * self.params.momentum)?
+                            + (1. - self.params.dampening) * (grad))?;
+                        if self.params.nesterov {
+                            let gt = (grad + (self.params.momentum * &bt)?)?;
+                            // println!("Momentum {}", bt);
+                            self.prev_step.insert(var.id(), bt);
+                            var.set(&var.sub(&(gt * self.params.lr)?)?)?;
+                        } else {
+                            // if not nesterov gt = bt
+                            var.set(&var.sub(&(&bt * self.params.lr)?)?)?;
+                            // println!("Momentum {}", bt);
+                            self.prev_step.insert(var.id(), bt);
+                        };
+                    } else {
+                        // println!("Doesn't Exist");
+                        // bt​←μbt−1​+(1−τ)gt
+                        // if there is no history bt = gt = grad with no weight_decay
+                        let bt = grad.clone(); // clone must occur invariably due to need to store in hashmap
+                        if self.params.nesterov {
+                            let gt = (grad + (self.params.momentum * &bt)?)?;
+                            // println!("Momentum {}", bt);
+                            self.prev_step.insert(var.id(), bt);
+                            var.set(&var.sub(&(gt * self.params.lr)?)?)?;
+                        } else {
+                            // if not nesterov gt = bt
+                            var.set(&var.sub(&(&bt * self.params.lr)?)?)?;
+                            // println!("Momentum {}", bt);
+                            self.prev_step.insert(var.id(), bt);
+                        };
+                    };
+                } else {
+                    let grad = &(grad + (self.params.weight_decay * var.as_tensor())?)?;
+                    if let Some(prev_step) = self.prev_step.get(&var.id()) {
+                        // println!("Exists");
+                        // bt​←μbt−1​+(1−τ)gt
+                        let bt = ((prev_step * self.params.momentum)?
+                            + (1. - self.params.dampening) * (grad))?;
+                        if self.params.nesterov {
+                            let gt = (grad + (self.params.momentum * &bt)?)?;
+                            // println!("Momentum {}", bt);
+                            self.prev_step.insert(var.id(), bt);
+                            var.set(&var.sub(&(gt * self.params.lr)?)?)?;
+                        } else {
+                            // if not nesterov gt = bt
+                            var.set(&var.sub(&(&bt * self.params.lr)?)?)?;
+                            // println!("Momentum {}", bt);
+                            self.prev_step.insert(var.id(), bt);
+                        };
+                    } else {
+                        // println!("Doesn't Exist");
+                        // bt​←μbt−1​+(1−τ)gt
+                        // if there is no history bt = gt = grad with no weight_decay
+                        let bt = grad.clone(); // clone must occur invariably due to need to store in hashmap
+                        if self.params.nesterov {
+                            let gt = (grad + (self.params.momentum * &bt)?)?;
+                            // println!("Momentum {}", bt);
+                            self.prev_step.insert(var.id(), bt);
+                            var.set(&var.sub(&(gt * self.params.lr)?)?)?;
+                        } else {
+                            // if not nesterov gt = bt
+                            var.set(&var.sub(&(&bt * self.params.lr)?)?)?;
+                            // println!("Momentum {}", bt);
+                            self.prev_step.insert(var.id(), bt);
+                        };
+                    };
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn set_learning_rate(&mut self, lr: f64) {
+        self.params.lr = lr;
+    }
+}
+
+impl MomentumEnhancedSGD {
+    #[must_use]
+    pub fn into_inner(self) -> Vec<Var> {
+        self.vars
+    }
+
+    pub fn push(&mut self, var: &Var) {
+        self.vars.push(var.clone());
+    }
+}

--- a/candle-optim/src/lib.rs
+++ b/candle-optim/src/lib.rs
@@ -1,0 +1,11 @@
+#![warn(
+    clippy::pedantic,
+    clippy::suspicious,
+    clippy::perf,
+    clippy::complexity,
+    clippy::style,
+    clippy::cargo
+)]
+pub mod adadelta;
+pub mod adagrad;
+pub mod esgd;

--- a/candle-optim/tests/adadelta_tests.rs
+++ b/candle-optim/tests/adadelta_tests.rs
@@ -1,0 +1,100 @@
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use candle::test_utils::{to_vec0_round, to_vec2_round};
+
+use anyhow::Result;
+use candle::{Device, Tensor, Var};
+use candle_nn::{Linear, Module, Optimizer};
+use candle_optim::adadelta::{Adadelta, ParamsAdaDelta};
+
+/* The results of this test have been checked against the following PyTorch code.
+    import torch
+    from torch import optim
+
+    w_gen = torch.tensor([[3., 1.]])
+    b_gen = torch.tensor([-2.])
+
+    sample_xs = torch.tensor([[2., 1.], [7., 4.], [-4., 12.], [5., 8.]])
+    sample_ys = sample_xs.matmul(w_gen.t()) + b_gen
+
+    m = torch.nn.Linear(2, 1)
+    with torch.no_grad():
+        m.weight.zero_()
+        m.bias.zero_()
+    optimizer = optim.Adadelta(m.parameters(), lr=0.004)
+    # optimizer.zero_grad()
+    for _step in range(100):
+        optimizer.zero_grad()
+        ys = m(sample_xs)
+        loss = ((ys - sample_ys)**2).sum()
+        loss.backward()
+        optimizer.step()
+        # print("Optimizer state begin")
+        # print(optimizer.state)
+        # print("Optimizer state end")
+    print(m.weight)
+    print(m.bias)
+*/
+#[test]
+fn adadelta_test() -> Result<()> {
+    // Generate some linear data, y = 3.x1 + x2 - 2.
+    let w_gen = Tensor::new(&[[3f32, 1.]], &Device::Cpu)?;
+    let b_gen = Tensor::new(-2f32, &Device::Cpu)?;
+    let gen = Linear::new(w_gen, Some(b_gen));
+    let sample_xs = Tensor::new(&[[2f32, 1.], [7., 4.], [-4., 12.], [5., 8.]], &Device::Cpu)?;
+    let sample_ys = gen.forward(&sample_xs)?;
+
+    let params = ParamsAdaDelta {
+        lr: 0.004,
+        rho: 0.9,
+        weight_decay: 0.0,
+        eps: 1e-6,
+    };
+    // Now use backprop to run a linear regression between samples and get the coefficients back.
+    let w = Var::new(&[[0f32, 0.]], &Device::Cpu)?;
+    let b = Var::new(0f32, &Device::Cpu)?;
+    let mut n_sgd = Adadelta::new(vec![w.clone(), b.clone()], params)?;
+    let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
+    for _step in 0..100 {
+        let ys = lin.forward(&sample_xs)?;
+        let loss = ys.sub(&sample_ys)?.sqr()?.sum_all()?;
+        n_sgd.backward_step(&loss)?;
+    }
+    assert_eq!(to_vec2_round(&w, 4)?, &[[0.0016, 0.0016]]);
+    assert_eq!(to_vec0_round(&b, 4)?, 0.0016);
+    Ok(())
+}
+
+#[test]
+fn adadelta_weight_decay_test() -> Result<()> {
+    // Generate some linear data, y = 3.x1 + x2 - 2.
+    let w_gen = Tensor::new(&[[3f32, 1.]], &Device::Cpu)?;
+    let b_gen = Tensor::new(-2f32, &Device::Cpu)?;
+    let gen = Linear::new(w_gen, Some(b_gen));
+    let sample_xs = Tensor::new(&[[2f32, 1.], [7., 4.], [-4., 12.], [5., 8.]], &Device::Cpu)?;
+    let sample_ys = gen.forward(&sample_xs)?;
+
+    let params = ParamsAdaDelta {
+        lr: 0.004,
+        rho: 0.9,
+        weight_decay: 0.8,
+        eps: 1e-6,
+    };
+    // Now use backprop to run a linear regression between samples and get the coefficients back.
+    let w = Var::new(&[[0f32, 0.]], &Device::Cpu)?;
+    let b = Var::new(0f32, &Device::Cpu)?;
+    let mut n_sgd = Adadelta::new(vec![w.clone(), b.clone()], params)?;
+    let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
+    for _step in 0..100 {
+        let ys = lin.forward(&sample_xs)?;
+        let loss = ys.sub(&sample_ys)?.sqr()?.sum_all()?;
+        n_sgd.backward_step(&loss)?;
+    }
+    assert_eq!(to_vec2_round(&w, 4)?, &[[0.0016, 0.0016]]);
+    assert_eq!(to_vec0_round(&b, 4)?, 0.0016);
+    Ok(())
+}

--- a/candle-optim/tests/adagrad_tests.rs
+++ b/candle-optim/tests/adagrad_tests.rs
@@ -1,0 +1,192 @@
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use candle::test_utils::{to_vec0_round, to_vec2_round};
+
+use anyhow::Result;
+use candle::{Device, Tensor, Var};
+use candle_nn::{Linear, Module, Optimizer};
+use candle_optim::adagrad::{Adagrad, ParamsAdaGrad};
+
+/* The results of this test have been checked against the following PyTorch code.
+    import torch
+    from torch import optim
+
+    w_gen = torch.tensor([[3., 1.]])
+    b_gen = torch.tensor([-2.])
+
+    sample_xs = torch.tensor([[2., 1.], [7., 4.], [-4., 12.], [5., 8.]])
+    sample_ys = sample_xs.matmul(w_gen.t()) + b_gen
+
+    m = torch.nn.Linear(2, 1)
+    with torch.no_grad():
+        m.weight.zero_()
+        m.bias.zero_()
+    optimizer = optim.Adagrad(m.parameters(), lr=0.004, weight_decay=0.00)
+    # optimizer.zero_grad()
+    for _step in range(1000):
+        optimizer.zero_grad()
+        ys = m(sample_xs)
+        loss = ((ys - sample_ys)**2).sum()
+        loss.backward()
+        optimizer.step()
+        # print("Optimizer state begin")
+        # print(optimizer.state)
+        # print("Optimizer state end")
+    print(m.weight)
+    print(m.bias)
+*/
+#[test]
+fn adagrad_test() -> Result<()> {
+    // Generate some linear data, y = 3.x1 + x2 - 2.
+    let w_gen = Tensor::new(&[[3f32, 1.]], &Device::Cpu)?;
+    let b_gen = Tensor::new(-2f32, &Device::Cpu)?;
+    let gen = Linear::new(w_gen, Some(b_gen));
+    let sample_xs = Tensor::new(&[[2f32, 1.], [7., 4.], [-4., 12.], [5., 8.]], &Device::Cpu)?;
+    let sample_ys = gen.forward(&sample_xs)?;
+
+    let params = ParamsAdaGrad {
+        lr: 0.004,
+        lr_decay: 0.0,
+        weight_decay: 0.0,
+        initial_acc: 0.0,
+        eps: 1e-10,
+        dampening: 0.0,
+    };
+    // Now use backprop to run a linear regression between samples and get the coefficients back.
+    let w = Var::new(&[[0f32, 0.]], &Device::Cpu)?;
+    let b = Var::new(0f32, &Device::Cpu)?;
+    let mut n_sgd = Adagrad::new(vec![w.clone(), b.clone()], params)?;
+    let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
+    for _step in 0..1000 {
+        let ys = lin.forward(&sample_xs)?;
+        let loss = ys.sub(&sample_ys)?.sqr()?.sum_all()?;
+        n_sgd.backward_step(&loss)?;
+    }
+    assert_eq!(to_vec2_round(&w, 4)?, &[[0.2424, 0.2341]]);
+    assert_eq!(to_vec0_round(&b, 4)?, 0.2379);
+    Ok(())
+}
+
+/* The results of this test have been checked against the following PyTorch code.
+    import torch
+    from torch import optim
+
+    w_gen = torch.tensor([[3., 1.]])
+    b_gen = torch.tensor([-2.])
+
+    sample_xs = torch.tensor([[2., 1.], [7., 4.], [-4., 12.], [5., 8.]])
+    sample_ys = sample_xs.matmul(w_gen.t()) + b_gen
+
+    m = torch.nn.Linear(2, 1)
+    with torch.no_grad():
+        m.weight.zero_()
+        m.bias.zero_()
+    optimizer = optim.Adagrad(m.parameters(), lr=0.004, lr_decay=0.2)
+    # optimizer.zero_grad()
+    for _step in range(1000):
+        optimizer.zero_grad()
+        ys = m(sample_xs)
+        loss = ((ys - sample_ys)**2).sum()
+        loss.backward()
+        optimizer.step()
+        # print("Optimizer state begin")
+        # print(optimizer.state)
+        # print("Optimizer state end")
+    print(m.weight)
+    print(m.bias)
+*/
+#[test]
+fn adagrad_lr_decay_test() -> Result<()> {
+    // Generate some linear data, y = 3.x1 + x2 - 2.
+    let w_gen = Tensor::new(&[[3f32, 1.]], &Device::Cpu)?;
+    let b_gen = Tensor::new(-2f32, &Device::Cpu)?;
+    let gen = Linear::new(w_gen, Some(b_gen));
+    let sample_xs = Tensor::new(&[[2f32, 1.], [7., 4.], [-4., 12.], [5., 8.]], &Device::Cpu)?;
+    let sample_ys = gen.forward(&sample_xs)?;
+
+    let params = ParamsAdaGrad {
+        lr: 0.004,
+        lr_decay: 0.2,
+        weight_decay: 0.0,
+        initial_acc: 0.0,
+        eps: 1e-10,
+        dampening: 0.0,
+    };
+    // Now use backprop to run a linear regression between samples and get the coefficients back.
+    let w = Var::new(&[[0f32, 0.]], &Device::Cpu)?;
+    let b = Var::new(0f32, &Device::Cpu)?;
+    let mut n_sgd = Adagrad::new(vec![w.clone(), b.clone()], params)?;
+    let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
+    for _step in 0..1000 {
+        let ys = lin.forward(&sample_xs)?;
+        let loss = ys.sub(&sample_ys)?.sqr()?.sum_all()?;
+        n_sgd.backward_step(&loss)?;
+    }
+    assert_eq!(to_vec2_round(&w, 4)?, &[[0.0231, 0.0230]]);
+    assert_eq!(to_vec0_round(&b, 4)?, 0.0230);
+    Ok(())
+}
+
+/* The results of this test have been checked against the following PyTorch code.
+    import torch
+    from torch import optim
+
+    w_gen = torch.tensor([[3., 1.]])
+    b_gen = torch.tensor([-2.])
+
+    sample_xs = torch.tensor([[2., 1.], [7., 4.], [-4., 12.], [5., 8.]])
+    sample_ys = sample_xs.matmul(w_gen.t()) + b_gen
+
+    m = torch.nn.Linear(2, 1)
+    with torch.no_grad():
+        m.weight.zero_()
+        m.bias.zero_()
+    optimizer = optim.Adagrad(m.parameters(), lr=0.004, weight_decay=0.2)
+    # optimizer.zero_grad()
+    for _step in range(1000):
+        optimizer.zero_grad()
+        ys = m(sample_xs)
+        loss = ((ys - sample_ys)**2).sum()
+        loss.backward()
+        optimizer.step()
+        # print("Optimizer state begin")
+        # print(optimizer.state)
+        # print("Optimizer state end")
+    print(m.weight)
+    print(m.bias)
+*/
+#[test]
+fn adagrad_weight_decay_test() -> Result<()> {
+    // Generate some linear data, y = 3.x1 + x2 - 2.
+    let w_gen = Tensor::new(&[[3f32, 1.]], &Device::Cpu)?;
+    let b_gen = Tensor::new(-2f32, &Device::Cpu)?;
+    let gen = Linear::new(w_gen, Some(b_gen));
+    let sample_xs = Tensor::new(&[[2f32, 1.], [7., 4.], [-4., 12.], [5., 8.]], &Device::Cpu)?;
+    let sample_ys = gen.forward(&sample_xs)?;
+
+    let params = ParamsAdaGrad {
+        lr: 0.004,
+        lr_decay: 0.0,
+        weight_decay: 0.2,
+        initial_acc: 0.0,
+        eps: 1e-10,
+        dampening: 0.0,
+    };
+    // Now use backprop to run a linear regression between samples and get the coefficients back.
+    let w = Var::new(&[[0f32, 0.]], &Device::Cpu)?;
+    let b = Var::new(0f32, &Device::Cpu)?;
+    let mut n_sgd = Adagrad::new(vec![w.clone(), b.clone()], params)?;
+    let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
+    for _step in 0..1000 {
+        let ys = lin.forward(&sample_xs)?;
+        let loss = ys.sub(&sample_ys)?.sqr()?.sum_all()?;
+        n_sgd.backward_step(&loss)?;
+    }
+    assert_eq!(to_vec2_round(&w, 4)?, &[[0.2424, 0.2341]]);
+    assert_eq!(to_vec0_round(&b, 4)?, 0.2378);
+    Ok(())
+}

--- a/candle-optim/tests/esgd_tests.rs
+++ b/candle-optim/tests/esgd_tests.rs
@@ -1,0 +1,247 @@
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use candle::test_utils::{to_vec0_round, to_vec2_round};
+
+use anyhow::Result;
+use candle::{Device, Tensor, Var};
+use candle_nn::{Linear, Module, Optimizer};
+use candle_optim::esgd::{MomentumEnhancedSGD, ParamsMESGD};
+
+/* The results of this test have been checked against the following PyTorch code.
+    import torch
+    from torch import optim
+
+    w_gen = torch.tensor([[3., 1.]])
+    b_gen = torch.tensor([-2.])
+
+    sample_xs = torch.tensor([[2., 1.], [7., 4.], [-4., 12.], [5., 8.]])
+    sample_ys = sample_xs.matmul(w_gen.t()) + b_gen
+
+    m = torch.nn.Linear(2, 1)
+    with torch.no_grad():
+        m.weight.zero_()
+        m.bias.zero_()
+    optimizer = optim.SGD(m.parameters(), lr=0.004, momentum=0.1, nesterov=True)
+    for _step in range(100):
+        optimizer.zero_grad()
+        ys = m(sample_xs)
+        loss = ((ys - sample_ys)**2).sum()
+        loss.backward()
+        optimizer.step()
+    print(m.weight)
+    print(m.bias)
+*/
+#[test]
+fn nesterov_sgd_test() -> Result<()> {
+    // Generate some linear data, y = 3.x1 + x2 - 2.
+    let w_gen = Tensor::new(&[[3f32, 1.]], &Device::Cpu)?;
+    let b_gen = Tensor::new(-2f32, &Device::Cpu)?;
+    let gen = Linear::new(w_gen, Some(b_gen));
+    let sample_xs = Tensor::new(&[[2f32, 1.], [7., 4.], [-4., 12.], [5., 8.]], &Device::Cpu)?;
+    let sample_ys = gen.forward(&sample_xs)?;
+
+    let params = ParamsMESGD {
+        lr: 0.004,
+        weight_decay: 0.0,
+        momentum: 0.1,
+        dampening: 0.0,
+        nesterov: true,
+    };
+    // Now use backprop to run a linear regression between samples and get the coefficients back.
+    let w = Var::new(&[[0f32, 0.]], &Device::Cpu)?;
+    let b = Var::new(0f32, &Device::Cpu)?;
+    let mut n_sgd = MomentumEnhancedSGD::new(vec![w.clone(), b.clone()], params)?;
+    let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
+    for _step in 0..100 {
+        let ys = lin.forward(&sample_xs)?;
+        let loss = ys.sub(&sample_ys)?.sqr()?.sum_all()?;
+        n_sgd.backward_step(&loss)?;
+    }
+    assert_eq!(to_vec2_round(&w, 4)?, &[[1.0750, -9.9042]]);
+    assert_eq!(to_vec0_round(&b, 4)?, -1.8961);
+    Ok(())
+}
+
+/* The results of this test have been checked against the following PyTorch code.
+    import torch
+    from torch import optim
+
+    w_gen = torch.tensor([[3., 1.]])
+    b_gen = torch.tensor([-2.])
+
+    sample_xs = torch.tensor([[2., 1.], [7., 4.], [-4., 12.], [5., 8.]])
+    sample_ys = sample_xs.matmul(w_gen.t()) + b_gen
+
+    m = torch.nn.Linear(2, 1)
+    with torch.no_grad():
+        m.weight.zero_()
+        m.bias.zero_()
+    optimizer = optim.SGD(m.parameters(), lr=0.004, momentum=0.1, nesterov=True, weight_decay = 0.1)
+    # optimizer.zero_grad()
+    for _step in range(100):
+        optimizer.zero_grad()
+        ys = m(sample_xs)
+        loss = ((ys - sample_ys)**2).sum()
+        loss.backward()
+        optimizer.step()
+        # print("Optimizer state begin")
+        # print(optimizer.state)
+        # print("Optimizer state end")
+    print(m.weight)
+    print(m.bias)
+*/
+#[test]
+fn nesterov_decay_sgd_test() -> Result<()> {
+    // Generate some linear data, y = 3.x1 + x2 - 2.
+    let w_gen = Tensor::new(&[[3f32, 1.]], &Device::Cpu)?;
+    let b_gen = Tensor::new(-2f32, &Device::Cpu)?;
+    let gen = Linear::new(w_gen, Some(b_gen));
+    let sample_xs = Tensor::new(&[[2f32, 1.], [7., 4.], [-4., 12.], [5., 8.]], &Device::Cpu)?;
+    let sample_ys = gen.forward(&sample_xs)?;
+
+    let params = ParamsMESGD {
+        lr: 0.004,
+        weight_decay: 0.1,
+        momentum: 0.1,
+        dampening: 0.0,
+        nesterov: true,
+    };
+    // Now use backprop to run a linear regression between samples and get the coefficients back.
+    let w = Var::new(&[[0f32, 0.]], &Device::Cpu)?;
+    let b = Var::new(0f32, &Device::Cpu)?;
+    let mut n_sgd = MomentumEnhancedSGD::new(vec![w.clone(), b.clone()], params)?;
+    let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
+    for _step in 0..100 {
+        let ys = lin.forward(&sample_xs)?;
+        let loss = ys.sub(&sample_ys)?.sqr()?.sum_all()?;
+        n_sgd.backward_step(&loss)?;
+    }
+
+    assert_eq!(to_vec2_round(&w, 4)?, &[[0.9921, -10.3803]]);
+    assert_eq!(to_vec0_round(&b, 4)?, -1.9331);
+    Ok(())
+}
+
+/* The results of this test have been checked against the following PyTorch code.
+    import torch
+    from torch import optim
+
+    w_gen = torch.tensor([[3., 1.]])
+    b_gen = torch.tensor([-2.])
+
+    sample_xs = torch.tensor([[2., 1.], [7., 4.], [-4., 12.], [5., 8.]])
+    sample_ys = sample_xs.matmul(w_gen.t()) + b_gen
+
+    m = torch.nn.Linear(2, 1)
+    with torch.no_grad():
+        m.weight.zero_()
+        m.bias.zero_()
+    optimizer = optim.SGD(m.parameters(), lr=0.004, momentum=0.1, nesterov=False, weight_decay = 0.0)
+    # optimizer.zero_grad()
+    for _step in range(100):
+        optimizer.zero_grad()
+        ys = m(sample_xs)
+        loss = ((ys - sample_ys)**2).sum()
+        loss.backward()
+        optimizer.step()
+        # print("Optimizer state begin")
+        # print(optimizer.state)
+        # print("Optimizer state end")
+    print(m.weight)
+    print(m.bias)
+*/
+#[test]
+fn momentum_sgd_test() -> Result<()> {
+    // Generate some linear data, y = 3.x1 + x2 - 2.
+    let w_gen = Tensor::new(&[[3f32, 1.]], &Device::Cpu)?;
+    let b_gen = Tensor::new(-2f32, &Device::Cpu)?;
+    let gen = Linear::new(w_gen, Some(b_gen));
+    let sample_xs = Tensor::new(&[[2f32, 1.], [7., 4.], [-4., 12.], [5., 8.]], &Device::Cpu)?;
+    let sample_ys = gen.forward(&sample_xs)?;
+
+    let params = ParamsMESGD {
+        lr: 0.004,
+        weight_decay: 0.0,
+        momentum: 0.1,
+        dampening: 0.0,
+        nesterov: false,
+    };
+    // Now use backprop to run a linear regression between samples and get the coefficients back.
+    let w = Var::new(&[[0f32, 0.]], &Device::Cpu)?;
+    let b = Var::new(0f32, &Device::Cpu)?;
+    let mut n_sgd = MomentumEnhancedSGD::new(vec![w.clone(), b.clone()], params)?;
+    let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
+    for _step in 0..100 {
+        let ys = lin.forward(&sample_xs)?;
+        let loss = ys.sub(&sample_ys)?.sqr()?.sum_all()?;
+        n_sgd.backward_step(&loss)?;
+    }
+
+    assert_eq!(to_vec2_round(&w, 4)?, &[[2.8870, 0.8589]]);
+    assert_eq!(to_vec0_round(&b, 4)?, -0.6341);
+    Ok(())
+}
+
+/* The results of this test have been checked against the following PyTorch code.
+    import torch
+    from torch import optim
+
+    w_gen = torch.tensor([[3., 1.]])
+    b_gen = torch.tensor([-2.])
+
+    sample_xs = torch.tensor([[2., 1.], [7., 4.], [-4., 12.], [5., 8.]])
+    sample_ys = sample_xs.matmul(w_gen.t()) + b_gen
+
+    m = torch.nn.Linear(2, 1)
+    with torch.no_grad():
+        m.weight.zero_()
+        m.bias.zero_()
+    optimizer = optim.SGD(m.parameters(), lr=0.004, momentum=0.1, nesterov=False, weight_decay = 0.0, dampening = 0.2)
+    # optimizer.zero_grad()
+    for _step in range(100):
+        optimizer.zero_grad()
+        ys = m(sample_xs)
+        loss = ((ys - sample_ys)**2).sum()
+        loss.backward()
+        optimizer.step()
+        # print("Optimizer state begin")
+        # print(optimizer.state)
+        # print("Optimizer state end")
+    print(m.weight)
+    print(m.bias)
+*/
+#[test]
+fn momentum_sgd_dampened_test() -> Result<()> {
+    // Generate some linear data, y = 3.x1 + x2 - 2.
+    let w_gen = Tensor::new(&[[3f32, 1.]], &Device::Cpu)?;
+    let b_gen = Tensor::new(-2f32, &Device::Cpu)?;
+    let gen = Linear::new(w_gen, Some(b_gen));
+    let sample_xs = Tensor::new(&[[2f32, 1.], [7., 4.], [-4., 12.], [5., 8.]], &Device::Cpu)?;
+    let sample_ys = gen.forward(&sample_xs)?;
+
+    let params = ParamsMESGD {
+        lr: 0.004,
+        weight_decay: 0.0,
+        momentum: 0.1,
+        dampening: 0.2,
+        nesterov: false,
+    };
+    // Now use backprop to run a linear regression between samples and get the coefficients back.
+    let w = Var::new(&[[0f32, 0.]], &Device::Cpu)?;
+    let b = Var::new(0f32, &Device::Cpu)?;
+    let mut n_sgd = MomentumEnhancedSGD::new(vec![w.clone(), b.clone()], params)?;
+    let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
+    for _step in 0..100 {
+        let ys = lin.forward(&sample_xs)?;
+        let loss = ys.sub(&sample_ys)?.sqr()?.sum_all()?;
+        n_sgd.backward_step(&loss)?;
+    }
+
+    assert_eq!(to_vec2_round(&w, 4)?, &[[2.8746, 0.8434]]);
+    assert_eq!(to_vec0_round(&b, 4)?, -0.4838);
+    Ok(())
+}


### PR DESCRIPTION
This creates a new crate called candle-optim.

The main optimizer trait still lives in candle-nn as moving it out would currently be a breaking API change.

This currently adds 3 new optimizers:

* MomentumEnhancedSGD able to implement all functionality of pytorch SGD although currently does not validate the parameters in the same manner
* AdaDelta
* AdaGrad

These have all been checked against their implementation in pytorch 2.1.0+cu118.

The main advantage of this being in the huggingface/candle repo as opposed to my own is visibility, to increase the likelihood of people able to implement other algorithms for optimisation and people able to speed up the current algorithms (such as implementing and equivalent of for_each and fused methods in candle)