### PR TITLE
feat: Return Cow on CpuStorage

### DIFF
--- a/candle-core/src/backend.rs
+++ b/candle-core/src/backend.rs
@@ -1,5 +1,6 @@
 use crate::op::{BinaryOpT, CmpOp, ReduceOp, UnaryOpT};
 use crate::{CpuStorage, DType, Layout, Result, Shape};
+use std::borrow::Cow;
 
 pub trait BackendStorage: Sized {
     type Device: BackendDevice;
@@ -10,8 +11,7 @@ pub trait BackendStorage: Sized {
 
     fn device(&self) -> &Self::Device;
 
-    // Maybe this should return a Cow instead so that no copy is done on the cpu case.
-    fn to_cpu_storage(&self) -> Result<CpuStorage>;
+    fn to_cpu_storage(&self) -> Result<Cow<'_, CpuStorage>>;
 
     fn affine(&self, _: &Layout, _: f64, _: f64) -> Result<Self>;
 

--- a/candle-core/src/cpu_backend.rs
+++ b/candle-core/src/cpu_backend.rs
@@ -3,6 +3,7 @@ use crate::op::{BinaryOpT, CmpOp, ReduceOp, UnaryOpT};
 use crate::{DType, Error, IntDType, Layout, Result, Shape, WithDType};
 use half::{bf16, f16};
 use rayon::prelude::*;
+use std::borrow::Cow;
 
 const USE_IM2COL_CONV1D: bool = true;
 const USE_IM2COL_CONV1D_TR: bool = true;
@@ -2732,8 +2733,8 @@ impl BackendStorage for CpuStorage {
         Ok(self.clone())
     }
 
-    fn to_cpu_storage(&self) -> Result<CpuStorage> {
-        Ok(self.clone())
+    fn to_cpu_storage(&self) -> Result<Cow<'_, CpuStorage>> {
+        Ok(Cow::Borrowed(self))
     }
 }
 

--- a/candle-core/src/cuda_backend.rs
+++ b/candle-core/src/cuda_backend.rs
@@ -9,6 +9,7 @@ use cudarc::driver::{
     ValidAsZeroBits,
 };
 use half::{bf16, f16};
+use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
 /// cudarc related errors
@@ -1755,44 +1756,44 @@ impl BackendStorage for CudaStorage {
         Ok(Self { slice, device })
     }
 
-    fn to_cpu_storage(&self) -> Result<CpuStorage> {
-        match &self.slice {
+    fn to_cpu_storage(&self) -> Result<Cow<'_, CpuStorage>> {
+        Ok(Cow::Owned(match &self.slice {
             CudaStorageSlice::U8(slice) => {
                 let dev = slice.device();
                 let cpu_storage = dev.dtoh_sync_copy(slice).w()?;
-                Ok(CpuStorage::U8(cpu_storage))
+                CpuStorage::U8(cpu_storage)
             }
             CudaStorageSlice::U32(slice) => {
                 let dev = slice.device();
                 let cpu_storage = dev.dtoh_sync_copy(slice).w()?;
-                Ok(CpuStorage::U32(cpu_storage))
+                CpuStorage::U32(cpu_storage)
             }
             CudaStorageSlice::I64(slice) => {
                 let dev = slice.device();
                 let cpu_storage = dev.dtoh_sync_copy(slice).w()?;
-                Ok(CpuStorage::I64(cpu_storage))
+                CpuStorage::I64(cpu_storage)
             }
             CudaStorageSlice::BF16(slice) => {
                 let dev = slice.device();
                 let cpu_storage = dev.dtoh_sync_copy(slice).w()?;
-                Ok(CpuStorage::BF16(cpu_storage))
+                CpuStorage::BF16(cpu_storage)
             }
             CudaStorageSlice::F16(slice) => {
                 let dev = slice.device();
                 let cpu_storage = dev.dtoh_sync_copy(slice).w()?;
-                Ok(CpuStorage::F16(cpu_storage))
+                CpuStorage::F16(cpu_storage)
             }
             CudaStorageSlice::F32(slice) => {
                 let dev = slice.device();
                 let cpu_storage = dev.dtoh_sync_copy(slice).w()?;
-                Ok(CpuStorage::F32(cpu_storage))
+                CpuStorage::F32(cpu_storage)
             }
             CudaStorageSlice::F64(slice) => {
                 let dev = slice.device();
                 let cpu_storage = dev.dtoh_sync_copy(slice).w()?;
-                Ok(CpuStorage::F64(cpu_storage))
+                CpuStorage::F64(cpu_storage)
             }
-        }
+        }))
     }
 
     fn where_cond(

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use crate::op::{BinaryOpT, CmpOp, ReduceOp, UnaryOpT};
 use crate::{CpuStorage, DType, Error, Layout, Result, Shape};
+use std::borrow::Cow;
 
 #[derive(Debug, Clone)]
 pub struct CudaDevice;
@@ -29,7 +30,7 @@ impl crate::backend::BackendStorage for CudaStorage {
         fail!()
     }
 
-    fn to_cpu_storage(&self) -> Result<CpuStorage> {
+    fn to_cpu_storage(&self) -> Result<Cow<'_, CpuStorage>> {
         Err(Error::NotCompiledWithCudaSupport)
     }
 

--- a/candle-core/src/dummy_metal_backend.rs
+++ b/candle-core/src/dummy_metal_backend.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use crate::op::{BinaryOpT, CmpOp, ReduceOp, UnaryOpT};
 use crate::{CpuStorage, DType, Error, Layout, Result, Shape};
+use std::borrow::Cow;
 
 #[derive(Debug, Clone)]
 pub struct MetalDevice;
@@ -41,7 +42,7 @@ impl crate::backend::BackendStorage for MetalStorage {
         fail!()
     }
 
-    fn to_cpu_storage(&self) -> Result<CpuStorage> {
+    fn to_cpu_storage(&self) -> Result<Cow<'_, CpuStorage>> {
         Err(Error::NotCompiledWithMetalSupport)
     }
 

--- a/candle-core/src/metal_backend.rs
+++ b/candle-core/src/metal_backend.rs
@@ -6,6 +6,7 @@ use candle_metal_kernels;
 use candle_metal_kernels::Kernels;
 use metal;
 use metal::{Buffer, CommandBuffer, CommandQueue, MTLResourceOptions, NSUInteger};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::path::Path;
@@ -344,16 +345,16 @@ impl BackendStorage for MetalStorage {
         &self.device
     }
 
-    fn to_cpu_storage(&self) -> Result<CpuStorage> {
-        match self.dtype {
-            DType::U8 => Ok(CpuStorage::U8(self.to_cpu()?)),
-            DType::U32 => Ok(CpuStorage::U32(self.to_cpu()?)),
-            DType::I64 => Ok(CpuStorage::I64(self.to_cpu()?)),
-            DType::F16 => Ok(CpuStorage::F16(self.to_cpu()?)),
-            DType::BF16 => Ok(CpuStorage::BF16(self.to_cpu()?)),
-            DType::F32 => Ok(CpuStorage::F32(self.to_cpu()?)),
-            DType::F64 => Ok(CpuStorage::F64(self.to_cpu()?)),
-        }
+    fn to_cpu_storage(&self) -> Result<Cow<'_, CpuStorage>> {
+        Ok(Cow::Owned(match self.dtype {
+            DType::U8 => CpuStorage::U8(self.to_cpu()?),
+            DType::U32 => CpuStorage::U32(self.to_cpu()?),
+            DType::I64 => CpuStorage::I64(self.to_cpu()?),
+            DType::F16 => CpuStorage::F16(self.to_cpu()?),
+            DType::BF16 => CpuStorage::BF16(self.to_cpu()?),
+            DType::F32 => CpuStorage::F32(self.to_cpu()?),
+            DType::F64 => CpuStorage::F64(self.to_cpu()?),
+        }))
     }
 
     fn affine(&self, layout: &Layout, mul: f64, add: f64) -> Result<Self> {

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -539,8 +539,8 @@ impl Tensor {
         };
         match &*self.storage() {
             Storage::Cpu(cpu_storage) => from_cpu_storage(cpu_storage),
-            Storage::Cuda(storage) => from_cpu_storage(&storage.to_cpu_storage()?),
-            Storage::Metal(storage) => from_cpu_storage(&storage.to_cpu_storage()?),
+            Storage::Cuda(storage) => from_cpu_storage(storage.to_cpu_storage()?.as_ref()),
+            Storage::Metal(storage) => from_cpu_storage(storage.to_cpu_storage()?.as_ref()),
         }
     }
 
@@ -1518,8 +1518,8 @@ impl Tensor {
         };
         match &*self.storage() {
             Storage::Cpu(storage) => from_cpu_storage(storage),
-            Storage::Cuda(storage) => from_cpu_storage(&storage.to_cpu_storage()?),
-            Storage::Metal(storage) => from_cpu_storage(&storage.to_cpu_storage()?),
+            Storage::Cuda(storage) => from_cpu_storage(storage.to_cpu_storage()?.as_ref()),
+            Storage::Metal(storage) => from_cpu_storage(storage.to_cpu_storage()?.as_ref()),
         }
     }
 
@@ -1549,8 +1549,8 @@ impl Tensor {
         };
         match &*self.storage() {
             Storage::Cpu(storage) => from_cpu_storage(storage),
-            Storage::Cuda(storage) => from_cpu_storage(&storage.to_cpu_storage()?),
-            Storage::Metal(storage) => from_cpu_storage(&storage.to_cpu_storage()?),
+            Storage::Cuda(storage) => from_cpu_storage(storage.to_cpu_storage()?.as_ref()),
+            Storage::Metal(storage) => from_cpu_storage(storage.to_cpu_storage()?.as_ref()),
         }
     }
 
