### PR TITLE
Add OpenChat 3.5 to quantized examples

### DIFF
--- a/candle-examples/examples/quantized/main.rs
+++ b/candle-examples/examples/quantized/main.rs
@@ -53,6 +53,8 @@ enum Which {
     Zephyr7bAlpha,
     #[value(name = "7b-zephyr-b")]
     Zephyr7bBeta,
+    #[value(name = "7b-open-chat-3.5")]
+    OpenChat35,
 }
 
 impl Which {
@@ -67,8 +69,9 @@ impl Which {
             | Self::L7bCode
             | Self::L13bCode
             | Self::L34bCode => false,
-            // Zephyr is a fine tuned version of mistral and should be treated in the same way.
-            Self::Zephyr7bAlpha
+            // Zephyr and OpenChart are fine tuned versions of mistral and should be treated in the same way.
+            Self::OpenChat35
+            | Self::Zephyr7bAlpha
             | Self::Zephyr7bBeta
             | Self::Mistral7b
             | Self::Mistral7bInstruct => true,
@@ -87,7 +90,8 @@ impl Which {
             | Self::L13bCode
             | Self::L34bCode
             | Self::Mistral7b
-            | Self::Mistral7bInstruct => false,
+            | Self::Mistral7bInstruct
+            | Self::OpenChat35 => false,
             Self::Zephyr7bAlpha | Self::Zephyr7bBeta => true,
         }
     }
@@ -207,6 +211,7 @@ impl Args {
                     Which::Zephyr7bBeta => {
                         ("TheBloke/zephyr-7B-beta-GGUF", "zephyr-7b-beta.Q4_K_M.gguf")
                     }
+                    Which::OpenChat35 => ("TheBloke/openchat_3.5-GGUF", "openchat_3.5.Q4_K_M.gguf"),
                 };
                 let api = hf_hub::api::sync::Api::new()?;
                 let api = api.model(repo.to_string());
@@ -308,7 +313,8 @@ fn main() -> anyhow::Result<()> {
                 | Which::Zephyr7bAlpha
                 | Which::Zephyr7bBeta
                 | Which::L70b
-                | Which::L70bChat => 8,
+                | Which::L70bChat
+                | Which::OpenChat35 => 8,
             };
             ModelWeights::from_ggml(model, args.gqa.unwrap_or(default_gqa))?
         }

--- a/candle-examples/examples/quantized/main.rs
+++ b/candle-examples/examples/quantized/main.rs
@@ -69,7 +69,8 @@ impl Which {
             | Self::L7bCode
             | Self::L13bCode
             | Self::L34bCode => false,
-            // Zephyr and OpenChart are fine tuned versions of mistral and should be treated in the same way.
+            // Zephyr and OpenChat are fine tuned versions of mistral and should be treated in the
+            // same way.
             Self::OpenChat35
             | Self::Zephyr7bAlpha
             | Self::Zephyr7bBeta


### PR DESCRIPTION
This MR adds the [OpenChat 3.5](https://huggingface.co/openchat/openchat_3.5/tree/main) model to the quantized example.

Specifically, the GGUF version from https://huggingface.co/TheBloke/openchat_3.5-GGUF/tree/main.

OpenChat is the best 7b model according to Arena ELO https://arena.lmsys.org/

It is a fine tune of mistral, and configuring it as mistral works well.


One prompt:

``` 
$ cargo run --example quantized --release -- --prompt "The best thing about coding in rust is " --which 7b-open-chat-3.5
   Compiling candle-examples v0.3.1 (/home/lucas/oss/candle/candle-examples)
    Finished release [optimized] target(s) in 4.12s
     Running `target/release/examples/quantized --prompt 'The best thing about coding in rust is ' --which 7b-open-chat-3.5`
avx: true, neon: false, simd128: false, f16c: true
temp: 0.80 repeat-penalty: 1.10 repeat-last-n: 64
loaded 291 tensors (4.37GB) in 0.08s
model built
The best thing about coding in rust is 0 cost abstractions. In other words, the compiler can inline functions if they meet certain conditions (having no side effects, being small enough etc.)

I've been working on a project that uses a lot of ffi (foreign function interface) and wanted to write some wrappers for the underlying library, since the language binding I was using lacked some utility functions. Now, writing these wrapper functions was not possible since any function that calls an external function is leftmost and thus cannot be inlined by rust's compiler. This was a problem since one of the functions is called very frequently (around 50'000 times per second) ...
```


Chat:

``` 
$ cargo run --example quantized --release -- --prompt "chat" --which 7b-open-chat-3.5
   Compiling candle-examples v0.3.1 (/home/lucas/oss/candle/candle-examples)
    Finished release [optimized] target(s) in 4.22s
     Running `target/release/examples/quantized --prompt chat --which 7b-open-chat-3.5`
avx: true, neon: false, simd128: false, f16c: true
temp: 0.80 repeat-penalty: 1.10 repeat-last-n: 64
loaded 291 tensors (4.37GB) in 0.08s
model built
> Tell me a joke.
User: Tell me a joke.<|end_of_turn|>Assistant: 1 Why don't scientists trust atoms? Because they make up everything!

  12 prompt tokens processed: 9.11 token/s
  15 tokens generated: 6.28 token/s
> 
```