### PR TITLE
Add one-hot/cold encoding

### DIFF
--- a/candle-nn/src/encoding.rs
+++ b/candle-nn/src/encoding.rs
@@ -77,21 +77,21 @@ const INDEX_EXCEEDS_DEPTH_MSG: &str = "one_hot: Index value exceeds the depth va
 /// As an example, the following tensor will be encoded to a one-hot matrix:
 ///
 /// ```
-/// [[0., 2.], [1., -1.]]
+/// [[0i64, 2], [1, -1]]
 /// ```
 ///
 /// with a depth of 4 will be encoded to:
 ///
 /// ```
-/// [[[1., 0., 0., 0.], [0., 0., 1., 0.]], [[0., 1., 0., 0.], [0., 0., 0., 0.]]]
+/// [[[1, 0, 0, 0], [0, 0, 1, 0]], [[0, 1, 0, 0], [0, 0, 0, 0]]]
 /// ```
 ///
 /// When the input tensor index has a value of -1, the corresponding one-hot vector will be ignored,
 /// resulting in a vector of values set to the `off_value`.
 ///
 ///
-/// This method supports one-cold encoding by setting `on_value` to `0.0` and `off_value` to `1.0`.
-/// By default `on_value` is `1.0` and `off_value` is `0.0`.
+/// This method supports one-cold encoding by setting `on_value` to `0` and `off_value` to `1`.
+/// By default `on_value` is `1` and `off_value` is `0`.
 ///
 /// Other encoding values can be used by setting `on_value` and `off_value` to the desired values.
 ///
@@ -158,7 +158,6 @@ const INDEX_EXCEEDS_DEPTH_MSG: &str = "one_hot: Index value exceeds the depth va
 /// This method will bail if the index value is less than -1.
 ///
 /// This method will bail if the index value is greater than or equal to the depth value.
-///
 ///
 /// This method will bail if the input data type is `f64`.
 ///
@@ -235,47 +234,43 @@ pub fn one_hot<D: WithDType>(
                 i * depth * dim2 + j * depth
             };
 
