### PR TITLE
fix paths and improve formatting for book (#1584)

### DIFF
--- a/candle-book/src/inference/inference.md
+++ b/candle-book/src/inference/inference.md
@@ -2,6 +2,6 @@
 
 
 In order to run an existing model, you will need to download and use existing weights.
-Most models are already available on https://huggingface.co/ in [`safetensors`](https://github.com/huggingface/safetensors) format.
+Most models are already available on [huggingface.co](https://huggingface.co/) in [`safetensors`](https://github.com/huggingface/safetensors) format.
 
 Let's get started by running an old model : `bert-base-uncased`.

--- a/candle-book/src/lib.rs
+++ b/candle-book/src/lib.rs
@@ -123,8 +123,10 @@ let repo = Repo::with_revision(
 let repo = api.repo(repo);
 let test_parquet_filename = repo.get("mnist/test/0000.parquet")?;
 let train_parquet_filename = repo.get("mnist/train/0000.parquet")?;
-let test_parquet = SerializedFileReader::new(std::fs::File::open(test_parquet_filename)?)?;
-let train_parquet = SerializedFileReader::new(std::fs::File::open(train_parquet_filename)?)?;
+let test_parquet =
+    SerializedFileReader::new(std::fs::File::open(test_parquet_filename)?)?;
+let train_parquet =
+    SerializedFileReader::new(std::fs::File::open(train_parquet_filename)?)?;
 // ANCHOR_END: book_training_1
 // Ignore unused
 let _train = train_parquet;

--- a/candle-book/src/training/training.md
+++ b/candle-book/src/training/training.md
@@ -1,7 +1,7 @@
 # Training
 
 
-Training starts with data. We're going to use the huggingface hub and 
+Training starts with data. We're going to use the huggingface hub and
 start with the Hello world dataset of machine learning, MNIST.
 
 Let's start with downloading `MNIST` from [huggingface](https://huggingface.co/datasets/mnist).
@@ -14,7 +14,7 @@ cargo add hf-hub
 This is going to be very hands-on for now.
 
 ```rust,ignore
-{{#include ../../../candle-examples/src/lib.rs:book_training_1}}
+{{#include ../lib.rs:book_training_1}}
 ```
 
 This uses the standardized `parquet` files from the `refs/convert/parquet` branch on every dataset.
@@ -23,7 +23,7 @@ Our handles are now [`parquet::file::serialized_reader::SerializedFileReader`].
 We can inspect the content of the files with:
 
 ```rust,ignore
-{{#include ../../../candle-examples/src/lib.rs:book_training_2}}
+{{#include ../lib.rs:book_training_2}}
 ```
 
 You should see something like:


### PR DESCRIPTION
Removes trailing white space and fixes paths in [training.md](https://github.com/huggingface/candle/blob/5270224f407502b82fe90bc2622894ce3871b002/candle-book/src/training/training.md).

Change formatting for [lib.rs](https://github.com/huggingface/candle/blob/5270224f407502b82fe90bc2622894ce3871b002/candle-book/src/lib.rs) to avoid horizontal scroll.

Creates link for book in [inference.md](https://github.com/huggingface/candle/blob/5270224f407502b82fe90bc2622894ce3871b002/candle-book/src/inference/inference.md).