### PR TITLE
Refactor usages of "from_raw_parts" to use bytemuck utilities instead

### DIFF
--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -30,6 +30,7 @@ safetensors = { workspace = true }
 thiserror = { workspace = true }
 yoke = { workspace = true }
 zip = { workspace = true }
+bytemuck = "1.15.0"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/candle-core/examples/safetensors.rs
+++ b/candle-core/examples/safetensors.rs
@@ -1,0 +1,9 @@
+use candle_core::quantized::{ggml_file::qtensor_from_ggml, GgmlDType};
+use candle_core::Device;
+
+fn main() {
+    let raw_data: [u8; 1] = [0x1; 1];
+    let dim: Vec<usize> = Vec::from([1usize, 2, 3, 4]);
+    let res = qtensor_from_ggml(GgmlDType::F32, &raw_data, dim, &Device::Cpu);
+    println!("{:?}", res.unwrap().data());
+}

--- a/candle-core/src/quantized/k_quants.rs
+++ b/candle-core/src/quantized/k_quants.rs
@@ -4,6 +4,7 @@ use super::utils::{
 };
 use super::GgmlDType;
 use crate::Result;
+use bytemuck::{Pod, Zeroable};
 use byteorder::{ByteOrder, LittleEndian};
 use half::f16;
 use rayon::prelude::*;
@@ -19,7 +20,7 @@ pub const QK5_1: usize = 32;
 pub const QK8_0: usize = 32;
 pub const QK8_1: usize = 32;
 
-pub trait GgmlType: Sized + Clone + Send + Sync {
+pub trait GgmlType: Sized + Clone + Send + Sync + Pod {
     const DTYPE: GgmlDType;
     const BLCK_SIZE: usize;
     type VecDotType: GgmlType;
@@ -39,7 +40,7 @@ pub trait GgmlType: Sized + Clone + Send + Sync {
     fn vec_dot_unopt(n: usize, xs: &[Self], ys: &[Self::VecDotType]) -> Result<f32>;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy, Zeroable, Pod)]
 #[repr(C)]
 pub struct BlockQ4_0 {
     pub(crate) d: f16,
@@ -47,7 +48,7 @@ pub struct BlockQ4_0 {
 }
 const _: () = assert!(std::mem::size_of::<BlockQ4_0>() == 18);
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy, Zeroable, Pod)]
 #[repr(C)]
 pub struct BlockQ4_1 {
     pub(crate) d: f16,
@@ -56,7 +57,7 @@ pub struct BlockQ4_1 {
 }
 const _: () = assert!(std::mem::size_of::<BlockQ4_1>() == 20);
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy, Zeroable, Pod)]
 #[repr(C)]
 pub struct BlockQ5_0 {
     pub(crate) d: f16,
@@ -65,7 +66,7 @@ pub struct BlockQ5_0 {
 }
 const _: () = assert!(std::mem::size_of::<BlockQ5_0>() == 22);
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy, Zeroable, Pod)]
 #[repr(C)]
 pub struct BlockQ5_1 {
     pub(crate) d: f16,
@@ -75,7 +76,7 @@ pub struct BlockQ5_1 {
 }
 const _: () = assert!(std::mem::size_of::<BlockQ5_1>() == 24);
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy, Zeroable, Pod)]
 #[repr(C)]
 pub struct BlockQ8_0 {
     pub(crate) d: f16,
@@ -83,7 +84,7 @@ pub struct BlockQ8_0 {
 }
 const _: () = assert!(std::mem::size_of::<BlockQ8_0>() == 34);
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy, Zeroable, Pod)]
 #[repr(C)]
 pub struct BlockQ8_1 {
     pub(crate) d: f16,
@@ -92,7 +93,7 @@ pub struct BlockQ8_1 {
 }
 const _: () = assert!(std::mem::size_of::<BlockQ8_1>() == 36);
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy, Zeroable, Pod)]
 #[repr(C)]
 pub struct BlockQ2K {
     pub(crate) scales: [u8; QK_K / 16],
@@ -102,7 +103,7 @@ pub struct BlockQ2K {
 }
 const _: () = assert!(QK_K / 16 + QK_K / 4 + 2 * 2 == std::mem::size_of::<BlockQ2K>());
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy, Zeroable, Pod)]
 #[repr(C)]
 pub struct BlockQ3K {
     pub(crate) hmask: [u8; QK_K / 8],
@@ -112,7 +113,7 @@ pub struct BlockQ3K {
 }
 const _: () = assert!(QK_K / 8 + QK_K / 4 + 12 + 2 == std::mem::size_of::<BlockQ3K>());
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy, Zeroable, Pod)]
 // https://github.com/ggerganov/llama.cpp/blob/468ea24fb4633a0d681f7ac84089566c1c6190cb/k_quants.h#L82
 #[repr(C)]
 pub struct BlockQ4K {
@@ -123,7 +124,7 @@ pub struct BlockQ4K {
 }
 const _: () = assert!(QK_K / 2 + K_SCALE_SIZE + 2 * 2 == std::mem::size_of::<BlockQ4K>());
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy, Zeroable, Pod)]
 #[repr(C)]
 pub struct BlockQ5K {
     pub(crate) d: f16,
@@ -135,7 +136,7 @@ pub struct BlockQ5K {
 const _: () =
     assert!(QK_K / 8 + QK_K / 2 + 2 * 2 + K_SCALE_SIZE == std::mem::size_of::<BlockQ5K>());
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy, Zeroable, Pod)]
 #[repr(C)]
 pub struct BlockQ6K {
     pub(crate) ql: [u8; QK_K / 2],
@@ -145,7 +146,7 @@ pub struct BlockQ6K {
 }
 const _: () = assert!(3 * QK_K / 4 + QK_K / 16 + 2 == std::mem::size_of::<BlockQ6K>());
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy, Zeroable, Pod)]
 #[repr(C)]
 pub struct BlockQ8K {
     pub(crate) d: f32,


### PR DESCRIPTION
Leaving as a draft to solicit feedback on the introduction of this package.

During my research on WebGPU it seemed like this was a pretty common util being used in the webgpu project, it seems like it could be worth offloading the safety of our unsafe code to this purpose built package. If we are open to this then I'll go ahead and replace pretty much all of our usages of the from_raw_parts to use this package so that safety is handled for us. Seems that the CPU package also has a lot of reliance on this too.

When running the example from this [issue](https://github.com/huggingface/candle/issues/2040), this branch correctly throws an error in release builds `cast_slice>TargetAlignmentGreaterAndInputNotAligned` whereas on main the example runs without error.