### PR TITLE
Fix sigmoid gradient on large negative arg

### DIFF
--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -46,7 +46,7 @@ pub fn swiglu(xs: &Tensor) -> Result<Tensor> {
 
 pub fn sigmoid(xs: &Tensor) -> Result<Tensor> {
     // TODO: Should we have a specialized op for this?
-    (xs.neg()?.exp()? + 1.0)?.recip()
+    (xs * 0.5)?.tanh()?.affine(0.5, 0.5)
 }
 
 pub fn hard_sigmoid(xs: &Tensor) -> Result<Tensor> {


### PR DESCRIPTION
Current sigmoid implementation provides `NaN` on backward pass for large negative input values.

For example, let we have input variable of type `f32` equals to:

```rust
[-548.3162, -201.7132,  -74.2032,  -27.2899,  -10.0179,   -3.6269,   -1.1752,    0.0000,    1.1752,    3.6269,   10.0179,   27.2899,   74.2032,  201.7132,  548.3162]
```

Current implementation gives the following result and gradient:

```rust
[  0.0000e0,   0.0000e0, 5.9423e-33, 1.4065e-12,  4.4594e-5,  2.5910e-2,  2.3592e-1,  5.0000e-1,  7.6408e-1,  9.7409e-1,  9.9996e-1,   1.0000e0,   1.0000e0,   1.0000e0,   1.0000e0]
[       NaN,        NaN,   0.0000e0, 1.4065e-12,  4.4592e-5,  2.5239e-2,  1.8026e-1,  2.5000e-1,  1.8026e-1,  2.5239e-2,  4.4592e-5, 1.4065e-12, 5.9423e-33,   0.0000e0,   0.0000e0]
```

While proposed version gives:

```rust
[ 0.0000e0,  0.0000e0,  0.0000e0,  0.0000e0, 4.4584e-5, 2.5910e-2, 2.3592e-1, 5.0000e-1, 7.6408e-1, 9.7409e-1, 9.9996e-1,  1.0000e0,  1.0000e0,  1.0000e0,  1.0000e0]
[ 0.0000e0,  0.0000e0,  0.0000e0,  0.0000e0, 4.4584e-5, 2.5239e-2, 1.8026e-1, 2.5000e-1, 1.8026e-1, 2.5239e-2, 4.4584e-5,  0.0000e0,  0.0000e0,  0.0000e0,  0.0000e0]
```