### PR TITLE
fix(onnx): No need to install protoc anymore

### DIFF
--- a/candle-onnx/Cargo.toml
+++ b/candle-onnx/Cargo.toml
@@ -15,6 +15,8 @@ candle-nn = { path = "../candle-nn", version = "0.5.0" }
 prost = "0.12.1"
 
 [build-dependencies]
+anyhow = { version = "1", features = ["backtrace"] }
+protox = "0.6.0"
 prost-build = "0.12.1"
 
 [dev-dependencies]

--- a/candle-onnx/README.md
+++ b/candle-onnx/README.md
@@ -2,20 +2,3 @@
 
 This crate adds ONNX support to candle
 
-## FAQ
-
-#### Missing protoc installation when compiling candle-onnx
-
-The candle-onnx dependency prost-build no longer comes bundled with prost
-binaries. This could cause the following error when attempting to compile
-candle-onnx:
-
-```
-error: failed to run custom build command for `candle-onnx`
-Caused by: // (...)
-  Could not find `protoc` installation and this build crate cannot proceed without this knowledge.
-```
-
-To fix this issue install protoc on your system and make it available in your
-system `PATH`. See the [protoc
-documentation](https://grpc.io/docs/protoc-installation/) for more information.

--- a/candle-onnx/build.rs
+++ b/candle-onnx/build.rs
@@ -1,6 +1,5 @@
-use std::io::Result;
-
-fn main() -> Result<()> {
-    prost_build::compile_protos(&["src/onnx.proto3"], &["src/"])?;
+fn main() -> anyhow::Result<()> {
+    let fds = protox::compile(&["src/onnx.proto3"], &["src/"])?;
+    prost_build::compile_fds(fds)?;
     Ok(())
 }


### PR DESCRIPTION
Use a pure rust implementation of `protox` instead of binary `protoc`

`protox` has more friendly error reporting and is better integrated with the rust ecosystem.