### PR TITLE
convert pytorch's tensor in Python API

### DIFF
--- a/candle-pyo3/py_src/candle/__init__.pyi
+++ b/candle-pyo3/py_src/candle/__init__.pyi
@@ -396,6 +396,11 @@ class Tensor:
         Convert the tensor to a new dtype.
         """
         pass
+    def to_torch(self) -> torch.Tensor:
+        """
+        Converts candle's tensor to pytorch's tensor
+        """
+        pass
     def transpose(self, dim1: int, dim2: int) -> Tensor:
         """
         Returns a tensor that is a transposed version of the input, the given dimensions are swapped.

--- a/candle-pyo3/src/lib.rs
+++ b/candle-pyo3/src/lib.rs
@@ -211,6 +211,16 @@ enum Indexer {
     IndexSelect(Tensor),
 }
 
+#[derive(Clone, Debug)]
+struct TorchTensor(PyObject);
+
+impl<'source> pyo3::FromPyObject<'source> for TorchTensor {
+    fn extract(ob: &'source PyAny) -> PyResult<Self> {
+        let numpy_value: PyObject = ob.getattr("numpy")?.call0()?.extract()?;
+        Ok(TorchTensor(numpy_value))
+    }
+}
+
 #[pymethods]
 impl PyTensor {
     #[new]
@@ -246,6 +256,8 @@ impl PyTensor {
             Tensor::new(vs, &Cpu).map_err(wrap_err)?
         } else if let Ok(vs) = data.extract::<Vec<Vec<Vec<f32>>>>(py) {
             Tensor::new(vs, &Cpu).map_err(wrap_err)?
+        } else if let Ok(TorchTensor(numpy)) = data.extract::<TorchTensor>(py) {
+            return PyTensor::new(py, numpy);
         } else {
             let ty = data.as_ref(py).get_type();
             Err(PyTypeError::new_err(format!(
@@ -297,6 +309,18 @@ impl PyTensor {
         }
         // TODO: Handle arbitrary shapes.
         M(py).map(self)
+    }
+
+    /// Converts candle's tensor to pytorch's tensor
+    /// &RETURNS&: torch.Tensor
+    fn to_torch(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let candle_values = self.values(py)?;
+        let torch_tensor: PyObject = py
+            .import("torch")?
+            .getattr("tensor")?
+            .call1((candle_values,))?
+            .extract()?;
+        Ok(torch_tensor)
     }
 
     #[getter]

--- a/candle-pyo3/test.py
+++ b/candle-pyo3/test.py
@@ -1,4 +1,5 @@
 import candle
+import torch
 
 print(f"mkl:         {candle.utils.has_mkl()}")
 print(f"accelerate:  {candle.utils.has_accelerate()}")
@@ -29,3 +30,15 @@ quant_t = t.quantize("q6k")
 dequant_t = quant_t.dequantize()
 diff2 = (t - dequant_t).sqr()
 print(diff2.mean_all())
+
+# convert from candle tensor to torch tensor
+t = candle.randn((3, 512, 512))
+torch_tensor = t.to_torch()
+print(torch_tensor)
+print(type(torch_tensor))
+
+# convert from torch tensor to candle tensor
+t = torch.randn((3, 512, 512))
+candle_tensor = candle.Tensor(t)
+print(candle_tensor)
+print(type(candle_tensor))

--- a/candle-pyo3/test.py
+++ b/candle-pyo3/test.py
@@ -1,5 +1,4 @@
 import candle
-import torch
 
 print(f"mkl:         {candle.utils.has_mkl()}")
 print(f"accelerate:  {candle.utils.has_accelerate()}")
@@ -30,15 +29,3 @@ quant_t = t.quantize("q6k")
 dequant_t = quant_t.dequantize()
 diff2 = (t - dequant_t).sqr()
 print(diff2.mean_all())
-
-# convert from candle tensor to torch tensor
-t = candle.randn((3, 512, 512))
-torch_tensor = t.to_torch()
-print(torch_tensor)
-print(type(torch_tensor))
-
-# convert from torch tensor to candle tensor
-t = torch.randn((3, 512, 512))
-candle_tensor = candle.Tensor(t)
-print(candle_tensor)
-print(type(candle_tensor))

--- a/candle-pyo3/test_pytorch.py
+++ b/candle-pyo3/test_pytorch.py
@@ -1,0 +1,14 @@
+import candle
+import torch
+
+# convert from candle tensor to torch tensor
+t = candle.randn((3, 512, 512))
+torch_tensor = t.to_torch()
+print(torch_tensor)
+print(type(torch_tensor))
+
+# convert from torch tensor to candle tensor
+t = torch.randn((3, 512, 512))
+candle_tensor = candle.Tensor(t)
+print(candle_tensor)
+print(type(candle_tensor))


### PR DESCRIPTION
regarding #1087, this PR implements the ability to convert `torch` tensor from/to `candle` tensor as follows:

- `candle` to `torch`: extract `candle` tensor value and use `PyO3` interop to create `torch` tensor.
- `torch` to `candle`: extract `numpy` value from the input `torch` tensor using `PyO3` interop and create `candle` tensor with it.