### PR TITLE
fix: deprecated option field (open-pull-requests-limit-per-dependency)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,3 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-    open-pull-requests-limit-per-dependency: 2


### PR DESCRIPTION
Sorry, looks like i broke the CI on main.
Just checked and the CI on main is red because of a deprecated field : `open-pull-requests-limit-per-dependency` that is no longer supported by dependabot.

Related to : https://github.com/huggingface/candle/pull/1553
![2024-01-10_15-10](https://github.com/huggingface/candle/assets/22576758/990c155c-4c26-424e-8123-838a573debdf)

