### PR TITLE
Add support for MADLAD400

### DIFF
--- a/candle-examples/examples/quantized-t5/main.rs
+++ b/candle-examples/examples/quantized-t5/main.rs
@@ -173,7 +173,11 @@ fn main() -> Result<()> {
         .to_vec();
     let input_token_ids = Tensor::new(&tokens[..], device)?.unsqueeze(0)?;
     let mut model = builder.build_model()?;
-    let mut output_token_ids = [builder.config.pad_token_id as u32].to_vec();
+    let mut output_token_ids = [builder
+        .config
+        .decoder_start_token_id
+        .unwrap_or(builder.config.pad_token_id) as u32]
+    .to_vec();
     let temperature = if args.temperature <= 0. {
         None
     } else {

--- a/candle-examples/examples/t5/main.rs
+++ b/candle-examples/examples/t5/main.rs
@@ -172,7 +172,12 @@ fn main() -> Result<()> {
                 println!("Took {:?}", start.elapsed());
             } else {
                 let mut model = builder.build_conditional_generation()?;
-                let mut output_token_ids = [builder.config.pad_token_id as u32].to_vec();
+                let mut output_token_ids = [builder
+                    .config
+                    .decoder_start_token_id
+                    .unwrap_or(builder.config.pad_token_id)
+                    as u32]
+                .to_vec();
                 if let Some(decoder_prompt) = &args.decoder_prompt {
                     print!("{decoder_prompt}");
                     output_token_ids.extend(

--- a/candle-transformers/src/models/quantized_t5.rs
+++ b/candle-transformers/src/models/quantized_t5.rs
@@ -65,6 +65,7 @@ pub struct Config {
     pub use_cache: bool,
     pub pad_token_id: usize,
     pub eos_token_id: usize,
+    pub decoder_start_token_id: Option<usize>,
 }
 
 impl Default for Config {
@@ -89,6 +90,7 @@ impl Default for Config {
             use_cache: true,
             pad_token_id: 0,
             eos_token_id: 1,
+            decoder_start_token_id: Some(0),
         }
     }
 }
@@ -642,7 +644,12 @@ pub struct T5EncoderModel {
 
 impl T5EncoderModel {
     pub fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
-        let shared = Embedding::new(cfg.vocab_size, cfg.d_model, vb.pp("shared"))?;
+        let shared_vb = if vb.contains_key("shared") {
+            vb.pp("shared")
+        } else {
+            vb.pp("decoder").pp("embed_tokens")
+        };
+        let shared = Embedding::new(cfg.vocab_size, cfg.d_model, shared_vb)?;
         let shared = Arc::new(shared);
         let encoder = T5Stack::load(false, vb.pp("encoder"), &shared, cfg)?;
         Ok(Self {
@@ -683,7 +690,12 @@ impl T5ForConditionalGeneration {
     pub fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
         assert!(cfg.is_encoder_decoder);
         let d_model = cfg.d_model;
-        let shared = Embedding::new(cfg.vocab_size, cfg.d_model, vb.pp("shared"))?;
+        let shared_vb = if vb.contains_key("shared") {
+            vb.pp("shared")
+        } else {
+            vb.pp("decoder").pp("embed_tokens")
+        };
+        let shared = Embedding::new(cfg.vocab_size, cfg.d_model, shared_vb)?;
         let shared = Arc::new(shared);
 
         let mut encoder_cfg = cfg.clone();

--- a/candle-transformers/src/quantized_var_builder.rs
+++ b/candle-transformers/src/quantized_var_builder.rs
@@ -90,4 +90,8 @@ impl VarBuilder {
     pub fn device(&self) -> &Device {
         &self.device
     }
+
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.data.contains_key(key)
+    }
 }


### PR DESCRIPTION
Google published models trained on [MADLAD400](https://github.com/google-research/google-research/tree/master/madlad_400) that do NMT for 400+ languages and are competitive with much larger models.

It's based on T5, and I - sorry for the shameless plug -, converted it to huggingface's safetensors: https://huggingface.co/jbochi/madlad400-3b-mt

The published weights work with the transformer library, but it doesn't work with candle because of two small things:
- [convert_t5x_checkpoint_to_pytorch.py](https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/convert_t5x_checkpoint_to_pytorch.py) created files with a `decoder.embed_tokens.weight` tensor instead of `shared.weight`. The python code handles both cases. I could manually rename the tensors and reupload the files, but they are huge.
- MADLAD uses a decoder start token different from the pad token. This is also handled correctly by the transformers but not by candle.


Example usage:

```
cargo run --example quantized-t5 --release  -- \
  --model-id "jbochi/madlad400-3b-mt" \
  --weight-file "model-q4k.gguf" \
  --prompt "<2pt> Note that a storm surge is what forecasters consider a hurricane's most treacherous aspect." \
  --temperature 0
    Finished release [optimized] target(s) in 0.19s
     Running `target/release/examples/quantized-t5 --model-id jbochi/madlad400-3b-mt --weight-file model-q4k.gguf --prompt '<2pt> Note that a storm surge is what forecasters consider a hurricane'\''s most treacherous aspect.' --temperature 0`
 Note que uma onda de tempestade é o que os meteorologistas consideram o aspecto mais traiçoeiro de um furacão.
30 tokens generated (9.72 token/s)
```