### PR TITLE
make fn name generic

### DIFF
--- a/candle-transformers/src/models/mistral.rs
+++ b/candle-transformers/src/models/mistral.rs
@@ -40,7 +40,8 @@ impl Config {
     }
 
     // https://huggingface.co/Open-Orca/Mistral-7B-OpenOrca/blob/main/config.json
-    pub fn config_open_orca_chat_ml(use_flash_attn: bool) -> Self {
+    // https://huggingface.co/teknium/OpenHermes-2.5-Mistral-7B/blob/main/config.json
+    pub fn config_chat_ml(use_flash_attn: bool) -> Self {
         Self {
             vocab_size: 32002,
             hidden_size: 4096,


### PR DESCRIPTION
I think that this fn name should be more generic since the important consideration is that it uses ChatML and not that it is OpenOrca.

Having `open_orca` in the fn name may lead to confusion, and I don't think we need to add another fn `config_open_hermes_chat_ml`, as that would lead to a lot of code duplication with a few more models.

To make that clear I have included another comment with a link to OpenHermes.

The extra tokens added are:
```json
      "<|im_end|>": 32000,
      "<|im_start|>": 32001
```

I followed your lead and linked to the original [OpenHermes-2.5-Mistral-7B](https://huggingface.co/teknium/OpenHermes-2.5-Mistral-7B) repo in the code, however neither of those repos include a `tokenizer.json` file.

It is not complicated to create one assuming an understanding of what is needed.

Here is a working [tokenizer.json](https://huggingface.co/DanielClough/Candle_Mistral-7B-OpenOrca/raw/main/tokenizer.json) in my repo (which also contains candle GGUF files), for reference.