### PR TITLE
Use the faster rms-norm kernel for llama.

### DIFF
--- a/candle-nn/src/layer_norm.rs
+++ b/candle-nn/src/layer_norm.rs
@@ -162,6 +162,10 @@ impl RmsNorm {
     pub fn into_inner(self) -> LayerNorm {
         self.0
     }
+
+    pub fn forward_cont(&self, xs: &Tensor) -> Result<Tensor> {
+        crate::ops::rms_norm(xs, &self.0.weight, self.0.eps as f32)
+    }
 }
 
 impl crate::Module for RmsNorm {

--- a/candle-nn/src/layer_norm.rs
+++ b/candle-nn/src/layer_norm.rs
@@ -28,7 +28,7 @@
 //! ```
 //!
 //! [`Layer Normalization`]: https://arxiv.org/abs/1607.06450
-use candle::{DType, Result, Tensor, D};
+use candle::{DType, Module, Result, Tensor, D};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LayerNormConfig {
@@ -105,7 +105,7 @@ impl LayerNorm {
     }
 }
 
-impl crate::Module for LayerNorm {
+impl Module for LayerNorm {
     fn forward(&self, x: &Tensor) -> Result<Tensor> {
         let x_dtype = x.dtype();
         let internal_dtype = match x_dtype {
@@ -163,14 +163,19 @@ impl RmsNorm {
         self.0
     }
 
-    pub fn forward_cont(&self, xs: &Tensor) -> Result<Tensor> {
-        crate::ops::rms_norm(xs, &self.0.weight, self.0.eps as f32)
+    /// Faster variant of the forward kernel, this can only be used on contiguous tensors though.
+    pub fn forward_diff(&self, xs: &Tensor) -> Result<Tensor> {
+        self.0.forward(xs)
     }
 }
 
-impl crate::Module for RmsNorm {
+impl Module for RmsNorm {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        self.0.forward(xs)
+        if xs.is_contiguous() {
+            crate::ops::rms_norm(xs, &self.0.weight, self.0.eps as f32)
+        } else {
+            self.0.forward(xs)
+        }
     }
 }
 

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -1,5 +1,5 @@
 use super::with_tracing::{linear_no_bias as linear, Linear, RmsNorm};
-use candle::{DType, Device, Result, Tensor, D};
+use candle::{DType, Device, IndexOp, Result, Tensor, D};
 use candle_nn::{embedding, Embedding, Module, VarBuilder};
 use std::collections::HashMap;
 
@@ -352,10 +352,10 @@ impl Block {
     ) -> Result<Tensor> {
         let _enter = self.span.enter();
         let residual = x;
-        let x = self.rms_1.forward_cont(x)?;
+        let x = self.rms_1.forward(x)?;
         let x = (self.attn.forward(&x, index_pos, block_idx, cache)? + residual)?;
         let residual = &x;
-        let x = (self.mlp.forward(&self.rms_2.forward_cont(&x)?)? + residual)?;
+        let x = (self.mlp.forward(&self.rms_2.forward(&x)?)? + residual)?;
         Ok(x)
     }
 
@@ -394,7 +394,7 @@ impl Llama {
         for (block_idx, block) in self.blocks.iter().enumerate() {
             x = block.forward(&x, index_pos, block_idx, cache)?;
         }
-        let x = self.ln_f.forward_cont(&x)?;
+        let x = self.ln_f.forward(&x)?;
         let x = x.i((.., seq_len - 1, ..))?.contiguous()?;
         let logits = self.lm_head.forward(&x)?;
         logits.to_dtype(DType::F32)

--- a/candle-transformers/src/models/with_tracing.rs
+++ b/candle-transformers/src/models/with_tracing.rs
@@ -181,9 +181,9 @@ impl RmsNorm {
         Ok(Self { inner, span })
     }
 
-    pub fn forward_cont(&self, x: &Tensor) -> Result<Tensor> {
+    pub fn forward_diff(&self, x: &Tensor) -> Result<Tensor> {
         let _enter = self.span.enter();
-        self.inner.forward_cont(x)
+        self.inner.forward_diff(x)
     }
 }
 

--- a/candle-transformers/src/models/with_tracing.rs
+++ b/candle-transformers/src/models/with_tracing.rs
@@ -180,6 +180,11 @@ impl RmsNorm {
         let inner = candle_nn::rms_norm(size, eps, vb)?;
         Ok(Self { inner, span })
     }
+
+    pub fn forward_cont(&self, x: &Tensor) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        self.inner.forward_cont(x)
+    }
 }
 
 impl Module for RmsNorm {


### PR DESCRIPTION
The llama example was still using the very slow rms-norm variant, this switches it (and all other models) to use the faster kernel.
On a H100 with flash-attn enabled, generation speed for llama-v3 8b goes from 74.4 token/s to 88.4 token/s.