### PR TITLE
Use the fast RmsNorm in the quantized models.

### DIFF
--- a/candle-transformers/src/models/quantized_mistral.rs
+++ b/candle-transformers/src/models/quantized_mistral.rs
@@ -327,6 +327,7 @@ impl Model {
             xs = layer.forward(&xs, attention_mask.as_ref(), seqlen_offset)?
         }
         xs.narrow(1, seq_len - 1, 1)?
+            .contiguous()?
             .apply(&self.norm)?
             .apply(&self.lm_head)
     }


### PR DESCRIPTION
Start using the fused RmsNorm kernel. On a RTX 4080, the mistral example goes from 77 token/s to 85 token/s.