### PR TITLE
Add top-k support to LogitsProcessor

### DIFF
--- a/candle-examples/examples/bigcode/main.rs
+++ b/candle-examples/examples/bigcode/main.rs
@@ -36,7 +36,7 @@ impl TextGeneration {
     ) -> Self {
         let top_p = match top_p {
             Some(p) => SamplingMethod::TopP(p),
-            None => SamplingMethod::Argmax,
+            None => SamplingMethod::Multinomial,
         };
         let logits_processor = LogitsProcessor::new(seed, temp, top_p);
         Self {

--- a/candle-examples/examples/bigcode/main.rs
+++ b/candle-examples/examples/bigcode/main.rs
@@ -7,7 +7,10 @@ extern crate accelerate_src;
 use anyhow::{Error as E, Result};
 use clap::Parser;
 
-use candle_transformers::models::bigcode::{Config, GPTBigCode};
+use candle_transformers::{
+    generation::SamplingMethod,
+    models::bigcode::{Config, GPTBigCode},
+};
 
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
@@ -31,6 +34,10 @@ impl TextGeneration {
         top_p: Option<f64>,
         device: &Device,
     ) -> Self {
+        let top_p = match top_p {
+            Some(p) => SamplingMethod::TopP(p),
+            None => SamplingMethod::Argmax,
+        };
         let logits_processor = LogitsProcessor::new(seed, temp, top_p);
         Self {
             model,

--- a/candle-examples/examples/blip/main.rs
+++ b/candle-examples/examples/blip/main.rs
@@ -5,6 +5,7 @@ extern crate intel_mkl_src;
 extern crate accelerate_src;
 
 use anyhow::Error as E;
+use candle_transformers::generation::SamplingMethod;
 use clap::Parser;
 
 use candle::{DType, Device, Result, Tensor};
@@ -102,7 +103,7 @@ pub fn main() -> anyhow::Result<()> {
     let tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;
     let mut tokenizer = TokenOutputStream::new(tokenizer);
     let mut logits_processor =
-        candle_transformers::generation::LogitsProcessor::new(1337, None, None);
+        candle_transformers::generation::LogitsProcessor::new(1337, None, SamplingMethod::Argmax);
 
     let config = blip::Config::image_captioning_large();
 

--- a/candle-examples/examples/blip/main.rs
+++ b/candle-examples/examples/blip/main.rs
@@ -102,8 +102,11 @@ pub fn main() -> anyhow::Result<()> {
     };
     let tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;
     let mut tokenizer = TokenOutputStream::new(tokenizer);
-    let mut logits_processor =
-        candle_transformers::generation::LogitsProcessor::new(1337, None, SamplingMethod::Multinomial);
+    let mut logits_processor = candle_transformers::generation::LogitsProcessor::new(
+        1337,
+        None,
+        SamplingMethod::Multinomial,
+    );
 
     let config = blip::Config::image_captioning_large();
 

--- a/candle-examples/examples/blip/main.rs
+++ b/candle-examples/examples/blip/main.rs
@@ -103,7 +103,7 @@ pub fn main() -> anyhow::Result<()> {
     let tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;
     let mut tokenizer = TokenOutputStream::new(tokenizer);
     let mut logits_processor =
-        candle_transformers::generation::LogitsProcessor::new(1337, None, SamplingMethod::Argmax);
+        candle_transformers::generation::LogitsProcessor::new(1337, None, SamplingMethod::Multinomial);
 
     let config = blip::Config::image_captioning_large();
 

--- a/candle-examples/examples/falcon/main.rs
+++ b/candle-examples/examples/falcon/main.rs
@@ -9,7 +9,7 @@ extern crate intel_mkl_src;
 use anyhow::{Error as E, Result};
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::{LogitsProcessor, SamplingMethod};
 use clap::Parser;
 use hf_hub::{api::sync::Api, Repo, RepoType};
 use tokenizers::Tokenizer;
@@ -40,8 +40,11 @@ impl TextGeneration {
         seed: u64,
         device: &Device,
     ) -> Self {
-        let logits_processor =
-            LogitsProcessor::new(seed, generation_options.temp, generation_options.top_p);
+        let top_p = match generation_options.top_p {
+            Some(p) => SamplingMethod::TopP(p),
+            None => SamplingMethod::Argmax,
+        };
+        let logits_processor = LogitsProcessor::new(seed, generation_options.temp, top_p);
         let repeat_penalty = generation_options.repeat_penalty;
         let repeat_last_n = generation_options.repeat_last_n;
         Self {

--- a/candle-examples/examples/falcon/main.rs
+++ b/candle-examples/examples/falcon/main.rs
@@ -42,7 +42,7 @@ impl TextGeneration {
     ) -> Self {
         let top_p = match generation_options.top_p {
             Some(p) => SamplingMethod::TopP(p),
-            None => SamplingMethod::Argmax,
+            None => SamplingMethod::Multinomial,
         };
         let logits_processor = LogitsProcessor::new(seed, generation_options.temp, top_p);
         let repeat_penalty = generation_options.repeat_penalty;

--- a/candle-examples/examples/llama/main.rs
+++ b/candle-examples/examples/llama/main.rs
@@ -191,7 +191,7 @@ fn main() -> Result<()> {
     print!("{prompt}");
     let top_p = match args.top_p {
         Some(p) => SamplingMethod::TopP(p),
-        None => SamplingMethod::Argmax,
+        None => SamplingMethod::Multinomial,
     };
     let mut logits_processor = LogitsProcessor::new(args.seed, args.temperature, top_p);
     let start_gen = std::time::Instant::now();

--- a/candle-examples/examples/llama/main.rs
+++ b/candle-examples/examples/llama/main.rs
@@ -17,7 +17,7 @@ use clap::Parser;
 
 use candle::{DType, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::{LogitsProcessor, SamplingMethod};
 use hf_hub::{api::sync::Api, Repo, RepoType};
 use std::io::Write;
 
@@ -189,7 +189,11 @@ fn main() -> Result<()> {
 
     println!("starting the inference loop");
     print!("{prompt}");
-    let mut logits_processor = LogitsProcessor::new(args.seed, args.temperature, args.top_p);
+    let top_p = match args.top_p {
+        Some(p) => SamplingMethod::TopP(p),
+        None => SamplingMethod::Argmax,
+    };
+    let mut logits_processor = LogitsProcessor::new(args.seed, args.temperature, top_p);
     let start_gen = std::time::Instant::now();
     let mut index_pos = 0;
     let mut token_generated = 0;

--- a/candle-examples/examples/llama2-c/main.rs
+++ b/candle-examples/examples/llama2-c/main.rs
@@ -322,7 +322,7 @@ fn run_inference(args: &InferenceCmd, common_args: &Args) -> Result<()> {
     println!("starting the inference loop");
     let top_p = match args.top_p {
         Some(p) => SamplingMethod::TopP(p),
-        None => SamplingMethod::Argmax,
+        None => SamplingMethod::Multinomial,
     };
     let mut logits_processor = LogitsProcessor::new(299792458, args.temperature, top_p);
     let mut index_pos = 0;

--- a/candle-examples/examples/llama2-c/main.rs
+++ b/candle-examples/examples/llama2-c/main.rs
@@ -6,6 +6,7 @@ extern crate accelerate_src;
 #[cfg(feature = "mkl")]
 extern crate intel_mkl_src;
 
+use candle_transformers::generation::SamplingMethod;
 use candle_transformers::models::llama2_c as model;
 use candle_transformers::models::llama2_c_weights as weights;
 use candle_transformers::models::quantized_llama2_c as qmodel;
@@ -319,7 +320,11 @@ fn run_inference(args: &InferenceCmd, common_args: &Args) -> Result<()> {
     };
 
     println!("starting the inference loop");
-    let mut logits_processor = LogitsProcessor::new(299792458, args.temperature, args.top_p);
+    let top_p = match args.top_p {
+        Some(p) => SamplingMethod::TopP(p),
+        None => SamplingMethod::Argmax,
+    };
+    let mut logits_processor = LogitsProcessor::new(299792458, args.temperature, top_p);
     let mut index_pos = 0;
 
     print!("{}", args.prompt);

--- a/candle-examples/examples/marian-mt/main.rs
+++ b/candle-examples/examples/marian-mt/main.rs
@@ -10,7 +10,7 @@ use clap::{Parser, ValueEnum};
 use candle::{DType, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
-use candle_transformers::models::marian;
+use candle_transformers::{generation::SamplingMethod, models::marian};
 
 use tokenizers::Tokenizer;
 
@@ -112,7 +112,7 @@ pub fn main() -> anyhow::Result<()> {
     let mut model = marian::MTModel::new(&config, vb)?;
 
     let mut logits_processor =
-        candle_transformers::generation::LogitsProcessor::new(1337, None, None);
+        candle_transformers::generation::LogitsProcessor::new(1337, None, SamplingMethod::Argmax);
 
     let encoder_xs = {
         let mut tokens = tokenizer

--- a/candle-examples/examples/marian-mt/main.rs
+++ b/candle-examples/examples/marian-mt/main.rs
@@ -112,7 +112,7 @@ pub fn main() -> anyhow::Result<()> {
     let mut model = marian::MTModel::new(&config, vb)?;
 
     let mut logits_processor =
-        candle_transformers::generation::LogitsProcessor::new(1337, None, SamplingMethod::Argmax);
+        candle_transformers::generation::LogitsProcessor::new(1337, None, SamplingMethod::Multinomial);
 
     let encoder_xs = {
         let mut tokens = tokenizer

--- a/candle-examples/examples/marian-mt/main.rs
+++ b/candle-examples/examples/marian-mt/main.rs
@@ -111,8 +111,11 @@ pub fn main() -> anyhow::Result<()> {
     };
     let mut model = marian::MTModel::new(&config, vb)?;
 
-    let mut logits_processor =
-        candle_transformers::generation::LogitsProcessor::new(1337, None, SamplingMethod::Multinomial);
+    let mut logits_processor = candle_transformers::generation::LogitsProcessor::new(
+        1337,
+        None,
+        SamplingMethod::Multinomial,
+    );
 
     let encoder_xs = {
         let mut tokens = tokenizer

--- a/candle-examples/examples/mistral/main.rs
+++ b/candle-examples/examples/mistral/main.rs
@@ -13,7 +13,7 @@ use candle_transformers::models::quantized_mistral::Model as QMistral;
 use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
-use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::{LogitsProcessor, SamplingMethod};
 use hf_hub::{api::sync::Api, Repo, RepoType};
 use tokenizers::Tokenizer;
 
@@ -43,6 +43,10 @@ impl TextGeneration {
         repeat_last_n: usize,
         device: &Device,
     ) -> Self {
+        let top_p = match top_p {
+            Some(p) => SamplingMethod::TopP(p),
+            None => SamplingMethod::Argmax,
+        };
         let logits_processor = LogitsProcessor::new(seed, temp, top_p);
         Self {
             model,

--- a/candle-examples/examples/mistral/main.rs
+++ b/candle-examples/examples/mistral/main.rs
@@ -45,7 +45,7 @@ impl TextGeneration {
     ) -> Self {
         let top_p = match top_p {
             Some(p) => SamplingMethod::TopP(p),
-            None => SamplingMethod::Argmax,
+            None => SamplingMethod::Multinomial,
         };
         let logits_processor = LogitsProcessor::new(seed, temp, top_p);
         Self {

--- a/candle-examples/examples/phi/main.rs
+++ b/candle-examples/examples/phi/main.rs
@@ -12,7 +12,7 @@ use candle_transformers::models::quantized_mixformer::MixFormerSequentialForCaus
 
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::{LogitsProcessor, SamplingMethod};
 use hf_hub::{api::sync::Api, Repo, RepoType};
 use tokenizers::Tokenizer;
 
@@ -44,6 +44,10 @@ impl TextGeneration {
         verbose_prompt: bool,
         device: &Device,
     ) -> Self {
+        let top_p = match top_p {
+            Some(p) => SamplingMethod::TopP(p),
+            None => SamplingMethod::Argmax,
+        };
         let logits_processor = LogitsProcessor::new(seed, temp, top_p);
         Self {
             model,

--- a/candle-examples/examples/phi/main.rs
+++ b/candle-examples/examples/phi/main.rs
@@ -46,7 +46,7 @@ impl TextGeneration {
     ) -> Self {
         let top_p = match top_p {
             Some(p) => SamplingMethod::TopP(p),
-            None => SamplingMethod::Argmax,
+            None => SamplingMethod::Multinomial,
         };
         let logits_processor = LogitsProcessor::new(seed, temp, top_p);
         Self {

--- a/candle-examples/examples/quantized-t5/main.rs
+++ b/candle-examples/examples/quantized-t5/main.rs
@@ -6,7 +6,7 @@ extern crate accelerate_src;
 use std::io::Write;
 use std::path::PathBuf;
 
-use candle_transformers::models::quantized_t5 as t5;
+use candle_transformers::{generation::SamplingMethod, models::quantized_t5 as t5};
 
 use anyhow::{Error as E, Result};
 use candle::{Device, Tensor};
@@ -179,7 +179,11 @@ fn main() -> Result<()> {
     } else {
         Some(args.temperature)
     };
-    let mut logits_processor = LogitsProcessor::new(299792458, temperature, args.top_p);
+    let top_p = match args.top_p {
+        Some(p) => SamplingMethod::TopP(p),
+        None => SamplingMethod::Argmax,
+    };
+    let mut logits_processor = LogitsProcessor::new(299792458, temperature, top_p);
     let encoder_output = model.encode(&input_token_ids)?;
     let start = std::time::Instant::now();
 

--- a/candle-examples/examples/quantized-t5/main.rs
+++ b/candle-examples/examples/quantized-t5/main.rs
@@ -181,7 +181,7 @@ fn main() -> Result<()> {
     };
     let top_p = match args.top_p {
         Some(p) => SamplingMethod::TopP(p),
-        None => SamplingMethod::Argmax,
+        None => SamplingMethod::Multinomial,
     };
     let mut logits_processor = LogitsProcessor::new(299792458, temperature, top_p);
     let encoder_output = model.encode(&input_token_ids)?;

--- a/candle-examples/examples/quantized/main.rs
+++ b/candle-examples/examples/quantized/main.rs
@@ -10,7 +10,7 @@ use tokenizers::Tokenizer;
 
 use candle::quantized::{ggml_file, gguf_file};
 use candle::{Device, Tensor};
-use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::{LogitsProcessor, SamplingMethod};
 
 use candle_transformers::models::quantized_llama as model;
 use model::ModelWeights;
@@ -362,7 +362,11 @@ fn main() -> anyhow::Result<()> {
             prompt_tokens
         };
         let mut all_tokens = vec![];
-        let mut logits_processor = LogitsProcessor::new(args.seed, temperature, args.top_p);
+        let top_p = match args.top_p {
+            Some(p) => SamplingMethod::TopP(p),
+            None => SamplingMethod::Argmax,
+        };
+        let mut logits_processor = LogitsProcessor::new(args.seed, temperature, top_p);
 
         let start_prompt_processing = std::time::Instant::now();
         let mut next_token = {

--- a/candle-examples/examples/quantized/main.rs
+++ b/candle-examples/examples/quantized/main.rs
@@ -364,7 +364,7 @@ fn main() -> anyhow::Result<()> {
         let mut all_tokens = vec![];
         let top_p = match args.top_p {
             Some(p) => SamplingMethod::TopP(p),
-            None => SamplingMethod::Argmax,
+            None => SamplingMethod::Multinomial,
         };
         let mut logits_processor = LogitsProcessor::new(args.seed, temperature, top_p);
 

--- a/candle-examples/examples/replit-code/main.rs
+++ b/candle-examples/examples/replit-code/main.rs
@@ -55,7 +55,7 @@ impl TextGeneration {
     ) -> Self {
         let top_p = match top_p {
             Some(p) => SamplingMethod::TopP(p),
-            None => SamplingMethod::Argmax,
+            None => SamplingMethod::Multinomial,
         };
         let logits_processor = LogitsProcessor::new(seed, temp, top_p);
         Self {

--- a/candle-examples/examples/replit-code/main.rs
+++ b/candle-examples/examples/replit-code/main.rs
@@ -12,7 +12,7 @@ use candle_transformers::models::quantized_mpt::Model as Q;
 
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::{LogitsProcessor, SamplingMethod};
 use hf_hub::{api::sync::Api, Repo, RepoType};
 use tokenizers::Tokenizer;
 
@@ -53,6 +53,10 @@ impl TextGeneration {
         verbose_prompt: bool,
         device: &Device,
     ) -> Self {
+        let top_p = match top_p {
+            Some(p) => SamplingMethod::TopP(p),
+            None => SamplingMethod::Argmax,
+        };
         let logits_processor = LogitsProcessor::new(seed, temp, top_p);
         Self {
             model,

--- a/candle-examples/examples/stable-lm/main.rs
+++ b/candle-examples/examples/stable-lm/main.rs
@@ -13,7 +13,7 @@ use candle_transformers::models::stable_lm::{Config, Model as StableLM};
 use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
-use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::{LogitsProcessor, SamplingMethod};
 use hf_hub::{api::sync::Api, Repo, RepoType};
 use tokenizers::Tokenizer;
 
@@ -43,6 +43,10 @@ impl TextGeneration {
         repeat_last_n: usize,
         device: &Device,
     ) -> Self {
+        let top_p = match top_p {
+            Some(p) => SamplingMethod::TopP(p),
+            None => SamplingMethod::Argmax,
+        };
         let logits_processor = LogitsProcessor::new(seed, temp, top_p);
         Self {
             model,

--- a/candle-examples/examples/stable-lm/main.rs
+++ b/candle-examples/examples/stable-lm/main.rs
@@ -45,7 +45,7 @@ impl TextGeneration {
     ) -> Self {
         let top_p = match top_p {
             Some(p) => SamplingMethod::TopP(p),
-            None => SamplingMethod::Argmax,
+            None => SamplingMethod::Multinomial,
         };
         let logits_processor = LogitsProcessor::new(seed, temp, top_p);
         Self {

--- a/candle-examples/examples/t5/main.rs
+++ b/candle-examples/examples/t5/main.rs
@@ -6,7 +6,7 @@ extern crate accelerate_src;
 use std::io::Write;
 use std::path::PathBuf;
 
-use candle_transformers::models::t5;
+use candle_transformers::{generation::SamplingMethod, models::t5};
 
 use anyhow::{Error as E, Result};
 use candle::{DType, Device, Tensor};
@@ -188,7 +188,11 @@ fn main() -> Result<()> {
                 } else {
                     Some(args.temperature)
                 };
-                let mut logits_processor = LogitsProcessor::new(299792458, temperature, args.top_p);
+                let top_p = match args.top_p {
+                    Some(p) => SamplingMethod::TopP(p),
+                    None => SamplingMethod::Argmax,
+                };
+                let mut logits_processor = LogitsProcessor::new(299792458, temperature, top_p);
                 let encoder_output = model.encode(&input_token_ids)?;
                 let start = std::time::Instant::now();
 

--- a/candle-examples/examples/t5/main.rs
+++ b/candle-examples/examples/t5/main.rs
@@ -190,7 +190,7 @@ fn main() -> Result<()> {
                 };
                 let top_p = match args.top_p {
                     Some(p) => SamplingMethod::TopP(p),
-                    None => SamplingMethod::Argmax,
+                    None => SamplingMethod::Multinomial,
                 };
                 let mut logits_processor = LogitsProcessor::new(299792458, temperature, top_p);
                 let encoder_output = model.encode(&input_token_ids)?;

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -11,7 +11,7 @@ pub struct LogitsProcessor {
 pub enum SamplingMethod {
     Argmax,
     TopP(f64),
-    TopK(isize),
+    TopK(usize),
 }
 
 impl LogitsProcessor {
@@ -100,11 +100,7 @@ impl LogitsProcessor {
                             self.sample_topp(&mut prs, top_p as f32)?
                         }
                     }
-                    SamplingMethod::TopK(top_k) => {
-                        // use top_k or n
-                        let top_k = top_k.try_into().unwrap_or(prs.len());
-                        self.sample_topk(&mut prs, top_k)?
-                    }
+                    SamplingMethod::TopK(top_k) => self.sample_topk(&mut prs, top_k)?,
                 }
             }
         };

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -71,9 +71,9 @@ impl LogitsProcessor {
         prs.sort_by(|x, y| x.total_cmp(y));
 
         // Clamp smaller probabilities to zero.
-        for index in 0..prs.len() {
+        for (index, val) in prs.iter_mut().enumerate() {
             if index >= top_k {
-                prs[index] = 0.0;
+                *val = 0.0;
             }
         }
 

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -7,6 +7,7 @@ pub struct LogitsProcessor {
     sampling_method: SamplingMethod,
 }
 
+#[derive(Debug, Clone)]
 pub enum SamplingMethod {
     Argmax,
     TopP(f64),

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -7,6 +7,11 @@ pub struct LogitsProcessor {
     sampling_method: SamplingMethod,
 }
 
+/// Sampling method for `LogitsProcessor`.
+///
+/// - Multinomial (sample over all tokens)
+/// - Top-P (nucleus sampling)
+/// - Top-K (top-k sampling)
 #[derive(Debug, Clone)]
 pub enum SamplingMethod {
     Multinomial,
@@ -81,6 +86,10 @@ impl LogitsProcessor {
         self.sample_multinomial(prs)
     }
 
+    /// Sample the provided tokens.
+    ///
+    /// If the temperature is `None`, argmax sampling is used. Otherwise, the selected sampling is used.
+    /// With `top-p` sampling, if the `top-p` value is `<= 0.0` or `>= 1.0`, multinomial sampling is used.
     pub fn sample(&mut self, logits: &Tensor) -> Result<u32> {
         let logits = logits.to_dtype(DType::F32)?;
         let next_token = match self.temperature {

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -9,7 +9,7 @@ pub struct LogitsProcessor {
 
 #[derive(Debug, Clone)]
 pub enum SamplingMethod {
-    Argmax,
+    Multinomial,
     TopP(f64),
     TopK(usize),
 }
@@ -90,7 +90,7 @@ impl LogitsProcessor {
                 let prs = candle_nn::ops::softmax_last_dim(&logits)?;
                 let mut prs: Vec<f32> = prs.to_vec1()?;
                 match self.sampling_method {
-                    SamplingMethod::Argmax => self.sample_argmax(logits)?,
+                    SamplingMethod::Multinomial => self.sample_multinomial(&prs)?,
                     SamplingMethod::TopP(top_p) => {
                         if top_p <= 0.0 || top_p >= 1.0 {
                             // simply sample from the predicted probability distribution

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -96,20 +96,20 @@ impl LogitsProcessor {
             None => self.sample_argmax(logits)?,
             Some(temperature) => {
                 let logits = (&logits / temperature)?;
-                let prs = candle_nn::ops::softmax_last_dim(&logits)?;
-                let mut prs: Vec<f32> = prs.to_vec1()?;
+                let probs = candle_nn::ops::softmax_last_dim(&logits)?;
+                let mut probs: Vec<f32> = probs.to_vec1()?;
                 match self.sampling_method {
-                    SamplingMethod::Multinomial => self.sample_multinomial(&prs)?,
+                    SamplingMethod::Multinomial => self.sample_multinomial(&probs)?,
                     SamplingMethod::TopP(top_p) => {
                         if top_p <= 0.0 || top_p >= 1.0 {
                             // simply sample from the predicted probability distribution
-                            self.sample_multinomial(&prs)?
+                            self.sample_multinomial(&probs)?
                         } else {
                             // top-p (nucleus) sampling, clamping the least likely tokens to zero
-                            self.sample_topp(&mut prs, top_p as f32)?
+                            self.sample_topp(&mut probs, top_p as f32)?
                         }
                     }
-                    SamplingMethod::TopK(top_k) => self.sample_topk(&mut prs, top_k)?,
+                    SamplingMethod::TopK(top_k) => self.sample_topk(&mut probs, top_k)?,
                 }
             }
         };

--- a/candle-transformers/tests/generation_tests.rs
+++ b/candle-transformers/tests/generation_tests.rs
@@ -1,9 +1,9 @@
 use candle::{Device, Result, Tensor};
-use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::{LogitsProcessor, SamplingMethod};
 
 #[test]
 fn sample_with_zero_temperature() -> Result<()> {
-    let mut logits_process = LogitsProcessor::new(1337, None, None);
+    let mut logits_process = LogitsProcessor::new(1337, None, SamplingMethod::Argmax);
     let logits = Tensor::new(&[0.1, 0.2, 0.3, 0.4], &Device::Cpu)?;
     let token = logits_process.sample(&logits)?;
     assert_eq!(token, 3);
@@ -12,7 +12,7 @@ fn sample_with_zero_temperature() -> Result<()> {
 
 #[test]
 fn sample_with_temperature() -> Result<()> {
-    let mut logits_process = LogitsProcessor::new(42, Some(0.9), None);
+    let mut logits_process = LogitsProcessor::new(42, Some(0.9), SamplingMethod::Argmax);
     let logits = Tensor::new(&[0.1, 0.2, 0.3, 0.4], &Device::Cpu)?;
     let token = logits_process.sample(&logits)?;
     assert_eq!(token, 0);
@@ -21,7 +21,7 @@ fn sample_with_temperature() -> Result<()> {
 
 #[test]
 fn sample_with_top_p() -> Result<()> {
-    let mut logits_process = LogitsProcessor::new(42, Some(1.0), Some(0.5));
+    let mut logits_process = LogitsProcessor::new(42, Some(1.0), SamplingMethod::TopP(0.5));
     let logits = Tensor::new(&[0.1, 0.2, 0.3, 0.4], &Device::Cpu)?;
     let token = logits_process.sample(&logits)?;
     assert_eq!(token, 2);

--- a/candle-transformers/tests/generation_tests.rs
+++ b/candle-transformers/tests/generation_tests.rs
@@ -3,7 +3,7 @@ use candle_transformers::generation::{LogitsProcessor, SamplingMethod};
 
 #[test]
 fn sample_with_zero_temperature() -> Result<()> {
-    let mut logits_process = LogitsProcessor::new(1337, None, SamplingMethod::Argmax);
+    let mut logits_process = LogitsProcessor::new(1337, None, SamplingMethod::Multinomial);
     let logits = Tensor::new(&[0.1, 0.2, 0.3, 0.4], &Device::Cpu)?;
     let token = logits_process.sample(&logits)?;
     assert_eq!(token, 3);
@@ -12,7 +12,7 @@ fn sample_with_zero_temperature() -> Result<()> {
 
 #[test]
 fn sample_with_temperature() -> Result<()> {
-    let mut logits_process = LogitsProcessor::new(42, Some(0.9), SamplingMethod::Argmax);
+    let mut logits_process = LogitsProcessor::new(42, Some(0.9), SamplingMethod::Multinomial);
     let logits = Tensor::new(&[0.1, 0.2, 0.3, 0.4], &Device::Cpu)?;
     let token = logits_process.sample(&logits)?;
     assert_eq!(token, 0);

--- a/candle-wasm-examples/blip/src/bin/m.rs
+++ b/candle-wasm-examples/blip/src/bin/m.rs
@@ -1,6 +1,7 @@
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::SamplingMethod;
 use candle_transformers::models::blip;
 use candle_transformers::models::quantized_blip;
 use candle_wasm_example_blip::console_log;
@@ -88,7 +89,7 @@ impl Model {
             SelectedModel::Q(m) => image.unsqueeze(0)?.apply(m.vision_model())?,
         };
         console_log!("image embedded in {:?}s", (Date::now() - start) / 1000.);
-        let mut logits_processor = LogitsProcessor::new(299792458, None, None);
+        let mut logits_processor = LogitsProcessor::new(299792458, None, SamplingMethod::Argmax);
         let mut token_ids = vec![30522u32];
         let mut text: String = "".to_string();
 

--- a/candle-wasm-examples/blip/src/bin/m.rs
+++ b/candle-wasm-examples/blip/src/bin/m.rs
@@ -89,7 +89,7 @@ impl Model {
             SelectedModel::Q(m) => image.unsqueeze(0)?.apply(m.vision_model())?,
         };
         console_log!("image embedded in {:?}s", (Date::now() - start) / 1000.);
-        let mut logits_processor = LogitsProcessor::new(299792458, None, SamplingMethod::Argmax);
+        let mut logits_processor = LogitsProcessor::new(299792458, None, SamplingMethod::Multinomial);
         let mut token_ids = vec![30522u32];
         let mut text: String = "".to_string();
 

--- a/candle-wasm-examples/blip/src/bin/m.rs
+++ b/candle-wasm-examples/blip/src/bin/m.rs
@@ -89,7 +89,8 @@ impl Model {
             SelectedModel::Q(m) => image.unsqueeze(0)?.apply(m.vision_model())?,
         };
         console_log!("image embedded in {:?}s", (Date::now() - start) / 1000.);
-        let mut logits_processor = LogitsProcessor::new(299792458, None, SamplingMethod::Multinomial);
+        let mut logits_processor =
+            LogitsProcessor::new(299792458, None, SamplingMethod::Multinomial);
         let mut token_ids = vec![30522u32];
         let mut text: String = "".to_string();
 

--- a/candle-wasm-examples/llama2-c/src/bin/m.rs
+++ b/candle-wasm-examples/llama2-c/src/bin/m.rs
@@ -47,7 +47,7 @@ impl Model {
             tokenizer,
             model: weights,
         });
-        let logits_processor = LogitsProcessor::new(299792458, None, SamplingMethod::Argmax);
+        let logits_processor = LogitsProcessor::new(299792458, None, SamplingMethod::Multinomial);
         match model {
             Ok(inner) => Ok(Self {
                 inner,
@@ -82,7 +82,7 @@ impl Model {
         }
         let temp = if temp <= 0. { None } else { Some(temp) };
         let top_p = if top_p <= 0. || top_p >= 1.0 {
-            SamplingMethod::Argmax
+            SamplingMethod::Multinomial
         } else {
             SamplingMethod::TopP(top_p)
         };

--- a/candle-wasm-examples/llama2-c/src/bin/m.rs
+++ b/candle-wasm-examples/llama2-c/src/bin/m.rs
@@ -1,5 +1,5 @@
 use candle::{Device, Tensor};
-use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::{LogitsProcessor, SamplingMethod};
 use candle_wasm_example_llama2::worker::{Model as M, ModelData};
 use wasm_bindgen::prelude::*;
 
@@ -47,7 +47,7 @@ impl Model {
             tokenizer,
             model: weights,
         });
-        let logits_processor = LogitsProcessor::new(299792458, None, None);
+        let logits_processor = LogitsProcessor::new(299792458, None, SamplingMethod::Argmax);
         match model {
             Ok(inner) => Ok(Self {
                 inner,
@@ -81,10 +81,10 @@ impl Model {
             }
         }
         let temp = if temp <= 0. { None } else { Some(temp) };
-        let top_p = if top_p <= 0. || top_p >= 1. {
-            None
+        let top_p = if top_p <= 0. || top_p >= 1.0 {
+            SamplingMethod::Argmax
         } else {
-            Some(top_p)
+            SamplingMethod::TopP(top_p)
         };
         self.logits_processor = LogitsProcessor::new(seed, temp, top_p);
         self.repeat_penalty = repeat_penalty;

--- a/candle-wasm-examples/llama2-c/src/worker.rs
+++ b/candle-wasm-examples/llama2-c/src/worker.rs
@@ -68,7 +68,7 @@ impl Model {
         let dev = Device::Cpu;
         let temp = if temp <= 0. { None } else { Some(temp) };
         let top_p = if top_p <= 0. || top_p >= 1.0 {
-            SamplingMethod::Argmax
+            SamplingMethod::Multinomial
         } else {
             SamplingMethod::TopP(top_p)
         };

--- a/candle-wasm-examples/llama2-c/src/worker.rs
+++ b/candle-wasm-examples/llama2-c/src/worker.rs
@@ -2,7 +2,7 @@ use crate::model::{Cache, Config, Llama};
 use byteorder::{LittleEndian, ReadBytesExt};
 use candle::{DType, Device, IndexOp, Result, Shape, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::{LogitsProcessor, SamplingMethod};
 use serde::{Deserialize, Serialize};
 use tokenizers::Tokenizer;
 use wasm_bindgen::prelude::*;
@@ -68,9 +68,9 @@ impl Model {
         let dev = Device::Cpu;
         let temp = if temp <= 0. { None } else { Some(temp) };
         let top_p = if top_p <= 0. || top_p >= 1.0 {
-            None
+            SamplingMethod::Argmax
         } else {
-            Some(top_p)
+            SamplingMethod::TopP(top_p)
         };
         console_log!("temp: {temp:?} top_p: {top_p:?} prompt: {prompt}");
         let mut logits_processor = LogitsProcessor::new(299792458, temp, top_p);

--- a/candle-wasm-examples/phi/src/bin/m.rs
+++ b/candle-wasm-examples/phi/src/bin/m.rs
@@ -50,7 +50,7 @@ impl Model {
             SelectedModel::MixFormer(model)
         };
         console_log!("model loaded in {:?}s", (Date::now() - start) / 1000.);
-        let logits_processor = LogitsProcessor::new(299792458, None, SamplingMethod::Argmax);
+        let logits_processor = LogitsProcessor::new(299792458, None, SamplingMethod::Multinomial);
         Ok(Self {
             model,
             tokenizer,
@@ -76,7 +76,7 @@ impl Model {
         };
         let temp = if temp <= 0. { None } else { Some(temp) };
         let top_p = if top_p <= 0. || top_p >= 1.0 {
-            SamplingMethod::Argmax
+            SamplingMethod::Multinomial
         } else {
             SamplingMethod::TopP(top_p)
         };

--- a/candle-wasm-examples/t5/src/bin/m-quantized.rs
+++ b/candle-wasm-examples/t5/src/bin/m-quantized.rs
@@ -1,5 +1,5 @@
 use candle::{Device, Tensor};
-use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::{LogitsProcessor, SamplingMethod};
 pub use candle_transformers::models::quantized_t5::{
     Config, T5EncoderModel, T5ForConditionalGeneration, VarBuilder,
 };
@@ -60,9 +60,9 @@ impl ModelConditionalGeneration {
             Some(input.temperature)
         };
         let top_p = if input.top_p <= 0. || input.top_p >= 1. {
-            None
+            SamplingMethod::Argmax
         } else {
-            Some(input.top_p)
+            SamplingMethod::TopP(input.top_p)
         };
         let mut logits_processor = LogitsProcessor::new(seed, temperature, top_p);
         let tokens = self

--- a/candle-wasm-examples/t5/src/bin/m-quantized.rs
+++ b/candle-wasm-examples/t5/src/bin/m-quantized.rs
@@ -60,7 +60,7 @@ impl ModelConditionalGeneration {
             Some(input.temperature)
         };
         let top_p = if input.top_p <= 0. || input.top_p >= 1. {
-            SamplingMethod::Argmax
+            SamplingMethod::Multinomial
         } else {
             SamplingMethod::TopP(input.top_p)
         };

--- a/candle-wasm-examples/t5/src/bin/m.rs
+++ b/candle-wasm-examples/t5/src/bin/m.rs
@@ -1,6 +1,6 @@
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::{LogitsProcessor, SamplingMethod};
 pub use candle_transformers::models::t5::{Config, T5EncoderModel, T5ForConditionalGeneration};
 use candle_wasm_example_t5::console_log;
 use tokenizers::Tokenizer;
@@ -57,10 +57,10 @@ impl ModelConditionalGeneration {
         } else {
             Some(input.temperature)
         };
-        let top_p = if input.top_p <= 0. || input.top_p >= 1. {
-            None
+        let top_p = if input.top_p <= 0. || input.top_p >= 1.0 {
+            SamplingMethod::Argmax
         } else {
-            Some(input.top_p)
+            SamplingMethod::TopP(input.top_p)
         };
         let mut logits_processor = LogitsProcessor::new(seed, temperature, top_p);
         let tokens = self

--- a/candle-wasm-examples/t5/src/bin/m.rs
+++ b/candle-wasm-examples/t5/src/bin/m.rs
@@ -58,7 +58,7 @@ impl ModelConditionalGeneration {
             Some(input.temperature)
         };
         let top_p = if input.top_p <= 0. || input.top_p >= 1.0 {
-            SamplingMethod::Argmax
+            SamplingMethod::Multinomial
         } else {
             SamplingMethod::TopP(input.top_p)
         };


### PR DESCRIPTION
Hello everybody,

During my recent development of `candle-vllm`, I have been working on sampling techniques and noticed that top-k, beam search and some other features are missing from `LogitsProcessor` (#1263).

In this PR, I have added the `top-k` technique (which selects the `k` most likely tokens and samples among those, ensuring that lesser likely tokens are not considered) to `LogitsProcessor`. Additionally, I restructured the `LogitsProcessor` API slightly to use enums in order to reduce the chance for subtle bugs.