### PR TITLE
Add tracking of memory allocations to Device

### DIFF
--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -30,6 +30,7 @@ safetensors = { workspace = true }
 thiserror = { workspace = true }
 yoke = { workspace = true }
 zip = { workspace = true }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/candle-core/src/backend.rs
+++ b/candle-core/src/backend.rs
@@ -1,5 +1,5 @@
 use crate::op::{BinaryOpT, CmpOp, ReduceOp, UnaryOpT};
-use crate::{CpuStorage, DType, Layout, Result, Shape};
+use crate::{CpuStorage, DType, Device, Layout, Result, Shape};
 
 pub trait BackendStorage: Sized {
     type Device: BackendDevice;
@@ -121,4 +121,8 @@ pub trait BackendDevice: Sized + std::fmt::Debug + Clone {
     fn rand_normal(&self, _: &Shape, _: DType, _: f64, _: f64) -> Result<Self::Storage>;
 
     fn set_seed(&self, _: u64) -> Result<()>;
+
+    fn reset_peak_memory_stats(&mut self, device: Device);
+
+    fn max_memory_allocated(&self, device: Device) -> usize;
 }

--- a/candle-core/src/cpu_backend.rs
+++ b/candle-core/src/cpu_backend.rs
@@ -24,7 +24,7 @@ pub enum CpuStorage {
 }
 
 lazy_static! {
-    static ref MAX_ALLOCATED_CPU: Mutex<usize> = { Mutex::new(0) };
+    static ref MAX_ALLOCATED_CPU: Mutex<usize> = Mutex::new(0);
 }
 
 fn get_max_allocated<'a>() -> MutexGuard<'a, usize> {

--- a/candle-core/src/device.rs
+++ b/candle-core/src/device.rs
@@ -179,6 +179,22 @@ impl Device {
         }
     }
 
+    pub fn reset_peak_memory_stats(&mut self, device: Device) {
+        match self {
+            Self::Cpu => CpuDevice.reset_peak_memory_stats(device),
+            Self::Cuda(cudadevice) => cudadevice.reset_peak_memory_stats(device),
+            Device::Metal(metaldevice) => metaldevice.reset_peak_memory_stats(device),
+        }
+    }
+
+    pub fn max_memory_allocated(&self, device: Device) -> usize {
+        match self {
+            Self::Cpu => CpuDevice.max_memory_allocated(device),
+            Self::Cuda(cudadevice) => cudadevice.max_memory_allocated(device),
+            Device::Metal(metaldevice) => metaldevice.max_memory_allocated(device),
+        }
+    }
+
     pub(crate) fn rand_uniform_f64(
         &self,
         lo: f64,

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -208,4 +208,10 @@ impl crate::backend::BackendDevice for CudaDevice {
     fn rand_normal(&self, _: &Shape, _: DType, _: f64, _: f64) -> Result<Self::Storage> {
         Err(Error::NotCompiledWithCudaSupport)
     }
+
+    fn reset_peak_memory_stats(&mut self, _device: crate::Device) {}
+
+    fn max_memory_allocated(&self, _device: crate::Device) -> usize {
+        usize::MAX
+    }
 }

--- a/candle-core/src/dummy_metal_backend.rs
+++ b/candle-core/src/dummy_metal_backend.rs
@@ -220,4 +220,10 @@ impl crate::backend::BackendDevice for MetalDevice {
     fn rand_normal(&self, _: &Shape, _: DType, _: f64, _: f64) -> Result<Self::Storage> {
         Err(Error::NotCompiledWithMetalSupport)
     }
+
+    fn reset_peak_memory_stats(&mut self, _device: crate::Device) {}
+
+    fn max_memory_allocated(&self, _device: crate::Device) -> usize {
+        usize::MAX
+    }
 }


### PR DESCRIPTION
Hello everybody,

This PR adds automatic tracking of the number of bytes allocated by each device, which is necessary for the immediate further development of candle-vllm. 

## Why this is necessary
This is a necessary addition because it will allow candle-vllm to profile the amount of memory allocated. Profiling the memory is essential to the initialization of a candle-vllm instance, which makes it necessary for the immediate further development of candle-vllm.

## Why this works
For each CPU, CUDA, or Metal allocation, a mutable state tracks the number of bytes allocated per device ordinal. Specifically, for CUDA and Metal kernels, a table that maps device ordinals to the allocation level is used. The state is behind a mutex for soundness.

Because allocations should of course not be done very often in performance critical sections, locking the mutex will only induce a negligible performance regression.

## API addition
I add the `reset_peak_memory_stats` and `max_memory_allocated` methods to `Device`. These respectively allow the state to be reset or read for a specific device ordinal.