### PR TITLE
Add support for `scatter`(torch.scatter)

### DIFF
--- a/candle-core/src/backend.rs
+++ b/candle-core/src/backend.rs
@@ -69,6 +69,15 @@ pub trait BackendStorage: Sized {
     fn upsample_nearest2d(&self, _: &Layout, _: usize, _: usize) -> Result<Self>;
 
     fn gather(&self, _: &Layout, _: &Self, _: &Layout, _: usize) -> Result<Self>;
+    fn scatter(
+        &self,
+        _: &Layout,
+        _: &Self,
+        _: &Layout,
+        _: &Self,
+        _: &Layout,
+        _: usize,
+    ) -> Result<Self>;
     fn scatter_add(
         &self,
         _: &Layout,

--- a/candle-core/src/cuda_backend.rs
+++ b/candle-core/src/cuda_backend.rs
@@ -1023,6 +1023,58 @@ impl<'a> Map2InPlace for IndexAdd<'a> {
     }
 }
 
+struct Scatter<'a>(&'a CudaStorage, &'a Layout, usize);
+
+impl<'a> Map2InPlace for Scatter<'a> {
+    fn f<T: DeviceRepr + WithDType + ValidAsZeroBits>(
+        &self,
+        dst: &mut CudaSlice<T>,
+        dst_shape: &Shape,
+        src: &CudaSlice<T>,
+        src_l: &Layout,
+        dev: &CudaDevice,
+    ) -> Result<()> {
+        let ids = &self.0;
+        let ids_l = &self.1;
+        let dim = self.2;
+        let (ids_o1, ids_o2) = match ids_l.contiguous_offsets() {
+            Some(o12) => o12,
+            None => Err(crate::Error::RequiresContiguous { op: "scatter" }.bt())?,
+        };
+        let (name, ids) = match &ids.slice {
+            CudaStorageSlice::U32(slice) => {
+                ("scatter_u32", *slice.slice(ids_o1..ids_o2).device_ptr())
+            }
+            CudaStorageSlice::I64(slice) => {
+                ("scatter_i64", *slice.slice(ids_o1..ids_o2).device_ptr())
+            }
+            CudaStorageSlice::U8(slice) => {
+                ("scatter_u8", *slice.slice(ids_o1..ids_o2).device_ptr())
+            }
+            _ => Err(CudaError::UnexpectedDType {
+                msg: "scatter ids should be u8/u32/i64",
+                expected: DType::U32,
+                got: ids.dtype(),
+            })?,
+        };
+        let src = match src_l.contiguous_offsets() {
+            Some((o1, o2)) => src.slice(o1..o2),
+            None => Err(crate::Error::RequiresContiguous { op: "scatter" }.bt())?,
+        };
+        let left_sz: usize = src_l.dims()[..dim].iter().product();
+        let right_sz: usize = src_l.dims()[dim + 1..].iter().product();
+        let src_dim_sz = src_l.dims()[dim];
+        let dst_dim_sz = dst_shape.dims()[dim];
+        let cfg = LaunchConfig::for_num_elems((left_sz * right_sz) as u32);
+        let func = dev.get_or_load_func(&kernel_name::<T>(name), kernels::INDEXING)?;
+        // SAFETY: Set later by running the kernel.
+        let params = (ids, &src, dst, left_sz, src_dim_sz, dst_dim_sz, right_sz);
+        // SAFETY: ffi.
+        unsafe { func.launch(cfg, params) }.w()?;
+        Ok(())
+    }
+}
+
 struct ScatterAdd<'a>(&'a CudaStorage, &'a Layout, usize);
 impl<'a> Map2InPlace for ScatterAdd<'a> {
     fn f<T: DeviceRepr + WithDType + ValidAsZeroBits>(
@@ -1993,6 +2045,21 @@ impl BackendStorage for CudaStorage {
         let device = self.device().clone();
         let slice = Gather(ids, ids_l, dim).map(&self.slice, &device, l)?;
         Ok(Self { slice, device })
+    }
+    fn scatter(
+        &self,
+        l: &Layout,
+        ids: &Self,
+        ids_l: &Layout,
+        src: &Self,
+        src_l: &Layout,
+        dim: usize,
+    ) -> Result<Self> {
+        let device = self.device().clone();
+        let mut acc = device.zeros_impl(l.shape(), self.dtype())?;
+        self.copy_strided_src(&mut acc, 0, l)?;
+        Scatter(ids, ids_l, dim).map(&mut acc.slice, l.shape(), &src.slice, src_l, &device)?;
+        Ok(acc)
     }
     fn scatter_add(
         &self,

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -116,6 +116,18 @@ impl crate::backend::BackendStorage for CudaStorage {
         Err(Error::NotCompiledWithCudaSupport)
     }
 
+    fn scatter(
+        &self,
+        _: &Layout,
+        _: &Self,
+        _: &Layout,
+        _: &Self,
+        _: &Layout,
+        _: usize,
+    ) -> Result<Self> {
+        Err(Error::NotCompiledWithCudaSupport)
+    }
+
     fn scatter_add(
         &self,
         _: &Layout,

--- a/candle-core/src/dummy_metal_backend.rs
+++ b/candle-core/src/dummy_metal_backend.rs
@@ -128,6 +128,18 @@ impl crate::backend::BackendStorage for MetalStorage {
         Err(Error::NotCompiledWithMetalSupport)
     }
 
+    fn scatter(
+        &self,
+        _: &Layout,
+        _: &Self,
+        _: &Layout,
+        _: &Self,
+        _: &Layout,
+        _: usize,
+    ) -> Result<Self> {
+        Err(Error::NotCompiledWithMetalSupport)
+    }
+
     fn scatter_add(
         &self,
         _: &Layout,

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -76,6 +76,7 @@ pub enum Op {
     Reduce(Tensor, ReduceOp, Vec<usize>),
     Matmul(Tensor, Tensor),
     Gather(Tensor, Tensor, usize),
+    Scatter(Tensor, Tensor, Tensor, usize),
     ScatterAdd(Tensor, Tensor, Tensor, usize),
     IndexSelect(Tensor, Tensor, usize),
     IndexAdd(Tensor, Tensor, Tensor, usize),

--- a/candle-core/src/storage.rs
+++ b/candle-core/src/storage.rs
@@ -559,6 +559,34 @@ impl Storage {
         }
     }
 
+    pub(crate) fn scatter(
+        &self,
+        l: &Layout,
+        indexes: &Self,
+        indexes_l: &Layout,
+        source: &Self,
+        source_l: &Layout,
+        d: usize,
+    ) -> Result<Self> {
+        self.same_device(indexes, "scatter")?;
+        self.same_device(source, "scatter")?;
+        match (self, indexes, source) {
+            (Self::Cpu(s), Self::Cpu(indexes), Self::Cpu(source)) => {
+                let storage = s.scatter(l, indexes, indexes_l, source, source_l, d)?;
+                Ok(Self::Cpu(storage))
+            }
+            (Self::Cuda(s), Self::Cuda(indexes), Self::Cuda(source)) => {
+                let storage = s.scatter(l, indexes, indexes_l, source, source_l, d)?;
+                Ok(Self::Cuda(storage))
+            }
+            (Self::Metal(s), Self::Metal(indexes), Self::Metal(source)) => {
+                let storage = s.scatter_add(l, indexes, indexes_l, source, source_l, d)?;
+                Ok(Self::Metal(storage))
+            }
+            _ => unreachable!(),
+        }
+    }
+
     pub(crate) fn scatter_add(
         &self,
         l: &Layout,

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -821,6 +821,46 @@ fn slice_scatter(device: &Device) -> Result<()> {
     Ok(())
 }
 
+fn scatter(device: &Device) -> Result<()> {
+    let t: Tensor = Tensor::arange(0f32, 12f32, device)?.reshape((4, 3))?;
+    assert_eq!(
+        t.to_vec2::<f32>()?,
+        &[
+            [0.0, 1.0, 2.0],
+            [3.0, 4.0, 5.0],
+            [6.0, 7.0, 8.0],
+            [9.0, 10.0, 11.0]
+        ]
+    );
+    let ids = Tensor::new(&[[0u32, 1, 2], [3, 4, 0], [3, 3, 1], [2, 0, 4]], device)?;
+    let init = Tensor::ones((4, 5), DType::F32, device)?;
+    let hs = init.scatter(&ids, &t, 1)?;
+    assert_eq!(
+        hs.to_vec2::<f32>()?,
+        &[
+            [0., 1., 2., 1., 1.],
+            [5., 1., 1., 3., 4.],
+            [1., 8., 1., 7., 1.],
+            [10., 1., 9., 1., 11.]
+        ]
+    );
+
+    let init = Tensor::ones((6, 3), DType::F32, device)?;
+    let hs = init.scatter(&ids, &t, 0)?;
+    assert_eq!(
+        hs.to_vec2::<f32>()?,
+        &[
+            [0., 10., 5.],
+            [1., 1., 8.],
+            [9., 1., 2.],
+            [6., 7., 1.],
+            [1., 4., 11.],
+            [1., 1., 1.]
+        ]
+    );
+    Ok(())
+}
+
 fn scatter_add(device: &Device) -> Result<()> {
     let t = Tensor::arange(0f32, 12f32, device)?.reshape((4, 3))?;
     assert_eq!(
@@ -1109,6 +1149,7 @@ test_device!(
 );
 test_device!(index_add, index_add_cpu, index_add_gpu, index_add_metal);
 test_device!(gather, gather_cpu, gather_gpu, gather_metal);
+test_device!(scatter, scatter_cpu, scatter_gpu, scatter_metal);
 test_device!(
     scatter_add,
     scatter_add_cpu,

--- a/candle-kernels/src/indexing.cu
+++ b/candle-kernels/src/indexing.cu
@@ -112,30 +112,7 @@ extern "C" __global__ void FN_NAME(  \
 ) { index_add(ids, ids_dim_size, inp, out, left_size, src_dim_size, dst_dim_size, right_size); } \
 
 
-template<typename T, typename I>
-__device__ void scatter_assign(
-    const I *ids,
-    const T *inp,
-    T *out,
-    const size_t left_size,
-    const size_t src_dim_size,
-    const size_t dst_dim_size,
-    const size_t right_size
-) {
-      const size_t numel = left_size * right_size;
-      for (unsigned int i = blockIdx.x * blockDim.x + threadIdx.x; i < numel; i += blockDim.x * gridDim.x) {
-          const size_t pre = i / right_size;
-          const size_t post = i % right_size;
-          for (unsigned int j = 0; j < src_dim_size; ++j) {
-              const size_t src_i = (pre * src_dim_size + j) * right_size + post;
-              const size_t idx = ids[src_i];
-              const size_t dst_i = (pre * dst_dim_size + idx) * right_size + post;
-              out[dst_i] = inp[src_i];
-          }
-      }
-}
-
-#define SCATTER_OP(TYPENAME, INDEX_TYPENAME, FN_NAME) \
+#define SCATTER_OP(TYPENAME, INDEX_TYPENAME, FN_NAME, OP) \
 extern "C" __global__ void FN_NAME(  \
     const INDEX_TYPENAME *ids, \
     const TYPENAME *inp, \
@@ -144,42 +121,19 @@ extern "C" __global__ void FN_NAME(  \
     const size_t src_dim_size, \
     const size_t dst_dim_size, \
     const size_t right_size \
-) { scatter_assign(ids, inp, out, left_size, src_dim_size, dst_dim_size, right_size); } \
-
-
-template<typename T, typename I>
-__device__ void scatter_add(
-    const I *ids,
-    const T *inp,
-    T *out,
-    const size_t left_size,
-    const size_t src_dim_size,
-    const size_t dst_dim_size,
-    const size_t right_size
-) {
-      const size_t numel = left_size * right_size;
-      for (unsigned int i = blockIdx.x * blockDim.x + threadIdx.x; i < numel; i += blockDim.x * gridDim.x) {
-          const size_t pre = i / right_size;
-          const size_t post = i % right_size;
-          for (unsigned int j = 0; j < src_dim_size; ++j) {
-              const size_t src_i = (pre * src_dim_size + j) * right_size + post;
-              const size_t idx = ids[src_i];
-              const size_t dst_i = (pre * dst_dim_size + idx) * right_size + post;
-              out[dst_i] += inp[src_i];
-          }
-      }
-}
-
-#define SA_OP(TYPENAME, INDEX_TYPENAME, FN_NAME) \
-extern "C" __global__ void FN_NAME(  \
-    const INDEX_TYPENAME *ids, \
-    const TYPENAME *inp, \
-    TYPENAME *out, \
-    const size_t left_size, \
-    const size_t src_dim_size, \
-    const size_t dst_dim_size, \
-    const size_t right_size \
-) { scatter_add(ids, inp, out, left_size, src_dim_size, dst_dim_size, right_size); } \
+) { \
+    const size_t numel = left_size * right_size;\
+      for (unsigned int i = blockIdx.x * blockDim.x + threadIdx.x; i < numel; i += blockDim.x * gridDim.x) {\
+          const size_t pre = i / right_size;\
+          const size_t post = i % right_size;\
+          for (unsigned int j = 0; j < src_dim_size; ++j) {\
+              const size_t src_i = (pre * src_dim_size + j) * right_size + post;\
+              const size_t idx = ids[src_i];\
+              const size_t dst_i = (pre * dst_dim_size + idx) * right_size + post;\
+              out[dst_i] OP inp[src_i];\
+          }\
+      }\
+ } \
 
 
 #if __CUDA_ARCH__ >= 800
@@ -192,9 +146,12 @@ GATHER_OP(__nv_bfloat16, uint8_t, gather_u8_bf16)
 IA_OP(__nv_bfloat16, int64_t, ia_i64_bf16)
 IA_OP(__nv_bfloat16, uint32_t, ia_u32_bf16)
 IA_OP(__nv_bfloat16, uint8_t, ia_u8_bf16)
-SA_OP(__nv_bfloat16, int64_t, sa_i64_bf16)
-SA_OP(__nv_bfloat16, uint32_t, sa_u32_bf16)
-SA_OP(__nv_bfloat16, uint8_t, sa_u8_bf16)
+SCATTER_OP(__nv_bfloat16, int64_t, sa_i64_bf16, +=)
+SCATTER_OP(__nv_bfloat16, uint32_t, sa_u32_bf16, +=)
+SCATTER_OP(__nv_bfloat16, uint8_t, sa_u8_bf16, +=)
+SCATTER_OP(__nv_bfloat16, int64_t, scatter_i64_bf16, =)
+SCATTER_OP(__nv_bfloat16, uint32_t, scatter_u32_bf16, =)
+SCATTER_OP(__nv_bfloat16, uint8_t, scatter_u8_bf16, =)
 #endif
 
 #if __CUDA_ARCH__ >= 530
@@ -206,8 +163,10 @@ GATHER_OP(__half, uint32_t, gather_u32_f16)
 GATHER_OP(__half, uint8_t, gather_u8_f16)
 IA_OP(__half, uint32_t, ia_u32_f16)
 IA_OP(__half, uint8_t, ia_u8_f16)
-SA_OP(__half, uint32_t, sa_u32_f16)
-SA_OP(__half, uint8_t, sa_u8_f16)
+SCATTER_OP(__half, uint32_t, sa_u32_f16, +=)
+SCATTER_OP(__half, uint8_t, sa_u8_f16, +=)
+SCATTER_OP(__half, uint32_t, scatter_u32_f16, =)
+SCATTER_OP(__half, uint8_t, scatter_u8_f16, =)
 #endif
 
 IS_OP(float, int64_t, is_i64_f32)
@@ -264,39 +223,43 @@ IA_OP(uint8_t, uint8_t, ia_u8_u8)
 IA_OP(uint32_t, uint8_t, ia_u8_u32)
 IA_OP(int64_t, uint8_t, ia_u8_i64)
 
-SA_OP(float, int64_t, sa_i64_f32)
-SA_OP(double, int64_t, sa_i64_f64)
-SA_OP(uint8_t, int64_t, sa_i64_u8)
-SA_OP(int64_t, int64_t, sa_i64_i64)
-SA_OP(uint32_t, int64_t, sa_i64_u32)
 
-SA_OP(float, uint32_t, sa_u32_f32)
-SA_OP(double, uint32_t, sa_u32_f64)
-SA_OP(uint8_t, uint32_t, sa_u32_u8)
-SA_OP(int64_t, uint32_t, sa_u32_i64)
-SA_OP(uint32_t, uint32_t, sa_u32_u32)
+#pragma region scatter_add
+SCATTER_OP(float, int64_t, sa_i64_f32, +=)
+SCATTER_OP(double, int64_t, sa_i64_f64, +=)
+SCATTER_OP(uint8_t, int64_t, sa_i64_u8, +=)
+SCATTER_OP(int64_t, int64_t, sa_i64_i64, +=)
+SCATTER_OP(uint32_t, int64_t, sa_i64_u32, +=)
 
-SA_OP(float, uint8_t, sa_u8_f32)
-SA_OP(double, uint8_t, sa_u8_f64)
-SA_OP(uint8_t, uint8_t, sa_u8_u8)
-SA_OP(uint32_t, uint8_t, sa_u8_u32)
-SA_OP(int64_t, uint8_t, sa_u8_i64)
+SCATTER_OP(float, uint32_t, sa_u32_f32, +=)
+SCATTER_OP(double, uint32_t, sa_u32_f64, +=)
+SCATTER_OP(uint8_t, uint32_t, sa_u32_u8, +=)
+SCATTER_OP(int64_t, uint32_t, sa_u32_i64, +=)
+SCATTER_OP(uint32_t, uint32_t, sa_u32_u32, +=)
 
+SCATTER_OP(float, uint8_t, sa_u8_f32, +=)
+SCATTER_OP(double, uint8_t, sa_u8_f64, +=)
+SCATTER_OP(uint8_t, uint8_t, sa_u8_u8, +=)
+SCATTER_OP(uint32_t, uint8_t, sa_u8_u32, +=)
+SCATTER_OP(int64_t, uint8_t, sa_u8_i64, +=)
+#pragma endregion scatter_add
 
-SCATTER_OP(float, int64_t, scatter_i64_f32)
-SCATTER_OP(double, int64_t, scatter_i64_f64)
-SCATTER_OP(uint8_t, int64_t, scatter_i64_u8)
-SCATTER_OP(int64_t, int64_t, scatter_i64_i64)
-SCATTER_OP(uint32_t, int64_t, scatter_i64_u32)
+#pragma region scatter_assign
+SCATTER_OP(float, int64_t, scatter_i64_f32, =)
+SCATTER_OP(double, int64_t, scatter_i64_f64, =)
+SCATTER_OP(uint8_t, int64_t, scatter_i64_u8, =)
+SCATTER_OP(int64_t, int64_t, scatter_i64_i64, =)
+SCATTER_OP(uint32_t, int64_t, scatter_i64_u32, =)
 
-SCATTER_OP(float, uint32_t, scatter_u32_f32)
-SCATTER_OP(double, uint32_t, scatter_u32_f64)
-SCATTER_OP(uint8_t, uint32_t, scatter_u32_u8)
-SCATTER_OP(int64_t, uint32_t, scatter_u32_i64)
-SCATTER_OP(uint32_t, uint32_t, scatter_u32_u32)
+SCATTER_OP(float, uint32_t, scatter_u32_f32, =)
+SCATTER_OP(double, uint32_t, scatter_u32_f64, =)
+SCATTER_OP(uint8_t, uint32_t, scatter_u32_u8, =)
+SCATTER_OP(int64_t, uint32_t, scatter_u32_i64, =)
+SCATTER_OP(uint32_t, uint32_t, scatter_u32_u32, =)
 
-SCATTER_OP(float, uint8_t, scatter_u8_f32)
-SCATTER_OP(double, uint8_t, scatter_u8_f64)
-SCATTER_OP(uint8_t, uint8_t, scatter_u8_u8)
-SCATTER_OP(uint32_t, uint8_t, scatter_u8_u32)
-SCATTER_OP(int64_t, uint8_t, scatter_u8_i64)
+SCATTER_OP(float, uint8_t, scatter_u8_f32, =)
+SCATTER_OP(double, uint8_t, scatter_u8_f64, =)
+SCATTER_OP(uint8_t, uint8_t, scatter_u8_u8, =)
+SCATTER_OP(uint32_t, uint8_t, scatter_u8_u32, =)
+SCATTER_OP(int64_t, uint8_t, scatter_u8_i64, =)
+#pragma endregion scatter_assign


### PR DESCRIPTION
Hi there,

This PR achieves pytorch's

https://pytorch.org/docs/stable/generated/torch.Tensor.scatter_.html#torch.Tensor.scatter_

---

Because `apply_repeat_penalty` is a bit slow here.
https://github.com/huggingface/candle/blob/main/candle-transformers/src/utils.rs#L3


This implementation should be faster.
https://github.com/huggingface/transformers/blob/main/src/transformers/generation/logits_process.py#L337
It needs `scatter` operation.