+            let iter = (0..dim1).flat_map(|i| (0..dim2).map(move |j| (i, j)));
+
             match dtype {
                 DType::U8 => {
                     let index = indices.to_vec2::<u8>()?;
-                    for i in 0..dim1 {
-                        for j in 0..dim2 {
-                            set_uint_value(
-                                index[i][j] as usize,
-                                idx(i, j, depth, dim2),
-                                depth,
-                                &mut v,
-                                on_value,
-                            )?;
-                        }
+                    for (i, j) in iter {
+                        set_uint_value(
+                            index[i][j] as usize,
+                            idx(i, j, depth, dim2),
+                            depth,
+                            &mut v,
+                            on_value,
+                        )?;
                     }
                 }
                 DType::U32 => {
                     let index = indices.to_vec2::<u32>()?;
-                    for i in 0..dim1 {
-                        for j in 0..dim2 {
-                            set_uint_value(
-                                index[i][j] as usize,
-                                idx(i, j, depth, dim2),
-                                depth,
-                                &mut v,
-                                on_value,
-                            )?;
-                        }
+                    for (i, j) in iter {
+                        set_uint_value(
+                            index[i][j] as usize,
+                            idx(i, j, depth, dim2),
+                            depth,
+                            &mut v,
+                            on_value,
+                        )?;
                     }
                 }
                 DType::I64 => {
                     let index = indices.to_vec2::<i64>()?;
-                    for i in 0..dim1 {
-                        for j in 0..dim2 {
-                            set_int_value(
-                                index[i][j],
-                                idx(i, j, depth, dim2),
-                                depth,
-                                &mut v,
-                                on_value,
-                            )?;
-                        }
+                    for (i, j) in iter {
+                        set_int_value(
+                            index[i][j],
+                            idx(i, j, depth, dim2),
+                            depth,
+                            &mut v,
+                            on_value,
+                        )?;
                     }
                 }
                 d => unsupported_dtype(d)?,
@@ -292,53 +287,44 @@ pub fn one_hot<D: WithDType>(
                     i * depth * dim2 * dim3 + j * depth * dim3 + k * depth
                 };
 
+            let iter = (0..dim1)
+                .flat_map(|i| (0..dim2).flat_map(move |j| (0..dim3).map(move |k| (i, j, k))));
+
             match dtype {
                 DType::U8 => {
                     let index = indices.to_vec3::<u8>()?;
-                    for i in 0..dim1 {
-                        for j in 0..dim2 {
-                            for k in 0..dim3 {
-                                set_uint_value(
-                                    index[i][j][k] as usize,
-                                    idx(i, j, k, depth, dim2, dim3),
-                                    depth,
-                                    &mut v,
-                                    on_value,
-                                )?;
-                            }
-                        }
+                    for (i, j, k) in iter {
+                        set_uint_value(
+                            index[i][j][k] as usize,
+                            idx(i, j, k, depth, dim2, dim3),
+                            depth,
+                            &mut v,
+                            on_value,
+                        )?;
                     }
                 }
                 DType::U32 => {
                     let index = indices.to_vec3::<u32>()?;
-                    for i in 0..dim1 {
-                        for j in 0..dim2 {
-                            for k in 0..dim3 {
-                                set_uint_value(
-                                    index[i][j][k] as usize,
-                                    idx(i, j, k, depth, dim2, dim3),
-                                    depth,
-                                    &mut v,
-                                    on_value,
-                                )?;
-                            }
-                        }
+                    for (i, j, k) in iter {
+                        set_uint_value(
+                            index[i][j][k] as usize,
+                            idx(i, j, k, depth, dim2, dim3),
+                            depth,
+                            &mut v,
+                            on_value,
+                        )?;
                     }
                 }
                 DType::I64 => {
                     let index = indices.to_vec3::<i64>()?;
-                    for i in 0..dim1 {
-                        for j in 0..dim2 {
-                            for k in 0..dim3 {
-                                set_int_value(
-                                    index[i][j][k],
-                                    idx(i, j, k, depth, dim2, dim3),
-                                    depth,
-                                    &mut v,
-                                    on_value,
-                                )?;
-                            }
-                        }
+                    for (i, j, k) in iter {
+                        set_int_value(
+                            index[i][j][k],
+                            idx(i, j, k, depth, dim2, dim3),
+                            depth,
+                            &mut v,
+                            on_value,
+                        )?;
                     }
                 }
                 d => unsupported_dtype(d)?,
@@ -364,7 +350,7 @@ fn check_negative(value: i64) -> Result<()> {
 fn check_value_bounds(value: usize, depth: usize) -> Result<()> {
     if value >= depth {
         bail!(
-            "{} Index value, {}, exceeds the depth value, {}.",
+            "{} Index value, {}, must be less than the depth value, {}.",
             INDEX_EXCEEDS_DEPTH_MSG,
             value,
             depth
@@ -449,7 +435,7 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test_f64_one_hot() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_i64_one_hot() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let device = candle::Device::Cpu;
 
         let indices = Tensor::new(vec![vec![0i64, 2], vec![1, -1]], &device)?;
@@ -475,7 +461,50 @@ mod tests {
     }
 
     #[test]
-    pub fn test_u8_one_cold() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_rank_3_one_hot() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let device = candle::Device::Cpu;
+
+        let indices = Tensor::new(
+            vec![
+                vec![vec![0i64, 1], vec![2, 3]],
+                vec![vec![3, 1], vec![1, -1]],
+            ],
+            &device,
+        )?;
+        let depth = 4;
+
+        let on_value = None;
+        let off_value = None;
+
+        let one_hot = one_hot::<f32>(indices, depth, on_value, off_value)?;
+
+        let expected_matrix = Tensor::new(
+            vec![
+                vec![
+                    vec![vec![1f32, 0., 0., 0.], vec![0., 1., 0., 0.]],
+                    vec![vec![0., 0., 1., 0.], vec![0., 0., 0., 1.]],
+                ],
+                vec![
+                    vec![vec![0., 0., 0., 1.], vec![0., 1., 0., 0.]],
+                    vec![vec![0., 1., 0., 0.], vec![0., 0., 0., 0.]],
+                ],
+            ],
+            &device,
+        )?;
+
+        assert_eq!(one_hot.shape(), expected_matrix.shape());
+        assert_eq!(one_hot.dims(), expected_matrix.dims());
+
+        let matrix = one_hot.get(1)?.to_vec3::<f32>()?;
+        let expected_matrix = expected_matrix.get(1)?.to_vec3::<f32>()?;
+
+        assert_eq!(matrix, expected_matrix);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_u8_one_cold() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let device = candle::Device::Cpu;
         let depth = 4;
         let indices = Tensor::new(vec![vec![0i64, 2], vec![1, -1]], &device)?;
@@ -493,6 +522,33 @@ mod tests {
         let matrix = one_cold.to_vec3::<u8>()?;
 
         assert_eq!(matrix, expected_matrix);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_iter() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let device = candle::Device::Cpu;
+        let depth = 4;
+        let indices = Tensor::new(vec![vec![0i64, 2], vec![1, -1]], &device)?;
+        let matrix = indices.to_vec2::<i64>()?;
+        let (dim1, dim2) = indices.dims2()?;
+
+        let iter = (0..dim1).flat_map(|i| (0..dim2).map(move |j| (i, j)));
+
+        let mut v = vec![0; depth * dim1 * dim2];
+
+        for (i, j) in iter {
+            let idx = i * depth * dim2 + j * depth;
+            v[idx] = matrix[i][j];
+        }
+
+        for i in 0..dim1 {
+            for j in 0..dim2 {
+                let idx = i * depth * dim2 + j * depth;
+                assert_eq!(v[idx], matrix[i][j]);
+            }
+        }
 
         Ok(())
     }

--- a/candle-nn/src/encoding.rs
+++ b/candle-nn/src/encoding.rs
@@ -8,21 +8,50 @@
 //! use candle::{Shape, Tensor, Device};
 //! use candle_nn::encoding::one_hot;
 //!
-//! let device = Device::Cpu;
+//! let device = candle::Device::Cpu;
+//!
+//! let indices = Tensor::new(vec![vec![0f32, 2.], vec![1., -1.]], &device)?;
 //! let depth = 4;
-//! let indices = Tensor::new(vec![vec![0f32, 2.], vec![1., -1.]], &device).unwrap();
 //!
-//! let on_value = Some(1.0); // default
-//! let off_value = Some(0.0); // default
+//! let allow_f64 = true;
+//! let on_value = None; // defaults to 1.0
+//! let off_value = None; // defaults to 0.0
 //!
-//! let one_hot = one_hot::<f32>(indices, depth, on_value, off_value).unwrap();
+//! let one_hot = one_hot::<f32, f32>(indices, depth, allow_f64, on_value, off_value)?;
+//!
 //! let expected_matrix = [
 //!     [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
 //!     [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
 //! ];
-//! assert_eq!(one_hot.shape(), &Shape::from((2, 2, 4)));
 //!
-//! let matrix = one_hot.to_vec3::<f32>().unwrap();
+//! assert_eq!(one_hot.shape(), &Shape::from((2, 2, depth)));
+//!
+//! let matrix = one_hot.to_vec3::<f32>()?;
+//!
+//! assert_eq!(matrix, expected_matrix);
+//!```
+//! ## One-cold Encoding
+//!
+//! ```rust
+//! use candle::{Shape, Tensor, Device};
+//! use candle_nn::encoding::one_hot;
+//!
+//!
+//! let device = candle::Device::Cpu;
+//! let depth = 4;
+//! let indices = Tensor::new(vec![vec![0i64, 2], vec![1, 3]], &device)?;
+//!
+//! let allow_f64 = false;
+//! let on_value = Some(0);
+//! let off_value = Some(1);
+//!
+//! let one_cold = one_hot::<i64, u8>(indices, depth, allow_f64, on_value, off_value)?;
+//!
+//! let expected_matrix = [[[0, 1, 1, 1], [1, 1, 0, 1]], [[1, 0, 1, 1], [1, 1, 1, 0]]];
+//!
+//! assert_eq!(one_cold.shape(), &Shape::from((2, 2, depth)));
+//!
+//! let matrix = one_cold.to_vec3::<u8>()?;
 //!
 //! assert_eq!(matrix, expected_matrix);
 //! ```
@@ -31,11 +60,11 @@
 use candle::{bail, Result, Tensor, WithDType};
 
 const INVALID_ONE_HOT_INDEX_MSG: &str =
-    "Invalid negative index value. Expected a positive index value or `-1` value to ignore.";
+    "one_hot: Invalid negative index value. Expected a positive index value or `-1` value to ignore.";
 
-const INDEX_OUT_OF_BOUNDS_MSG: &str = "Index out of bounds.";
+const INDEX_OUT_OF_BOUNDS_MSG: &str = "one_hot: Index out of bounds.";
 
-const INDEX_EXCEEDS_DEPTH_MSG: &str = "Index value exceeds the depth value.";
+const INDEX_EXCEEDS_DEPTH_MSG: &str = "one_hot: Index value exceeds the depth value.";
 
 /// One-hot/cold encoding.
 ///
@@ -68,60 +97,106 @@ const INDEX_EXCEEDS_DEPTH_MSG: &str = "Index value exceeds the depth value.";
 ///
 /// # Examples
 ///
-///```rust
+/// ## One-hot encoding
+///
+/// ```rust
 /// use candle::{Shape, Tensor, Device};
 /// use candle_nn::encoding::one_hot;
 ///
-/// let device = Device::Cpu;
+/// let device = candle::Device::Cpu;
+///
+/// let indices = Tensor::new(vec![vec![0f32, 2.], vec![1., -1.]], &device)?;
 /// let depth = 4;
-/// let indices = Tensor::new(vec![vec![0f32, 2.], vec![1., -1.]], &device).unwrap();
 ///
-/// let on_value = Some(1.0); // default
-/// let off_value = Some(0.0); // default
+/// let allow_f64 = true;
+/// let on_value = None; // defaults to 1.0
+/// let off_value = None; // defaults to 0.0
 ///
-/// let one_hot = one_hot::<f32>(indices, depth, on_value, off_value).unwrap();
+/// let one_hot = one_hot::<f32, f32>(indices, depth, allow_f64, on_value, off_value)?;
+///
 /// let expected_matrix = [
 ///     [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
 ///     [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
 /// ];
-/// assert_eq!(one_hot.shape(), &Shape::from((2, 2, 4)));
 ///
-/// let matrix = one_hot.to_vec3::<f32>().unwrap();
+/// assert_eq!(one_hot.shape(), &Shape::from((2, 2, depth)));
+///
+/// let matrix = one_hot.to_vec3::<f32>()?;
+///
+/// assert_eq!(matrix, expected_matrix);
+///```
+/// ## One-cold Encoding
+///
+/// ```rust
+/// use candle::{Shape, Tensor, Device};
+/// use candle_nn::encoding::one_hot;
+///
+///
+/// let device = candle::Device::Cpu;
+/// let depth = 4;
+/// let indices = Tensor::new(vec![vec![0i64, 2], vec![1, 3]], &device)?;
+///
+/// let allow_f64 = false;
+/// let on_value = Some(0);
+/// let off_value = Some(1);
+///
+/// let one_cold = one_hot::<i64, u8>(indices, depth, allow_f64, on_value, off_value)?;
+///
+/// let expected_matrix = [[[0, 1, 1, 1], [1, 1, 0, 1]], [[1, 0, 1, 1], [1, 1, 1, 0]]];
+///
+/// assert_eq!(one_cold.shape(), &Shape::from((2, 2, depth)));
+///
+/// let matrix = one_cold.to_vec3::<u8>()?;
 ///
 /// assert_eq!(matrix, expected_matrix);
 /// ```
+///
 ///
 /// # Bails
 ///
 /// This method will bail on tensors with a rank greater than 3.
 ///
+/// This method will bail if the index value is less than -1.
+///
+/// This method will bail if the index value is greater than or equal to the depth value.
+///
+/// This method will bail if the input data type does not equal the generic data type provided.
+///
+/// This method will bail if the input data type is `f64` and `allow_f64` is false.
+///
 /// # API Design
 ///
 /// The api design for this method is loosely based on the [TensorFlow One-Hot](https://www.tensorflow.org/api_docs/python/tf/one_hot) method.
-pub fn one_hot<D: WithDType>(
+pub fn one_hot<I: WithDType, O: WithDType>(
     indices: Tensor,
     depth: usize,
-    on_value: Option<D>,
-    off_value: Option<D>,
+    allow_f64: bool,
+    on_value: Option<O>,
+    off_value: Option<O>,
 ) -> Result<Tensor> {
-    let on_value = on_value.unwrap_or(D::from_f64(1.));
-    let off_value = off_value.unwrap_or(D::from_f64(0.));
+    let on_value = on_value.unwrap_or(O::from_f64(1.));
+    let off_value = off_value.unwrap_or(O::from_f64(0.));
+
+    if I::DTYPE != indices.dtype() {
+        bail!(
+            "one_hot: indices dtype {} does not match expected dtype {}",
+            indices.dtype().as_str(),
+            I::DTYPE.as_str()
+        )
+    }
+
+    if !allow_f64 && I::DTYPE.as_str() == "f64" {
+        bail!("one_hot: f64 is not supported")
+    }
 
     let rank = indices.rank();
     match rank {
         0 => {
             let mut v = vec![off_value; depth];
-            let index = indices.to_vec0::<D>()?;
+            let index = indices.to_vec0::<I>()?;
             let vi = index.to_f64();
 
-            if vi as usize >= depth {
-                bail!(
-                    "{} Index value, {}, exceeds the depth value, {}.",
-                    INDEX_EXCEEDS_DEPTH_MSG,
-                    vi,
-                    depth
-                )
-            }
+            check_value(vi, depth)?;
 
             if vi >= 0. {
                 v[vi as usize] = on_value;
@@ -132,23 +207,15 @@ pub fn one_hot<D: WithDType>(
         1 => {
             let dim1 = indices.dims1()?;
             let mut v = vec![off_value; depth * dim1];
-            let index = indices.to_vec1::<D>()?;
+            let index = indices.to_vec1::<I>()?;
             for i in 0..dim1 {
                 let vi = index[i].to_f64();
 
                 if vi == -1. {
-                    // Ignore -1 indicies, leave the vector as all off values
                     continue;
-                } else if vi < -1. {
-                    bail!("{}. Received {}", INVALID_ONE_HOT_INDEX_MSG, vi);
-                } else if vi as usize >= depth {
-                    bail!(
-                        "{} Index value, {}, exceeds the depth value, {}.",
-                        INDEX_EXCEEDS_DEPTH_MSG,
-                        vi,
-                        depth
-                    )
                 }
+
+                check_value(vi, depth)?;
 
                 let idx = i * depth + vi as usize;
 
@@ -169,24 +236,16 @@ pub fn one_hot<D: WithDType>(
         2 => {
             let (dim1, dim2) = indices.dims2()?;
             let mut v = vec![off_value; depth * dim1 * dim2];
-            let index = indices.to_vec2::<D>()?;
+            let index = indices.to_vec2::<I>()?;
             for i in 0..dim1 {
                 for j in 0..dim2 {
                     let vij = index[i][j].to_f64();
 
                     if vij == -1. {
-                        // Ignore -1 indicies, leave the vector as all off values
                         continue;
-                    } else if vij < -1. {
-                        bail!("{}. Received {}", INVALID_ONE_HOT_INDEX_MSG, vij);
-                    } else if vij as usize >= depth {
-                        bail!(
-                            "{} Index value, {}, exceeds the depth value, {}.",
-                            INDEX_EXCEEDS_DEPTH_MSG,
-                            vij,
-                            depth
-                        )
                     }
+
+                    check_value(vij, depth)?;
 
                     let idx = i * depth * dim2 + j * depth + vij as usize;
 
@@ -208,25 +267,17 @@ pub fn one_hot<D: WithDType>(
         3 => {
             let (dim1, dim2, dim3) = indices.dims3()?;
             let mut v = vec![off_value; depth * dim1 * dim2 * dim3];
-            let index = indices.to_vec3::<D>()?;
+            let index = indices.to_vec3::<I>()?;
             for i in 0..dim1 {
                 for j in 0..dim2 {
                     for k in 0..dim3 {
                         let vijk = index[i][j][k].to_f64();
 
                         if vijk == -1. {
-                            // Ignore -1 indicies, leave the vector as all off values
                             continue;
-                        } else if vijk < -1. {
-                            bail!("{}. Received {}", INVALID_ONE_HOT_INDEX_MSG, vijk);
-                        } else if vijk as usize >= depth {
-                            bail!(
-                                "{} Index value, {}, exceeds the depth value, {}.",
-                                INDEX_EXCEEDS_DEPTH_MSG,
-                                vijk,
-                                depth
-                            )
                         }
+
+                        check_value(vijk, depth)?; // bail on invalid index value
 
                         let idx =
                             i * depth * dim2 * dim3 + j * depth * dim3 + k * depth + vijk as usize;
@@ -248,9 +299,26 @@ pub fn one_hot<D: WithDType>(
             Tensor::new(v, indices.device())?.reshape(&[dim1, dim2, dim3, depth])
         }
         _ => {
-            bail!("one_hot: rank {} is not supported", rank)
+            bail!("one_hot: rank {} is not supported. ", rank)
         }
     }
+}
+
+fn check_value(value: f64, depth: usize) -> Result<()> {
+    if value < -1. {
+        bail!("{}. Received {}", INVALID_ONE_HOT_INDEX_MSG, value);
+    }
+
+    if value as usize >= depth {
+        bail!(
+            "{} Index value, {}, exceeds the depth value, {}.",
+            INDEX_EXCEEDS_DEPTH_MSG,
+            value,
+            depth
+        )
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -262,17 +330,22 @@ mod tests {
     #[test]
     pub fn test_f64_one_hot() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let device = candle::Device::Cpu;
-        let depth = 4;
-        let indices = Tensor::new(vec![vec![0f32, 2.], vec![1., -1.]], &device)?;
 
-        let one_hot = one_hot::<f32>(indices, depth, None, None)?;
+        let indices = Tensor::new(vec![vec![0f32, 2.], vec![1., -1.]], &device)?;
+        let depth = 4;
+
+        let allow_f64 = true;
+        let on_value = None; // defaults to 1.0
+        let off_value = None; // defaults to 0.0
+
+        let one_hot = one_hot::<f32, f32>(indices, depth, allow_f64, on_value, off_value)?;
 
         let expected_matrix = [
             [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
             [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
         ];
 
-        assert_eq!(one_hot.shape(), &Shape::from((2, 2, 4)));
+        assert_eq!(one_hot.shape(), &Shape::from((2, 2, depth)));
 
         let matrix = one_hot.to_vec3::<f32>()?;
 
@@ -282,21 +355,22 @@ mod tests {
     }
 
     #[test]
-    pub fn test_u8_one_hot() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    pub fn test_u8_one_cold() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let device = candle::Device::Cpu;
         let depth = 4;
-        let indices = Tensor::new(vec![vec![0u8, 2], vec![1, 3]], &device)?;
+        let indices = Tensor::new(vec![vec![0i64, 2], vec![1, -1]], &device)?;
 
-        let on_value = Some(0u8);
+        let allow_f64 = false;
+        let on_value = Some(0);
         let off_value = Some(1);
 
-        let one_hot = one_hot(indices, depth, on_value, off_value)?;
+        let one_cold = one_hot::<i64, u8>(indices, depth, allow_f64, on_value, off_value)?;
 
-        let expected_matrix = [[[0, 1, 1, 1], [1, 1, 0, 1]], [[1, 0, 1, 1], [1, 1, 1, 0]]];
+        let expected_matrix = [[[0, 1, 1, 1], [1, 1, 0, 1]], [[1, 0, 1, 1], [1, 1, 1, 1]]];
 
-        assert_eq!(one_hot.shape(), &Shape::from((2, 2, 4)));
+        assert_eq!(one_cold.shape(), &Shape::from((2, 2, depth)));
 
-        let matrix = one_hot.to_vec3::<u8>()?;
+        let matrix = one_cold.to_vec3::<u8>()?;
 
         assert_eq!(matrix, expected_matrix);
 

--- a/candle-nn/src/encoding.rs
+++ b/candle-nn/src/encoding.rs
@@ -1,0 +1,193 @@
+//! Encoding Utilities. (e.g., one-hot/cold encoding)
+//!
+//! # Examples
+//!
+//! ## One-hot encoding
+//!
+//! ```rust
+//! use candle::{Shape, Tensor, Device};
+//! use candle_nn::encoding::one_hot;
+//!
+//! let device = Device::Cpu;
+//! let depth = 4;
+//! let indices = Tensor::new(vec![vec![0f32, 2.], vec![1., -1.]], &device).unwrap();
+//!
+//! let on_value = Some(1.0); // default
+//! let off_value = Some(0.0); // default
+//!
+//! let one_hot = one_hot::<f32>(indices, depth, on_value, off_value).unwrap();
+//! let expected_matrix = [
+//!     [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
+//!     [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
+//! ];
+//! assert_eq!(one_hot.shape(), &Shape::from((2, 2, 4)));
+//!
+//! let matrix = one_hot.to_vec3::<f32>().unwrap();
+//!
+//! assert_eq!(matrix, expected_matrix);
+//! ```
+//!
+
+use candle::{bail, Result, Tensor, WithDType};
+
+/// One-hot/cold encoding.
+///
+/// Given an input tensor of indices, this function returns a tensor of the same shape as the input
+/// tensor with an additional dimension of the given depth size. The values in the returned tensor are
+/// all zeros except for the positions represented by the indices.
+///
+/// This method returns a tensor with a rank that is one larger than the input tensor.
+///
+/// As an example, the following tensor will be converted to a one-hot matrix:
+///
+/// ```
+/// [[0., 2.], [1., -1.]]
+/// ```
+///
+/// with a depth of 4 will be converted to:
+///
+/// ```
+/// [[[1., 0., 0., 0.], [0., 0., 1., 0.]], [[0., 1., 0., 0.], [0., 0., 0., 0.]]]
+/// ```
+///
+/// When the input tensor index has a value of -1, the corresponding one-hot vector will be all zeros.
+///
+///
+/// This method supports one-cold encoding by setting `on_value` to `0.0` and `off_value` to `1.0`.
+/// By default `on_value` is `1.0` and `off_value` is `0.0`.
+///
+/// Other encoding values can be used by setting `on_value` and `off_value` to the desired values.
+///
+/// # Examples
+///
+///```rust
+/// use candle::{Shape, Tensor, Device};
+/// use candle_nn::encoding::one_hot;
+///
+/// let device = Device::Cpu;
+/// let depth = 4;
+/// let indices = Tensor::new(vec![vec![0f32, 2.], vec![1., -1.]], &device).unwrap();
+///
+/// let on_value = Some(1.0); // default
+/// let off_value = Some(0.0); // default
+///
+/// let one_hot = one_hot::<f32>(indices, depth, on_value, off_value).unwrap();
+/// let expected_matrix = [
+///     [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
+///     [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
+/// ];
+/// assert_eq!(one_hot.shape(), &Shape::from((2, 2, 4)));
+///
+/// let matrix = one_hot.to_vec3::<f32>().unwrap();
+///
+/// assert_eq!(matrix, expected_matrix);
+/// ```
+///
+/// # Bails
+///
+/// This method will bail on tensors with a rank greater than 3.
+///
+/// # API Design
+///
+/// The api design for this method is loosely based on the [TensorFlow One-Hot](https://www.tensorflow.org/api_docs/python/tf/one_hot) method.
+pub fn one_hot<D: WithDType>(
+    indices: Tensor,
+    depth: usize,
+    on_value: Option<D>,
+    off_value: Option<D>,
+) -> Result<Tensor> {
+    let on_value = on_value.unwrap_or(D::from_f64(1.0));
+    let off_value = off_value.unwrap_or(D::from_f64(0.0));
+
+    let rank = indices.rank();
+    let dims = indices.dims();
+    match rank {
+        0 => {
+            let mut v = vec![off_value; depth];
+            let index = indices.to_vec0::<f32>()?;
+            v[index as usize] = on_value;
+
+            Tensor::new(v, indices.device())
+        }
+        1 => {
+            let mut v = vec![off_value; depth * dims[0]];
+            let index = indices.to_vec1::<f32>()?;
+            for i in 0..dims[0] {
+                if index[i] < 0.0 {
+                    continue;
+                }
+
+                v[(i * depth + index[i] as usize) as usize] = on_value;
+            }
+
+            Tensor::new(v, indices.device())?.reshape(&[dims[0], depth])
+        }
+        2 => {
+            let mut v = vec![off_value; depth * dims[0] * dims[1]];
+            let index = indices.to_vec2::<f32>()?;
+            for i in 0..dims[0] {
+                for j in 0..dims[1] {
+                    if index[i][j] < 0.0 {
+                        continue;
+                    }
+
+                    v[(i * depth * dims[1] + j * depth + index[i][j] as usize) as usize] = on_value;
+                }
+            }
+
+            Tensor::new(v, indices.device())?.reshape(&[dims[0], dims[1], depth])
+        }
+        3 => {
+            let mut v = vec![off_value; depth * dims[0] * dims[1] * dims[2]];
+            let index = indices.to_vec3::<f32>()?;
+            for i in 0..dims[0] {
+                for j in 0..dims[1] {
+                    for k in 0..dims[2] {
+                        if index[i][j][k] < 0.0 {
+                            continue;
+                        }
+
+                        v[(i * depth * dims[1] * dims[2]
+                            + j * depth * dims[2]
+                            + k * depth
+                            + index[i][j][k] as usize) as usize] = on_value;
+                    }
+                }
+            }
+
+            Tensor::new(v, indices.device())?.reshape(&[dims[0], dims[1], dims[2], depth])
+        }
+        _ => {
+            bail!("one_hot: rank {} is not supported", rank)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candle::Shape;
+
+    use super::*;
+
+    #[test]
+    pub fn test_one_hot() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let device = candle::Device::Cpu;
+        let depth = 4;
+        let indices = Tensor::new(vec![vec![0f32, 2.], vec![1., -1.]], &device)?;
+
+        let one_hot = one_hot::<f32>(indices, depth, None, None)?;
+
+        let expected_matrix = [
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
+            [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
+        ];
+
+        assert_eq!(one_hot.shape(), &Shape::from((2, 2, 4)));
+
+        let matrix = one_hot.to_vec3::<f32>()?;
+
+        assert_eq!(matrix, expected_matrix);
+
+        Ok(())
+    }
+}

--- a/candle-nn/src/encoding.rs
+++ b/candle-nn/src/encoding.rs
@@ -30,27 +30,35 @@
 
 use candle::{bail, Result, Tensor, WithDType};
 
+const INVALID_ONE_HOT_INDEX_MSG: &str =
+    "Invalid negative index value. Expected a positive index value or `-1` value to ignore.";
+
+const INDEX_OUT_OF_BOUNDS_MSG: &str = "Index out of bounds.";
+
+const INDEX_EXCEEDS_DEPTH_MSG: &str = "Index value exceeds the depth value.";
+
 /// One-hot/cold encoding.
 ///
 /// Given an input tensor of indices, this function returns a tensor of the same shape as the input
 /// tensor with an additional dimension of the given depth size. The values in the returned tensor are
-/// all zeros except for the positions represented by the indices.
+/// all set to the `off_value` except for the positions represented by the indices, which are set to the `on_value`.
 ///
-/// This method returns a tensor with a rank that is one larger than the input tensor.
+/// This method returns a tensor with a rank that is one rank larger than the input tensor.
 ///
-/// As an example, the following tensor will be converted to a one-hot matrix:
+/// As an example, the following tensor will be encoded to a one-hot matrix:
 ///
 /// ```
 /// [[0., 2.], [1., -1.]]
 /// ```
 ///
-/// with a depth of 4 will be converted to:
+/// with a depth of 4 will be encoded to:
 ///
 /// ```
 /// [[[1., 0., 0., 0.], [0., 0., 1., 0.]], [[0., 1., 0., 0.], [0., 0., 0., 0.]]]
 /// ```
 ///
-/// When the input tensor index has a value of -1, the corresponding one-hot vector will be all zeros.
+/// When the input tensor index has a value of -1, the corresponding one-hot vector will be ignored,
+/// resulting in a vector of values set to the `off_value`.
 ///
 ///
 /// This method supports one-cold encoding by setting `on_value` to `0.0` and `off_value` to `1.0`.
@@ -96,66 +104,148 @@ pub fn one_hot<D: WithDType>(
     on_value: Option<D>,
     off_value: Option<D>,
 ) -> Result<Tensor> {
-    let on_value = on_value.unwrap_or(D::from_f64(1.0));
-    let off_value = off_value.unwrap_or(D::from_f64(0.0));
+    let on_value = on_value.unwrap_or(D::from_f64(1.));
+    let off_value = off_value.unwrap_or(D::from_f64(0.));
 
     let rank = indices.rank();
-    let dims = indices.dims();
     match rank {
         0 => {
             let mut v = vec![off_value; depth];
-            let index = indices.to_vec0::<f32>()?;
-            v[index as usize] = on_value;
+            let index = indices.to_vec0::<D>()?;
+            let vi = index.to_f64();
+
+            if vi as usize >= depth {
+                bail!(
+                    "{} Index value, {}, exceeds the depth value, {}.",
+                    INDEX_EXCEEDS_DEPTH_MSG,
+                    vi,
+                    depth
+                )
+            }
+
+            if vi >= 0. {
+                v[vi as usize] = on_value;
+            }
 
             Tensor::new(v, indices.device())
         }
         1 => {
-            let mut v = vec![off_value; depth * dims[0]];
-            let index = indices.to_vec1::<f32>()?;
-            for i in 0..dims[0] {
-                if index[i] < 0.0 {
+            let dim1 = indices.dims1()?;
+            let mut v = vec![off_value; depth * dim1];
+            let index = indices.to_vec1::<D>()?;
+            for i in 0..dim1 {
+                let vi = index[i].to_f64();
+
+                if vi == -1. {
+                    // Ignore -1 indicies, leave the vector as all off values
                     continue;
+                } else if vi < -1. {
+                    bail!("{}. Received {}", INVALID_ONE_HOT_INDEX_MSG, vi);
+                } else if vi as usize >= depth {
+                    bail!(
+                        "{} Index value, {}, exceeds the depth value, {}.",
+                        INDEX_EXCEEDS_DEPTH_MSG,
+                        vi,
+                        depth
+                    )
                 }
 
-                v[(i * depth + index[i] as usize) as usize] = on_value;
+                let idx = i * depth + vi as usize;
+
+                if idx >= v.len() {
+                    bail!(
+                        "{} Expected index value, {}, to be less than {}.",
+                        INDEX_OUT_OF_BOUNDS_MSG,
+                        idx,
+                        v.len()
+                    );
+                }
+
+                v[idx] = on_value;
             }
 
-            Tensor::new(v, indices.device())?.reshape(&[dims[0], depth])
+            Tensor::new(v, indices.device())?.reshape(&[dim1, depth])
         }
         2 => {
-            let mut v = vec![off_value; depth * dims[0] * dims[1]];
-            let index = indices.to_vec2::<f32>()?;
-            for i in 0..dims[0] {
-                for j in 0..dims[1] {
-                    if index[i][j] < 0.0 {
+            let (dim1, dim2) = indices.dims2()?;
+            let mut v = vec![off_value; depth * dim1 * dim2];
+            let index = indices.to_vec2::<D>()?;
+            for i in 0..dim1 {
+                for j in 0..dim2 {
+                    let vij = index[i][j].to_f64();
+
+                    if vij == -1. {
+                        // Ignore -1 indicies, leave the vector as all off values
                         continue;
+                    } else if vij < -1. {
+                        bail!("{}. Received {}", INVALID_ONE_HOT_INDEX_MSG, vij);
+                    } else if vij as usize >= depth {
+                        bail!(
+                            "{} Index value, {}, exceeds the depth value, {}.",
+                            INDEX_EXCEEDS_DEPTH_MSG,
+                            vij,
+                            depth
+                        )
                     }
 
-                    v[(i * depth * dims[1] + j * depth + index[i][j] as usize) as usize] = on_value;
+                    let idx = i * depth * dim2 + j * depth + vij as usize;
+
+                    if idx >= v.len() {
+                        bail!(
+                            "{} Expected index value, {}, to be less than {}.",
+                            INDEX_OUT_OF_BOUNDS_MSG,
+                            idx,
+                            v.len()
+                        );
+                    }
+
+                    v[idx] = on_value;
                 }
             }
 
-            Tensor::new(v, indices.device())?.reshape(&[dims[0], dims[1], depth])
+            Tensor::new(v, indices.device())?.reshape(&[dim1, dim2, depth])
         }
         3 => {
-            let mut v = vec![off_value; depth * dims[0] * dims[1] * dims[2]];
-            let index = indices.to_vec3::<f32>()?;
-            for i in 0..dims[0] {
-                for j in 0..dims[1] {
-                    for k in 0..dims[2] {
-                        if index[i][j][k] < 0.0 {
+            let (dim1, dim2, dim3) = indices.dims3()?;
+            let mut v = vec![off_value; depth * dim1 * dim2 * dim3];
+            let index = indices.to_vec3::<D>()?;
+            for i in 0..dim1 {
+                for j in 0..dim2 {
+                    for k in 0..dim3 {
+                        let vijk = index[i][j][k].to_f64();
+
+                        if vijk == -1. {
+                            // Ignore -1 indicies, leave the vector as all off values
                             continue;
+                        } else if vijk < -1. {
+                            bail!("{}. Received {}", INVALID_ONE_HOT_INDEX_MSG, vijk);
+                        } else if vijk as usize >= depth {
+                            bail!(
+                                "{} Index value, {}, exceeds the depth value, {}.",
+                                INDEX_EXCEEDS_DEPTH_MSG,
+                                vijk,
+                                depth
+                            )
                         }
 
-                        v[(i * depth * dims[1] * dims[2]
-                            + j * depth * dims[2]
-                            + k * depth
-                            + index[i][j][k] as usize) as usize] = on_value;
+                        let idx =
+                            i * depth * dim2 * dim3 + j * depth * dim3 + k * depth + vijk as usize;
+
+                        if idx >= v.len() {
+                            bail!(
+                                "{} Expected index value, {}, to be less than {}.",
+                                INDEX_OUT_OF_BOUNDS_MSG,
+                                idx,
+                                v.len()
+                            );
+                        }
+
+                        v[idx] = on_value;
                     }
                 }
             }
 
-            Tensor::new(v, indices.device())?.reshape(&[dims[0], dims[1], dims[2], depth])
+            Tensor::new(v, indices.device())?.reshape(&[dim1, dim2, dim3, depth])
         }
         _ => {
             bail!("one_hot: rank {} is not supported", rank)
@@ -170,7 +260,7 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test_one_hot() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    pub fn test_f64_one_hot() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let device = candle::Device::Cpu;
         let depth = 4;
         let indices = Tensor::new(vec![vec![0f32, 2.], vec![1., -1.]], &device)?;
@@ -185,6 +275,28 @@ mod tests {
         assert_eq!(one_hot.shape(), &Shape::from((2, 2, 4)));
 
         let matrix = one_hot.to_vec3::<f32>()?;
+
+        assert_eq!(matrix, expected_matrix);
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn test_u8_one_hot() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let device = candle::Device::Cpu;
+        let depth = 4;
+        let indices = Tensor::new(vec![vec![0u8, 2], vec![1, 3]], &device)?;
+
+        let on_value = Some(0u8);
+        let off_value = Some(1);
+
+        let one_hot = one_hot(indices, depth, on_value, off_value)?;
+
+        let expected_matrix = [[[0, 1, 1, 1], [1, 1, 0, 1]], [[1, 0, 1, 1], [1, 1, 1, 0]]];
+
+        assert_eq!(one_hot.shape(), &Shape::from((2, 2, 4)));
+
+        let matrix = one_hot.to_vec3::<u8>()?;
 
         assert_eq!(matrix, expected_matrix);
 

--- a/candle-nn/src/encoding.rs
+++ b/candle-nn/src/encoding.rs
@@ -14,10 +14,10 @@
 //! let depth = 4;
 //!
 //! let allow_f64 = true;
-//! let on_value = None; // defaults to 1.0
-//! let off_value = None; // defaults to 0.0
+//! let on_value = 1.0;
+//! let off_value = 0.0;
 //!
-//! let one_hot = one_hot::<f32, f32>(indices, depth, allow_f64, on_value, off_value)?;
+//! let one_hot = one_hot::<f32>(indices, depth, allow_f64, on_value, off_value)?;
 //!
 //! let expected_matrix = [
 //!     [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
@@ -42,10 +42,10 @@
 //! let indices = Tensor::new(vec![vec![0i64, 2], vec![1, 3]], &device)?;
 //!
 //! let allow_f64 = false;
-//! let on_value = Some(0);
-//! let off_value = Some(1);
+//! let on_value = 0;
+//! let off_value = 1;
 //!
-//! let one_cold = one_hot::<i64, u8>(indices, depth, allow_f64, on_value, off_value)?;
+//! let one_cold = one_hot::<u8>(indices, depth, allow_f64, on_value, off_value)?;
 //!
 //! let expected_matrix = [[[0, 1, 1, 1], [1, 1, 0, 1]], [[1, 0, 1, 1], [1, 1, 1, 0]]];
 //!
@@ -59,13 +59,6 @@
 
 use candle::{bail, DType, Result, Tensor, WithDType};
 
-const INVALID_ONE_HOT_INDEX_MSG: &str =
-    "one_hot: Invalid negative index value. Expected a positive index value or `-1` value to ignore.";
-
-const INDEX_OUT_OF_BOUNDS_MSG: &str = "one_hot: Index out of bounds.";
-
-const INDEX_EXCEEDS_DEPTH_MSG: &str = "one_hot: Index value exceeds the depth value.";
-
 /// One-hot/cold encoding.
 ///
 /// Given an input tensor of indices, this function returns a tensor of the same shape as the input
@@ -76,15 +69,11 @@ const INDEX_EXCEEDS_DEPTH_MSG: &str = "one_hot: Index value exceeds the depth va
 ///
 /// As an example, the following tensor will be encoded to a one-hot matrix:
 ///
-/// ```
-/// [[0i64, 2], [1, -1]]
-/// ```
+/// `[[0i64, 2], [1, -1]]`
 ///
 /// with a depth of 4 will be encoded to:
 ///
-/// ```
-/// [[[1, 0, 0, 0], [0, 0, 1, 0]], [[0, 1, 0, 0], [0, 0, 0, 0]]]
-/// ```
+/// `[[[1, 0, 0, 0], [0, 0, 1, 0]], [[0, 1, 0, 0], [0, 0, 0, 0]]]`
 ///
 /// When the input tensor index has a value of -1, the corresponding one-hot vector will be ignored,
 /// resulting in a vector of values set to the `off_value`.
@@ -105,13 +94,13 @@ const INDEX_EXCEEDS_DEPTH_MSG: &str = "one_hot: Index value exceeds the depth va
 ///
 /// let device = candle::Device::Cpu;
 ///
-/// let indices = Tensor::new(vec![vec![0i64, 2], vec![1, -1]], &device)?;
+/// let indices = Tensor::new(vec![vec![0i64, 2], vec![1, -1]], &device).unwrap();
 /// let depth = 4;
 ///
-/// let on_value = None; // defaults to 1.
-/// let off_value = None; // defaults to 0.
+/// let on_value = 1.0;
+/// let off_value = 0.0;
 ///
-/// let one_hot = one_hot::<f32>(indices, depth, on_value, off_value)?;
+/// let one_hot = one_hot::<f32>(indices, depth, on_value, off_value).unwrap();
 ///
 /// let expected_matrix = [
 ///     [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
@@ -120,7 +109,7 @@ const INDEX_EXCEEDS_DEPTH_MSG: &str = "one_hot: Index value exceeds the depth va
 ///
 /// assert_eq!(one_hot.shape(), &Shape::from((2, 2, depth)));
 ///
-/// let matrix = one_hot.to_vec3::<f32>()?;
+/// let matrix = one_hot.to_vec3::<f32>().unwrap();
 ///
 /// assert_eq!(matrix, expected_matrix);
 ///```
@@ -133,19 +122,19 @@ const INDEX_EXCEEDS_DEPTH_MSG: &str = "one_hot: Index value exceeds the depth va
 ///
 /// let device = candle::Device::Cpu;
 /// let depth = 4;
-/// let indices = Tensor::new(vec![vec![0u8, 2], vec![1, 3]], &device)?;
+/// let indices = Tensor::new(vec![vec![0u8, 2], vec![1, 3]], &device).unwrap();
 ///
-/// let on_value = Some(0u8);
-/// let off_value = Some(1);
+/// let on_value: u8 = 0;
+/// let off_value = 1;
 ///
 /// // Note: the method does not require the turbofish operator, as the type is inferred from the `on_value` and `off_value`.
-/// let one_cold = one_hot(indices, depth, on_value, off_value)?;
+/// let one_cold = one_hot(indices, depth, on_value, off_value).unwrap();
 ///
 /// let expected_matrix = [[[0, 1, 1, 1], [1, 1, 0, 1]], [[1, 0, 1, 1], [1, 1, 1, 0]]];
 ///
 /// assert_eq!(one_cold.shape(), &Shape::from((2, 2, depth)));
 ///
-/// let matrix = one_cold.to_vec3::<u8>()?;
+/// let matrix = one_cold.to_vec3::<u8>().unwrap();
 ///
 /// assert_eq!(matrix, expected_matrix);
 /// ```
@@ -159,7 +148,7 @@ const INDEX_EXCEEDS_DEPTH_MSG: &str = "one_hot: Index value exceeds the depth va
 ///
 /// This method will bail if the index value is greater than or equal to the depth value.
 ///
-/// This method will bail if the input data type is `f64`.
+/// This method will bail if the input data type is not one of `U8`, `U32` or `I64`.
 ///
 /// # API Design
 ///
@@ -167,12 +156,9 @@ const INDEX_EXCEEDS_DEPTH_MSG: &str = "one_hot: Index value exceeds the depth va
 pub fn one_hot<D: WithDType>(
     indices: Tensor,
     depth: usize,
-    on_value: Option<D>,
-    off_value: Option<D>,
+    on_value: D,
+    off_value: D,
 ) -> Result<Tensor> {
-    let on_value = on_value.unwrap_or(D::from_f64(1.));
-    let off_value = off_value.unwrap_or(D::from_f64(0.));
-
     let dtype = indices.dtype();
     let rank = indices.rank();
 
@@ -183,15 +169,15 @@ pub fn one_hot<D: WithDType>(
             match dtype {
                 DType::U8 => {
                     let vi = indices.to_vec0::<u8>()?;
-                    set_uint_value(vi as usize, idx, depth, &mut v, on_value)?;
+                    set_usize_value(vi as usize, idx, depth, &mut v, on_value)?;
                 }
                 DType::U32 => {
                     let vi = indices.to_vec0::<u32>()?;
-                    set_uint_value(vi as usize, idx, depth, &mut v, on_value)?;
+                    set_usize_value(vi as usize, idx, depth, &mut v, on_value)?;
                 }
                 DType::I64 => {
                     let vi = indices.to_vec0::<i64>()?;
-                    set_int_value(vi, idx, depth, &mut v, on_value)?;
+                    set_int64_value(vi, idx, depth, &mut v, on_value)?;
                 }
                 d => unsupported_dtype(d)?,
             };
@@ -206,19 +192,19 @@ pub fn one_hot<D: WithDType>(
                 DType::U8 => {
                     let index = indices.to_vec1::<u8>()?;
                     for i in 0..dim1 {
-                        set_uint_value(index[i] as usize, i * depth, depth, &mut v, on_value)?;
+                        set_usize_value(index[i] as usize, i * depth, depth, &mut v, on_value)?;
                     }
                 }
                 DType::U32 => {
                     let index = indices.to_vec1::<u32>()?;
                     for i in 0..dim1 {
-                        set_uint_value(index[i] as usize, i * depth, depth, &mut v, on_value)?;
+                        set_usize_value(index[i] as usize, i * depth, depth, &mut v, on_value)?;
                     }
                 }
                 DType::I64 => {
                     let index = indices.to_vec1::<i64>()?;
                     for i in 0..dim1 {
-                        set_int_value(index[i], i * depth, depth, &mut v, on_value)?;
+                        set_int64_value(index[i], i * depth, depth, &mut v, on_value)?;
                     }
                 }
                 d => unsupported_dtype(d)?,
@@ -240,7 +226,7 @@ pub fn one_hot<D: WithDType>(
                 DType::U8 => {
                     let index = indices.to_vec2::<u8>()?;
                     for (i, j) in iter {
-                        set_uint_value(
+                        set_usize_value(
                             index[i][j] as usize,
                             idx(i, j, depth, dim2),
                             depth,
@@ -252,7 +238,7 @@ pub fn one_hot<D: WithDType>(
                 DType::U32 => {
                     let index = indices.to_vec2::<u32>()?;
                     for (i, j) in iter {
-                        set_uint_value(
+                        set_usize_value(
                             index[i][j] as usize,
                             idx(i, j, depth, dim2),
                             depth,
@@ -264,7 +250,7 @@ pub fn one_hot<D: WithDType>(
                 DType::I64 => {
                     let index = indices.to_vec2::<i64>()?;
                     for (i, j) in iter {
-                        set_int_value(
+                        set_int64_value(
                             index[i][j],
                             idx(i, j, depth, dim2),
                             depth,
@@ -294,7 +280,7 @@ pub fn one_hot<D: WithDType>(
                 DType::U8 => {
                     let index = indices.to_vec3::<u8>()?;
                     for (i, j, k) in iter {
-                        set_uint_value(
+                        set_usize_value(
                             index[i][j][k] as usize,
                             idx(i, j, k, depth, dim2, dim3),
                             depth,
@@ -306,7 +292,7 @@ pub fn one_hot<D: WithDType>(
                 DType::U32 => {
                     let index = indices.to_vec3::<u32>()?;
                     for (i, j, k) in iter {
-                        set_uint_value(
+                        set_usize_value(
                             index[i][j][k] as usize,
                             idx(i, j, k, depth, dim2, dim3),
                             depth,
@@ -318,7 +304,7 @@ pub fn one_hot<D: WithDType>(
                 DType::I64 => {
                     let index = indices.to_vec3::<i64>()?;
                     for (i, j, k) in iter {
-                        set_int_value(
+                        set_int64_value(
                             index[i][j][k],
                             idx(i, j, k, depth, dim2, dim3),
                             depth,
@@ -333,7 +319,7 @@ pub fn one_hot<D: WithDType>(
             Tensor::new(v, indices.device())?.reshape(&[dim1, dim2, dim3, depth])
         }
         _ => {
-            bail!("one_hot: rank {} is not supported. ", rank)
+            bail!("one_hot: rank {} is not supported.", rank)
         }
     }
 }
@@ -341,7 +327,7 @@ pub fn one_hot<D: WithDType>(
 // Bail if the value is less than -1.
 fn check_negative(value: i64) -> Result<()> {
     if value < -1 {
-        bail!("{}. Received {}", INVALID_ONE_HOT_INDEX_MSG, value);
+        bail!("one_hot: Invalid negative index value. Expected a positive index value or `-1` value to ignore. Received {}", value);
     }
     Ok(())
 }
@@ -350,8 +336,7 @@ fn check_negative(value: i64) -> Result<()> {
 fn check_value_bounds(value: usize, depth: usize) -> Result<()> {
     if value >= depth {
         bail!(
-            "{} Index value, {}, must be less than the depth value, {}.",
-            INDEX_EXCEEDS_DEPTH_MSG,
+            "one_hot: Index value exceeds the depth value. Index value, {}, must be less than the depth value, {}.",
             value,
             depth
         )
@@ -364,8 +349,7 @@ fn check_value_bounds(value: usize, depth: usize) -> Result<()> {
 fn check_idx(idx: usize, len: usize) -> Result<()> {
     if idx >= len {
         bail!(
-            "{} Expected index value, {}, to be less than {}.",
-            INDEX_OUT_OF_BOUNDS_MSG,
+            "one_hot: Index out of bounds. Expected index value, {}, to be less than {}.",
             idx,
             len
         );
@@ -382,8 +366,8 @@ fn unsupported_dtype(dtype: DType) -> Result<()> {
     );
 }
 
-// Set unsigned integer index values to the given value.
-fn set_uint_value<D: WithDType>(
+// Set unsigned usize index values to the given value.
+fn set_usize_value<D: WithDType>(
     value: usize,
     idx: usize,
     depth: usize,
@@ -401,7 +385,11 @@ fn set_uint_value<D: WithDType>(
 }
 
 // Set signed integer index values to the given value.
-fn set_int_value<D: WithDType>(
+// Signed integer values are only permitted for `-1` values.
+// Otherwise, the value must be positive for unsigned usize values.
+// This method will only case i64 values to usize values if the value is positive,
+// otherwise the method will bail.
+fn set_int64_value<D: WithDType>(
     value: i64,
     idx: usize,
     depth: usize,
@@ -416,16 +404,9 @@ fn set_int_value<D: WithDType>(
     // Bail if the index value is less than -1
     check_negative(value)?;
 
-    // Bail if the index value is greater than or equal to the depth value.
-    check_value_bounds(value as usize, depth)?;
-
-    let idx = idx + value as usize;
-
-    check_idx(idx, v.len())?;
-
-    v[idx] = on_value;
-
-    Ok(())
+    // Since i64 cannot be negative after the previous check,
+    // we can safely cast to usize.
+    set_usize_value(value as usize, idx, depth, v, on_value)
 }
 
 #[cfg(test)]
@@ -441,8 +422,8 @@ mod tests {
         let indices = Tensor::new(vec![vec![0i64, 2], vec![1, -1]], &device)?;
         let depth = 4;
 
-        let on_value = None;
-        let off_value = None;
+        let on_value = 1.0;
+        let off_value = 0.0;
 
         let one_hot = one_hot::<f32>(indices, depth, on_value, off_value)?;
 
@@ -473,8 +454,8 @@ mod tests {
         )?;
         let depth = 4;
 
-        let on_value = None;
-        let off_value = None;
+        let on_value = 1.0;
+        let off_value = 0.0;
 
         let one_hot = one_hot::<f32>(indices, depth, on_value, off_value)?;
 
@@ -509,8 +490,8 @@ mod tests {
         let depth = 4;
         let indices = Tensor::new(vec![vec![0i64, 2], vec![1, -1]], &device)?;
 
-        let on_value = Some(0u8);
-        let off_value = Some(1);
+        let on_value = 0u8;
+        let off_value = 1;
 
         // Note that the method does not require the turbofish operator, as the type is inferred from the on_value.
         let one_cold = one_hot(indices, depth, on_value, off_value)?;

--- a/candle-nn/src/lib.rs
+++ b/candle-nn/src/lib.rs
@@ -2,6 +2,7 @@ pub mod activation;
 pub mod batch_norm;
 pub mod conv;
 pub mod embedding;
+pub mod encoding;
 pub mod func;
 pub mod group_norm;
 pub mod init;

--- a/candle-nn/tests/one_hot.rs
+++ b/candle-nn/tests/one_hot.rs
@@ -1,0 +1,120 @@
+use candle::{Result, Shape, Tensor};
+use candle_nn::encoding::one_hot;
+
+#[test]
+fn test_i64_one_hot() -> Result<()> {
+    let device = candle::Device::Cpu;
+
+    let indices = Tensor::new(vec![vec![0i64, 2], vec![1, -1]], &device)?;
+    let depth = 4;
+
+    let on_value = 1.0;
+    let off_value = 0.0;
+
+    let one_hot = one_hot::<f32>(indices, depth, on_value, off_value)?;
+
+    let expected_matrix = [
+        [[1., 0., 0., 0.], [0., 0., 1., 0.]],
+        [[0., 1., 0., 0.], [0., 0., 0., 0.]],
+    ];
+
+    assert_eq!(one_hot.shape(), &Shape::from((2, 2, depth)));
+
+    let matrix = one_hot.to_vec3::<f32>()?;
+
+    assert_eq!(matrix, expected_matrix);
+
+    Ok(())
+}
+
+#[test]
+fn test_rank_3_one_hot() -> Result<()> {
+    let device = candle::Device::Cpu;
+
+    let indices = Tensor::new(
+        vec![
+            vec![vec![0i64, 1], vec![2, 3]],
+            vec![vec![3, 1], vec![1, -1]],
+        ],
+        &device,
+    )?;
+    let depth = 4;
+
+    let on_value = 1.0;
+    let off_value = 0.0;
+
+    let one_hot = one_hot::<f32>(indices, depth, on_value, off_value)?;
+
+    let expected_matrix = Tensor::new(
+        vec![
+            vec![
+                vec![vec![1f32, 0., 0., 0.], vec![0., 1., 0., 0.]],
+                vec![vec![0., 0., 1., 0.], vec![0., 0., 0., 1.]],
+            ],
+            vec![
+                vec![vec![0., 0., 0., 1.], vec![0., 1., 0., 0.]],
+                vec![vec![0., 1., 0., 0.], vec![0., 0., 0., 0.]],
+            ],
+        ],
+        &device,
+    )?;
+
+    assert_eq!(one_hot.shape(), expected_matrix.shape());
+    assert_eq!(one_hot.dims(), expected_matrix.dims());
+
+    let matrix = one_hot.get(1)?.to_vec3::<f32>()?;
+    let expected_matrix = expected_matrix.get(1)?.to_vec3::<f32>()?;
+
+    assert_eq!(matrix, expected_matrix);
+
+    Ok(())
+}
+
+#[test]
+fn test_u8_one_cold() -> Result<()> {
+    let device = candle::Device::Cpu;
+    let depth = 4;
+    let indices = Tensor::new(vec![vec![0i64, 2], vec![1, -1]], &device)?;
+
+    let on_value = 0u8;
+    let off_value = 1;
+
+    // Note that the method does not require the turbofish operator, as the type is inferred from the on_value.
+    let one_cold = one_hot(indices, depth, on_value, off_value)?;
+
+    let expected_matrix = [[[0, 1, 1, 1], [1, 1, 0, 1]], [[1, 0, 1, 1], [1, 1, 1, 1]]];
+
+    assert_eq!(one_cold.shape(), &Shape::from((2, 2, depth)));
+
+    let matrix = one_cold.to_vec3::<u8>()?;
+
+    assert_eq!(matrix, expected_matrix);
+
+    Ok(())
+}
+
+#[test]
+fn test_iter() -> Result<()> {
+    let device = candle::Device::Cpu;
+    let depth = 4;
+    let indices = Tensor::new(vec![vec![0i64, 2], vec![1, -1]], &device)?;
+    let matrix = indices.to_vec2::<i64>()?;
+    let (dim1, dim2) = indices.dims2()?;
+
+    let iter = (0..dim1).flat_map(|i| (0..dim2).map(move |j| (i, j)));
+
+    let mut v = vec![0; depth * dim1 * dim2];
+
+    for (i, j) in iter {
+        let idx = i * depth * dim2 + j * depth;
+        v[idx] = matrix[i][j];
+    }
+
+    for (i, row) in matrix.iter().enumerate() {
+        for (j, &value) in row.iter().enumerate() {
+            let idx = i * depth * dim2 + j * depth;
+            assert_eq!(v[idx], value);
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
 One-hot/cold encoding.

 Given an input tensor of indices, this function returns a tensor of the same shape as the input
 tensor with an additional dimension of the given depth size. The values in the returned tensor are
 all set to the `off_value` except for the positions represented by the indices, which are set to the `on_value`.

 This method returns a tensor with a rank that is one rank larger than the input tensor.

 As an example, the following tensor will be encoded to a one-hot matrix:

 `[[0i64, 2], [1, -1]]`

 with a depth of 4 will be encoded to:

 `[[[1, 0, 0, 0], [0, 0, 1, 0]], [[0, 1, 0, 0], [0, 0, 0, 0]]]`

 When the input tensor index has a value of -1, the corresponding one-hot vector will be ignored,
 resulting in a vector of values set to the `off_value`.


 This method supports one-cold encoding by setting `on_value` to `0` and `off_value` to `1`.
 By default `on_value` is `1` and `off_value` is `0`.

 Other encoding values can be used by setting `on_value` and `off_value` to the desired values.

 # Examples

 ## One-hot encoding

 ```rust
 use candle::{Shape, Tensor, Device};
 use candle_nn::encoding::one_hot;

 let device = candle::Device::Cpu;

 let indices = Tensor::new(vec![vec![0i64, 2], vec![1, -1]], &device).unwrap();
 let depth = 4;

 let on_value = 1.0;
 let off_value = 0.0;

 let one_hot = one_hot::<f32>(indices, depth, on_value, off_value).unwrap();

 let expected_matrix = [
     [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
     [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]],
 ];

 assert_eq!(one_hot.shape(), &Shape::from((2, 2, depth)));

 let matrix = one_hot.to_vec3::<f32>().unwrap();

 assert_eq!(matrix, expected_matrix);
```
 ## One-cold Encoding

 ```rust
 use candle::{Shape, Tensor, Device};
 use candle_nn::encoding::one_hot;


 let device = candle::Device::Cpu;
 let depth = 4;
 let indices = Tensor::new(vec![vec![0u8, 2], vec![1, 3]], &device).unwrap();

 let on_value: u8 = 0;
 let off_value = 1;

 // Note: the method does not require the turbofish operator, as the type is inferred from the `on_value` and `off_value`.
 let one_cold = one_hot(indices, depth, on_value, off_value).unwrap();

 let expected_matrix = [[[0, 1, 1, 1], [1, 1, 0, 1]], [[1, 0, 1, 1], [1, 1, 1, 0]]];

 assert_eq!(one_cold.shape(), &Shape::from((2, 2, depth)));

 let matrix = one_cold.to_vec3::<u8>().unwrap();

 assert_eq!(matrix, expected_matrix);
 ```


 # Bails

 This method will bail on tensors with a rank greater than 3.

 This method will bail if the index value is less than -1.

 This method will bail if the index value is greater than or equal to the depth value.

 This method will bail if the input data type is not one of `U8`, `U32` or `I64`.

 # API Design

 The api design for this method is loosely based on the [TensorFlow One-Hot](https://www.tensorflow.org/api_docs/python/tf/one_hot) method.