### PR TITLE
Add  grads for interpolate1d

### DIFF
--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -132,7 +132,10 @@ pub enum Op {
         stride: (usize, usize),
     },
 
-    UpsampleNearest1D(Tensor),
+    UpsampleNearest1D {
+        arg: Tensor,
+        target_size: usize,
+    },
     UpsampleNearest2D {
         arg: Tensor,
         target_h: usize,

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -1015,7 +1015,7 @@ impl Tensor {
     /// tensor also has three dimensions, `(batch, channels, target_size)`.
     pub fn interpolate1d(&self, target_size: usize) -> Result<Self> {
         let (n, c, _l) = self.dims3()?;
-        let op = BackpropOp::new1(self, Op::UpsampleNearest1D);
+        let op = BackpropOp::new1(self, |arg| Op::UpsampleNearest1D { arg, target_size });
         let storage = self
             .storage()
             .upsample_nearest1d(self.layout(), target_size)?;

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -283,6 +283,39 @@ fn unary_grad(device: &Device) -> Result<()> {
         [1.0881, 0.9277, 1.0527, 0.5747],
     );
 
+    let x = Var::new(&[[[1f32, 2., 3.], [4., 5., 6.], [7., 8., 9.]]], device)?;
+    let y = x.interpolate1d(12)?.reshape(36)?;
+
+    println!("y: {}", y.unsqueeze(1)?);
+    #[rustfmt::skip]
+    let z = Tensor::new(
+        &[
+            1_f32, 02., 03., 04.,
+            05.,   06., 07., 08.,
+            09.,   10., 11., 12.,
+            13.,   14., 15., 16.,
+            17.,   18., 19., 20.,
+            21.,   22., 23., 24.,
+            25.,   26., 27., 28.,
+            29.,   30., 31., 32.,
+            33.,   34., 35., 36.,
+        ],
+        device,
+    )?;
+
+    let loss = y.unsqueeze(1)?.transpose(0, 1)?.matmul(&z.unsqueeze(1)?)?;
+
+    let grads = loss.backward()?;
+
+    let grad_x = grads.get(&x).context("no grad for x")?;
+
+    println!("grad: {grad_x}");
+
+    assert_eq!(
+        test_utils::to_vec3_round(&grad_x, 4)?,
+        [[[10_f32, 26., 42.], [58., 74., 90.], [106., 122., 138.]]]
+    );
+
     // manually checked: see comments
     let x = Var::new(&[[[[1f32, 2., 3.], [4., 5., 6.], [7., 8., 9.]]]], device)?;
     let y = x.interpolate2d(6, 6)?.reshape(36)?;

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -312,7 +312,7 @@ fn unary_grad(device: &Device) -> Result<()> {
     println!("grad: {grad_x}");
 
     assert_eq!(
-        test_utils::to_vec3_round(&grad_x, 4)?,
+        test_utils::to_vec3_round(grad_x, 4)?,
         [[[10_f32, 26., 42.], [58., 74., 90.], [106., 122., 138.]]]
     );
 


### PR DESCRIPTION
This adds gradients for interpolate1d: this is done in the same manner as for interpolate2d by using a convolution to sum the grads for integer scaling factors, and checked manually in a similar way