### PR TITLE
add send and sync trait bounds for scheduler config in stable diffusion models 

### DIFF
--- a/candle-transformers/src/models/stable_diffusion/schedulers.rs
+++ b/candle-transformers/src/models/stable_diffusion/schedulers.rs
@@ -5,7 +5,7 @@
 //! inference speed and quality.
 use candle::{Result, Tensor};
 
-pub trait SchedulerConfig: std::fmt::Debug + Send {
+pub trait SchedulerConfig: std::fmt::Debug + Send + Sync {
     fn build(&self, inference_steps: usize) -> Result<Box<dyn Scheduler>>;
 }
 

--- a/candle-transformers/src/models/stable_diffusion/schedulers.rs
+++ b/candle-transformers/src/models/stable_diffusion/schedulers.rs
@@ -5,7 +5,7 @@
 //! inference speed and quality.
 use candle::{Result, Tensor};
 
-pub trait SchedulerConfig: std::fmt::Debug + Send + Sync + 'static {
+pub trait SchedulerConfig: std::fmt::Debug + Send + Sync {
     fn build(&self, inference_steps: usize) -> Result<Box<dyn Scheduler>>;
 }
 

--- a/candle-transformers/src/models/stable_diffusion/schedulers.rs
+++ b/candle-transformers/src/models/stable_diffusion/schedulers.rs
@@ -5,7 +5,7 @@
 //! inference speed and quality.
 use candle::{Result, Tensor};
 
-pub trait SchedulerConfig: std::fmt::Debug + Send + Sync {
+pub trait SchedulerConfig: std::fmt::Debug + Send + Sync + 'static {
     fn build(&self, inference_steps: usize) -> Result<Box<dyn Scheduler>>;
 }
 

--- a/candle-transformers/src/models/stable_diffusion/schedulers.rs
+++ b/candle-transformers/src/models/stable_diffusion/schedulers.rs
@@ -5,7 +5,7 @@
 //! inference speed and quality.
 use candle::{Result, Tensor};
 
-pub trait SchedulerConfig: std::fmt::Debug {
+pub trait SchedulerConfig: std::fmt::Debug + Send {
     fn build(&self, inference_steps: usize) -> Result<Box<dyn Scheduler>>;
 }
 


### PR DESCRIPTION
Motivation: This small change is needed if we want to operate `StableDiffusion` models across threads.