### PR TITLE
Remove unnecessary memset for reshape, concat and contiguous

### DIFF
--- a/candle-core/src/backend.rs
+++ b/candle-core/src/backend.rs
@@ -114,6 +114,8 @@ pub trait BackendDevice: Sized + std::fmt::Debug + Clone {
 
     fn ones_impl(&self, _shape: &Shape, _dtype: DType) -> Result<Self::Storage>;
 
+    fn alloc_impl(&self, _shape: &Shape, _dtype: DType, _: Option<u8>) -> Result<Self::Storage>;
+
     fn storage_from_cpu_storage(&self, _: &CpuStorage) -> Result<Self::Storage>;
 
     fn rand_uniform(&self, _: &Shape, _: DType, _: f64, _: f64) -> Result<Self::Storage>;

--- a/candle-core/src/cpu_backend.rs
+++ b/candle-core/src/cpu_backend.rs
@@ -2520,7 +2520,7 @@ impl BackendStorage for CpuStorage {
             col.matmul(kernel, (b, m, n, k), &col_l, &kernel_l)?
         } else {
             // Make the kernel contiguous if not already the case.
-            let mut kernel_c = self.device().zeros_impl(kernel_l.shape(), kernel.dtype())?;
+            let mut kernel_c = self.device().alloc_impl(kernel_l.shape(), kernel.dtype(), None)?;
             kernel.copy_strided_src(&mut kernel_c, 0, kernel_l)?;
             let kernel_l = Layout::contiguous_with_offset((1, n, k), kernel_l.start_offset())
                 .transpose(1, 2)?
@@ -2528,7 +2528,7 @@ impl BackendStorage for CpuStorage {
             col.matmul(kernel, (b, m, n, k), &col_l, &kernel_l)?
         };
         let res_l = Layout::contiguous((b, l_out, params.c_out)).transpose(1, 2)?;
-        let mut res_t = self.device().zeros_impl(res_l.shape(), res.dtype())?;
+        let mut res_t = self.device().alloc_impl(res_l.shape(), res.dtype(), None)?;
         res.copy_strided_src(&mut res_t, 0, &res_l)?;
         Ok(res_t)
     }
@@ -2619,7 +2619,7 @@ impl BackendStorage for CpuStorage {
             col.matmul(kernel, (b, m, n, k), &col_l, &kernel_l)?
         } else {
             // Make the kernel contiguous if not already the case.
-            let mut kernel_c = self.device().zeros_impl(kernel_l.shape(), kernel.dtype())?;
+            let mut kernel_c = self.device().alloc_impl(kernel_l.shape(), kernel.dtype(), None)?;
             kernel.copy_strided_src(&mut kernel_c, 0, kernel_l)?;
             let kernel_l = Layout::contiguous_with_offset((1, n, k), kernel_l.start_offset())
                 .transpose(1, 2)?
@@ -2629,7 +2629,7 @@ impl BackendStorage for CpuStorage {
         let res_l = Layout::contiguous((b, h_out, w_out, params.c_out))
             .transpose(1, 2)?
             .transpose(1, 3)?;
-        let mut res_t = self.device().zeros_impl(res_l.shape(), res.dtype())?;
+        let mut res_t = self.device().alloc_impl(res_l.shape(), res.dtype(), None)?;
         res.copy_strided_src(&mut res_t, 0, &res_l)?;
         Ok(res_t)
     }
@@ -2853,32 +2853,35 @@ impl BackendDevice for CpuDevice {
         }
     }
 
-    fn ones_impl(&self, shape: &Shape, dtype: DType) -> Result<CpuStorage> {
+    fn alloc_impl(
+        &self,
+        shape: &Shape,
+        dtype: DType,
+        init_value: Option<u8>,
+    ) -> Result<CpuStorage> {
         let elem_count = shape.elem_count();
+        let v = match init_value {
+            Some(v) => v,
+            None => 0,
+        };
         let storage = match dtype {
-            DType::U8 => CpuStorage::U8(vec![1u8; elem_count]),
-            DType::U32 => CpuStorage::U32(vec![1u32; elem_count]),
-            DType::I64 => CpuStorage::I64(vec![1i64; elem_count]),
-            DType::BF16 => CpuStorage::BF16(vec![bf16::ONE; elem_count]),
-            DType::F16 => CpuStorage::F16(vec![f16::ONE; elem_count]),
-            DType::F32 => CpuStorage::F32(vec![1f32; elem_count]),
-            DType::F64 => CpuStorage::F64(vec![1f64; elem_count]),
+            DType::U8 => CpuStorage::U8(vec![v as u8; elem_count]),
+            DType::U32 => CpuStorage::U32(vec![v as u32; elem_count]),
+            DType::I64 => CpuStorage::I64(vec![v as i64; elem_count]),
+            DType::BF16 => CpuStorage::BF16(vec![bf16::from_f32(v as f32); elem_count]),
+            DType::F16 => CpuStorage::F16(vec![f16::from_f32(v as f32); elem_count]),
+            DType::F32 => CpuStorage::F32(vec![v as f32; elem_count]),
+            DType::F64 => CpuStorage::F64(vec![v as f64; elem_count]),
         };
         Ok(storage)
     }
 
+    fn ones_impl(&self, shape: &Shape, dtype: DType) -> Result<CpuStorage> {
+        self.alloc_impl(shape, dtype, Some(1))
+    }
+
     fn zeros_impl(&self, shape: &Shape, dtype: DType) -> Result<CpuStorage> {
-        let elem_count = shape.elem_count();
-        let storage = match dtype {
-            DType::U8 => CpuStorage::U8(vec![0u8; elem_count]),
-            DType::U32 => CpuStorage::U32(vec![0u32; elem_count]),
-            DType::I64 => CpuStorage::I64(vec![0i64; elem_count]),
-            DType::BF16 => CpuStorage::BF16(vec![bf16::ZERO; elem_count]),
-            DType::F16 => CpuStorage::F16(vec![f16::ZERO; elem_count]),
-            DType::F32 => CpuStorage::F32(vec![0f32; elem_count]),
-            DType::F64 => CpuStorage::F64(vec![0f64; elem_count]),
-        };
-        Ok(storage)
+        self.alloc_impl(shape, dtype, Some(0))
     }
 }
 

--- a/candle-core/src/cuda_backend.rs
+++ b/candle-core/src/cuda_backend.rs
@@ -279,6 +279,56 @@ impl BackendDevice for CudaDevice {
         })
     }
 
