### PR TITLE
Relax the contiguous check for cuda kernels.

### DIFF
--- a/candle-kernels/src/cuda_utils.cuh
+++ b/candle-kernels/src/cuda_utils.cuh
@@ -14,7 +14,7 @@ __device__ bool is_contiguous(
     size_t acc = 1;
     for (unsigned int d = 0; d < num_dims; d++) {
         unsigned int dim_idx = num_dims - 1 - d;
-        if (acc != strides[dim_idx]) {
+        if (dims[dim_idx] > 1 && acc != strides[dim_idx]) {
             return false;
         }
         acc *= dims[dim_idx];

--- a/candle-nn/src/rnn.rs
+++ b/candle-nn/src/rnn.rs
@@ -31,7 +31,7 @@ pub trait RNN {
         let (_b_size, seq_len, _features) = input.dims3()?;
         let mut output = Vec::with_capacity(seq_len);
         for seq_index in 0..seq_len {
-            let input = input.i((.., seq_index, ..))?;
+            let input = input.i((.., seq_index, ..))?.contiguous()?;
             let state = if seq_index == 0 {
                 self.step(&input, init_state)?
             } else {

--- a/candle-transformers/src/models/segment_anything/prompt_encoder.rs
+++ b/candle-transformers/src/models/segment_anything/prompt_encoder.rs
@@ -218,7 +218,8 @@ impl PromptEncoder {
             (Some(se_points), None) => se_points,
             (None, Some(se_boxes)) => se_boxes,
             (None, None) => {
-                Tensor::zeros((1, 0, self.embed_dim), DType::F32, &candle::Device::Cpu)?
+                let dev = self.no_mask_embed.embeddings().device();
+                Tensor::zeros((1, 0, self.embed_dim), DType::F32, dev)?
             }
         };
 


### PR DESCRIPTION
Ran the tests without any issue. This also include a change in the RNN layout which was broken prior to this change.
Model tested:
- Llama (quantized and unquantized).
- Mistral (quantized and unquantized).
- Stable diffusion.
- Qwen1.5 + the MoE variant.
- Encodec.
- Vision: resnet, blip, efficientnet.
- Segment anything (this includes an unrelated fix to get it to work with cuda).
- RWKV.
- Mamba.
- Clip.