### PR TITLE
Batch llama prompt

### DIFF
--- a/candle-examples/examples/llama/main.rs
+++ b/candle-examples/examples/llama/main.rs
@@ -175,7 +175,7 @@ fn main() -> Result<()> {
         println!("processing the prompt");
         for (chunk_index, chunk) in tokens.chunks(chunk_size).enumerate() {
             let input = Some(Tensor::new(chunk, &device)?.unsqueeze(0)?);
-            prompt_logits = Some(llama.forward(&input.unwrap(), chunk_index * 128, &mut cache)?);
+            prompt_logits = Some(llama.forward(&input.unwrap(), chunk_index * chunk_size, &mut cache)?);
             index_pos += chunk.len();
         }
     }

--- a/candle-examples/examples/llama/main.rs
+++ b/candle-examples/examples/llama/main.rs
@@ -131,8 +131,7 @@ fn main() -> Result<()> {
         let model_id = args.model_id.unwrap_or_else(|| match args.which {
             Which::V1 => "Narsil/amall-7b".to_string(),
             Which::V2 => "meta-llama/Llama-2-7b-hf".to_string(),
-            //Which::V3 => "meta-llama/Meta-Llama-3-8B".to_string(),
-            Which::V3 => "NousResearch/Meta-Llama-3-8B".to_string(),
+            Which::V3 => "meta-llama/Meta-Llama-3-8B".to_string(),
             Which::V3Instruct => "meta-llama/Meta-Llama-3-8B-Instruct".to_string(),
             Which::Solar10_7B => "upstage/SOLAR-10.7B-v1.0".to_string(),
             Which::TinyLlama1_1BChat => "TinyLlama/TinyLlama-1.1B-Chat-v1.0".to_string(),

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -141,7 +141,7 @@ impl Cache {
             let mask: Vec<_> = 
                 (0..t).flat_map(|i| 
                     (0..u).map(move |j| 
-                        u8::from(j > i+(u-t))))
+                        u8::from(j + t > i + u)))
                     .collect();
             let mask = Tensor::from_slice(&mask, (t, u), &self.device)?;
             self.masks.insert((t, u), mask.clone());


### PR DESCRIPTION
This PR is discussed in #2108 and handles mask creation for the Llama model that allows for processing a user supplied prompt in token batches instead of all at once. The key change was to `Cache::mask()`, adding a second `usize` and then creating the appropriately sized vector to turn into a `Tensor` there.

The code in candle-examples/examples/llama/main.rs in this PR may need smoothing, but other than that, I've tested the example with and without the new `--prompt-batch-size` CLI parameter and at a variety of sizes.