### PR TITLE
Run metal and accelerate features on CI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -35,7 +35,7 @@ jobs:
         rust: [stable]
         features: [default]
         include:
-          - os: macos-14-arm64
+          - os: macOS-14-arm64
             features: metal
             rust: stable
           - os: macOS-latest

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -31,12 +31,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest]
         rust: [stable]
-        features: ["default"]
+        features: [default]
         include:
           - os: macOS-latest
             features: [default, metal, accelerate]
+            rust: [stable]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -35,7 +35,7 @@ jobs:
         rust: [stable]
         features: [default]
         include:
-          - os: macOS-latest
+          - os: macos-14-arm64
             features: metal
             rust: stable
           - os: macOS-latest

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -35,10 +35,10 @@ jobs:
         rust: [stable]
         features: [default]
         include:
-          - os: macOS-14-arm64
+          - os: macOS-14
             features: metal
             rust: stable
-          - os: macOS-latest
+          - os: macOS-14
             features: accelerate
             rust: stable
     steps:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -31,13 +31,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable]
         features: [default]
         include:
           - os: macOS-latest
-            features: [default, metal, accelerate]
-            rust: [stable]
+            features: metal
+            rust: stable
+          - os: macOS-latest
+            features: accelerate
+            rust: stable
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,6 +1,6 @@
-on: 
+on:
   push:
-    branches: 
+    branches:
       - main
   pull_request:
 
@@ -33,6 +33,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable]
+        features: ["default"]
+        include:
+          - os: macOS-latest
+            features: [default, metal, accelerate]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -43,7 +47,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace
+          args: --workspace --features ${{ matrix.features }}
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
This adds two new configurations that enabled testing the metal and accelerate features. The macos latest runners are run on M1s, as such we should get access to MPS.