### PR TITLE
feat: impl backprop for erf and gelu-erf

### DIFF
--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -534,14 +534,14 @@ impl Tensor {
                     }
                     Op::Unary(arg, UnaryOp::Erf) => {
                         let sum_grad = grads.or_insert(arg)?;
-                        // d/dx = erf(x) = 2/sqrt(pi) * e^(-x^2)
+                        // d/dx erf(x) = 2/sqrt(pi) * e^(-x^2)
                         let erf_grad =
                             (2. / std::f64::consts::PI.sqrt()) * (arg.sqr()?.neg()?).exp()?;
                         *sum_grad = sum_grad.add(&(&grad * erf_grad)?)?
                     }
                     Op::Unary(arg, UnaryOp::GeluErf) => {
                         let sum_grad = grads.or_insert(arg)?;
-                        // d/dx = 0.5 + 0.398942 e^(-x^2/2) x + 0.5 erf(x/sqrt(2))
+                        // d/dx gelu_erf(x) = 0.5 + 0.398942 e^(-x^2/2) x + 0.5 erf(x/sqrt(2))
                         let neg_half_square = (arg.sqr()?.neg()? / 2.)?;
                         let scaled_exp_arg = (0.398942 * neg_half_square.exp()? * arg)?;
                         let arg_scaled_sqrt = (arg / 2f64.sqrt())?;

--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -532,9 +532,22 @@ impl Tensor {
                             + 0.5)?;
                         *sum_grad = sum_grad.add(&(&grad * gelu_grad)?)?
                     }
