### PR TITLE
Add fuse-conv-bn method for Conv2d

### DIFF
--- a/candle-examples/examples/yolo-v8/model.rs
+++ b/candle-examples/examples/yolo-v8/model.rs
@@ -1,7 +1,5 @@
 use candle::{DType, IndexOp, Result, Tensor, D};
-use candle_nn::{
-    batch_norm, conv2d, conv2d_no_bias, Conv2d, Conv2dConfig, Module, VarBuilder,
-};
+use candle_nn::{batch_norm, conv2d, conv2d_no_bias, Conv2d, Conv2dConfig, Module, VarBuilder};
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Multiples {

--- a/candle-nn/src/batch_norm.rs
+++ b/candle-nn/src/batch_norm.rs
@@ -111,7 +111,7 @@ impl BatchNorm {
 
     pub fn eps(&self) -> f64 {
         self.eps
-    }    
+    }
 
     pub fn weight_and_bias(&self) -> Option<(&Tensor, &Tensor)> {
         self.weight_and_bias.as_ref().map(|v| (&v.0, &v.1))

--- a/candle-nn/src/batch_norm.rs
+++ b/candle-nn/src/batch_norm.rs
@@ -109,6 +109,10 @@ impl BatchNorm {
         &self.running_var
     }
 
+    pub fn eps(&self) -> f64 {
+        self.eps
+    }    
+
     pub fn weight_and_bias(&self) -> Option<(&Tensor, &Tensor)> {
         self.weight_and_bias.as_ref().map(|v| (&v.0, &v.1))
     }

--- a/candle-nn/src/conv.rs
+++ b/candle-nn/src/conv.rs
@@ -118,18 +118,21 @@ impl Conv2d {
     }
 
     pub fn absorb_bn(&self, bn: &BatchNorm) -> Result<Self> {
-        let (w_bn, b_bn) = bn.weight_and_bias().unwrap();
-        let std_ = w_bn.div(&((bn.running_var() + bn.eps())?.sqrt()?))?;
-        let weight = self.weight().broadcast_mul(&(std_.reshape((self.weight().dims4()?.0, 1, 1, 1))?))?;
-        let bias = match &self.bias {
-            None => b_bn.sub(&(std_.mul(&bn.running_mean())?))?,
-            Some(bias) => b_bn.add(&(std_.mul(&bias.sub(&bn.running_mean())?)?))?,
-        };
-        Ok(Self {
-            weight,
-            bias: Some(bias),
-            config: self.config
-        })
+        if let Some((w_bn, b_bn)) = bn.weight_and_bias() {
+           let std_ = w_bn.div(&((bn.running_var() + bn.eps())?.sqrt()?))?;
+            let weight = self.weight().broadcast_mul(&(std_.reshape((self.weight().dims4()?.0, 1, 1, 1))?))?;
+            let bias = match &self.bias {
+                None => b_bn.sub(&(std_.mul(&bn.running_mean())?))?,
+                Some(bias) => b_bn.add(&(std_.mul(&bias.sub(&bn.running_mean())?)?))?,
+            };
+            Ok(Self {
+                weight,
+                bias: Some(bias),
+                config: self.config
+            }) 
+        } else {
+            candle::bail!("batch norm does not have weight_and_bias")
+        }
     }
 }
 

--- a/candle-nn/src/conv.rs
+++ b/candle-nn/src/conv.rs
@@ -1,6 +1,6 @@
 //! Convolution Layers.
-use candle::{Result, Tensor};
 use crate::BatchNorm;
+use candle::{Result, Tensor};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Conv1dConfig {
@@ -119,17 +119,19 @@ impl Conv2d {
 
     pub fn absorb_bn(&self, bn: &BatchNorm) -> Result<Self> {
         if let Some((w_bn, b_bn)) = bn.weight_and_bias() {
-           let std_ = w_bn.div(&((bn.running_var() + bn.eps())?.sqrt()?))?;
-            let weight = self.weight().broadcast_mul(&(std_.reshape((self.weight().dims4()?.0, 1, 1, 1))?))?;
+            let std_ = w_bn.div(&((bn.running_var() + bn.eps())?.sqrt()?))?;
+            let weight = self
+                .weight()
+                .broadcast_mul(&(std_.reshape((self.weight().dims4()?.0, 1, 1, 1))?))?;
             let bias = match &self.bias {
-                None => b_bn.sub(&(std_.mul(&bn.running_mean())?))?,
-                Some(bias) => b_bn.add(&(std_.mul(&bias.sub(&bn.running_mean())?)?))?,
+                None => b_bn.sub(&(std_.mul(bn.running_mean())?))?,
+                Some(bias) => b_bn.add(&(std_.mul(&bias.sub(bn.running_mean())?)?))?,
             };
             Ok(Self {
                 weight,
                 bias: Some(bias),
-                config: self.config
-            }) 
+                config: self.config,
+            })
         } else {
             candle::bail!("batch norm does not have weight_and_bias")
         }


### PR DESCRIPTION
### PR for [https://github.com/huggingface/candle/issues/1149](url)


### 1. Add a fuse-conv-bn method: `absorb_bn(&self, bn: &BatchNorm) -> Result<Self>` for Conv2d.
The BatchNorm2d layer will be absorb into Conv2d, and return a Conv2d which has bias parameter. Whether the Conv2d layer has bias or not, this method can fuse adjacent Conv2d and BatchNorm2d layers together.

**usage:**
```
...
let bn = batch_norm(c2, 1e-3, vb.pp("bn"))?;
let conv = conv2d_no_bias(c1, c2, k, cfg, vb.pp("conv"))?.absorb_bn(&bn)?;
...
```

### 2. Expose another filed from BatchNorm in order to fuse Conv2d and BatchNorm.
```
impl BatchNorm {
    ...
    pub fn eps(&self) -> f64 {
        self.eps
    } 
}
```

### 3. A slight modification to yolo-v8 example: 

- Removed `bn` field in `ConvBlock`
- Add fused_conv for inference



## Comparative experiment
### Env
- GPU: NVIDIA GeForce RTX 3060, 12036MiB)
- CPU: 12th Gen Intel(R) Core(TM) i5-12400F
- OS: Ubuntu 23.04
- Model: yolov8s.pt, yolov8s.onnx, yolov8s.safetensors

### Example
`cargo run --release --features cuda  --example yolo-v8 -- --model ./yolov8s.safetensors --which s candle-examples/examples/yolo-v8/assets/bike.jpg`

###  20 times inference of `let predictions = model.forward(&image_t)?.squeeze(0)?;`

**Before** ==>  `Silu(BN(Conv2d(xs)))`  
Forward : 61.892098ms
Forward : 29.135077ms
Forward : 27.852497ms
Forward : 28.609387ms
Forward : 27.01425ms
Forward : 27.019482ms
Forward : 26.935323ms
Forward : 27.050945ms
Forward : 26.719977ms
Forward : 26.942656ms
Forward : 25.886604ms
Forward : 27.8262ms
Forward : 26.914334ms
Forward : 27.045991ms
Forward : 26.954339ms
Forward : 26.752925ms
Forward : 26.563086ms
Forward : 26.795354ms
Forward : 26.647943ms
Forward : 26.849186ms
Forward : 26.854436ms

**After** ==>  `Silu(Conv2d(xs))`  
Forward : 41.397483ms
Forward : 24.402086ms
Forward : 24.167527ms
Forward : 23.946848ms
Forward : 22.95527ms
Forward : 22.527519ms
Forward : 22.992553ms
Forward : 22.022945ms
Forward : 21.245696ms
Forward : 22.592846ms
Forward : 23.00923ms
Forward : 22.073522ms
Forward : 21.979598ms
Forward : 23.03203ms
Forward : 22.92703ms
Forward : 21.764525ms
Forward : 22.368902ms
Forward : 23.05773ms
Forward : 22.122301ms
Forward : 20.983996ms
Forward : 22.300197ms

**Accelerated by ~4ms**