### PR TITLE
feat: support multithread spectrogram and small perf tweaks

### DIFF
--- a/candle-transformers/src/models/whisper/audio.rs
+++ b/candle-transformers/src/models/whisper/audio.rs
@@ -139,6 +139,10 @@ fn log_mel_spectrogram_w<T: Float>(
         for j in 0..fft_size {
             fft_out[j] = fft_out[2 * j] * fft_out[2 * j] + fft_out[2 * j + 1] * fft_out[2 * j + 1];
         }
+        for j in 1..fft_size / 2 {
+            let v = fft_out[fft_size - j];
+            fft_out[j] += v;
+        }
 
         if speed_up {
             // scale down in the frequency domain results in a speed up in the time domain

--- a/candle-transformers/src/models/whisper/audio.rs
+++ b/candle-transformers/src/models/whisper/audio.rs
@@ -125,9 +125,10 @@ fn log_mel_spectrogram_w<T: Float>(
 
         // fill the rest with zeros
         if n_samples - offset < fft_size {
-            for j in n_samples - offset..fft_size {
-                fft_in[j] = zero;
-            }
+            fft_in
+                .iter_mut()
+                .skip(n_samples - offset)
+                .for_each(|x| *x = zero);
         }
 
         // FFT

--- a/candle-transformers/src/models/whisper/audio.rs
+++ b/candle-transformers/src/models/whisper/audio.rs
@@ -110,6 +110,7 @@ fn log_mel_spectrogram_w<T: Float>(
     };
 
     let zero = T::zero();
+    let half = T::from(0.5).unwrap();
     let mut fft_in = vec![zero; fft_size];
     let mut mel = vec![zero; n_len * n_mel];
     let n_samples = samples.len();
@@ -137,6 +138,13 @@ fn log_mel_spectrogram_w<T: Float>(
         // Calculate modulus^2 of complex numbers
         for j in 0..fft_size {
             fft_out[j] = fft_out[2 * j] * fft_out[2 * j] + fft_out[2 * j + 1] * fft_out[2 * j + 1];
+        }
+
+        if speed_up {
+            // scale down in the frequency domain results in a speed up in the time domain
+            for j in 0..n_fft {
+                fft_out[j] = half * (fft_out[2 * j] + fft_out[2 * j + 1]);
+            }
         }
 
         // mel spectrogram

--- a/candle-transformers/src/models/whisper/quantized_model.rs
+++ b/candle-transformers/src/models/whisper/quantized_model.rs
@@ -191,14 +191,14 @@ impl ResidualAttentionBlock {
     }
 }
 
-fn sinusoids(length: usize, channels: usize) -> Result<Tensor> {
+fn sinusoids(length: usize, channels: usize, device: &Device) -> Result<Tensor> {
     let max_timescale = 10000f32;
     let log_timescale_increment = max_timescale.ln() / (channels / 2 - 1) as f32;
     let inv_timescales: Vec<_> = (0..channels / 2)
         .map(|i| (i as f32 * (-log_timescale_increment)).exp())
         .collect();
-    let inv_timescales = Tensor::new(inv_timescales.as_slice(), &Device::Cpu)?.unsqueeze(0)?;
-    let arange = Tensor::arange(0, length as u32, &Device::Cpu)?
+    let inv_timescales = Tensor::new(inv_timescales.as_slice(), device)?.unsqueeze(0)?;
+    let arange = Tensor::arange(0, length as u32, device)?
         .to_dtype(candle::DType::F32)?
         .unsqueeze(1)?;
     let sh = (length, channels / 2);
@@ -242,7 +242,7 @@ impl AudioEncoder {
         };
         let conv1 = conv1d(cfg.num_mel_bins, n_state, 3, cfg1, vb.pp("conv1"))?;
         let conv2 = conv1d(n_state, n_state, 3, cfg2, vb.pp("conv2"))?;
-        let positional_embedding = sinusoids(n_ctx, n_state)?.to_device(vb.device())?;
+        let positional_embedding = sinusoids(n_ctx, n_state, vb.device())?;
         let blocks = (0..cfg.encoder_layers)
             .map(|i| {
                 ResidualAttentionBlock::load(n_state, n_head, false, vb.pp(format!("layers.{i}")))


### PR DESCRIPTION
This PR adds support for multithreaded workers in `log_mel_spectrogram_` and significantly speeds up the `pcm_to_mel` step.

On an Apple M3 Max this adds a ~6-7x speed up `139.284375ms` -> `21.299458ms` using the following commands

```bash
cargo run --release --example whisper --features metal
```

additionally there are a few new tests that can be run

```bash
cargo test --package candle-transformers --lib -- models::whisper::audio::tests --nocapture
```

**note this speed up is particularly useful with smaller models since the `pcm_to_mel` can take as much time or more as the decoding step on some backends (cuda, metal) so in those cases `pcm_to_mel` is no longer the bottleneck