### PR TITLE
Use the Euler Ancestral scheduler by default with SDXL

### DIFF
--- a/candle-examples/examples/stable-diffusion/README.md
+++ b/candle-examples/examples/stable-diffusion/README.md
@@ -32,10 +32,10 @@ cargo run --example stable-diffusion --release --features=cuda,cudnn \
     -- --prompt "a cosmonaut on a horse (hd, realistic, high-def)" --sd-version turbo
 ```
 
-The default scheduler for the v1.5, v2.1 and XL 1.0 version is the Denoising
+The default scheduler for the v1.5 and v2.1 version is the Denoising
 Diffusion Implicit Model scheduler (DDIM). The original paper and some code can
 be found in the [associated repo](https://github.com/ermongroup/ddim).
-The default scheduler for the XL Turbo version is the Euler Ancestral scheduler.
+The default scheduler for the XL 1.0 and XL Turbo version is the Euler Ancestral scheduler.
 
 ### Command-line flags
 

--- a/candle-transformers/src/models/stable_diffusion/mod.rs
+++ b/candle-transformers/src/models/stable_diffusion/mod.rs
@@ -215,10 +215,12 @@ impl StableDiffusionConfig {
             latent_channels: 4,
             norm_num_groups: 32,
         };
-        let scheduler = Arc::new(ddim::DDIMSchedulerConfig {
-            prediction_type,
-            ..Default::default()
-        });
+        let scheduler = Arc::new(
+            euler_ancestral_discrete::EulerAncestralDiscreteSchedulerConfig {
+                prediction_type,
+                ..Default::default()
+            },
+        );
 
         let height = if let Some(height) = height {
             assert_eq!(height % 8, 0, "height has to be divisible by 8");


### PR DESCRIPTION
This PR changes the default Scheduler for SDXL to Euler Ancestral as requested in #1508 

