### PR TITLE
feat: add dependabot to the project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    open-pull-requests-limit-per-dependency: 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ categories = ["science"]
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-accelerate-src = { version = "^0.3.2" }
-anyhow = { version = "^1", features = ["backtrace"] }
-byteorder = "^1.4.3"
+accelerate-src = { version = "0.3.2" }
+anyhow = { version = "1", features = ["backtrace"] }
+byteorder = "1.4.3"
 candle = { path = "./candle-core", package = "candle-core" }
 candle-datasets = { path = "./candle-datasets" }
 candle-flash-attn = { path = "./candle-flash-attn" }
@@ -39,38 +39,38 @@ candle-metal-kernels = { path = "./candle-metal-kernels" }
 candle-nn = { path = "./candle-nn" }
 candle-onnx = { path = "./candle-onnx" }
 candle-transformers = { path = "./candle-transformers" }
-clap = { version = "^4.2.4", features = ["derive"] }
-criterion = { version = "^0.5.1", default-features=false }
-cudarc = { version = "^0.9.14", features = ["f16"] }
-gemm = { version = "^0.16.6", features = ["wasm-simd128-enable"] }
-hf-hub = "^0.3.0"
-half = { version = "^2.3.1", features = ["num-traits", "use-intrinsics", "rand_distr"] }
-image = { version = "^0.24.7", default-features = false, features = ["jpeg", "png"] }
-imageproc = { version = "^0.23.0", default-features = false }
-intel-mkl-src = { version = "^0.8.1", features = ["mkl-static-lp64-iomp"] }
-libc = { version = "^0.2.147" }
-log = "^0.4"
-memmap2 = { version = "^0.7.1", features = ["stable_deref_trait"] }
-num_cpus = "^1.15.0"
-num-traits = "^0.2.15"
-parquet = { version = "^45.0.0" }
-rand = "^0.8.5"
-rand_distr = "^0.4.3"
-rayon = "^1.7.0"
-rusttype = { version = "^0.9", default-features = false }
-safetensors = "^0.3.1"
-serde = { version = "^1.0.171", features = ["derive"] }
-serde_plain = "^1.0.2"
-serde_json = "^1.0.99"
-thiserror = "^1"
-tokenizers = { version = "^0.13.4", default-features = false }
-tracing = "^0.1.37"
-tracing-chrome = "^0.7.1"
-tracing-subscriber = "^0.3.7"
-wav = "^1.0.0"
-yoke = { version = "^0.7.2", features = ["derive"] }
-zip = { version = "^0.6.6", default-features = false }
-metal = { version = "^0.27.0", features = ["mps"]}
+clap = { version = "4.2.4", features = ["derive"] }
+criterion = { version = "0.5.1", default-features=false }
+cudarc = { version = "0.9.14", features = ["f16"] }
+gemm = { version = "0.16.6", features = ["wasm-simd128-enable"] }
+hf-hub = "0.3.0"
+half = { version = "2.3.1", features = ["num-traits", "use-intrinsics", "rand_distr"] }
+image = { version = "0.24.7", default-features = false, features = ["jpeg", "png"] }
+imageproc = { version = "0.23.0", default-features = false }
+intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"] }
+libc = { version = "0.2.147" }
+log = "0.4"
+memmap2 = { version = "0.7.1", features = ["stable_deref_trait"] }
+num_cpus = "1.15.0"
+num-traits = "0.2.15"
+parquet = { version = "45.0.0" }
+rand = "0.8.5"
+rand_distr = "0.4.3"
+rayon = "1.7.0"
+rusttype = { version = "0.9", default-features = false }
+safetensors = "0.3.1"
+serde = { version = "1.0.171", features = ["derive"] }
+serde_plain = "1.0.2"
+serde_json = "1.0.99"
+thiserror = "1"
+tokenizers = { version = "0.13.4", default-features = false }
+tracing = "0.1.37"
+tracing-chrome = "0.7.1"
+tracing-subscriber = "0.3.7"
+wav = "1.0.0"
+yoke = { version = "0.7.2", features = ["derive"] }
+zip = { version = "0.6.6", default-features = false }
+metal = { version = "0.27.0", features = ["mps"]}
 
 [profile.release-with-debug]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ categories = ["science"]
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-accelerate-src = { version = "0.3.2" }
-anyhow = { version = "1", features = ["backtrace"] }
-byteorder = "1.4.3"
+accelerate-src = { version = "^0.3.2" }
+anyhow = { version = "^1", features = ["backtrace"] }
+byteorder = "^1.4.3"
 candle = { path = "./candle-core", package = "candle-core" }
 candle-datasets = { path = "./candle-datasets" }
 candle-flash-attn = { path = "./candle-flash-attn" }
