### PR TITLE
Add benchmarks for qmatmul operations

### DIFF
--- a/candle-core/benches/bench_main.rs
+++ b/candle-core/benches/bench_main.rs
@@ -2,9 +2,10 @@ mod benchmarks;
 
 use criterion::criterion_main;
 criterion_main!(
-    benchmarks::affine::benches,
-    benchmarks::matmul::benches,
-    benchmarks::random::benches,
-    benchmarks::where_cond::benches,
-    benchmarks::conv_transpose2d::benches,
+    // benchmarks::affine::benches,
+    // benchmarks::matmul::benches,
+    // benchmarks::random::benches,
+    // benchmarks::where_cond::benches,
+    // benchmarks::conv_transpose2d::benches,
+    benchmarks::qmatmul::benches,
 );

--- a/candle-core/benches/bench_main.rs
+++ b/candle-core/benches/bench_main.rs
@@ -2,10 +2,10 @@ mod benchmarks;
 
 use criterion::criterion_main;
 criterion_main!(
-    // benchmarks::affine::benches,
-    // benchmarks::matmul::benches,
-    // benchmarks::random::benches,
-    // benchmarks::where_cond::benches,
-    // benchmarks::conv_transpose2d::benches,
+    benchmarks::affine::benches,
+    benchmarks::matmul::benches,
+    benchmarks::random::benches,
+    benchmarks::where_cond::benches,
+    benchmarks::conv_transpose2d::benches,
     benchmarks::qmatmul::benches,
 );

--- a/candle-core/benches/benchmarks/mod.rs
+++ b/candle-core/benches/benchmarks/mod.rs
@@ -62,7 +62,7 @@ impl BenchDeviceHandler {
         } else if cfg!(feature = "cuda") {
             devices.push(Device::new_cuda(0)?);
         }
-        // devices.push(Device::Cpu);
+        devices.push(Device::Cpu);
         Ok(Self { devices })
     }
 }

--- a/candle-core/benches/benchmarks/mod.rs
+++ b/candle-core/benches/benchmarks/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod affine;
 pub(crate) mod conv_transpose2d;
 pub(crate) mod matmul;
+pub(crate) mod qmatmul;
 pub(crate) mod random;
 pub(crate) mod where_cond;
 
@@ -61,7 +62,7 @@ impl BenchDeviceHandler {
         } else if cfg!(feature = "cuda") {
             devices.push(Device::new_cuda(0)?);
         }
-        devices.push(Device::Cpu);
+        // devices.push(Device::Cpu);
         Ok(Self { devices })
     }
 }

--- a/candle-core/benches/benchmarks/qmatmul.rs
+++ b/candle-core/benches/benchmarks/qmatmul.rs
@@ -13,8 +13,8 @@ fn run(matmul: &QMatMul, x: &Tensor) {
 fn run_bench(c: &mut Criterion, device: &Device, dtype: GgmlDType) {
     let b = 1;
     let m = 1;
-    let n = 2048;
-    let k = 2048;
+    let n = 1024;
+    let k = 1024;
 
     let lhs = (0..(m * k))
         .map(|v| v as f32 / (m * k) as f32)
@@ -31,7 +31,8 @@ fn run_bench(c: &mut Criterion, device: &Device, dtype: GgmlDType) {
 
     let flops = b * m * n * k;
 
-    let mut group = c.benchmark_group(device.bench_name("qmatmul"));
+    let mut group = c.benchmark_group(device.bench_name(format!("qmatmul_{:?}", dtype)));
+    group.sample_size(200);
     group.throughput(Throughput::Bytes(flops as u64));
     group.bench_function("iter", move |b| {
         b.iter_custom(|iters| {
@@ -49,7 +50,20 @@ fn run_bench(c: &mut Criterion, device: &Device, dtype: GgmlDType) {
 fn criterion_benchmark(c: &mut Criterion) {
     let handler = BenchDeviceHandler::new().unwrap();
     for device in handler.devices {
-        for dtype in vec![GgmlDType::Q4K] {
+        for dtype in vec![
+            GgmlDType::F32,
+            GgmlDType::F16,
+            GgmlDType::Q4_0,
+            GgmlDType::Q4_1,
+            GgmlDType::Q5_0,
+            GgmlDType::Q5_1,
+            GgmlDType::Q8_0,
+            GgmlDType::Q2K,
+            GgmlDType::Q3K,
+            GgmlDType::Q4K,
+            GgmlDType::Q5K,
+            GgmlDType::Q6K,
+        ] {
             run_bench(c, &device, dtype);
         }
     }

--- a/candle-core/benches/benchmarks/qmatmul.rs
+++ b/candle-core/benches/benchmarks/qmatmul.rs
@@ -1,0 +1,58 @@
+use crate::benchmarks::{BenchDevice, BenchDeviceHandler};
+use candle_core::{
+    quantized::{self, GgmlDType, QMatMul},
+    Device, Module, Tensor,
+};
+use criterion::{black_box, criterion_group, Criterion, Throughput};
+use std::time::Instant;
+
+fn run(matmul: &QMatMul, x: &Tensor) {
+    matmul.forward(&x).unwrap();
+}
+
+fn run_bench(c: &mut Criterion, device: &Device, dtype: GgmlDType) {
+    let b = 1;
+    let m = 1;
+    let n = 2048;
+    let k = 2048;
+
+    let lhs = (0..(m * k))
+        .map(|v| v as f32 / (m * k) as f32)
+        .collect::<Vec<_>>();
+    let rhs = (0..(k * n))
+        .map(|v| v as f32 / (n * k) as f32)
+        .collect::<Vec<_>>();
+
+    let lhs = Tensor::from_slice(&lhs, (m, k), device).unwrap();
+    let rhs = Tensor::from_slice(&rhs, (k, n), device).unwrap();
+
+    let qtensor = quantized::QTensor::quantize(&rhs.t().unwrap(), dtype).unwrap();
+    let matmul = quantized::QMatMul::from_qtensor(qtensor).unwrap();
+
+    let flops = b * m * n * k;
+
+    let mut group = c.benchmark_group(device.bench_name("qmatmul"));
+    group.throughput(Throughput::Bytes(flops as u64));
+    group.bench_function("iter", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            for _i in 0..iters {
+                run(black_box(&matmul), black_box(&lhs));
+            }
+            device.sync().unwrap();
+            start.elapsed()
+        })
+    });
+    group.finish();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let handler = BenchDeviceHandler::new().unwrap();
+    for device in handler.devices {
+        for dtype in vec![GgmlDType::Q4K] {
+            run_bench(c, &device, dtype);
+        }
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
Adds benchmarks for the qmatmul operation across all the different dtypes, will be useful moving forwards as we tune or adjust our quantized kernels.