### PR TITLE
Add Kalosm to the list of external resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ And then head over to
   that conforms to the official `peft` implementation.
 - [`candle-vllm`](https://github.com/EricLBuehler/candle-vllm): Efficent platform for inference and
   serving local LLMs including an OpenAI compatible API server.
+- [`kalosm`](https://github.com/floneum/floneum/tree/master/kalosm): A multi-modal meta-framework in Rust for interfacing with local pre-trained models with support for controlled generation, custom samplers, in-memory vector databases, audio transcription, and more.
 
 If you have an addition to this list, please submit a pull request.
 


### PR DESCRIPTION
👋 I have been working on a meta-framework built around candle model for the past month called [kalosm](https://github.com/floneum/floneum/blob/master/kalosm/README.md). It provides a higher level API over some models from `candle-tranformers`:
- LLMs (Phi, Mistral)
   - Controlled generation support through a [nom](https://github.com/rust-bakery/nom)-like incremental parser combinator framework
   - Custom sampler support
   - Streaming support
- Embeddings (Bert, Llama through `llm.rs`)
   - Document databases with support for fetching data from the web, search engines and local documents in various formats
   - Batched embedding support
- Transcription support through Whisper
   - Microphone integration (eg. [gather context from the live surroundings](https://github.com/floneum/floneum/blob/master/kalosm/examples/live_qa.rs))
- Image generation through Wuerstchen with support for the image crate
- Image segmentation with segmant-anything with support for the image crate

This PR adds `Kalosm` to the resources section of `candle`.

Thank you for your work on candle, it has been great to work with so far!