### PR TITLE
Add StableLM-2, StableLM Code and Zephyr variants

### DIFF
--- a/candle-examples/examples/stable-lm/README.md
+++ b/candle-examples/examples/stable-lm/README.md
@@ -8,6 +8,11 @@ Card](https://huggingface.co/stabilityai/stablelm-3b-4e1t).
 Note that this model is gated so you will have to request access on the Hub in
 order to be able to use it.
 
+Other available models are Stable-Code-3B, StableLM-2 and Zephyr variants.
+
+StableLM-2 uses a Tiktoken based GPT-3.5/GPT-4 tokenizer not supported by Candle, so to run it you can download a somewhat compatible [tokenizer.json](https://huggingface.co/Xenova/gpt-4/resolve/main/tokenizer.json?download=true)
+and pass it via the --tokenizer-file argument.
+
 ## Running some example
 
 ```bash

--- a/candle-examples/examples/stable-lm/main.rs
+++ b/candle-examples/examples/stable-lm/main.rs
@@ -127,6 +127,8 @@ enum Which {
     V1Orig,
     V1,
     V1Zephyr,
+    V2,
+    V2Zephyr,
     Code,
 }
 
@@ -225,6 +227,8 @@ fn main() -> Result<()> {
             Which::V1 => "stabilityai/stablelm-3b-4e1t".to_string(),
             Which::V1Zephyr => "stabilityai/stablelm-zephyr-3b".to_string(),
             Which::Code => "stabilityai/stable-code-3b".to_string(),
+            Which::V2 => "stabilityai/stablelm-2-1_6b".to_string(),
+            Which::V2Zephyr => "stabilityai/stablelm-2-zephyr-1_6b".to_string(),
         },
     };
 
@@ -244,10 +248,10 @@ fn main() -> Result<()> {
             .collect::<Vec<_>>(),
         None => match (args.which, args.quantized) {
             (Which::V1Orig, true) => vec![repo.get("model-q4k.gguf")?],
-            (Which::V1 | Which::V1Zephyr | Which::Code, true) => {
+            (Which::V1 | Which::V1Zephyr | Which::V2 | Which::V2Zephyr | Which::Code, true) => {
                 anyhow::bail!("Quantized {:?} variant not supported.", args.which)
             }
-            (Which::V1Orig | Which::V1 | Which::V1Zephyr, false) => {
+            (Which::V1Orig | Which::V1 | Which::V1Zephyr | Which::V2 | Which::V2Zephyr, false) => {
                 vec![repo.get("model.safetensors")?]
             }
             (Which::Code, false) => {
@@ -262,7 +266,7 @@ fn main() -> Result<()> {
     let start = std::time::Instant::now();
     let config = match args.which {
         Which::V1Orig => Config::stablelm_3b_4e1t(args.use_flash_attn),
-        Which::V1 | Which::V1Zephyr | Which::Code => {
+        Which::V1 | Which::V1Zephyr | Which::V2 | Which::V2Zephyr | Which::Code => {
             let config_filename = repo.get("config.json")?;
             let config = std::fs::read_to_string(config_filename)?;
             let mut config: Config = serde_json::from_str(&config)?;


### PR DESCRIPTION
Add Stable-Code, StableLM-2 and Zephyr variants for V1 and V2. For completeness also added the V1 variant from the stabilityai repos (same as the existing one which I renamed to V1Orig). The GGUF quantized versions of the newer models use llama.cpp tensor names that are different from the ones used in the non-quantized model so I did not add those.