@@ -1590,8 +1590,8 @@ impl Tensor {
         };
         match &*self.storage() {
             Storage::Cpu(storage) => from_cpu_storage(storage),
-            Storage::Cuda(storage) => from_cpu_storage(&storage.to_cpu_storage()?),
-            Storage::Metal(storage) => from_cpu_storage(&storage.to_cpu_storage()?),
+            Storage::Cuda(storage) => from_cpu_storage(storage.to_cpu_storage()?.as_ref()),
+            Storage::Metal(storage) => from_cpu_storage(storage.to_cpu_storage()?.as_ref()),
         }
     }
 
@@ -1912,8 +1912,12 @@ impl Tensor {
                 (Storage::Cpu(storage), Device::Metal(metal)) => {
                     Storage::Metal(metal.storage_from_cpu_storage(storage)?)
                 }
-                (Storage::Cuda(storage), Device::Cpu) => Storage::Cpu(storage.to_cpu_storage()?),
-                (Storage::Metal(storage), Device::Cpu) => Storage::Cpu(storage.to_cpu_storage()?),
+                (Storage::Cuda(storage), Device::Cpu) => {
+                    Storage::Cpu(storage.to_cpu_storage()?.into_owned())
+                }
+                (Storage::Metal(storage), Device::Cpu) => {
+                    Storage::Cpu(storage.to_cpu_storage()?.into_owned())
+                }
                 (Storage::Cuda(storage), Device::Cuda(cuda)) => {
                     // TODO: Avoid passing through the cpu storage here, especially if the gpu ids
                     // are the same.


### PR DESCRIPTION
Return a Cow from to_cpu_storage to avoid unnecessary copy.

Address one of the issues in https://github.com/huggingface/candle/issues/1699