### PR TITLE
Check min to buckets in relative_position_bucket

### DIFF
--- a/candle-transformers/src/models/t5.rs
+++ b/candle-transformers/src/models/t5.rs
@@ -462,7 +462,7 @@ impl T5Attention {
                                             self.relative_attention_max_distance as f32
                                                 / max_exact as f32,
                                         ) * (num_buckets - max_exact) as f32;
-                                        max_exact + b as u32
+                                        u32::min(max_exact + b as u32, num_buckets - 1)
                                     }
                                 })
                                 .collect::<Vec<u32>>()


### PR DESCRIPTION
Without min function buckets has wrong value in some cases.
In python version this check here - https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/modeling_t5.py#L429-L431

After this fix encode has same result between rust and python versions. 