### PR TITLE
Fix WASM T5 example task

### DIFF
--- a/candle-wasm-examples/t5/utils.js
+++ b/candle-wasm-examples/t5/utils.js
@@ -172,10 +172,6 @@ export const MODELS = {
         max_length: 300,
       },
       simplification: {
-        prefix: "translate English to Romanian: ",
-        max_length: 300,
-      },
-      simplification: {
         prefix: "Paraphrase this: ",
         max_length: 300,
       },


### PR DESCRIPTION
`simplification` should be only paraphrase, not translate.