### PR TITLE
Preliminary support for inplace ops.

### DIFF
--- a/candle-core/src/lib.rs
+++ b/candle-core/src/lib.rs
@@ -74,7 +74,7 @@ pub mod utils;
 mod variable;
 
 pub use cpu_backend::CpuStorage;
-pub use custom_op::{CustomOp1, CustomOp2, CustomOp3};
+pub use custom_op::{CustomOp1, CustomOp2, CustomOp3, InplaceOp1, InplaceOp2, InplaceOp3};
 pub use device::{Device, DeviceLocation, NdArray};
 pub use dtype::{DType, FloatDType, IntDType, WithDType};
 pub use error::{Error, Result};

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -2254,6 +2254,10 @@ impl Tensor {
         self.storage.read().unwrap()
     }
 
+    pub(crate) fn storage_mut(&self) -> std::sync::RwLockWriteGuard<'_, Storage> {
+        self.storage.write().unwrap()
+    }
+
     // If we extend the visibility of this function to be usable outside of this crate, we should
     // make it unsafe.
     pub(crate) fn storage_mut_and_layout(


### PR DESCRIPTION
This PR adds some preliminary support for inplace ops (standard and custom). These ops are key in high performance application to avoid re-allocating buffers over and over + touch generally less memory, however they are tricky to work with. In particular running a backward pass on a forward that used an inplace op is likely to end up being UB.