### PR TITLE
Examples - Fix OpenChat 3.5 tokenizer

### DIFF
--- a/candle-examples/examples/quantized/main.rs
+++ b/candle-examples/examples/quantized/main.rs
@@ -181,7 +181,9 @@ impl Args {
             Some(config) => std::path::PathBuf::from(config),
             None => {
                 let api = hf_hub::api::sync::Api::new()?;
-                let repo = if self.which.is_mistral() {
+                let repo = if self.which.is_open_chat() {
+                    "openchat/openchat_3.5"
+                } else if self.which.is_mistral() {
                     "mistralai/Mistral-7B-v0.1"
                 } else {
                     "hf-internal-testing/llama-tokenizer"


### PR DESCRIPTION
On https://github.com/huggingface/candle/pull/1346 this commit https://github.com/huggingface/candle/pull/1346/commits/b5b558a432096976dee2fca48670f2a49b621ddf removed the different tokenizer for OpenChat, but it is required.

Without the tokenizer:

```
$ cargo run --example quantized --release -- --prompt "chat" --which 7b-open-chat-3.5
   Compiling candle-examples v0.3.1 (/home/lucas/oss/candle/candle-examples)
    Finished release [optimized] target(s) in 4.33s
     Running `target/release/examples/quantized --prompt chat --which 7b-open-chat-3.5`
avx: true, neon: false, simd128: false, f16c: true
temp: 0.80 repeat-penalty: 1.10 repeat-last-n: 64
loaded 291 tensors (4.37GB) in 0.08s
model built
> Tell me a joke.
User: Tell me a joke.<|end_of_turn|>Assistant: Whythread 'main' panicked at candle-examples/examples/quantized/main.rs:426:73:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
``` 


With it

``` 
$ cargo run --example quantized --release -- --prompt "chat" --which 7b-open-chat-3.5
   Compiling candle-examples v0.3.1 (/home/lucas/oss/candle/candle-examples)
    Finished release [optimized] target(s) in 4.19s
     Running `target/release/examples/quantized --prompt chat --which 7b-open-chat-3.5`
avx: true, neon: false, simd128: false, f16c: true
temp: 0.80 repeat-penalty: 1.10 repeat-last-n: 64
loaded 291 tensors (4.37GB) in 0.10s
model built
> Tell me a joke.
User: Tell me a joke.<|end_of_turn|>Assistant: 1 Why don't scientists trust atoms? Because they make up everything!

  12 prompt tokens processed: 9.60 token/s
  15 tokens generated: 6.39 token/s
```