### PR TITLE
Refactor candle-metal-kernels to accept an encoder instead of a command buffer

### DIFF
--- a/candle-metal-kernels/src/unary.metal
+++ b/candle-metal-kernels/src/unary.metal
@@ -175,5 +175,5 @@ BFLOAT_UNARY_OP(sign)
 
 UNARY(id, bfloat, copy_bf16, copy_bf16_strided)
 
-COPY2D(copy2d_bf16, bfloat)
+COPY2D(copy2d_bf64, bfloat)
 #endif

--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -225,9 +225,10 @@ impl candle::CustomOp1 for SoftmaxLastDim {
         let last_dim = layout.dims()[layout.shape().rank() - 1];
         let elem_count = layout.shape().elem_count();
         let output = device.new_buffer(elem_count, storage.dtype(), "softmax")?;
+        let command_encoder = command_buffer.new_compute_command_encoder();
         candle_metal_kernels::call_last_softmax(
             device.metal_device(),
-            &command_buffer,
+            &command_encoder,
             kernels,
             name,
             elem_count,
@@ -237,6 +238,7 @@ impl candle::CustomOp1 for SoftmaxLastDim {
             &output,
         )
         .map_err(candle::Error::wrap)?;
+        command_encoder.end_encoding();
         let newstorage =
             candle::MetalStorage::new(output, device.clone(), elem_count, storage.dtype());
         Ok((newstorage, layout.shape().clone()))
@@ -410,9 +412,10 @@ impl candle::CustomOp2 for RmsNorm {
         let last_dim = l1.dims()[l1.shape().rank() - 1];
         let elem_count = l1.shape().elem_count();
         let output = device.new_buffer(elem_count, s1.dtype(), "rmsnorm")?;
+        let command_encoder = command_buffer.new_compute_command_encoder();
         candle_metal_kernels::call_rms_norm(
             device.metal_device(),
-            &command_buffer,
+            &command_encoder,
             kernels,
             name,
             elem_count,
@@ -425,6 +428,7 @@ impl candle::CustomOp2 for RmsNorm {
             &output,
         )
         .map_err(candle::Error::wrap)?;
+        command_encoder.end_encoding();
         let newstorage = candle::MetalStorage::new(output, device.clone(), elem_count, s1.dtype());
         Ok((newstorage, l1.shape().clone()))
     }

--- a/candle-nn/src/rotary_emb.rs
+++ b/candle-nn/src/rotary_emb.rs
@@ -177,9 +177,10 @@ impl candle::CustomOp3 for RotaryEmbI {
         let (b, h, t, d) = l_src.shape().dims4()?;
         let el = b * h * t * d;
         let output = device.new_buffer(el, src.dtype(), "rope-i")?;
+        let command_encoder = command_buffer.new_compute_command_encoder();
         candle_metal_kernels::call_rope_i(
             device.metal_device(),
-            &command_buffer,
+            &command_encoder,
             kernels,
             name,
             b * h,
@@ -193,6 +194,7 @@ impl candle::CustomOp3 for RotaryEmbI {
             &output,
         )
         .map_err(candle::Error::wrap)?;
+        command_encoder.end_encoding();
         let out = candle::MetalStorage::new(output, device.clone(), el, src.dtype());
         Ok((out, l_src.shape().clone()))
     }
@@ -430,9 +432,10 @@ impl candle::CustomOp3 for RotaryEmb {
         let (b, h, t, d) = l_src.shape().dims4()?;
         let el = b * h * t * d;
         let output = device.new_buffer(el, src.dtype(), "rope-i")?;
+        let command_encoder = command_buffer.new_compute_command_encoder();
         candle_metal_kernels::call_rope(
             device.metal_device(),
-            &command_buffer,
+            &command_encoder,
             kernels,
             name,
             b * h,
@@ -447,6 +450,7 @@ impl candle::CustomOp3 for RotaryEmb {
             &output,
         )
         .map_err(candle::Error::wrap)?;
+        command_encoder.end_encoding();
         let out = candle::MetalStorage::new(output, device.clone(), el, src.dtype());
         Ok((out, l_src.shape().clone()))
     }
@@ -678,9 +682,10 @@ impl candle::CustomOp3 for RotaryEmbThd {
         let (b, t, h, d) = l_src.shape().dims4()?;
         let el = b * h * t * d;
         let output = device.new_buffer(el, src.dtype(), "rope-thd")?;
+        let command_encoder = command_buffer.new_compute_command_encoder();
         candle_metal_kernels::call_rope_thd(
             device.metal_device(),
-            &command_buffer,
+            &command_encoder,
             kernels,
             name,
             b,
@@ -696,6 +701,7 @@ impl candle::CustomOp3 for RotaryEmbThd {
             &output,
         )
         .map_err(candle::Error::wrap)?;
+        command_encoder.end_encoding();
         let out = candle::MetalStorage::new(output, device.clone(), el, src.dtype());
         Ok((out, l_src.shape().clone()))
     }


### PR DESCRIPTION
This PR is setting up the metal backend for the change proposed in this PR: https://github.com/huggingface/candle/pull/2037

The goal here is to have no actual change at runtime for this diff, but to decrease the complexity of the linked MR above.