### PR TITLE
Faster mask implementation for mixformers.

### DIFF
--- a/candle-transformers/src/models/mixformer.rs
+++ b/candle-transformers/src/models/mixformer.rs
@@ -310,7 +310,7 @@ impl MHA {
             None => attn_weights,
             Some(mask) => {
                 let _enter = self.span_mask.enter();
-                attn_weights.broadcast_add(&mask)?
+                attn_weights.broadcast_add(mask)?
             }
         };
         let attn_weights = {


### PR DESCRIPTION
When running the moondream example on a 7950x, this reduces the `load_t` step from 7.13s to 6.46s.