### PR TITLE
Move image tensor to device in trocr example

### DIFF
--- a/candle-examples/examples/trocr/main.rs
+++ b/candle-examples/examples/trocr/main.rs
@@ -115,7 +115,7 @@ pub fn main() -> anyhow::Result<()> {
     let processor = image_processor::ViTImageProcessor::new(&processor_config);
 
     let image = vec![args.image.as_str()];
-    let image = processor.preprocess(image)?;
+    let image = processor.preprocess(image)?.to_device(&device)?;
 
     let encoder_xs = model.encoder().forward(&image)?;
 


### PR DESCRIPTION
Was getting `Error: device mismatch in conv2d, lhs: Cpu, rhs: Cuda { gpu_id: 0 }` when running with `--features cuda` but it seems it was just missing the `to_device` call like in https://github.com/huggingface/candle/pull/1856