@@ -39,38 +39,38 @@ candle-metal-kernels = { path = "./candle-metal-kernels" }
 candle-nn = { path = "./candle-nn" }
 candle-onnx = { path = "./candle-onnx" }
 candle-transformers = { path = "./candle-transformers" }
-clap = { version = "4.2.4", features = ["derive"] }
-criterion = { version = "0.5.1", default-features=false }
-cudarc = { version = "0.9.14", features = ["f16"] }
-gemm = { version = "0.16.6", features = ["wasm-simd128-enable"] }
-hf-hub = "0.3.0"
-half = { version = "2.3.1", features = ["num-traits", "use-intrinsics", "rand_distr"] }
-image = { version = "0.24.7", default-features = false, features = ["jpeg", "png"] }
-imageproc = { version = "0.23.0", default-features = false }
-intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"] }
-libc = { version = "0.2.147" }
-log = "0.4"
-memmap2 = { version = "0.7.1", features = ["stable_deref_trait"] }
-num_cpus = "1.15.0"
-num-traits = "0.2.15"
-parquet = { version = "45.0.0" }
-rand = "0.8.5"
-rand_distr = "0.4.3"
-rayon = "1.7.0"
-rusttype = { version = "0.9", default-features = false }
-safetensors = "0.3.1"
-serde = { version = "1.0.171", features = ["derive"] }
-serde_plain = "1.0.2"
-serde_json = "1.0.99"
-thiserror = "1"
-tokenizers = { version = "0.13.4", default-features = false }
-tracing = "0.1.37"
-tracing-chrome = "0.7.1"
-tracing-subscriber = "0.3.7"
-wav = "1.0.0"
-yoke = { version = "0.7.2", features = ["derive"] }
-zip = { version = "0.6.6", default-features = false }
-metal = { version = "0.27.0", features = ["mps"]}
+clap = { version = "^4.2.4", features = ["derive"] }
+criterion = { version = "^0.5.1", default-features=false }
+cudarc = { version = "^0.9.14", features = ["f16"] }
+gemm = { version = "^0.16.6", features = ["wasm-simd128-enable"] }
+hf-hub = "^0.3.0"
+half = { version = "^2.3.1", features = ["num-traits", "use-intrinsics", "rand_distr"] }
+image = { version = "^0.24.7", default-features = false, features = ["jpeg", "png"] }
+imageproc = { version = "^0.23.0", default-features = false }
+intel-mkl-src = { version = "^0.8.1", features = ["mkl-static-lp64-iomp"] }
+libc = { version = "^0.2.147" }
+log = "^0.4"
+memmap2 = { version = "^0.7.1", features = ["stable_deref_trait"] }
+num_cpus = "^1.15.0"
+num-traits = "^0.2.15"
+parquet = { version = "^45.0.0" }
+rand = "^0.8.5"
+rand_distr = "^0.4.3"
+rayon = "^1.7.0"
+rusttype = { version = "^0.9", default-features = false }
+safetensors = "^0.3.1"
+serde = { version = "^1.0.171", features = ["derive"] }
+serde_plain = "^1.0.2"
+serde_json = "^1.0.99"
+thiserror = "^1"
+tokenizers = { version = "^0.13.4", default-features = false }
+tracing = "^0.1.37"
+tracing-chrome = "^0.7.1"
+tracing-subscriber = "^0.3.7"
+wav = "^1.0.0"
+yoke = { version = "^0.7.2", features = ["derive"] }
+zip = { version = "^0.6.6", default-features = false }
+metal = { version = "^0.27.0", features = ["mps"]}
 
 [profile.release-with-debug]
 inherits = "release"


### PR DESCRIPTION
Hi there,
I really like the project, and i was wondering if we can add dependabot to it, to be always up to date regarding deps.
I set it to 5 max PRs and also on weekly only.
Let me know if you want to adjust those params, thanks.