### PR TITLE
Add candle-vllm as an external resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ And then head over to
   including SGD with momentum, AdaGrad, AdaDelta, AdaMax, NAdam, RAdam, and RMSprop.
 - [`candle-lora`](https://github.com/EricLBuehler/candle-lora): a LoRA implementation
   that conforms to the official `peft` implementation.
+- [`candle-vllm`](https://github.com/EricLBuehler/candle-vllm): Efficent platform for inference and
+  serving local LLMs including an OpenAI compatible API server.
 
 If you have an addition to this list, please submit a pull request.
 


### PR DESCRIPTION
Hello everybody,

I have been developing [`candle-vllm`](https://github.com/EricLBuehler/candle-vllm) for the past week now - it is an OpenAI compatible API server that allows you to serve Candle LLMs locally. 

As mentioned in #1247, it currently has a Llama pipeline implemented and will shortly have support for other pipelines (other Candle models) added.

In this PR, I have simply added a link to [`candle-vllm`](https://github.com/EricLBuehler/candle-vllm) in the external resources section. 

Thank you for your consideration!
