### PR TITLE
Fix contiguous affine check for metal backend

### DIFF
--- a/candle-core/src/metal_backend.rs
+++ b/candle-core/src/metal_backend.rs
@@ -126,8 +126,11 @@ impl BackendStorage for MetalStorage {
         let el = shape.elem_count();
         let dtype = self.dtype;
 
-        if layout.is_contiguous() || layout.start_offset() != 0 || dtype != DType::F32 {
-            crate::bail!("Not contiguous, non-f32 affine is not implemented yet.");
+        if !layout.is_contiguous() || layout.start_offset() != 0 {
+            crate::bail!("Not contiguous affine is not implemented yet.");
+        }
+        if dtype != DType::F32 {
+            crate::bail!("Non-f32 affine is not implemented yet.");
         }
 
         let mut buffer = device.new_buffer(el, self.dtype);


### PR DESCRIPTION
I believe the logic is reversed. When `layout.is_contiguous` we don't need to bail.

I also broke the check into two so that the error message is more specific.