### PR TITLE
Add weight and bias functions to LayerNorm

### DIFF
--- a/candle-nn/src/layer_norm.rs
+++ b/candle-nn/src/layer_norm.rs
@@ -95,6 +95,14 @@ impl LayerNorm {
             eps,
         }
     }
+
+    pub fn weight(&self) -> &Tensor {
+        &self.weight
+    }
+
+    pub fn bias(&self) -> Option<&Tensor> {
+        self.bias.as_ref()
+    }
 }
 
 impl crate::Module for LayerNorm {


### PR DESCRIPTION
While porting some code from PyTorch to Candle, I needed to check the values of the weights and biases from LayerNorm layers, but as the values are private they can not be explicitly accessed. 

However, this functionality is present in the Linear layer with the use of two `pub fn weight(&self)` and `pub fn bias(&self)` functions.

I propose adding these two (QOL) functions to the LayerNorm `impl` to match the functionality of the Linear layer, while providing access to the weight and bias Tensors in the LayerNorm layer.