### PR TITLE
Upsample grad

### DIFF
--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -361,12 +361,12 @@ impl Tensor {
                         }
                         let scale_h = target_h / h;
                         let scale_w = target_w / w;
-                        println!("scale_h {scale_h} scale_w {scale_w}");
+
                         if scale_h != scale_w {
                             crate::bail!("backward not supported for non uniform upscaling factors")
                         };
                         let kernel =
-                            Tensor::ones((1, 1, scale_h, scale_w), arg.dtype(), arg.device())?;
+                            Tensor::ones((c, 1, scale_h, scale_w), arg.dtype(), arg.device())?;
                         let conv_sum = grad.conv2d(&kernel, 0, scale_h, 1, c)?;
                         let sum_grad = grads.or_insert(arg)?;
                         *sum_grad = conv_sum;

--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -350,9 +350,27 @@ impl Tensor {
                     Op::UpsampleNearest1D { .. } => Err(Error::BackwardNotSupported {
                         op: "upsample-nearest1d",
                     })?,
-                    Op::UpsampleNearest2D { .. } => Err(Error::BackwardNotSupported {
-                        op: "upsample-nearest2d",
-                    })?,
+                    Op::UpsampleNearest2D {
+                        arg,
+                        target_h,
+                        target_w,
+                    } => {
+                        let (_n, c, h, w) = arg.dims4()?;
+                        if target_h % h != 0 || target_w % w != 0 {
+                            crate::bail!("backward not supported for non integer upscaling factors")
+                        }
+                        let scale_h = target_h / h;
+                        let scale_w = target_w / w;
+                        println!("scale_h {scale_h} scale_w {scale_w}");
+                        if scale_h != scale_w {
+                            crate::bail!("backward not supported for non uniform upscaling factors")
+                        };
+                        let kernel =
+                            Tensor::ones((1, 1, scale_h, scale_w), arg.dtype(), arg.device())?;
+                        let conv_sum = grad.conv2d(&kernel, 0, scale_h, 1, c)?;
+                        let sum_grad = grads.or_insert(arg)?;
+                        *sum_grad = conv_sum;
+                    }
                     Op::SliceScatter0(lhs, rhs, start_rhs) => {
                         let rhs_sum_grad = grads.or_insert(rhs)?;
                         let rhs_grad = grad.narrow(0, *start_rhs, rhs.dim(0)?)?;

--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -114,7 +114,7 @@ impl Tensor {
                     | Op::Unary(_node, UnaryOp::Round) => nodes,
                     Op::Reshape(node)
                     | Op::UpsampleNearest1D(node)
-                    | Op::UpsampleNearest2D(node)
+                    | Op::UpsampleNearest2D { arg: node, .. }
                     | Op::AvgPool2D { arg: node, .. }
                     | Op::MaxPool2D { arg: node, .. }
                     | Op::Copy(node)

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -132,7 +132,11 @@ pub enum Op {
     },
 
     UpsampleNearest1D(Tensor),
-    UpsampleNearest2D(Tensor),
+    UpsampleNearest2D {
+        arg: Tensor,
+        target_h: usize,
+        target_w: usize,
+    },
 
     Cat(Vec<Tensor>, usize),
 

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -999,7 +999,6 @@ impl Tensor {
             target_h,
             target_w,
         });
-        // let op = BackpropOp::new1(self, Op::UpsampleNearest2D);
         let storage = self
             .storage()
             .upsample_nearest2d(self.layout(), target_h, target_w)?;

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -994,7 +994,12 @@ impl Tensor {
     /// tensor also has four dimensions, `(batch, channels, target_h, target_w)`.
     pub fn interpolate2d(&self, target_h: usize, target_w: usize) -> Result<Self> {
         let (n, c, _h, _w) = self.dims4()?;
-        let op = BackpropOp::new1(self, Op::UpsampleNearest2D);
+        let op = BackpropOp::new1(self, |arg| Op::UpsampleNearest2D {
+            arg,
+            target_h,
+            target_w,
+        });
+        // let op = BackpropOp::new1(self, Op::UpsampleNearest2D);
         let storage = self
             .storage()
             .upsample_nearest2d(self.layout(), target_h, target_w)?;

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -270,6 +270,33 @@ fn unary_grad(device: &Device) -> Result<()> {
         [0.7358, 2.0000, 0.2707, 1.0000]
     );
 
+    // Testing against
+    // x = torch.tensor([[[[3.0, 1.0], [4.0, 0.15]]]], requires_grad=True)
+    // upsample1 = torch.nn.Upsample(scale_factor=2, mode='nearest')
+    // print(x.shape)
+    // # print(x)
+    // # print(upsample1(x) )
+    // y = upsample1(x)
+    // print(x)
+    // print(y)
+    // loss = y.sum()
+    // loss.backward()
+    // print(x.grad)
+    let x = Var::new(&[[[[3f32, 1.], [4., 0.15]]]], device)?;
+    let y = x.upsample_nearest2d(4, 4)?.reshape((4, 4))?;
+    let loss = y.sum_all()?;
+    print!("{}", y);
+    assert_eq!(
+        test_utils::to_vec2_round(&y, 4)?,
+        [
+            [3.0, 3.0, 1.0, 1.0],
+            [3.0, 3.0, 1.0, 1.0],
+            [4.0, 4.0, 0.15, 0.15],
+            [4.0, 4.0, 0.15, 0.15]
+        ]
+    );
+    loss.backward()?;
+
     Ok(())
 }
 


### PR DESCRIPTION
This should implement backprop for interpolate_2D for a limited set of cases (integer scale factor that is the same for both h and w). However this should be sufficient for common use cases such as unpooling images for deconvolutions (ie when in pytorch Upsample nearest would have been used).