### PR TITLE
add fn config_chat_ml

### DIFF
--- a/candle-transformers/src/models/mistral.rs
+++ b/candle-transformers/src/models/mistral.rs
@@ -37,6 +37,22 @@ impl Config {
             use_flash_attn,
         }
     }
+    pub fn config_chat_ml(use_flash_attn: bool) -> Self {
+        Self {
+            vocab_size: 32002,
+            hidden_size: 4096,
+            intermediate_size: 14336,
+            num_hidden_layers: 32,
+            num_attention_heads: 32,
+            num_key_value_heads: 8,
+            hidden_act: Activation::Silu,
+            max_position_embeddings: 32768,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10_000.,
+            sliding_window: 4096,
+            use_flash_attn,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/candle-transformers/src/models/mistral.rs
+++ b/candle-transformers/src/models/mistral.rs
@@ -21,6 +21,7 @@ pub struct Config {
 }
 
 impl Config {
+    // https://huggingface.co/mistralai/Mistral-7B-v0.1/blob/main/config.json
     pub fn config_7b_v0_1(use_flash_attn: bool) -> Self {
         Self {
             vocab_size: 32000,
@@ -37,7 +38,9 @@ impl Config {
             use_flash_attn,
         }
     }
-    pub fn config_chat_ml(use_flash_attn: bool) -> Self {
+
+    // https://huggingface.co/Open-Orca/Mistral-7B-OpenOrca/blob/main/config.json
+    pub fn config_open_orca_chat_ml(use_flash_attn: bool) -> Self {
         Self {
             vocab_size: 32002,
             hidden_size: 4096,


### PR DESCRIPTION
Models which use Mistral as a base and the ChatML template format require a different `vocab_size` than using the `config_7b_v0_1` allows.

Adding a new fn should work with all Mistral models using the ChatML template format.

I have tested this in my project and will make another PR to adjust the [mistral cli example](https://github.com/huggingface/candle/blob/main/candle-examples/examples/mistral/main.rs) work with the [Mistral-7B-OpenOrca](https://huggingface.co/Open-Orca/Mistral-7B-OpenOrca) model.

Read more about template formats here:
https://huggingface.co/docs/transformers/main/chat_templating