### PR TITLE
Add methods to clear cache for Llama models

### DIFF
--- a/candle-examples/examples/llama_multiprocess/model.rs
+++ b/candle-examples/examples/llama_multiprocess/model.rs
@@ -306,6 +306,11 @@ impl CausalSelfAttention {
             cache: cache.clone(),
         })
     }
+
+    fn clear_cache(&mut self, config: &Config) {
+        self.cache.masks = Arc::new(Mutex::new(HashMap::new()));
+        self.cache.kvs = Arc::new(Mutex::new(vec![None; config.num_hidden_layers]));
+    }
 }
 
 struct Mlp {
@@ -391,15 +396,23 @@ pub struct Llama {
     blocks: Vec<Block>,
     ln_f: RmsNorm,
     lm_head: Linear,
+    cfg: Config,
 }
 
 impl Llama {
-    fn new(wte: Embedding, blocks: Vec<Block>, ln_f: RmsNorm, lm_head: Linear) -> Self {
+    fn new(
+        wte: Embedding,
+        blocks: Vec<Block>,
+        ln_f: RmsNorm,
+        lm_head: Linear,
+        cfg: Config,
+    ) -> Self {
         Self {
             wte,
             blocks,
             ln_f,
             lm_head,
+            cfg,
         }
     }
 
@@ -431,6 +444,16 @@ impl Llama {
             })
             .collect();
 
-        Ok(Self::new(wte, blocks, norm, lm_head))
+        Ok(Self::new(wte, blocks, norm, lm_head, cfg.clone()))
+    }
+
+    pub fn clear_cache(&mut self, config: &Config) {
+        for block in &mut self.blocks {
+            block.attn.clear_cache(config);
+        }
+    }
+
+    pub fn get_config(&self) -> &Config {
+        &self.cfg
     }
 }

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -40,6 +40,7 @@ impl LlamaConfig {
     }
 }
 
+#[derive(Clone)]
 pub struct Config {
     pub hidden_size: usize,
     pub intermediate_size: usize,
@@ -310,6 +311,11 @@ impl CausalSelfAttention {
             span_rot,
         })
     }
+
+    fn clear_cache(&mut self, config: &Config) {
+        self.cache.masks = Arc::new(Mutex::new(HashMap::new()));
+        self.cache.kvs = Arc::new(Mutex::new(vec![None; config.num_hidden_layers]));
+    }
 }
 
 fn masked_fill(on_false: &Tensor, mask: &Tensor, on_true: f32) -> Result<Tensor> {
@@ -393,6 +399,7 @@ pub struct Llama {
     blocks: Vec<Block>,
     ln_f: RmsNorm,
     lm_head: Linear,
+    cfg: Config,
 }
 
 impl Llama {
@@ -421,6 +428,17 @@ impl Llama {
             blocks,
             ln_f,
             lm_head,
+            cfg: cfg.clone(),
         })
+    }
+
+    pub fn clear_cache(&mut self, config: &Config) {
+        for block in &mut self.blocks {
+            block.attn.clear_cache(config);
+        }
+    }
+
+    pub fn get_config(&self) -> &Config {
+        &self.cfg
     }
 }

--- a/candle-transformers/src/models/llama2_c.rs
+++ b/candle-transformers/src/models/llama2_c.rs
@@ -235,6 +235,11 @@ impl CausalSelfAttention {
             cache: cache.clone(),
         })
     }
+
+    fn clear_cache(&mut self, config: &Config) {
+        self.cache.masks = Arc::new(Mutex::new(HashMap::new()));
+        self.cache.kvs = Arc::new(Mutex::new(vec![None; config.n_layers]));
+    }
 }
 
 fn masked_fill(on_false: &Tensor, mask: &Tensor, on_true: f32) -> Result<Tensor> {
@@ -349,5 +354,15 @@ impl Llama {
             lm_head,
             config: cfg,
         })
+    }
+
+    pub fn clear_cache(&mut self, config: &Config) {
+        for block in &mut self.blocks {
+            block.attn.clear_cache(config);
+        }
+    }
+
+    pub fn get_config(&self) -> &Config {
+        &self.config
     }
 }


### PR DESCRIPTION
Hello everybody,

I have added some methods to clear the KV and (if applicable) the mask caches for the Llama models. These methods take an `&mut self` to emphasize their mutation. 

This functionality is necessary for the resolution of EricLBuehler/candle-vllm#6. Do you think it would be a good idea to add these methods to the Llama models here, or should I have a separate, modified Llama implementation? I would prefer to have a dependency to `candle-transformers`, but please let me know what you think.