### PR TITLE
Improve where_cond performance for metal

### DIFF
--- a/candle-metal-kernels/src/ternary.metal
+++ b/candle-metal-kernels/src/ternary.metal
@@ -34,9 +34,20 @@ METAL_FUNC void where_cond(
     if (i >= numel){
        return;
     }
-    uint strided_i = get_strided_index(i, num_dims, dims, strides);
-    uint strided_i_t = get_strided_index(i, num_dims, dims, strides_t);
-    uint strided_i_f = get_strided_index(i, num_dims, dims, strides_f);
+
+    // while calculating the first stride, check if all other strides are the same as the first to skip later
+    bool strides_match = true;
+    uint strided_i = 0;
+    for (uint d = 0; d < num_dims; d++) {
+        if (strides_match && !(strides[d] == strides_t[d] && strides[d] == strides_f[d])) {
+            strides_match = false;
+        }
+        uint dim_idx = num_dims - 1 - d;
+        strided_i += (i % dims[dim_idx]) * strides[dim_idx];
+        i /= dims[dim_idx];
+    }
+    uint strided_i_t = strides_match ? strided_i : get_strided_index(i, num_dims, dims, strides_t);
+    uint strided_i_f = strides_match ? strided_i : get_strided_index(i, num_dims, dims, strides_f);
     out[i] = ids[strided_i] ? t[strided_i_t] : f[strided_i_f];
 }
 

--- a/candle-metal-kernels/src/ternary.metal
+++ b/candle-metal-kernels/src/ternary.metal
@@ -35,17 +35,15 @@ METAL_FUNC void where_cond(
        return;
     }
 
-    // while calculating the first stride, check if all other strides are the same as the first to skip later
     bool strides_match = true;
-    uint strided_i = 0;
     for (uint d = 0; d < num_dims; d++) {
-        if (strides_match && !(strides[d] == strides_t[d] && strides[d] == strides_f[d])) {
+        if (!(strides[d] == strides_t[d] && strides[d] == strides_f[d])) {
             strides_match = false;
+            break;
         }
-        uint dim_idx = num_dims - 1 - d;
-        strided_i += (i % dims[dim_idx]) * strides[dim_idx];
-        i /= dims[dim_idx];
     }
+    
+    uint strided_i = get_strided_index(i, num_dims, dims, strides);
     uint strided_i_t = strides_match ? strided_i : get_strided_index(i, num_dims, dims, strides_t);
     uint strided_i_f = strides_match ? strided_i : get_strided_index(i, num_dims, dims, strides_f);
     out[i] = ids[strided_i] ? t[strided_i_t] : f[strided_i_f];


### PR DESCRIPTION
Optimized by removing the calculation of the strides in the later lines if the strides are identical. Gives a nice 60% reduction in computation time! This only affects the case where the strides are identical for all inputs, still not experienced enough with this sort of codebase to know if that's the general case.

Before:
```

     Running benches/bench_main.rs (/Users/tomsanbear/workspace/github.com/huggingface/candle/target/release/deps/bench_main-6d14ba67934e72b5)
metal_where_cond_f32/iter
                        time:   [554.82 µs 559.58 µs 565.11 µs]
                        thrpt:  [15.553 GiB/s 15.707 GiB/s 15.841 GiB/s]
                 change:
                        time:   [-0.2532% +0.8258% +1.7981%] (p = 0.12 > 0.05)
                        thrpt:  [-1.7663% -0.8190% +0.2539%]
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  5 (5.00%) high mild
  10 (10.00%) high severe

metal_where_cond_bf16/iter
                        time:   [547.20 µs 547.90 µs 548.81 µs]
                        thrpt:  [8.8972 GiB/s 8.9119 GiB/s 8.9232 GiB/s]
                 change:
                        time:   [-1.0194% -0.0965% +0.7947%] (p = 0.84 > 0.05)
                        thrpt:  [-0.7885% +0.0966% +1.0299%]
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe

metal_where_cond_f16/iter
                        time:   [547.18 µs 547.60 µs 548.08 µs]
                        thrpt:  [8.9090 GiB/s 8.9167 GiB/s 8.9237 GiB/s]
                 change:
                        time:   [-0.9490% -0.0499% +0.8704%] (p = 0.92 > 0.05)
                        thrpt:  [-0.8629% +0.0500% +0.9581%]
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe
```

After:
```

     Running benches/bench_main.rs (/Users/tomsanbear/workspace/github.com/huggingface/candle/target/release/deps/bench_main-6d14ba67934e72b5)
metal_where_cond_f32/iter
                        time:   [216.35 µs 217.18 µs 218.12 µs]
                        thrpt:  [40.295 GiB/s 40.469 GiB/s 40.625 GiB/s]
                 change:
                        time:   [-61.271% -60.678% -59.808%] (p = 0.00 < 0.05)
                        thrpt:  [+148.81% +154.31% +158.20%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe

metal_where_cond_bf16/iter
                        time:   [215.17 µs 216.21 µs 217.63 µs]
                        thrpt:  [22.436 GiB/s 22.584 GiB/s 22.692 GiB/s]
                 change:
                        time:   [-61.138% -60.816% -60.526%] (p = 0.00 < 0.05)
                        thrpt:  [+153.33% +155.21% +157.32%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe

metal_where_cond_f16/iter
                        time:   [214.47 µs 214.75 µs 215.02 µs]
                        thrpt:  [22.709 GiB/s 22.737 GiB/s 22.767 GiB/s]
                 change:
                        time:   [-61.132% -60.778% -60.409%] (p = 0.00 < 0.05)
                        thrpt:  [+152.58% +154.96% +157.28%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) low mild
  4 (4.00%) high mild
  7 (7.00%) high severe

```