### PR TITLE
Add clone to candle dropout

### DIFF
--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -74,7 +74,7 @@ pub fn dropout(xs: &Tensor, drop_p: f32) -> Result<Tensor> {
     xs * mask
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Dropout {
     drop_p: f32,
 }


### PR DESCRIPTION
Derives clone for a dropour layer, mildly useful as it allows models with a dropout layer to derive clone themselves and makes it consistent with Linear and Conv layers deriving clone