### PR TITLE
Support loading BF16 models in Cuda on T4

### DIFF
--- a/candle-core/src/device.rs
+++ b/candle-core/src/device.rs
@@ -166,6 +166,13 @@ impl Device {
     pub fn is_cuda(&self) -> bool {
         matches!(self, Self::Cuda(_))
     }
+    pub fn support_native_bf16(&self) -> Result<bool> {
+        match self {
+            Self::Cpu => Ok(true),
+            Self::Cuda(c) => c.support_native_bf16(),
+            Self::Metal(_) => Ok(true),
+        }
+    }
 
     pub fn is_metal(&self) -> bool {
         matches!(self, Self::Metal(_))

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -13,7 +13,11 @@ macro_rules! fail {
         unimplemented!("cuda support has not been enabled, add `cuda` feature to enable.")
     };
 }
-
+impl CudaDevice {
+    pub fn support_native_bf16(&self) -> Result<bool> {
+        Err(Error::NotCompiledWithCudaSupport)
+    }
+}
 impl crate::backend::BackendStorage for CudaStorage {
     type Device = CudaDevice;
 

--- a/candle-examples/examples/falcon/main.rs
+++ b/candle-examples/examples/falcon/main.rs
@@ -172,8 +172,10 @@ fn main() -> Result<()> {
     let start = std::time::Instant::now();
     let dtype = if args.use_f32 {
         DType::F32
-    } else {
+    } else if device.support_native_bf16()? {
         DType::BF16
+    } else {
+        DType::F16
     };
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&filenames, dtype, &device)? };
     let config = Config::falcon7b();

--- a/candle-examples/examples/mistral/main.rs
+++ b/candle-examples/examples/mistral/main.rs
@@ -252,7 +252,11 @@ fn main() -> Result<()> {
     } else {
         let device = candle_examples::device(args.cpu)?;
         let dtype = if device.is_cuda() {
-            DType::BF16
+            if device.support_native_bf16()? {
+                DType::BF16
+            } else {
+                DType::F16
+            }
         } else {
             DType::F32
         };

--- a/candle-examples/examples/mixtral/main.rs
+++ b/candle-examples/examples/mixtral/main.rs
@@ -218,7 +218,11 @@ fn main() -> Result<()> {
     let config = Config::v0_1_8x7b(args.use_flash_attn);
     let device = candle_examples::device(args.cpu)?;
     let dtype = if device.is_cuda() {
-        DType::BF16
+        if device.support_native_bf16()? {
+            DType::BF16
+        } else {
+            DType::F16
+        }
     } else {
         DType::F32
     };

--- a/candle-examples/examples/stable-lm/main.rs
+++ b/candle-examples/examples/stable-lm/main.rs
@@ -242,7 +242,11 @@ fn main() -> Result<()> {
     } else {
         let device = candle_examples::device(args.cpu)?;
         let dtype = if device.is_cuda() {
-            DType::BF16
+            if device.support_native_bf16()? {
+                DType::BF16
+            } else {
+                DType::F16
+            }
         } else {
             DType::F32
         };

--- a/candle-examples/examples/yi/main.rs
+++ b/candle-examples/examples/yi/main.rs
@@ -230,7 +230,11 @@ fn main() -> Result<()> {
     };
     let device = candle_examples::device(args.cpu)?;
     let dtype = if device.is_cuda() {
-        DType::BF16
+        if device.support_native_bf16()? {
+            DType::BF16
+        } else {
+            DType::F16
+        }
     } else {
         DType::F32
     };

--- a/candle-kernels/src/cast.cu
+++ b/candle-kernels/src/cast.cu
@@ -83,6 +83,32 @@ CAST_OP(double,   __nv_bfloat16, cast_f64_bf16)
 CAST_THROUGH_OP(__nv_bfloat16, uint8_t, float, cast_bf16_u8)
 CAST_THROUGH_OP(__nv_bfloat16, __half,   float, cast_bf16_f16)
 CAST_THROUGH_OP(__half,   __nv_bfloat16, float, cast_f16_bf16)
+#else
+#define LOCAL_CAST_OP(SRC_TYPENAME, DST_TYPENAME, FN_NAME) extern "C" __global__ void FN_NAME( \
+                         const size_t numel, \
+                         const size_t num_dims, \
+                         const size_t *info, \
+                         const SRC_TYPENAME *inp, \
+                         DST_TYPENAME *out \
+                     ) { \
+    const size_t *dims = info; \
+    const size_t *strides = info + num_dims; \
+    if (is_contiguous(num_dims, dims, strides)) { \
+        for (unsigned int i = blockIdx.x * blockDim.x + threadIdx.x; i < numel; i += blockDim.x * gridDim.x) { \
+            out[i] = inp[i]; \
+        } \
+    } \
+    else { \
+        for (unsigned int i = blockIdx.x * blockDim.x + threadIdx.x; i < numel; i += blockDim.x * gridDim.x) { \
+            unsigned strided_i = get_strided_index(i, num_dims, dims, strides); \
+            out[i] = inp[strided_i]; \
+        } \
+    }  \
+} \
+
+LOCAL_CAST_OP(__nv_bfloat16, float, cast_bf16_f32)
+LOCAL_CAST_OP(__nv_bfloat16, __half, cast_bf16_f16)
+
 #endif
 
 #if __CUDA_ARCH__ >= 530
@@ -127,3 +153,12 @@ CAST_OP(double, uint32_t, cast_f64_u32)
 CAST_OP(double, int64_t,  cast_f64_i64 )
 CAST_OP(double, float,    cast_f64_f32)
 CAST_OP(double, double,   cast_f64_f64)
+
+extern "C" __global__ void support_native_bf16(bool *ret){
+#if __CUDA_ARCH__ >= 800
+    *ret = true;
+#else
+    *ret = false;
+#endif
+
+}


### PR DESCRIPTION
NVidia T4 does not support B16 floating types natively. Add a method to cast BF16 to F32 or F16 so that mistral can be loaded on T4