### PR TITLE
Quantized model small tweaks

### DIFF
--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -477,6 +477,12 @@ impl Tensor {
     broadcast_binary_op!(broadcast_div, div);
     broadcast_binary_op!(broadcast_maximum, maximum);
     broadcast_binary_op!(broadcast_minimum, minimum);
+    broadcast_binary_op!(broadcast_eq, eq);
+    broadcast_binary_op!(broadcast_ne, ne);
+    broadcast_binary_op!(broadcast_lt, lt);
+    broadcast_binary_op!(broadcast_le, le);
+    broadcast_binary_op!(broadcast_gt, gt);
+    broadcast_binary_op!(broadcast_ge, ge);
 
     unary_op!(recip, Recip);
     unary_op!(neg, Neg);

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -2406,6 +2406,23 @@ impl Tensor {
     ) -> Result<Self> {
         self.apply_op3_arc(t2, t3, Arc::new(Box::new(c)))
     }
+
+    /// Normalize a 'relative' axis value: positive values are kept, negative
+    /// values means counting the dimensions from the back.
+    pub fn normalize_axis(&self, axis: i64) -> Result<usize> {
+        let rank = self.rank() as i64;
+        if rank <= axis {
+            crate::bail!("axis {axis} is too large, tensor rank {rank}")
+        } else if 0 <= axis {
+            Ok(axis as usize)
+        } else {
+            let naxis = rank + axis;
+            if naxis < 0 {
+                crate::bail!("axis {axis} is too small, tensor rank {rank}")
+            }
+            Ok(naxis as usize)
+        }
+    }
 }
 
 macro_rules! bin_trait {

--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -69,3 +69,7 @@ required-features = ["pyo3"]
 [[example]]
 name = "onnx"
 required-features = ["onnx"]
+
+[[example]]
+name = "onnx_basics"
+required-features = ["onnx"]

--- a/candle-examples/examples/onnx_basics.rs
+++ b/candle-examples/examples/onnx_basics.rs
@@ -67,7 +67,7 @@ pub fn main() -> Result<()> {
                                 .iter()
                                 .map(|dim| match dim.value.as_ref().expect("no dim value") {
                                     candle_onnx::onnx::tensor_shape_proto::dimension::Value::DimValue(v) => Ok(*v as usize),
-                                    candle_onnx::onnx::tensor_shape_proto::dimension::Value::DimParam(_) => anyhow::bail!("DimParam is unsupported for input {}", input.name),
+                                    candle_onnx::onnx::tensor_shape_proto::dimension::Value::DimParam(_) => Ok(42),
                                 })
                                 .collect::<Result<Vec<usize>>>()?;
                         Tensor::zeros(dims, dt, &Device::Cpu)?

--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -439,14 +439,8 @@ pub fn simple_eval(
                     get(&node.input[1])?
                         .to_vec1::<i64>()?
                         .iter()
-                        .map(|&i| {
-                            if i < 0 {
-                                (xs.rank() as i64 + i) as usize
-                            } else {
-                                i as usize
-                            }
-                        })
-                        .collect::<Vec<_>>()
+                        .map(|&i| xs.normalize_axis(i))
+                        .collect::<Result<Vec<_>>>()?
                 };
                 axes.sort();
                 let mut xs = xs.clone();
@@ -476,14 +470,8 @@ pub fn simple_eval(
                 let xs = get(&node.input[0])?;
                 let start = get_attr_opt::<i64>(node, "start")?.copied().unwrap_or(0);
                 let end = get_attr_opt::<i64>(node, "end")?.copied().unwrap_or(-1);
-                let start = if start < 0 {
-                    start + xs.rank() as i64
-                } else {
-                    start
-                };
-                let end = if end < 0 { end + xs.rank() as i64 } else { end };
-                let start = (start as usize).clamp(0, xs.rank().saturating_sub(1));
-                let end = (end as usize).clamp(0, xs.rank().saturating_sub(1));
+                let start = xs.normalize_axis(start)?;
+                let end = xs.normalize_axis(end)?;
                 let mut dims = vec![];
                 for idx in start..=end {
                     dims.push(xs.dim(idx)? as i64)

--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -245,7 +245,7 @@ pub fn simple_eval(
             "Equal" => {
                 let input0 = get(&node.input[0])?;
                 let input1 = get(&node.input[1])?;
-                let output = input0.eq(input1)?;
+                let output = input0.broadcast_eq(input1)?;
                 values.insert(node.output[0].clone(), output);
             }
             "MatMul" => {
@@ -447,6 +447,16 @@ pub fn simple_eval(
                 for &axis in axes.iter().rev() {
                     xs = xs.squeeze(axis)?
                 }
+                values.insert(node.output[0].clone(), xs);
+            }
+            "ConstantOfShape" => {
+                let dims = get(&node.input[0])?;
+                let shape = dims
+                    .to_vec1::<i64>()?
+                    .into_iter()
+                    .map(|v| v as usize)
+                    .collect::<Vec<_>>();
+                let xs = Tensor::zeros(shape, DType::F32, dims.device())?;
                 values.insert(node.output[0].clone(), xs);
             }
             "Unsqueeze" => {

--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -465,6 +465,15 @@ pub fn simple_eval(
                 };
                 values.insert(node.output[0].clone(), xs);
             }
+            "Gather" => {
+                let xs = get(&node.input[0])?;
+                let indices = get(&node.input[1])?;
+                let axis = get_attr_opt::<i64>(node, "axis")?.copied().unwrap_or(0);
+                let axis = xs.normalize_axis(axis)?;
+                println!("{xs} {indices}");
+                let xs = xs.gather(indices, axis)?;
+                values.insert(node.output[0].clone(), xs);
+            }
             "Shape" => {
                 // https://github.com/onnx/onnx/blob/main/docs/Operators.md#Shape
                 let xs = get(&node.input[0])?;


### PR DESCRIPTION
- Support zephyr-7b-beta.
- Use `TokenOutputStream`.
- Fix the number of generated tokens / generation speed measure.