### PR TITLE
Fix NaN errors for Gelu in Metal

### DIFF
--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -295,7 +295,7 @@ fn run_affine<T: Clone>(v: &[T], mul: f64, add: f64) -> Vec<T> {
     output.read_to_vec::<T>(v.len())
 }
 
-fn _run_affine_strided<T: Clone>(
+fn run_affine_strided<T: Clone>(
     v: &[T],
     shape: &[usize],
     strides: &[usize],
@@ -314,7 +314,7 @@ fn _run_affine_strided<T: Clone>(
         &device,
         command_buffer,
         &kernels,
-        "affine_float",
+        "affine_float_strided",
         shape,
         &input,
         strides,
@@ -327,7 +327,8 @@ fn _run_affine_strided<T: Clone>(
     command_buffer.commit();
     command_buffer.wait_until_completed();
 
-    output.read_to_vec::<T>(v.len())
+    let len: usize = shape.iter().product();
+    output.read_to_vec::<T>(len)
 }
 
 #[test]
@@ -345,15 +346,17 @@ fn affine() {
     assert_eq!(result, vec![2.6; 40_000]);
 }
 
-// #[test]
-// fn affine_strided() {
-//     let input = [1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
-//     let mul = 1.5;
-//     let add = 1.1;
-//     let result = run_affine_(&input, mul, add);
-//     assert_eq!(result, vec![2.6, 4.1, 5.6, 7.1, 8.6, 10.1, 11.6, 13.1]);
-
-// }
+#[test]
+fn affine_strided() {
+    let input = [1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+    let mul = 1.5;
+    let add = 1.1;
+    let shape = [4];
+    let strides = [2];
+    let result = run_affine_strided(&input, &shape, &strides, mul, add);
+    // 1 on 2
+    assert_eq!(result, vec![2.6, 5.6, 8.6, 11.6]);
+}
 
 #[test]
 fn index_select() {

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -206,6 +206,25 @@ fn cos_strided_random() {
 }
 
 #[test]
+fn gelu_f16() {
+    let v: Vec<f16> = [-10f32, -1.0, 0., 1., 2., 3., 10.0, 20.0]
+        .iter()
+        .map(|v| f16::from_f32(*v))
+        .collect();
+    let expected: Vec<f32> = vec![-0.0, -0.16, 0.0, 0.84, 1.96, 3.0, 10.0, 20.0];
+    let results = run(&v, unary::contiguous::gelu::HALF);
+    assert_eq!(approx_f16(results, 2), expected);
+}
+
+#[test]
+fn gelu_f32() {
+    let v: Vec<f32> = vec![-10f32, -1.0, 0., 1., 2., 3., 10.0, 20.0];
+    let expected: Vec<f32> = vec![-0.0, -0.159, 0.0, 0.841, 1.955, 2.996, 10.0, 20.0];
+    let results = run(&v, unary::contiguous::gelu::FLOAT);
+    assert_eq!(approx(results, 3), expected);
+}
+
+#[test]
 fn binary_add_f32() {
     let left = vec![1.0f32, 2.0, 3.0];
     let right = vec![2.0f32, 3.1, 4.2];
@@ -527,8 +546,8 @@ fn cos_f16() {
         .collect();
     let results = run(&v, unary::contiguous::cos::HALF);
     let expected: Vec<f16> = v.iter().map(|v| f16::from_f32(v.to_f32().cos())).collect();
-    assert_eq!(approx_f16(results, 4), vec![0.5405, -0.4163, -0.9902]);
-    assert_eq!(approx_f16(expected, 4), vec![0.5405, -0.4163, -0.9902]);
+    assert_eq!(approx_f16(results, 2), vec![0.54, -0.42, -0.99]);
+    assert_eq!(approx_f16(expected, 2), vec![0.54, -0.42, -0.99]);
 }
 
 fn run_reduce<T: Clone>(v: &[T], out_length: usize, name: &'static str) -> Vec<T> {

--- a/candle-metal-kernels/src/unary.metal
+++ b/candle-metal-kernels/src/unary.metal
@@ -42,9 +42,14 @@ template <typename T> METAL_FUNC T erf(T in){
 
     return T(sign*y);
 }
-template <typename T> METAL_FUNC T id(T in){ return in; }
-template <typename T> METAL_FUNC T gelu_erf(T x){ return T(x * (1 + erf(x * M_SQRT1_2_F)) / 2); }
-template <typename T> METAL_FUNC T gelu(T x){
+template <typename T> METAL_FUNC T id(T in) { return in; }
+template <typename T> METAL_FUNC T gelu_erf(T x) {
+    return T(x * (1 + erf(x * M_SQRT1_2_F)) / 2);
+}
+template <typename T> METAL_FUNC T gelu(T x) {
+    if (x > 5) {
+        return x;
+    }
     T x_sq = x * x;
     T x_cube = x_sq * x;
     T alpha = x + static_cast<T>(0.044715) * x_cube;


### PR DESCRIPTION
This is based on https://github.com/huggingface/candle/pull/1318, which is adding the gelu kernel. cc @Narsil 

The flan t5 embeddings are all NaN when metal is enabled. This is because the output of gelu(x) for x > 10 is NaN.

```
$ cargo run --example t5 --release --features metal -- --model-id "google/flan-t5-small" --prompt "translate to German: A beautiful candle."
[[[NaN, NaN, NaN, ..., NaN, NaN, NaN],
  [NaN, NaN, NaN, ..., NaN, NaN, NaN],
  [NaN, NaN, NaN, ..., NaN, NaN, NaN],
  ...
  [NaN, NaN, NaN, ..., NaN, NaN, NaN],
  [NaN, NaN, NaN, ..., NaN, NaN, NaN],
  [NaN, NaN, NaN, ..., NaN, NaN, NaN]]]
Tensor[[1, 9, 512], f32, metal:4294968146]
Took 26.179209ms
```

With this change, I get embeddings approximately equal to the ones I get on the CPU.
