### PR TITLE
Add support for conv_transpose1d for metal backend

### DIFF
--- a/candle-core/src/metal_backend.rs
+++ b/candle-core/src/metal_backend.rs
@@ -966,6 +966,10 @@ impl BackendStorage for MetalStorage {
         let command_buffer = self.device.command_buffer()?;
         let name = match self.dtype {
             DType::F32 => "conv_transpose1d_f32",
+            DType::F16 => "conv_transpose1d_f16",
+            DType::BF16 => "conv_transpose1d_bf16",
+            DType::U32 => "conv_transpose1d_u32",
+            DType::U8 => "conv_transpose1d_u8",
             dtype => crate::bail!("Metal conv_transpose1d {dtype:?} not implemented"),
         };
         candle_metal_kernels::call_conv_transpose1d(

--- a/candle-core/tests/conv_tests.rs
+++ b/candle-core/tests/conv_tests.rs
@@ -54,11 +54,6 @@ fn conv1d(dev: &Device) -> Result<()> {
         [2.4509, 2.6357, -1.3336, 4.1393, 0.5657, 1.8091, -1.1784, 3.5675, 0.5069, 3.3352]
     );
 
-    // conv-transposes are not implemented for metal.
-    if dev.is_metal() {
-        return Ok(());
-    }
-
     let w = w.transpose(0, 1)?;
     // The CPU kernels applied in the contiguous and non contiguous cases are different.
     for w in [w.clone(), w.contiguous()?] {

--- a/candle-metal-kernels/src/conv.metal
+++ b/candle-metal-kernels/src/conv.metal
@@ -434,3 +434,9 @@ AVGPOOL2D_OP(bfloat, float, avg_pool2d_bf16)
 #endif
 
 CONVT1D_OP(float, float, conv_transpose1d_f32)
+CONVT1D_OP(half, float, conv_transpose1d_f16)
+CONVT1D_OP(uint8_t, uint8_t, conv_transpose1d_u8)
+CONVT1D_OP(uint32_t, uint32_t, conv_transpose1d_u32)
+#if defined(__HAVE_BFLOAT__)
+CONVT1D_OP(bfloat, float, conv_transpose1d_bf16)
+#endif

--- a/candle-metal-kernels/src/lib.rs
+++ b/candle-metal-kernels/src/lib.rs
@@ -1869,19 +1869,19 @@ pub fn call_conv_transpose1d(
     stride: usize,
     padding: usize,
     out_padding: usize,
+    c_out: usize,
+    l_out: usize,
+    b_size: usize,
     src_shape: &[usize],
     src_strides: &[usize],
     kernel_shape: &[usize],
     kernel_strides: &[usize],
     input: &Buffer,
+    input_offset: usize,
     kernel: &Buffer,
+    kernel_offset: usize,
     output: &Buffer,
 ) -> Result<(), MetalKernelError> {
-    let c_out = kernel_shape[1];
-    let k_size = kernel_shape[2];
-    let b_size = src_shape[0];
-    let l_in = src_shape[2];
-    let l_out = (l_in - 1) * stride - 2 * padding + dilation * (k_size - 1) + out_padding + 1;
     let dst_el = c_out * l_out * b_size;
     let pipeline: ComputePipelineState = kernels.load_pipeline(device, Source::Conv, name)?;
     let (thread_group_count, thread_group_size) = linear_split(&pipeline, dst_el);
@@ -1899,13 +1899,13 @@ pub fn call_conv_transpose1d(
             src_strides,
             kernel_shape,
             kernel_strides,
-            input,
-            kernel,
+            (input, input_offset),
+            (kernel, kernel_offset),
             output
         )
     );
-    encoder.use_resource(kernel, metal::MTLResourceUsage::Read);
     encoder.use_resource(input, metal::MTLResourceUsage::Read);
+    encoder.use_resource(kernel, metal::MTLResourceUsage::Read);
     encoder.use_resource(output, metal::MTLResourceUsage::Write);
     encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
     encoder.end_encoding();

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -1772,18 +1772,19 @@ fn run_conv_transpose1d<T: Clone>(
     .unwrap();
     command_buffer.commit();
     command_buffer.wait_until_completed();
+
     read_to_vec(&output, dst_el)
 }
 
 #[test]
 fn conv_transpose1d_f32() {
     let input = vec![0.0f32, 1.0, 2.0, 3.0];
-    let input_shape = &[1, 2, 2];
-    let input_stride = &[2, 2, 1];
+    let input_shape = &[1, 1, 4];
+    let input_stride = &[4, 4, 1];
 
     let kernel = vec![0.0f32, 1.0, 2.0, 3.0];
-    let kernel_shape = &[1, 2, 2];
-    let kernel_stride = &[2, 2, 1];
+    let kernel_shape = &[1, 1, 2];
+    let kernel_stride = &[4, 4, 1];
 
     let results = run_conv_transpose1d(
         &input,
@@ -1799,6 +1800,6 @@ fn conv_transpose1d_f32() {
         "conv_transpose1d_f32",
     );
 
-    let expected = vec![0.0, 0.0, 1.0, 0.0, 4.0, 6.0, 4.0, 12.0, 9.0];
+    let expected = vec![0.0, 0.0, 1.0, 4.0, 12.0, 9.0];
     assert_eq!(results, expected);
 }

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -1756,12 +1756,17 @@ fn run_conv_transpose1d<T: Clone>(
         stride,
         padding,
         out_padding,
+        c_out,
+        l_out,
+        b_size,
         input_shape,
         input_stride,
         kernel_shape,
         kernel_stride,
         &input,
+        0,
         &kernel,
+        0,
         &output,
     )
     .unwrap();

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -1803,3 +1803,133 @@ fn conv_transpose1d_f32() {
     let expected = vec![1., 4., 10., 20., 25., 24., 16.];
     assert_eq!(results, expected);
 }
+
+#[test]
+fn conv_transpose1d_f16() {
+    let input: Vec<f16> = vec![1.0, 2.0, 3.0, 4.0]
+        .iter()
+        .map(|v| f16::from_f32(*v))
+        .collect();
+    let input_shape = &[1, 1, 4];
+    let input_stride = &[4, 4, 1];
+
+    let kernel: Vec<f16> = vec![1.0, 2.0, 3.0, 4.0]
+        .iter()
+        .map(|v| f16::from_f32(*v))
+        .collect();
+    let kernel_shape = &[1, 1, 4];
+    let kernel_stride = &[4, 4, 1];
+
+    let results = run_conv_transpose1d(
+        &input,
+        input_shape,
+        input_stride,
+        &kernel,
+        kernel_shape,
+        kernel_stride,
+        1,
+        1,
+        0,
+        0,
+        "conv_transpose1d_f16",
+    );
+
+    let expected = vec![1., 4., 10., 20., 25., 24., 16.]
+        .iter()
+        .map(|v| f16::from_f32(*v))
+        .collect::<Vec<_>>();
+    assert_eq!(results, expected);
+}
+
+#[test]
+fn conv_transpose1d_bf16() {
+    let input: Vec<bf16> = vec![1.0, 2.0, 3.0, 4.0]
+        .iter()
+        .map(|v| bf16::from_f32(*v))
+        .collect();
+    let input_shape = &[1, 1, 4];
+    let input_stride = &[4, 4, 1];
+
+    let kernel: Vec<bf16> = vec![1.0, 2.0, 3.0, 4.0]
+        .iter()
+        .map(|v| bf16::from_f32(*v))
+        .collect();
+    let kernel_shape = &[1, 1, 4];
+    let kernel_stride = &[4, 4, 1];
+
+    let results = run_conv_transpose1d(
+        &input,
+        input_shape,
+        input_stride,
+        &kernel,
+        kernel_shape,
+        kernel_stride,
+        1,
+        1,
+        0,
+        0,
+        "conv_transpose1d_bf16",
+    );
+
+    let expected = vec![1., 4., 10., 20., 25., 24., 16.]
+        .iter()
+        .map(|v| bf16::from_f32(*v))
+        .collect::<Vec<_>>();
+    assert_eq!(results, expected);
+}
+
+#[test]
+fn conv_transpose1d_u8() {
+    let input: Vec<u8> = vec![1, 2, 3, 4];
+    let input_shape = &[1, 1, 4];
+    let input_stride = &[4, 4, 1];
+
+    let kernel: Vec<u8> = vec![1, 2, 3, 4];
+    let kernel_shape = &[1, 1, 4];
+    let kernel_stride = &[4, 4, 1];
+
+    let results = run_conv_transpose1d(
+        &input,
+        input_shape,
+        input_stride,
+        &kernel,
+        kernel_shape,
+        kernel_stride,
+        1,
+        1,
+        0,
+        0,
+        "conv_transpose1d_u8",
+    );
+
+    let expected = vec![1, 4, 10, 20, 25, 24, 16];
+    assert_eq!(results, expected);
+}
+
+#[test]
+fn conv_transpose1d_u32() {
+    let input: Vec<u32> = vec![1, 2, 3, 4];
+    let input_shape = &[1, 1, 4];
+    let input_stride = &[4, 4, 1];
+
+    let kernel: Vec<u32> = vec![1, 2, 3, 4];
+    let kernel_shape = &[1, 1, 4];
+    let kernel_stride = &[4, 4, 1];
+
+    let results = run_conv_transpose1d(
+        &input,
+        input_shape,
+        input_stride,
+        &kernel,
+        kernel_shape,
+        kernel_stride,
+        1,
+        1,
+        0,
+        0,
+        "conv_transpose1d_u32",
+    );
+
+    let expected = vec![1, 4, 10, 20, 25, 24, 16];
+    assert_eq!(results, expected);
+}

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -1735,11 +1735,9 @@ fn run_conv_transpose1d<T: Clone>(
     let command_queue = device.new_command_queue();
     let command_buffer = command_queue.new_command_buffer();
 
-    let c_in_k = kernel_shape[0];
     let c_out = kernel_shape[1];
     let k_size = kernel_shape[2];
     let b_size = input_shape[0];
-    let c_in = input_shape[1];
     let l_in = input_shape[2];
     let l_out = (l_in - 1) * stride - 2 * padding + dilation * (k_size - 1) + out_padding + 1;
     let dst_el = c_out * l_out * b_size;
@@ -1754,9 +1752,6 @@ fn run_conv_transpose1d<T: Clone>(
         command_buffer,
         &kernels,
         name,
-        c_out,
-        l_out,
-        b_size,
         dilation,
         stride,
         padding,
@@ -1778,12 +1773,12 @@ fn run_conv_transpose1d<T: Clone>(
 
 #[test]
 fn conv_transpose1d_f32() {
-    let input = vec![0.0f32, 1.0, 2.0, 3.0];
+    let input = vec![1.0f32, 2.0, 3.0, 4.0];
     let input_shape = &[1, 1, 4];
     let input_stride = &[4, 4, 1];
 
-    let kernel = vec![0.0f32, 1.0, 2.0, 3.0];
-    let kernel_shape = &[1, 1, 2];
+    let kernel = vec![1.0f32, 2.0, 3.0, 4.0];
+    let kernel_shape = &[1, 1, 4];
     let kernel_stride = &[4, 4, 1];
 
     let results = run_conv_transpose1d(
@@ -1800,6 +1795,6 @@ fn conv_transpose1d_f32() {
         "conv_transpose1d_f32",
     );
 
-    let expected = vec![0.0, 0.0, 1.0, 4.0, 12.0, 9.0];
+    let expected = vec![1., 4., 10., 20., 25., 24., 16.];
     assert_eq!(results, expected);
 }


### PR DESCRIPTION
Adds support for the conv_transpose1d function by porting the cuda backend implementation.

Added support for
- f32
- f16
- bf16
- u8
- u32