### PR TITLE
Fix linspace implementation

### DIFF
--- a/candle-examples/examples/yolo-v8/main.rs
+++ b/candle-examples/examples/yolo-v8/main.rs
@@ -7,7 +7,7 @@ extern crate accelerate_src;
 mod model;
 use model::{Multiples, YoloV8, YoloV8Pose};
 
-use candle::{DType, IndexOp, Result, Tensor, Device};
+use candle::{DType, Device, IndexOp, Result, Tensor};
 use candle_nn::{Module, VarBuilder};
 use candle_transformers::object_detection::{non_maximum_suppression, Bbox, KeyPoint};
 use clap::{Parser, ValueEnum};

--- a/candle-transformers/src/models/stable_diffusion/utils.rs
+++ b/candle-transformers/src/models/stable_diffusion/utils.rs
@@ -1,12 +1,15 @@
 use candle::{Device, Result, Tensor};
 
 pub fn linspace(start: f64, stop: f64, steps: usize) -> Result<Tensor> {
-    if steps <= 1 {
-        candle::bail!("cannot use linspace with steps {steps} <= 1")
+    if steps == 0 {
+        Tensor::from_vec(Vec::<f64>::new(), steps, &Device::Cpu)
+    } else if steps == 1 {
+        Tensor::from_vec(vec![start], steps, &Device::Cpu)
+    } else {
+        let delta = (stop - start) / (steps - 1) as f64;
+        let vs = (0..steps)
+            .map(|step| start + step as f64 * delta)
+            .collect::<Vec<_>>();
+        Tensor::from_vec(vs, steps, &Device::Cpu)
     }
-    let delta = (stop - start) / (steps - 1) as f64;
-    let vs = (0..steps)
-        .map(|step| start + step as f64 * delta)
-        .collect::<Vec<_>>();
-    Tensor::from_vec(vs, steps, &Device::Cpu)
 }

--- a/candle-transformers/src/models/stable_diffusion/utils.rs
+++ b/candle-transformers/src/models/stable_diffusion/utils.rs
@@ -1,7 +1,7 @@
 use candle::{Device, Result, Tensor};
 
 pub fn linspace(start: f64, stop: f64, steps: usize) -> Result<Tensor> {
-    if steps < 1 {
+    if steps <= 1 {
         candle::bail!("cannot use linspace with steps {steps} <= 1")
     }
     let delta = (stop - start) / (steps - 1) as f64;


### PR DESCRIPTION
This pull request attempts to fix a potential issue in linspace implementation.

`steps` should be strictly greater than 1 to make it consistent with the context (namely, to make it consistent with the error message and to avoid a potential divide-by-zero/NaN).

Although this implementation of linspace is still not completely conformant to the PyTorch equivalent, for example:
```python3
torch.linspace(0.0, 1.0, steps=1)    # tensor([0.])
torch.linspace(0.0, 1.0, steps=0)    # tensor([])
torch.linspace(0.0, 1.0, steps=-1)    # RuntimeError: number of steps must be non-negative
```