### PR TITLE
Fix token generation in bilingual models (non-English outputs)

### DIFF
--- a/candle-examples/examples/yi/main.rs
+++ b/candle-examples/examples/yi/main.rs
@@ -104,6 +104,7 @@ impl TextGeneration {
                 break;
             }
             if let Some(t) = self.tokenizer.next_token(next_token)? {
+                let t = t.replace("<|im_end|>", "\n");
                 print!("{t}");
                 std::io::stdout().flush()?;
             }

--- a/candle-examples/src/token_output_stream.rs
+++ b/candle-examples/src/token_output_stream.rs
@@ -40,7 +40,7 @@ impl TokenOutputStream {
         };
         self.tokens.push(token);
         let text = self.decode(&self.tokens[self.prev_index..])?;
-        if text.len() > prev_text.len() && text.chars().last().unwrap().is_ascii() {
+        if text.len() > prev_text.len() && text.chars().last().unwrap().is_alphabetic() {
             let text = text.split_at(prev_text.len());
             self.prev_index = self.current_index;
             self.current_index = self.tokens.len();


### PR DESCRIPTION
There is a token generation problem for bilingual models (Yi, StableLM-v2, etc.) for non-English outputs, as shown below:

![NonSmooth](https://github.com/huggingface/candle/assets/27915071/f0b1c7e4-4fbe-4927-937b-62972f60c216)


This patch will fix the non-smooth token generation for non-English outputs and **does not** affect English generation:

![Smooth](https://github.com/huggingface/candle/assets/27915071/e5cc6a3e-56fd-4776-9686-669bc537f26a)