+        //TODO: implement alloc_values in cudarc (possiblely using memset) and pass init_value to alloc_values
+    //alloc uninitlized buffer if init_value is None, otherwise, allocate a buffer and memset it with init_value
+    fn alloc_impl(
+        &self,
+        shape: &Shape,
+        dtype: DType,
+        init_value: Option<u8>,
+    ) -> Result<CudaStorage> {
+        match init_value {
+            Some(v) => self.const_impl(v as f64, shape, dtype),
+            _ => {
+                let elem_count = shape.elem_count();
+                let slice = match dtype {
+                    DType::U8 => {
+                        let data = unsafe { self.alloc::<u8>(elem_count).w()? };
+                        CudaStorageSlice::U8(data)
+                    }
+                    DType::U32 => {
+                        let data = unsafe { self.alloc::<u32>(elem_count).w()? };
+                        CudaStorageSlice::U32(data)
+                    }
+                    DType::I64 => {
+                        let data = unsafe { self.alloc::<i64>(elem_count).w()? };
+                        CudaStorageSlice::I64(data)
+                    }
+                    DType::BF16 => {
+                        let data = unsafe { self.alloc::<bf16>(elem_count).w()? };
+                        CudaStorageSlice::BF16(data)
+                    }
+                    DType::F16 => {
+                        let data = unsafe { self.alloc::<f16>(elem_count).w()? };
+                        CudaStorageSlice::F16(data)
+                    }
+                    DType::F32 => {
+                        let data = unsafe { self.alloc::<f32>(elem_count).w()? };
+                        CudaStorageSlice::F32(data)
+                    }
+                    DType::F64 => {
+                        let data = unsafe { self.alloc::<f64>(elem_count).w()? };
+                        CudaStorageSlice::F64(data)
+                    }
+                };
+                Ok(CudaStorage {
+                    slice,
+                    device: self.clone(),
+                })
+            }
+        }
+    }
+
     fn rand_uniform(&self, shape: &Shape, dtype: DType, lo: f64, up: f64) -> Result<CudaStorage> {
         let elem_count = shape.elem_count();
         let curand = self.curand.lock().unwrap();
@@ -1844,7 +1894,7 @@ impl BackendStorage for CudaStorage {
             col.matmul(kernel, (b, m, n, k), &col_l, &kernel_l)?
         } else {
             // Make the kernel contiguous if not already the case.
-            let mut kernel_c = self.device().zeros_impl(kernel_l.shape(), kernel.dtype())?;
+            let mut kernel_c = self.device().alloc_impl(kernel_l.shape(), kernel.dtype(), None)?;
             kernel.copy_strided_src(&mut kernel_c, 0, kernel_l)?;
             let kernel_l = Layout::contiguous_with_offset((1, n, k), kernel_l.start_offset())
                 .transpose(1, 2)?
@@ -1852,7 +1902,7 @@ impl BackendStorage for CudaStorage {
             col.matmul(kernel, (b, m, n, k), &col_l, &kernel_l)?
         };
         let res_l = Layout::contiguous((b, l_out, n)).transpose(1, 2)?;
-        let mut res_t = self.device().zeros_impl(res_l.shape(), res.dtype())?;
+        let mut res_t = self.device().alloc_impl(res_l.shape(), res.dtype(), None)?;
         res.copy_strided_src(&mut res_t, 0, &res_l)?;
         Ok(res_t)
     }
@@ -1909,7 +1959,7 @@ impl BackendStorage for CudaStorage {
             col.matmul(kernel, (b, m, n, k), &col_l, &kernel_l)?
         } else {
             // Make the kernel contiguous if not already the case.
-            let mut kernel_c = self.device().zeros_impl(kernel_l.shape(), kernel.dtype())?;
+            let mut kernel_c = self.device().alloc_impl(kernel_l.shape(), kernel.dtype(), None)?;
             kernel.copy_strided_src(&mut kernel_c, 0, kernel_l)?;
             let kernel_l = Layout::contiguous_with_offset((1, n, k), kernel_l.start_offset())
                 .transpose(1, 2)?
@@ -1919,7 +1969,7 @@ impl BackendStorage for CudaStorage {
         let res_l = Layout::contiguous((b, h_out, w_out, n))
             .transpose(1, 2)?
             .transpose(1, 3)?;
-        let mut res_t = self.device().zeros_impl(res_l.shape(), res.dtype())?;
+        let mut res_t = self.device().alloc_impl(res_l.shape(), res.dtype(), None)?;
         res.copy_strided_src(&mut res_t, 0, &res_l)?;
         Ok(res_t)
     }
@@ -2056,7 +2106,7 @@ impl BackendStorage for CudaStorage {
         dim: usize,
     ) -> Result<Self> {
         let device = self.device().clone();
-        let mut acc = device.zeros_impl(l.shape(), self.dtype())?;
+        let mut acc = device.alloc_impl(l.shape(), self.dtype(), None)?;
         self.copy_strided_src(&mut acc, 0, l)?;
         ScatterAdd(ids, ids_l, dim).map(&mut acc.slice, l.shape(), &src.slice, src_l, &device)?;
         Ok(acc)

--- a/candle-core/src/device.rs
+++ b/candle-core/src/device.rs
@@ -255,38 +255,34 @@ impl Device {
         self.rand_normal_f64(mean.to_f64(), std.to_f64(), shape, T::DTYPE)
     }
 
-    pub(crate) fn ones(&self, shape: &Shape, dtype: DType) -> Result<Storage> {
+    pub(crate) fn alloc(
+        &self,
+        shape: &Shape,
+        dtype: DType,
+        init_value: Option<u8>,
+    ) -> Result<Storage> {
         match self {
             Device::Cpu => {
-                let storage = CpuDevice.ones_impl(shape, dtype)?;
+                let storage = CpuDevice.alloc_impl(shape, dtype, init_value)?;
                 Ok(Storage::Cpu(storage))
             }
             Device::Cuda(device) => {
-                let storage = device.ones_impl(shape, dtype)?;
+                let storage = device.alloc_impl(shape, dtype, init_value)?;
                 Ok(Storage::Cuda(storage))
             }
             Device::Metal(device) => {
-                let storage = device.ones_impl(shape, dtype)?;
+                let storage = device.alloc_impl(shape, dtype, init_value)?;
                 Ok(Storage::Metal(storage))
             }
         }
     }
 
+    pub(crate) fn ones(&self, shape: &Shape, dtype: DType) -> Result<Storage> {
+        self.alloc(shape, dtype, Some(1))
+    }
+
     pub(crate) fn zeros(&self, shape: &Shape, dtype: DType) -> Result<Storage> {
-        match self {
-            Device::Cpu => {
-                let storage = CpuDevice.zeros_impl(shape, dtype)?;
-                Ok(Storage::Cpu(storage))
-            }
-            Device::Cuda(device) => {
-                let storage = device.zeros_impl(shape, dtype)?;
-                Ok(Storage::Cuda(storage))
-            }
-            Device::Metal(device) => {
-                let storage = device.zeros_impl(shape, dtype)?;
-                Ok(Storage::Metal(storage))
-            }
-        }
+        self.alloc(shape, dtype, Some(0))
     }
 
     pub(crate) fn storage<A: NdArray>(&self, array: A) -> Result<Storage> {

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -197,6 +197,15 @@ impl crate::backend::BackendDevice for CudaDevice {
         Err(Error::NotCompiledWithCudaSupport)
     }
 
+    fn alloc_impl(
+        &self,
+        _shape: &Shape,
+        _dtype: DType,
+        init_value: Option<u8>,
+    ) -> Result<Self::Storage> {
+        Err(Error::NotCompiledWithCudaSupport)
+    }
+    
     fn storage_from_cpu_storage(&self, _: &CpuStorage) -> Result<Self::Storage> {
         Err(Error::NotCompiledWithCudaSupport)
     }

--- a/candle-core/src/dummy_metal_backend.rs
+++ b/candle-core/src/dummy_metal_backend.rs
@@ -209,6 +209,15 @@ impl crate::backend::BackendDevice for MetalDevice {
         Err(Error::NotCompiledWithMetalSupport)
     }
 
+    fn alloc_impl(
+        &self,
+        _shape: &Shape,
+        _dtype: DType,
+        init_value: Option<u8>,
+    ) -> Result<Self::Storage> {
+        Err(Error::NotCompiledWithMetalSupport)
+    }
+    
     fn storage_from_cpu_storage(&self, _: &CpuStorage) -> Result<Self::Storage> {
         Err(Error::NotCompiledWithMetalSupport)
     }

--- a/candle-core/src/metal_backend.rs
+++ b/candle-core/src/metal_backend.rs
@@ -1629,6 +1629,18 @@ impl BackendDevice for MetalDevice {
         self.storage_from_cpu_storage(&cpu_storage)
     }
 
+    //TODO: fill buffer with init_value
+    fn alloc_impl(&self, shape: &Shape, dtype: DType, init_value: Option<u8>,) -> Result<MetalStorage> {
+        let size = shape.elem_count() * dtype.size_in_bytes();
+        let buffer = self.allocate_zeros(size)?;
+        Ok(MetalStorage::new(
+            buffer,
+            self.clone(),
+            shape.elem_count(),
+            dtype,
+        ))
+    }
+
     fn storage_from_cpu_storage(&self, storage: &CpuStorage) -> Result<Self::Storage> {
         let (count, buffer) = match storage {
             CpuStorage::U8(storage) => (storage.len(), self.new_buffer_with_data(storage)),

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -1351,7 +1351,7 @@ impl Tensor {
             }
             .bt())?
         }
-        let mut storage = self.device().zeros(self.shape(), self.dtype())?;
+        let mut storage = self.device().alloc(self.shape(), self.dtype(), None)?;
         self.storage()
             .copy_strided_src(&mut storage, 0, self.layout())?;
         let offset = start * src.dims()[1..].iter().product::<usize>();
@@ -2001,7 +2001,7 @@ impl Tensor {
             Ok(self.clone())
         } else {
             let shape = self.shape();
-            let mut storage = self.device().zeros(shape, self.dtype())?;
+            let mut storage = self.device().alloc(shape, self.dtype(), None)?;
             self.storage()
                 .copy_strided_src(&mut storage, 0, self.layout())?;
             let op = BackpropOp::new1(self, Op::Copy);
@@ -2066,7 +2066,7 @@ impl Tensor {
             };
             Ok(Tensor(Arc::new(tensor_)))
         } else {
-            let mut storage = self.device().zeros(&shape, self.dtype())?;
+            let mut storage = self.device().alloc(&shape, self.dtype(), None)?;
             self.storage()
                 .copy_strided_src(&mut storage, 0, self.layout())?;
             Ok(from_storage(storage, shape, op, false))
@@ -2286,7 +2286,7 @@ impl Tensor {
         }
         let shape = Shape::from(cat_dims);
         let op = BackpropOp::new(args, |args| Op::Cat(args, 0));
-        let mut storage = device.zeros(&shape, dtype)?;
+        let mut storage = device.alloc(&shape, dtype, None)?;
         for (arg, &offset) in args.iter().zip(offsets.iter()) {
             let arg = arg.as_ref();
             arg.storage()

--- a/candle-examples/examples/llama/main.rs
+++ b/candle-examples/examples/llama/main.rs
@@ -82,6 +82,15 @@ struct Args {
     #[arg(long)]
     revision: Option<String>,
 
+    #[arg(long)]
+    tokenizer_file: Option<String>,
+
+    #[arg(long)]
+    config_file: Option<String>,
+
+    #[arg(long)]
+    weight_files: Option<String>,
+
     /// The model size to use.
     #[arg(long, default_value = "v2")]
     which: Which,
@@ -132,14 +141,29 @@ fn main() -> Result<()> {
         let revision = args.revision.unwrap_or("main".to_string());
         let api = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
 
-        let tokenizer_filename = api.get("tokenizer.json")?;
-        let config_filename = api.get("config.json")?;
+        let tokenizer_filename = match args.tokenizer_file {
+            Some(file) => std::path::PathBuf::from(file),
+            None => api.get("tokenizer.json")?,
+        };
+        let config_filename = match args.config_file {
+            Some(file) => std::path::PathBuf::from(file),
+            None => api.get("config.json")?,
+        };
         let config: LlamaConfig = serde_json::from_slice(&std::fs::read(config_filename)?)?;
         let config = config.into_config(args.use_flash_attn);
 
         let filenames = match args.which {
             Which::V1 | Which::V2 | Which::Solar10_7B => {
-                candle_examples::hub_load_safetensors(&api, "model.safetensors.index.json")?
+                let filenames = match args.weight_files {
+                    Some(files) => files
+                        .split(',')
+                        .map(std::path::PathBuf::from)
+                        .collect::<Vec<_>>(),
+                    None => {
+                        candle_examples::hub_load_safetensors(&api, "model.safetensors.index.json")?
+                    }
+                };
+                filenames
             }
             Which::TinyLlama1_1BChat => vec![api.get("model.safetensors")?],
         };

--- a/candle-examples/examples/stable-lm/main.rs
+++ b/candle-examples/examples/stable-lm/main.rs
@@ -181,6 +181,9 @@ struct Args {
     weight_files: Option<String>,
 
     #[arg(long)]
+    config_file: Option<String>,
+
+    #[arg(long)]
     quantized: bool,
 
     /// Penalty to be applied for repeating tokens, 1. means no penalty.
@@ -286,7 +289,11 @@ fn main() -> Result<()> {
     let config = match args.which {
         Which::V1Orig => Config::stablelm_3b_4e1t(args.use_flash_attn),
         Which::V1 | Which::V1Zephyr | Which::V2 | Which::V2Zephyr | Which::Code => {
-            let config_filename = repo.get("config.json")?;
+            let config_filename = match args.config_file {
+                Some(file) => std::path::PathBuf::from(file),
+                None => repo.get("config.json")?,
+            };
+            // let config_filename = repo.get("config.json")?;
             let config = std::fs::read_to_string(config_filename)?;
             let mut config: Config = serde_json::from_str(&config)?;
             config.set_use_flash_attn(args.use_flash_attn);


### PR DESCRIPTION
This is a reopened PR #1680, it will improve around 5% - 10% performance for every LLM model in candle-examples. This was also adopted by @EricLBuehler in his Mistralrs project and proved its effectiveness. Therefore, we hope this can be merged into candle main branch.

--- previous comments
Some tensor operations (e.g., reshape, concat, and contiguous) have redundant memset operations. This occurs when alloc_zeros is called unnecessarily to fill the destination buffer. This patch introduces an alloc operation with an optional value for buffer filling. By default, the alloc function will call device::alloc if there is no value to fill. This change will prevent unnecessary memset calls for certain tensor operations, including reshape, concat, and contiguous, thereby speeding up the inference process.

To streamline the implementation, it would be more intuitive to incorporate an alloc_values function in the external crate "cudarc". This function would accept the optional init_value parameter. If init_value is None, the function would allocate an uninitialized buffer; otherwise, it would allocate a buffer and memset it with init_value (see changes in cuda_backend.rs -> alloc_impl). This would eliminate the need for separate implementations such as ones_impl, zeros_impl, and so on.