### PR TITLE
Metal fill kernel

### DIFF
--- a/candle-metal-kernels/Cargo.toml
+++ b/candle-metal-kernels/Cargo.toml
@@ -14,7 +14,7 @@ metal = { version = "0.27.0", features = ["mps"]}
 once_cell = "1.18.0"
 thiserror = "1"
 tracing = "0.1.37"
+half = { version = "2.3.1", features = ["num-traits", "use-intrinsics", "rand_distr"] }
 
 [dev-dependencies]
-half = { version = "2.3.1", features = ["num-traits", "use-intrinsics", "rand_distr"] }
 rand = "0.8.5"

--- a/candle-metal-kernels/Cargo.toml
+++ b/candle-metal-kernels/Cargo.toml
@@ -15,6 +15,7 @@ once_cell = "1.18.0"
 thiserror = "1"
 tracing = "0.1.37"
 half = { version = "2.3.1", features = ["num-traits", "use-intrinsics", "rand_distr"] }
+num-traits = "0.2.17"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/candle-metal-kernels/src/fill.metal
+++ b/candle-metal-kernels/src/fill.metal
@@ -1,0 +1,31 @@
+#include <metal_stdlib>
+using namespace metal;
+
+template<typename T>
+void fill(
+    device T *buffer [[buffer(0)]],
+    constant T &value,
+    constant size_t &numel,
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= numel) return;
+    buffer[gid] = value;
+}
+
+#define FILL_OP(T, FN_NAME)                 \
+kernel void FN_NAME(                        \
+    device T *buffer [[buffer(0)]],         \
+    constant T &value,                      \
+    constant size_t &numel,                 \
+    uint gid [[thread_position_in_grid]]    \
+) { fill<T>(buffer, value, numel, gid); }   \
+
+FILL_OP(uint8_t, fill_u8)
+FILL_OP(uint32_t, fill_u32)
+FILL_OP(int64_t, fill_i64)
+FILL_OP(half, fill_f16)
+FILL_OP(float, fill_f32)
+
+#if __METAL_VERSION__ >= 310
+FILL_OP(bfloat, fill_bf16)
+#endif

--- a/candle-metal-kernels/src/unary.metal
+++ b/candle-metal-kernels/src/unary.metal
@@ -1,6 +1,5 @@
 #include <metal_stdlib>
 #include <metal_math>
-#
 using namespace metal;
 
 METAL_FUNC uint get_strided_index(


### PR DESCRIPTION
Still uses blit command encoder for zeroes and all u8 values.