### PR TITLE
Add support to UL2 model family

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ rayon = "1.7.0"
 rusttype = { version = "0.9", default-features = false }
 safetensors = "0.3.1"
 serde = { version = "1.0.171", features = ["derive"] }
+serde_plain = "1.0.2"
 serde_json = "1.0.99"
 thiserror = "1"
 tokenizers = { version = "0.13.4", default-features = false }

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ If you have an addition to this list, please submit a pull request.
         - Replit-code-v1.5-3B.
         - Bert.
     - Text to text.
-        - T5 and its variants: FlanT5, MADLAD400 (translation), CoEdit (Grammar correction).
+        - T5 and its variants: FlanT5, UL2, MADLAD400 (translation), CoEdit (Grammar correction).
         - Marian MT (Machine Translation).
     - Whisper (multi-lingual support).
     - Text to image.

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -551,7 +551,8 @@ unary_op!(Recip, "recip", v, v.recip());
 unary_op!(Sqr, "sqr", v, v * v, vs_sqr, vd_sqr);
 unary_op!(Sqrt, "sqrt", v, v.sqrt(), vs_sqrt, vd_sqrt);
 
-/// `gelu` operation
+/// Tanh based approximation of the `gelu` operation
+/// GeluErf is the more precise one.
 /// <https://en.wikipedia.org/wiki/Activation_function#Comparison_of_activation_functions>
 impl UnaryOpT for Gelu {
     const NAME: &'static str = "gelu";

--- a/candle-examples/examples/t5/README.md
+++ b/candle-examples/examples/t5/README.md
@@ -9,7 +9,7 @@ $ cargo run --example t5 --release -- --model-id "t5-small" --prompt "translate 
 9 tokens generated (2.42 token/s)
 ```
 
-[flan-t5](https://huggingface.co/google/flan-t5-small) models, and [flan-ul2](https://huggingface.co/google/flan-ul2) (with `--revision "refs/pr/25"`) are also supported.
+Variants such as [flan-t5](https://huggingface.co/google/flan-t5-small), [flan-ul2](https://huggingface.co/google/flan-ul2) (with `--revision "refs/pr/25"`), and [Co-EdIT](https://huggingface.co/grammarly/coedit-large) are also supported.
 
 ## Translation with [MADLAD-400](https://arxiv.org/abs/2309.04662)
 

--- a/candle-examples/examples/t5/README.md
+++ b/candle-examples/examples/t5/README.md
@@ -9,6 +9,8 @@ $ cargo run --example t5 --release -- --model-id "t5-small" --prompt "translate 
 9 tokens generated (2.42 token/s)
 ```
 
+[flan-t5](https://huggingface.co/google/flan-t5-small) models, and [flan-ul2](https://huggingface.co/google/flan-ul2) (with `--revision "refs/pr/25"`) are also supported.
+
 ## Translation with [MADLAD-400](https://arxiv.org/abs/2309.04662)
 
 MADLAD-400 is a series of multilingual machine translation T5 models trained on 250 billion tokens covering over 450 languages using publicly available data. These models are competitive with significantly larger models.
@@ -22,7 +24,7 @@ cargo run --example t5 --release  -- \
  Wie geht es dir, mein Freund?
 ```
 
-## Sentence embedding example:
+## Sentence embedding example
 
 ```bash
 $ cargo run --example t5 --release -- --model-id "t5-small" --prompt "A beautiful candle."

--- a/candle-examples/examples/t5/main.rs
+++ b/candle-examples/examples/t5/main.rs
@@ -104,6 +104,17 @@ impl T5ModelBuilder {
                 api.get("model-00004-of-00005.safetensors")?,
                 api.get("model-00005-of-00005.safetensors")?,
             ]
+        } else if model_id == "google/flan-ul2" {
+            vec![
+                api.get("model-00001-of-00008.safetensors")?,
+                api.get("model-00002-of-00008.safetensors")?,
+                api.get("model-00003-of-00008.safetensors")?,
+                api.get("model-00004-of-00008.safetensors")?,
+                api.get("model-00005-of-00008.safetensors")?,
+                api.get("model-00006-of-00008.safetensors")?,
+                api.get("model-00007-of-00008.safetensors")?,
+                api.get("model-00008-of-00008.safetensors")?,
+            ]
         } else {
             vec![api.get("model.safetensors")?]
         };

--- a/candle-nn/src/activation.rs
+++ b/candle-nn/src/activation.rs
@@ -12,6 +12,8 @@ pub enum Activation {
     Relu2,
     Relu6,
     Silu,
+    #[serde(rename = "gated-silu")]
+    GatedSilu,
     Sigmoid,
     HardSigmoid,
     Swiglu,
@@ -31,6 +33,7 @@ impl super::Module for Activation {
             Self::Relu2 => xs.relu()?.sqr(),
             Self::Relu6 => xs.clamp(0f32, 6f32),
             Self::Silu => crate::ops::silu(xs),
+            Self::GatedSilu => crate::ops::silu(xs),
             Self::Sigmoid => crate::ops::sigmoid(xs),
             Self::HardSigmoid => crate::ops::hard_sigmoid(xs),
             Self::Swiglu => crate::ops::swiglu(xs),

--- a/candle-nn/src/activation.rs
+++ b/candle-nn/src/activation.rs
@@ -6,14 +6,11 @@ use serde::Deserialize;
 pub enum Activation {
     #[default]
     Gelu,
-    #[serde(rename = "gated-gelu")]
-    NewGelu,
+    ApproximateGelu,
     Relu,
     Relu2,
     Relu6,
     Silu,
-    #[serde(rename = "gated-silu")]
-    GatedSilu,
     Sigmoid,
     HardSigmoid,
     Swiglu,
@@ -28,12 +25,11 @@ impl super::Module for Activation {
         match self {
             Self::Gelu => xs.gelu_erf(),
             // https://github.com/huggingface/transformers/blob/12f043eaeaabfef6f6efea411d98e6f6d3c094b7/src/transformers/activations.py#L49-L78
-            Self::NewGelu => xs.gelu(),
+            Self::ApproximateGelu => xs.gelu(),
             Self::Relu => xs.relu(),
             Self::Relu2 => xs.relu()?.sqr(),
             Self::Relu6 => xs.clamp(0f32, 6f32),
             Self::Silu => crate::ops::silu(xs),
-            Self::GatedSilu => crate::ops::silu(xs),
             Self::Sigmoid => crate::ops::sigmoid(xs),
             Self::HardSigmoid => crate::ops::hard_sigmoid(xs),
             Self::Swiglu => crate::ops::swiglu(xs),

--- a/candle-nn/src/activation.rs
+++ b/candle-nn/src/activation.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 pub enum Activation {
     #[default]
     Gelu,
-    ApproximateGelu,
+    NewGelu,
     Relu,
     Relu2,
     Relu6,
@@ -25,7 +25,7 @@ impl super::Module for Activation {
         match self {
             Self::Gelu => xs.gelu_erf(),
             // https://github.com/huggingface/transformers/blob/12f043eaeaabfef6f6efea411d98e6f6d3c094b7/src/transformers/activations.py#L49-L78
-            Self::ApproximateGelu => xs.gelu(),
+            Self::NewGelu => xs.gelu(),
             Self::Relu => xs.relu(),
             Self::Relu2 => xs.relu()?.sqr(),
             Self::Relu6 => xs.clamp(0f32, 6f32),

--- a/candle-transformers/Cargo.toml
+++ b/candle-transformers/Cargo.toml
@@ -21,6 +21,7 @@ rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_plain = { workspace = true }
 tracing = { workspace = true }
 wav = { workspace = true }
 

--- a/candle-transformers/src/models/mixformer.rs
+++ b/candle-transformers/src/models/mixformer.rs
@@ -84,7 +84,7 @@ impl Config {
             n_inner: None,
             n_head: 32,
             rotary_dim: usize::min(32, 2048 / 32),
-            activation_function: Activation::NewGelu,
+            activation_function: Activation::ApproximateGelu,
             layer_norm_epsilon: 1e-5,
             tie_word_embeddings: false,
             pad_vocab_size_multiple: 64,

--- a/candle-transformers/src/models/mixformer.rs
+++ b/candle-transformers/src/models/mixformer.rs
@@ -84,7 +84,7 @@ impl Config {
             n_inner: None,
             n_head: 32,
             rotary_dim: usize::min(32, 2048 / 32),
-            activation_function: Activation::ApproximateGelu,
+            activation_function: Activation::NewGelu,
             layer_norm_epsilon: 1e-5,
             tie_word_embeddings: false,
             pad_vocab_size_multiple: 64,

--- a/candle-transformers/src/models/quantized_t5.rs
+++ b/candle-transformers/src/models/quantized_t5.rs
@@ -45,8 +45,12 @@ struct ActivationWithOptionalGating {
     activation: candle_nn::Activation,
 }
 
-fn deserialize_feed_forward_proj_activation<'de, D>(deserializer: D) -> std::result::Result<ActivationWithOptionalGating, D::Error>
-where D: serde::de::Deserializer<'de> {
+fn deserialize_feed_forward_proj_activation<'de, D>(
+    deserializer: D,
+) -> std::result::Result<ActivationWithOptionalGating, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
     let buf = String::deserialize(deserializer)?;
     if buf == "gated-gelu" {
         return Ok(ActivationWithOptionalGating {
@@ -63,7 +67,7 @@ where D: serde::de::Deserializer<'de> {
     let activation = serde_plain::from_str(&buf).map_err(serde::de::Error::custom)?;
     Ok(ActivationWithOptionalGating {
         gated: false,
-        activation: activation,
+        activation,
     })
 }
 
@@ -111,7 +115,10 @@ impl Default for Config {
             dropout_rate: 0.1,
             layer_norm_epsilon: 1e-6,
             initializer_factor: 1.0,
-            feed_forward_proj: ActivationWithOptionalGating { gated: false, activation: Activation::Relu },
+            feed_forward_proj: ActivationWithOptionalGating {
+                gated: false,
+                activation: Activation::Relu,
+            },
             tie_word_embeddings: true,
             is_decoder: false,
             is_encoder_decoder: true,

--- a/candle-transformers/src/models/quantized_t5.rs
+++ b/candle-transformers/src/models/quantized_t5.rs
@@ -176,7 +176,7 @@ impl T5DenseGatedActDense {
             wi_0,
             wi_1,
             wo,
-            act: Activation::NewGelu,
+            act: Activation::ApproximateGelu,
             span: tracing::span!(tracing::Level::TRACE, "dense-gated-act-dense"),
         })
     }

--- a/candle-transformers/src/models/quantized_t5.rs
+++ b/candle-transformers/src/models/quantized_t5.rs
@@ -39,6 +39,34 @@ fn masked_fill(on_false: &Tensor, mask: &Tensor, on_true: f32) -> Result<Tensor>
     Ok(m)
 }
 
+#[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+struct ActivationWithOptionalGating {
+    gated: bool,
+    activation: candle_nn::Activation,
+}
+
+fn deserialize_feed_forward_proj_activation<'de, D>(deserializer: D) -> std::result::Result<ActivationWithOptionalGating, D::Error>
+where D: serde::de::Deserializer<'de> {
+    let buf = String::deserialize(deserializer)?;
+    if buf == "gated-gelu" {
+        return Ok(ActivationWithOptionalGating {
+            gated: true,
+            activation: candle_nn::Activation::ApproximateGelu,
+        });
+    }
+    if buf == "gated-silu" {
+        return Ok(ActivationWithOptionalGating {
+            gated: true,
+            activation: candle_nn::Activation::Silu,
+        });
+    }
+    let activation = serde_plain::from_str(&buf).map_err(serde::de::Error::custom)?;
+    return Ok(ActivationWithOptionalGating {
+        gated: false,
+        activation: Activation::from(activation),
+    });
+}
+
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct Config {
     vocab_size: usize,
@@ -54,8 +82,8 @@ pub struct Config {
     dropout_rate: f64,
     layer_norm_epsilon: f64,
     initializer_factor: f64,
-    #[serde(default)]
-    feed_forward_proj: Activation,
+    #[serde(default, deserialize_with = "deserialize_feed_forward_proj_activation")]
+    feed_forward_proj: ActivationWithOptionalGating,
     #[serde(default = "default_tie_word_embeddings")]
     tie_word_embeddings: bool,
     #[serde(default = "default_is_decoder")]
@@ -83,7 +111,7 @@ impl Default for Config {
             dropout_rate: 0.1,
             layer_norm_epsilon: 1e-6,
             initializer_factor: 1.0,
-            feed_forward_proj: Activation::Relu,
+            feed_forward_proj: ActivationWithOptionalGating { gated: false, activation: Activation::Relu },
             tie_word_embeddings: true,
             is_decoder: false,
             is_encoder_decoder: true,
@@ -176,7 +204,7 @@ impl T5DenseGatedActDense {
             wi_0,
             wi_1,
             wo,
-            act: Activation::ApproximateGelu,
+            act: cfg.feed_forward_proj.activation,
             span: tracing::span!(tracing::Level::TRACE, "dense-gated-act-dense"),
         })
     }
@@ -205,7 +233,7 @@ impl T5LayerFF {
     fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
         let layer_norm =
             T5LayerNorm::load(cfg.d_model, cfg.layer_norm_epsilon, vb.pp("layer_norm"))?;
-        let (dense_act, gated_dense_act) = if cfg.feed_forward_proj == Activation::NewGelu {
+        let (dense_act, gated_dense_act) = if cfg.feed_forward_proj.gated {
             (
                 None,
                 Some(T5DenseGatedActDense::load(vb.pp("DenseReluDense"), cfg)?),

--- a/candle-transformers/src/models/quantized_t5.rs
+++ b/candle-transformers/src/models/quantized_t5.rs
@@ -63,7 +63,7 @@ where D: serde::de::Deserializer<'de> {
     let activation = serde_plain::from_str(&buf).map_err(serde::de::Error::custom)?;
     return Ok(ActivationWithOptionalGating {
         gated: false,
-        activation: Activation::from(activation),
+        activation: activation,
     });
 }
 

--- a/candle-transformers/src/models/quantized_t5.rs
+++ b/candle-transformers/src/models/quantized_t5.rs
@@ -61,10 +61,10 @@ where D: serde::de::Deserializer<'de> {
         });
     }
     let activation = serde_plain::from_str(&buf).map_err(serde::de::Error::custom)?;
-    return Ok(ActivationWithOptionalGating {
+    Ok(ActivationWithOptionalGating {
         gated: false,
         activation: activation,
-    });
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]

--- a/candle-transformers/src/models/quantized_t5.rs
+++ b/candle-transformers/src/models/quantized_t5.rs
@@ -51,7 +51,7 @@ where D: serde::de::Deserializer<'de> {
     if buf == "gated-gelu" {
         return Ok(ActivationWithOptionalGating {
             gated: true,
-            activation: candle_nn::Activation::ApproximateGelu,
+            activation: candle_nn::Activation::NewGelu,
         });
     }
     if buf == "gated-silu" {

--- a/candle-transformers/src/models/t5.rs
+++ b/candle-transformers/src/models/t5.rs
@@ -43,8 +43,12 @@ struct ActivationWithOptionalGating {
     activation: candle_nn::Activation,
 }
 
-fn deserialize_feed_forward_proj_activation<'de, D>(deserializer: D) -> std::result::Result<ActivationWithOptionalGating, D::Error>
-where D: serde::de::Deserializer<'de> {
+fn deserialize_feed_forward_proj_activation<'de, D>(
+    deserializer: D,
+) -> std::result::Result<ActivationWithOptionalGating, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
     let buf = String::deserialize(deserializer)?;
     if buf == "gated-gelu" {
         return Ok(ActivationWithOptionalGating {
@@ -61,7 +65,7 @@ where D: serde::de::Deserializer<'de> {
     let activation = serde_plain::from_str(&buf).map_err(serde::de::Error::custom)?;
     Ok(ActivationWithOptionalGating {
         gated: false,
-        activation: activation,
+        activation,
     })
 }
 

--- a/candle-transformers/src/models/t5.rs
+++ b/candle-transformers/src/models/t5.rs
@@ -59,10 +59,10 @@ where D: serde::de::Deserializer<'de> {
         });
     }
     let activation = serde_plain::from_str(&buf).map_err(serde::de::Error::custom)?;
-    return Ok(ActivationWithOptionalGating {
+    Ok(ActivationWithOptionalGating {
         gated: false,
         activation: activation,
-    });
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]

--- a/candle-transformers/src/models/t5.rs
+++ b/candle-transformers/src/models/t5.rs
@@ -61,7 +61,7 @@ where D: serde::de::Deserializer<'de> {
     let activation = serde_plain::from_str(&buf).map_err(serde::de::Error::custom)?;
     return Ok(ActivationWithOptionalGating {
         gated: false,
-        activation: Activation::from(activation),
+        activation: activation,
     });
 }
 

--- a/candle-transformers/src/models/t5.rs
+++ b/candle-transformers/src/models/t5.rs
@@ -231,7 +231,9 @@ impl T5LayerFF {
     fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
         let layer_norm =
             T5LayerNorm::load(cfg.d_model, cfg.layer_norm_epsilon, vb.pp("layer_norm"))?;
-        let (dense_act, gated_dense_act) = if cfg.feed_forward_proj == Activation::NewGelu {
+        let gated = cfg.feed_forward_proj == Activation::NewGelu
+            || cfg.feed_forward_proj == Activation::GatedSilu;
+        let (dense_act, gated_dense_act) = if gated {
             (
                 None,
                 Some(T5DenseGatedActDense::load(vb.pp("DenseReluDense"), cfg)?),

--- a/candle-transformers/src/models/t5.rs
+++ b/candle-transformers/src/models/t5.rs
@@ -49,7 +49,7 @@ where D: serde::de::Deserializer<'de> {
     if buf == "gated-gelu" {
         return Ok(ActivationWithOptionalGating {
             gated: true,
-            activation: candle_nn::Activation::ApproximateGelu,
+            activation: candle_nn::Activation::NewGelu,
         });
     }
     if buf == "gated-silu" {

--- a/candle-transformers/src/models/t5.rs
+++ b/candle-transformers/src/models/t5.rs
@@ -38,12 +38,12 @@ fn masked_fill(on_false: &Tensor, mask: &Tensor, on_true: f32) -> Result<Tensor>
 }
 
 #[derive(Debug, Deserialize, Default, Clone, PartialEq)]
-struct ActivationWithOptionalGating {
-    gated: bool,
-    activation: candle_nn::Activation,
+pub struct ActivationWithOptionalGating {
+    pub gated: bool,
+    pub activation: candle_nn::Activation,
 }
 
-fn deserialize_feed_forward_proj_activation<'de, D>(
+pub fn deserialize_feed_forward_proj_activation<'de, D>(
     deserializer: D,
 ) -> std::result::Result<ActivationWithOptionalGating, D::Error>
 where

--- a/candle-transformers/src/models/t5.rs
+++ b/candle-transformers/src/models/t5.rs
@@ -49,24 +49,23 @@ pub fn deserialize_feed_forward_proj_activation<'de, D>(
 where
     D: serde::de::Deserializer<'de>,
 {
-    let buf = String::deserialize(deserializer)?;
-    if buf == "gated-gelu" {
-        return Ok(ActivationWithOptionalGating {
+    match String::deserialize(deserializer)?.as_str() {
+        "gated-gelu" => Ok(ActivationWithOptionalGating {
             gated: true,
             activation: candle_nn::Activation::NewGelu,
-        });
-    }
-    if buf == "gated-silu" {
-        return Ok(ActivationWithOptionalGating {
+        }),
+        "gated-silu" => Ok(ActivationWithOptionalGating {
             gated: true,
             activation: candle_nn::Activation::Silu,
-        });
+        }),
+        buf => {
+            let activation = serde_plain::from_str(buf).map_err(serde::de::Error::custom)?;
+            Ok(ActivationWithOptionalGating {
+                gated: false,
+                activation,
+            })
+        }
     }
-    let activation = serde_plain::from_str(&buf).map_err(serde::de::Error::custom)?;
-    Ok(ActivationWithOptionalGating {
-        gated: false,
-        activation,
-    })
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]


### PR DESCRIPTION
This is yet another variant of the T5 encoder/decoder models.

It works, but it's terribly slow on MacOS. I interrupted the following command after at least 15 minutes, and it had generated just the first 4 words.

```
$ RUST_BACKTRACE=1 cargo run --example t5 --release --features accelerate -- --model-id "google/flan-ul2" --revision "refs/pr/25"  --prompt "A step by step recipe to make bolognese pasta:" --decode
    Finished release [optimized] target(s) in 1.06s
     Running `target/release/examples/t5 --model-id google/flan-ul2 --revision refs/pr/25 --prompt 'A step by step recipe to make bolognese pasta:' --decode`
Running on CPU, to run on GPU, build this example with `--features cuda`
 - In a large skillet
```