### PR TITLE
Port of Karpathy's Let's Build GPT tutorial to Candle

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ And then head over to
 - [`candle-ext`](https://github.com/mokeyish/candle-ext): An extension library to Candle that provides PyTorch functions not currently available in Candle.
 - [`kalosm`](https://github.com/floneum/floneum/tree/master/interfaces/kalosm): A multi-modal meta-framework in Rust for interfacing with local pre-trained models with support for controlled generation, custom samplers, in-memory vector databases, audio transcription, and more.
 - [`candle-sampling`](https://github.com/EricLBuehler/candle-sampling): Sampling techniques for Candle.
+- [`gpt-from-scratch-rs`](https://github.com/jeroenvlek/gpt-from-scratch-rs): A port of Andrej Karpathy's _Let's build GPT_ tutorial on YouTube showcasing the Candle API on a toy problem.
 
 If you have an addition to this list, please submit a pull request.
 


### PR DESCRIPTION
This adds a [link to a port](https://github.com/jeroenvlek/gpt-from-scratch-rs) of  this [tutorial](https://www.youtube.com/watch?v=kCc8FmEb1nY) to Candle. I moved all comments from his notebook to this code as well. 

You will also see a struggle between following his variable naming and my own standards ;) I will probably make that more consistent soon.

It is meant as a complement to the other tutorial link and it showcases different sides of the Candle API applied to a toy example, especially for people trying to build a model from scratch (as opposed to loading pre-trained weights).

I'm sure not everything in the port might be idiomatic use of Candle, happy to receive feedback! Just know that it works and I had to dive into the API quite often to find the corresponding functionality. (Only thing I couldn't find/work around was on-device multinomial sampling)