### PR TITLE
Add candle-lora transformers to readme?

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,20 +141,8 @@ And then head over to
 ## Useful External Resources
 - [`candle-tutorial`](https://github.com/ToluClassics/candle-tutorial): A
   very detailed tutorial showing how to convert a PyTorch model to Candle.
-- [`candle-lora`](https://github.com/EricLBuehler/candle-lora): Efficient and ergonomic LoRA implemenation for Candle.
-
-  Additionally, `candle-lora` has out-of-the-box LoRA support for many models from Candle, including:
-    - [Falcon](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/falcon.rs)
-    - [Llama](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/llama.rs)
-    - [Mistral](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/mistral.rs)
-    - [BERT](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/bert.rs)
-    - [Bigcode (Starcoder)](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/bigcode.rs)
-    - [BLIP](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/blip.rs)
-    - [DINOv2](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/dinov2.rs)
-    - [MPT](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/mpt.rs)
-    - [ResNet](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/resnet.rs)
-    - [StableLM](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/stable_lm.rs)
-    - [T5](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/t5.rs)
+- [`candle-lora`](https://github.com/EricLBuehler/candle-lora): Efficient and ergonomic LoRA implemenation for Candle. `candle-lora` has      
+  out-of-the-box LoRA support for many models from Candle, which can be found [here](https://github.com/EricLBuehler/candle-lora/tree/master/candle-lora-transformers/examples).
 - [`optimisers`](https://github.com/KGrewal1/optimisers): A collection of optimisers
   including SGD with momentum, AdaGrad, AdaDelta, AdaMax, NAdam, RAdam, and RMSprop.
 - [`candle-vllm`](https://github.com/EricLBuehler/candle-vllm): Efficient platform for inference and

--- a/README.md
+++ b/README.md
@@ -139,15 +139,27 @@ And then head over to
 <!--- ANCHOR: useful_libraries --->
 
 ## Useful External Resources
-- [`candle-tutorial`](https://github.com/ToluClassics/candle-tutorial): a
+- [`candle-tutorial`](https://github.com/ToluClassics/candle-tutorial): A
   very detailed tutorial showing how to convert a PyTorch model to Candle.
-- [`optimisers`](https://github.com/KGrewal1/optimisers): a collection of optimisers
+- [`candle-lora`](https://github.com/EricLBuehler/candle-lora): Efficient and ergonomic LoRA implemenation for Candle.
+
+  Additionally, `candle-lora` has out-of-the-box LoRA support for many models from Candle, including:
+    - [Falcon](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/falcon.rs)
+    - [Llama](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/llama.rs)
+    - [Mistral](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/mistral.rs)
+    - [BERT](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/bert.rs)
+    - [Bigcode (Starcoder)](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/bigcode.rs)
+    - [BLIP](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/blip.rs)
+    - [DINOv2](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/dinov2.rs)
+    - [MPT](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/mpt.rs)
+    - [ResNet](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/resnet.rs)
+    - [StableLM](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/stable_lm.rs)
+    - [T5](https://github.com/EricLBuehler/candle-lora/blob/master/candle-lora-transformers/examples/t5.rs)
+- [`optimisers`](https://github.com/KGrewal1/optimisers): A collection of optimisers
   including SGD with momentum, AdaGrad, AdaDelta, AdaMax, NAdam, RAdam, and RMSprop.
-- [`candle-lora`](https://github.com/EricLBuehler/candle-lora): a LoRA implementation
-  that conforms to the official `peft` implementation.
 - [`candle-vllm`](https://github.com/EricLBuehler/candle-vllm): Efficient platform for inference and
   serving local LLMs including an OpenAI compatible API server.
-- [`candle-ext`](https://github.com/mokeyish/candle-ext): an extension library to Candle that provides PyTorch functions not currently available in Candle.
+- [`candle-ext`](https://github.com/mokeyish/candle-ext): An extension library to Candle that provides PyTorch functions not currently available in Candle.
 - [`kalosm`](https://github.com/floneum/floneum/tree/master/interfaces/kalosm): A multi-modal meta-framework in Rust for interfacing with local pre-trained models with support for controlled generation, custom samplers, in-memory vector databases, audio transcription, and more.
 - [`candle-sampling`](https://github.com/EricLBuehler/candle-sampling): Sampling techniques for Candle.
 


### PR DESCRIPTION
Hi @LaurentMazare,

I have recently added LoRA support to many models in `candle-transformers`. These "LoRA transformers" are in `candle-lora`. However, I think that it would be helpful to add a link for these into the README as it would increase discoverability for developers who want to fine-tune models. Currently, one would need to go to the `candle-lora` repository to find these models, and while that may be intuitive I think making their location explicit would be better.

What do you think about this addition?