### PR TITLE
candle-transformers: minor differences between t5 and quantized_t5

### DIFF
--- a/candle-transformers/src/models/quantized_t5.rs
+++ b/candle-transformers/src/models/quantized_t5.rs
@@ -536,7 +536,7 @@ impl T5Block {
             None
         };
         let ff_i = if cross_attn.is_some() { 2 } else { 1 };
-        let ff = T5LayerFF::load(vb.pp(ff_i), cfg)?;
+        let ff = T5LayerFF::load(vb.pp(&ff_i.to_string()), cfg)?;
         Ok(Self {
             self_attn,
             cross_attn,
@@ -594,7 +594,7 @@ struct T5Stack {
 impl T5Stack {
     fn load(decoder: bool, vb: VarBuilder, shared: &Arc<Embedding>, cfg: &Config) -> Result<Self> {
         let block = (0..cfg.num_layers)
-            .map(|i| T5Block::load(i == 0, decoder, vb.pp(format!("block.{i}")), cfg))
+            .map(|i| T5Block::load(i == 0, decoder, vb.pp(&format!("block.{i}")), cfg))
             .collect::<Result<Vec<_>>>()?;
         let final_layer_norm = T5LayerNorm::load(
             cfg.d_model,


### PR DESCRIPTION
Background: I am thinking about implementing quantized_bert. To better understand the changes necessary, I went through t5 vs quantized_t5 - and noticed a smaller difference.

Not sure if this is just a nit, or if there is some potential bug that can be caused from this.

`quantized_t5.rs` uses:
```rust
vb.pp(ff_i)
```
but `t5.rs` uses
```rust
vb.pp(&ff_i.to_string()
```
