### PR TITLE
Run nvcc via ccache in flash-attn

### DIFF
--- a/candle-flash-attn/build.rs
+++ b/candle-flash-attn/build.rs
@@ -104,8 +104,9 @@ fn main() -> Result<()> {
         cu_files
             .par_iter()
             .map(|(cu_file, obj_file)| {
-                let mut command = std::process::Command::new("nvcc");
+                let mut command = std::process::Command::new("ccache");
                 command
+                    .arg("nvcc")
                     .arg("-std=c++17")
                     .arg("-O3")
                     .arg("-U__CUDA_NO_HALF_OPERATORS__")


### PR DESCRIPTION
On my test box, compiling `candle-flash-attn` from scratch in debug takes about 3 minutes, but most of this time is spent running `nvcc` on the flash attention kernels. Running `nvcc` via `ccache` brings this down to around 15 seconds (on the second build). Also, the ccache is shared between debug and release builds.

Do you think it's OK to always run via ccache? It seems straightforward to install.