### PR TITLE
Add storage_mut safely

### DIFF
--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -2346,6 +2346,7 @@ impl Tensor {
     ///
     /// ## Panics
     /// - If the lock was poisoned
+    /// - If the lock is held by the current thread
     pub fn storage_mut_and_layout(&self) -> (std::sync::RwLockWriteGuard<'_, Storage>, &Layout) {
         let storage = self.storage.write().expect("Lock was poisoned");
         (storage, &self.layout)

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -2341,12 +2341,13 @@ impl Tensor {
         self.storage.read().unwrap()
     }
 
-    // If we extend the visibility of this function to be usable outside of this crate, we should
-    // make it unsafe.
-    pub(crate) fn storage_mut_and_layout(
-        &self,
-    ) -> (std::sync::RwLockWriteGuard<'_, Storage>, &Layout) {
-        let storage = self.storage.write().unwrap();
+    /// The storage used by this tensor, together with the layout to use to access it safely.
+    /// This blocks if there are other references to the lock.
+    ///
+    /// ## Panics
+    /// - If the lock was poisoned
+    pub fn storage_mut_and_layout(&self) -> (std::sync::RwLockWriteGuard<'_, Storage>, &Layout) {
+        let storage = self.storage.write().expect("Lock was poisoned");
         (storage, &self.layout)
     }
 


### PR DESCRIPTION
This PR makes the `storage_mut_and_layout` method public. This is safe because of the use of RwLock and panicking, in contrast to the previous commend regarding the addition of unsafe.

