### PR TITLE
Example: Linear regression using gradient descent

### DIFF
--- a/candle-examples/examples/linear-regression/README.md
+++ b/candle-examples/examples/linear-regression/README.md
@@ -1,0 +1,3 @@
+# Linear Regression
+
+Linear regression model implemented for the Kaggle insurance [dataset](https://www.kaggle.com/code/kianwee/linear-regression-insurance-dataset)

--- a/candle-examples/examples/linear-regression/README.md
+++ b/candle-examples/examples/linear-regression/README.md
@@ -1,3 +1,7 @@
 # Linear Regression
 
-Linear regression model implemented for the Kaggle insurance [dataset](https://www.kaggle.com/code/kianwee/linear-regression-insurance-dataset)
+Linear regression model implemented for the Kaggle insurance [dataset](https://www.kaggle.com/code/kianwee/linear-regression-insurance-dataset). The example can be run using the following command
+
+```bash
+cargo run --example linear-regression --  --data-csv ./insurance.csv
+```

--- a/candle-examples/examples/linear-regression/README.md
+++ b/candle-examples/examples/linear-regression/README.md
@@ -1,6 +1,6 @@
 # Linear Regression
 
-Linear regression model implemented for the Kaggle insurance [dataset](https://www.kaggle.com/code/kianwee/linear-regression-insurance-dataset). The example can be run using the following command
+Linear regression model using gradient descent implemented for the Kaggle insurance [dataset](https://www.kaggle.com/code/kianwee/linear-regression-insurance-dataset). The example can be run using the following command
 
 ```bash
 cargo run --example linear-regression --  --data-csv ./insurance.csv

--- a/candle-examples/examples/linear-regression/main.rs
+++ b/candle-examples/examples/linear-regression/main.rs
@@ -1,0 +1,190 @@
+extern crate csv;
+use anyhow::Result;
+use candle::{Device, Tensor, D};
+use core::panic;
+use std::fs::File;
+use std::rc::Rc;
+use clap::Parser;
+
+pub struct Dataset {
+    pub training_data: Tensor,
+    pub training_labels: Tensor,
+    pub test_data: Tensor,
+    pub test_labels: Tensor,
+    pub feature_cnt: usize,
+}
+
+// Implement Linear Regression model using Gradient Descent
+// https://www.youtube.com/watch?v=UVCFaaEBnTE
+pub struct LinearRegression {
+    thetas: Tensor,
+    device: Rc<Device>,
+}
+
+impl LinearRegression {
+    pub fn new(feature_cnt: usize, device: Rc<Device>) -> Result<Self> {
+        let thetas: Vec<f32> = vec![0.0; feature_cnt];
+        let thetas = Tensor::from_vec(thetas, (feature_cnt,), &device)?;
+        Ok(Self { thetas, device })
+    }
+
+    pub fn predict(&self, x: &Tensor) -> Result<Tensor> {
+        Ok(x.matmul(&self.thetas.unsqueeze(1)?)?.squeeze(1)?)
+    }
+
+    pub fn cost(&self, x: &Tensor, y: &Tensor) -> Result<Tensor> {
+        let m = y.shape().dims1()?;
+        let predictions = self.predict(x)?;
+        let deltas = predictions.sub(y)?;
+        let cost = deltas
+            .mul(&deltas)?
+            .mean(D::Minus1)?
+            .div(&Tensor::new(2.0 * m as f32, &self.device)?)?;
+        Ok(cost)
+    }
+
+    pub fn train(&mut self, x: &Tensor, y: &Tensor, learning_rate: f32) -> Result<()> {
+        let m = y.shape().dims1()?;
+        let predictions = self.predict(x)?;
+        let deltas = predictions.sub(y)?;
+        let gradient = x
+            .t()?
+            .matmul(&deltas.unsqueeze(D::Minus1)?)?
+            .broadcast_div(&Tensor::new(m as f32, &self.device)?)?;
+        let gradient = gradient.squeeze(D::Minus1)?.squeeze(D::Minus1)?;
+        self.thetas = self
+            .thetas
+            .sub(&gradient.broadcast_mul(&Tensor::new(learning_rate, &self.device)?)?)?;
+        Ok(())
+    }
+}
+
+pub fn r2_score(predictions: &Tensor, labels: &Tensor) -> Result<f32, Box<dyn std::error::Error>> {
+    let mean = labels.mean(D::Minus1)?;
+
+    let rss = labels.sub(predictions)?;
+    let rss = rss.mul(&rss)?.sum(D::Minus1)?;
+
+    let sst = labels.broadcast_sub(&mean)?;
+    let sst = sst.mul(&sst)?.sum(D::Minus1)?;
+
+    let tmp = rss.div(&sst)?.to_scalar::<f32>()?;
+
+    Ok(1.0 - tmp)
+}
+
+const LEARNING_RATE: f32 = 0.01;
+const ITERATIONS: i32 = 100000;
+
+fn insurance_dataset(file_path: &str, device: &Device) -> Result<Dataset> {
+    // https://www.kaggle.com/mirichoi0218/insurance
+
+    let file = File::open(file_path)?;
+    let mut rdr = csv::Reader::from_reader(file);
+    let mut data: Vec<Vec<f32>> = vec![];
+    let mut labels: Vec<f32> = vec![];
+
+    const FEATURE_CNT: usize = 7;
+    const MALE: f32 = 0.5;
+    const FEMALE: f32 = -0.5;
+
+    const YES: f32 = 0.5;
+    const NO: f32 = -0.5;
+
+    const NORTHWEST: f32 = 0.25;
+    const NORTHEAST: f32 = -0.25;
+    const SOUTHWEST: f32 = 0.5;
+    const SOUTHEAST: f32 = -0.5;
+
+    for result in rdr.records() {
+        let record = result?;
+        let age: f32 = (record[0].parse::<u32>()? as f32) / 100.0;
+        let gender = match record[1].parse::<String>()?.as_str() {
+            "male" => MALE,
+            "female" => FEMALE,
+            _ => panic!("Invalid Gender"),
+        };
+        let bmi: f32 = record[2].parse::<f32>()? / 100.0;
+        let children: f32 = record[3].parse()?;
+        let smoker = match record[4].parse::<String>()?.as_str() {
+            "yes" => YES,
+            "no" => NO,
+            _ => panic!("Invalid Smoker"),
+        };
+        let region = match record[5].parse::<String>()?.as_str() {
+            "northwest" => NORTHWEST,
+            "northeast" => NORTHEAST,
+            "southwest" => SOUTHWEST,
+            "southeast" => SOUTHEAST,
+            _ => panic!("Invalid Region"),
+        };
+        let charges: f32 = record[6].parse()?;
+
+        // IMPORTANT: The first column of the row needs to be 1.0 for the bias term
+        let row = vec![1.0, age, gender, bmi, children, smoker, region];
+        data.push(row);
+
+        let label = charges;
+        labels.push(label);
+    }
+    let training_size = labels.len() * 8 / 10;
+    let training_data = data[..training_size].to_vec();
+    let training_labels = labels[..training_size].to_vec();
+
+    let training_data = training_data
+        .iter()
+        .flatten()
+        .copied()
+        .collect::<Vec<f32>>();
+    let training_data_tensor =
+        Tensor::from_slice(&training_data, (training_labels.len(), FEATURE_CNT), device)?;
+    let training_labels_tensor =
+        Tensor::from_slice(&training_labels, (training_labels.len(),), device)?;
+
+    let test_data = data[training_size..].to_vec();
+    let test_labels = labels[training_size..].to_vec();
+
+    let test_data = test_data.iter().flatten().copied().collect::<Vec<f32>>();
+    let test_data_tensor =
+        Tensor::from_slice(&test_data, (test_labels.len(), FEATURE_CNT), device)?;
+    let test_labels_tensor = Tensor::from_slice(&test_labels, (test_labels.len(),), device)?;
+
+    Ok(Dataset {
+        training_data: training_data_tensor,
+        training_labels: training_labels_tensor,
+        test_data: test_data_tensor,
+        test_labels: test_labels_tensor,
+        feature_cnt: FEATURE_CNT,
+    })
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(long)]
+    data_csv: String,
+}
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let file_path = args.data_csv;
+
+    let device = Rc::new(Device::cuda_if_available(0)?);
+
+    let dataset = insurance_dataset(&file_path, &device)?;
+
+    let mut model = LinearRegression::new(dataset.feature_cnt, device)?;
+
+    for _ in 0..ITERATIONS {
+        model.train(
+            &dataset.training_data,
+            &dataset.training_labels,
+            LEARNING_RATE,
+        )?;
+    }
+
+    let predictions = model.predict(&dataset.test_data)?;
+    let r2 = r2_score(&predictions, &dataset.test_labels).unwrap();
+    println!("r2: {r2}");
+
+    Ok(())
+}

--- a/candle-examples/examples/linear-regression/main.rs
+++ b/candle-examples/examples/linear-regression/main.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use std::rc::Rc;
 use clap::Parser;
 
-pub struct Dataset {
+struct Dataset {
     pub training_data: Tensor,
     pub training_labels: Tensor,
     pub test_data: Tensor,
@@ -16,23 +16,24 @@ pub struct Dataset {
 
 // Implement Linear Regression model using Gradient Descent
 // https://www.youtube.com/watch?v=UVCFaaEBnTE
-pub struct LinearRegression {
+struct LinearRegression {
     thetas: Tensor,
     device: Rc<Device>,
 }
 
 impl LinearRegression {
-    pub fn new(feature_cnt: usize, device: Rc<Device>) -> Result<Self> {
+    fn new(feature_cnt: usize, device: Rc<Device>) -> Result<Self> {
         let thetas: Vec<f32> = vec![0.0; feature_cnt];
         let thetas = Tensor::from_vec(thetas, (feature_cnt,), &device)?;
         Ok(Self { thetas, device })
     }
 
-    pub fn predict(&self, x: &Tensor) -> Result<Tensor> {
+    fn predict(&self, x: &Tensor) -> Result<Tensor> {
         Ok(x.matmul(&self.thetas.unsqueeze(1)?)?.squeeze(1)?)
     }
 
-    pub fn cost(&self, x: &Tensor, y: &Tensor) -> Result<Tensor> {
+    #[allow(unused)]
+    fn cost(&self, x: &Tensor, y: &Tensor) -> Result<Tensor> {
         let m = y.shape().dims1()?;
         let predictions = self.predict(x)?;
         let deltas = predictions.sub(y)?;
@@ -43,7 +44,7 @@ impl LinearRegression {
         Ok(cost)
     }
 
-    pub fn train(&mut self, x: &Tensor, y: &Tensor, learning_rate: f32) -> Result<()> {
+    fn train(&mut self, x: &Tensor, y: &Tensor, learning_rate: f32) -> Result<()> {
         let m = y.shape().dims1()?;
         let predictions = self.predict(x)?;
         let deltas = predictions.sub(y)?;
@@ -59,7 +60,7 @@ impl LinearRegression {
     }
 }
 
-pub fn r2_score(predictions: &Tensor, labels: &Tensor) -> Result<f32, Box<dyn std::error::Error>> {
+fn r2_score(predictions: &Tensor, labels: &Tensor) -> Result<f32, Box<dyn std::error::Error>> {
     let mean = labels.mean(D::Minus1)?;
 
     let rss = labels.sub(predictions)?;

--- a/candle-examples/examples/linear-regression/main.rs
+++ b/candle-examples/examples/linear-regression/main.rs
@@ -28,14 +28,14 @@ impl LinearRegression {
         Ok(Self { thetas, device })
     }
 
-    fn predict(&self, x: &Tensor) -> Result<Tensor> {
+    fn hypothesis(&self, x: &Tensor) -> Result<Tensor> {
         Ok(x.matmul(&self.thetas.unsqueeze(1)?)?.squeeze(1)?)
     }
 
     #[allow(unused)]
     fn cost(&self, x: &Tensor, y: &Tensor) -> Result<Tensor> {
         let m = y.shape().dims1()?;
-        let predictions = self.predict(x)?;
+        let predictions = self.hypothesis(x)?;
         let deltas = predictions.sub(y)?;
         let cost = deltas
             .mul(&deltas)?
@@ -46,7 +46,7 @@ impl LinearRegression {
 
     fn train(&mut self, x: &Tensor, y: &Tensor, learning_rate: f32) -> Result<()> {
         let m = y.shape().dims1()?;
-        let predictions = self.predict(x)?;
+        let predictions = self.hypothesis(x)?;
         let deltas = predictions.sub(y)?;
         let gradient = x
             .t()?
@@ -183,7 +183,7 @@ fn main() -> Result<()> {
         )?;
     }
 
-    let predictions = model.predict(&dataset.test_data)?;
+    let predictions = model.hypothesis(&dataset.test_data)?;
     let r2 = r2_score(&predictions, &dataset.test_labels).unwrap();
     println!("r2: {r2}");
 

--- a/candle-examples/examples/linear-regression/main.rs
+++ b/candle-examples/examples/linear-regression/main.rs
@@ -63,13 +63,13 @@ impl LinearRegression {
 fn r2_score(predictions: &Tensor, labels: &Tensor) -> Result<f32, Box<dyn std::error::Error>> {
     let mean = labels.mean(D::Minus1)?;
 
-    let rss = labels.sub(predictions)?;
-    let rss = rss.mul(&rss)?.sum(D::Minus1)?;
+    let ssr = labels.sub(predictions)?;
+    let ssr = ssr.mul(&ssr)?.sum(D::Minus1)?;
 
     let sst = labels.broadcast_sub(&mean)?;
     let sst = sst.mul(&sst)?.sum(D::Minus1)?;
 
-    let tmp = rss.div(&sst)?.to_scalar::<f32>()?;
+    let tmp = ssr.div(&sst)?.to_scalar::<f32>()?;
 
     Ok(1.0 - tmp)
 }


### PR DESCRIPTION
Example of a [Linear regression model](https://www.youtube.com/watch?v=UVCFaaEBnTE) using gradient descent implemented for the Kaggle insurance [dataset](https://www.kaggle.com/code/kianwee/linear-regression-insurance-dataset)