-                    Op::Unary(_, UnaryOp::Erf) => Err(Error::BackwardNotSupported { op: "erf" })?,
-                    Op::Unary(_, UnaryOp::GeluErf) => {
-                        Err(Error::BackwardNotSupported { op: "gelu-erf" })?
+                    Op::Unary(arg, UnaryOp::Erf) => {
+                        let sum_grad = grads.or_insert(arg)?;
+                        // d/dx = erf(x) = 2/sqrt(pi) * e^(-x^2)
+                        let erf_grad =
+                            (2. / std::f64::consts::PI.sqrt()) * (arg.sqr()?.neg()?).exp()?;
+                        *sum_grad = sum_grad.add(&(&grad * erf_grad)?)?
+                    }
+                    Op::Unary(arg, UnaryOp::GeluErf) => {
+                        let sum_grad = grads.or_insert(arg)?;
+                        // d/dx = 0.5 + 0.398942 e^(-x^2/2) x + 0.5 erf(x/sqrt(2))
+                        let neg_half_square = (arg.sqr()?.neg()? / 2.)?;
+                        let scaled_exp_arg = (0.398942 * neg_half_square.exp()? * arg)?;
+                        let arg_scaled_sqrt = (arg / 2f64.sqrt())?;
+                        let erf_scaled_sqrt = (0.5 * arg_scaled_sqrt.erf()?)?;
+                        let gelu_erf_grad = (0.5 + scaled_exp_arg + erf_scaled_sqrt)?;
+                        *sum_grad = sum_grad.add(&(&grad * gelu_erf_grad)?)?;
                     }
                     Op::Unary(arg, UnaryOp::Relu) => {
                         let sum_grad = grads.or_insert(arg)?;

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -641,6 +641,8 @@ impl UnaryOpT for Gelu {
     }
 }
 
+/// `erf` operation
+/// <https://en.wikipedia.org/wiki/Error_function>
 impl UnaryOpT for Erf {
     const NAME: &'static str = "erf";
     const KERNEL: &'static str = "uerf";

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -206,8 +206,34 @@ fn unary_grad(device: &Device) -> Result<()> {
         [1.0116, 1.0830, 1.0003, 0.6188],
     );
 
-    // testing compared to pytorch nn.GELU(approximate = None)
-    // https://pytorch.org/docs/stable/generated/torch.nn.functional.gelu.html
+    // Testing compared to pytorch torch.erf
+    //
+    // import torch
+    // x = torch.tensor([3.0, 1.0, 4.0, 0.15], requires_grad=True)
+    // y = x.erf()
+    // print(y)
+    // loss = y.sum()
+    // loss.backward()
+    // print(x.grad)
+    let y = x.erf()?;
+    let grads = y.backward()?;
+    let grad_x = grads.get(&x).context("no grad for x")?;
+    assert_eq!(test_utils::to_vec1_round(&y, 4)?, [1.0, 0.8427, 1.0, 0.168]);
+    assert_eq!(
+        test_utils::to_vec1_round(grad_x, 4)?,
+        [0.0001, 0.4151, 0.0, 1.1033],
+    );
+
+    // Testing compared to pytorch nn.GELU(approximate = 'none')
+    //
+    // import torch
+    // import torch.nn.functional as F
+    // x = torch.tensor([3.0, 1.0, 4.0, 0.15], requires_grad=True)
+    // y = F.gelu(x, approximate='none')
+    // print(y)
+    // loss = y.sum()
+    // loss.backward()
+    // print(x.grad)
     let y = x.gelu_erf()?;
     let grads = y.backward()?;
     let grad_x = grads.get(&x).context("no grad for x")?;
@@ -218,19 +244,6 @@ fn unary_grad(device: &Device) -> Result<()> {
     assert_eq!(
         test_utils::to_vec1_round(grad_x, 4)?,
         [1.0119, 1.0833, 1.0005, 0.6188],
-    );
-
-    // testing compared to pytorch Tensor.erf()
-    let y = x.erf()?;
-    let grads = y.backward()?;
-    let grad_x = grads.get(&x).context("no grad for x")?;
-    assert_eq!(
-        test_utils::to_vec1_round(&y, 4)?,
-        [1.0, 0.8427, 1.0, 0.168]
-    );
-    assert_eq!(
-        test_utils::to_vec1_round(grad_x, 4)?,
-        [0.0001, 0.4151, 0.0, 1.1033],
     );
 
     Ok(())

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -205,6 +205,34 @@ fn unary_grad(device: &Device) -> Result<()> {
         test_utils::to_vec1_round(grad_x, 4)?,
         [1.0116, 1.0830, 1.0003, 0.6188],
     );
+
+    // testing compared to pytorch nn.GELU(approximate = None)
+    // https://pytorch.org/docs/stable/generated/torch.nn.functional.gelu.html
+    let y = x.gelu_erf()?;
+    let grads = y.backward()?;
+    let grad_x = grads.get(&x).context("no grad for x")?;
+    assert_eq!(
+        test_utils::to_vec1_round(&y, 4)?,
+        [2.9960, 0.8413, 3.9999, 0.0839]
+    );
+    assert_eq!(
+        test_utils::to_vec1_round(&grad_x, 4)?,
+        [1.0119, 1.0833, 1.0005, 0.6188],
+    );
+
+    // testing compared to pytorch Tensor.erf()
+    let y = x.erf()?;
+    let grads = y.backward()?;
+    let grad_x = grads.get(&x).context("no grad for x")?;
+    assert_eq!(
+        test_utils::to_vec1_round(&y, 4)?,
+        [1.0, 0.8427, 1.0, 0.168]
+    );
+    assert_eq!(
+        test_utils::to_vec1_round(&grad_x, 4)?,
+        [0.0001, 0.4151, 0.0, 1.1033],
+    );
+
     Ok(())
 }
 

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -216,7 +216,7 @@ fn unary_grad(device: &Device) -> Result<()> {
         [2.9960, 0.8413, 3.9999, 0.0839]
     );
     assert_eq!(
-        test_utils::to_vec1_round(&grad_x, 4)?,
+        test_utils::to_vec1_round(grad_x, 4)?,
         [1.0119, 1.0833, 1.0005, 0.6188],
     );
 
@@ -229,7 +229,7 @@ fn unary_grad(device: &Device) -> Result<()> {
         [1.0, 0.8427, 1.0, 0.168]
     );
     assert_eq!(
-        test_utils::to_vec1_round(&grad_x, 4)?,
+        test_utils::to_vec1_round(grad_x, 4)?,
         [0.0001, 0.4151, 0.0, 1.1033],
     );
 


### PR DESCRIPTION
This PR adds backprop support for erf anf gelu-erf.

ERF is based on the erf derivation supplied here: https://en.wikipedia.org/wiki/Error_function and here: https://www.wolframalpha.com/input?i=erf

GELU-ERF is based on the derivation of `0.5x*(1+erf(x/sqrt(2)))` or (`erf(v / 2f64.sqrt()) + 1.) * 0.5 * v`) which can be found here https://www.wolframalpha.com/input?i=0.5x*%281%2Berf%28x%2Fsqrt%282%29%29%29