### PR TITLE
Add hard-sigmoid and hard-swish activations

### DIFF
--- a/candle-nn/src/activation.rs
+++ b/candle-nn/src/activation.rs
@@ -13,7 +13,9 @@ pub enum Activation {
     Relu6,
     Silu,
     Sigmoid,
+    HardSigmoid,
     Swish,
+    HardSwish,
     Elu(f64),
     LeakyRelu(f64),
 }
@@ -29,7 +31,9 @@ impl super::Module for Activation {
             Self::Relu6 => xs.clamp(0f32, 6f32),
             Self::Silu => crate::ops::silu(xs),
             Self::Sigmoid => crate::ops::sigmoid(xs),
+            Self::HardSigmoid => crate::ops::hard_sigmoid(xs),
             Self::Swish => xs * crate::ops::sigmoid(xs)?,
+            Self::HardSwish => xs * crate::ops::hard_sigmoid(xs)?,
             &Self::Elu(alpha) => xs.elu(alpha),
             &Self::LeakyRelu(negative_slope) => crate::ops::leaky_relu(xs, negative_slope),
         }

--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -1,5 +1,6 @@
 use candle::{CpuStorage, Layout, Result, Shape, Tensor};
 use rayon::prelude::*;
+use std::ops::Div;
 
 /// Applies the softmax function to the input tensor, rescaling the element so that elements on
 /// a slice of fixed index on dimension `dim` are between 0 and 1 and sum to 1.
@@ -46,8 +47,7 @@ pub fn sigmoid(xs: &Tensor) -> Result<Tensor> {
 
 pub fn hard_sigmoid(xs: &Tensor) -> Result<Tensor> {
     // TODO: Should we have a specialized op for this?
-    let six = Tensor::new(6f32, xs.device())?;
-    ((xs + 3.0) / six)?.clamp(0f32, 1f32)
+    ((xs + 3.0)?.div(6.0))?.clamp(0f32, 1f32)
 }
 
 pub fn leaky_relu(xs: &Tensor, negative_slope: f64) -> Result<Tensor> {

--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -44,6 +44,12 @@ pub fn sigmoid(xs: &Tensor) -> Result<Tensor> {
     (xs.neg()?.exp()? + 1.0)?.recip()
 }
 
+pub fn hard_sigmoid(xs: &Tensor) -> Result<Tensor> {
+    // TODO: Should we have a specialized op for this?
+    let six = Tensor::new(6f32, xs.device())?;
+    ((xs + 3.0) / six)?.clamp(0f32, 1f32)
+}
+
 pub fn leaky_relu(xs: &Tensor, negative_slope: f64) -> Result<Tensor> {
     let zeros = xs.zeros_like()?;
     xs.maximum(&zeros)? + xs.minimum(&zeros)? * negative_slope

--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -1,6 +1,5 @@
 use candle::{CpuStorage, Layout, Result, Shape, Tensor};
 use rayon::prelude::*;
-use std::ops::Div;
 
 /// Applies the softmax function to the input tensor, rescaling the element so that elements on
 /// a slice of fixed index on dimension `dim` are between 0 and 1 and sum to 1.
@@ -47,7 +46,7 @@ pub fn sigmoid(xs: &Tensor) -> Result<Tensor> {
 
 pub fn hard_sigmoid(xs: &Tensor) -> Result<Tensor> {
     // TODO: Should we have a specialized op for this?
-    ((xs + 3.0)?.div(6.0))?.clamp(0f32, 1f32)
+    ((xs + 3.0)? / 6.0)?.clamp(0f32, 1f32)
 }
 
 pub fn leaky_relu(xs: &Tensor, negative_slope: f64) -> Result<Tensor> {


### PR DESCRIPTION
I am building a model which use hardsigmoid() activation, basically equals: relu6(x+3) / 6
More details at: [https://pytorch.org/docs/stable/generated/torch.nn.functional.hardsigmoid.html#torch.nn.functional.hardsigmoid](url)


And I found Candle hasn't provide it yet. So This PR is for that.