### PR TITLE
Update cudarc requirement from 0.11.0 to 0.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ candle-onnx = { path = "./candle-onnx", version = "0.5.1" }
 candle-transformers = { path = "./candle-transformers", version = "0.5.1" }
 clap = { version = "4.2.4", features = ["derive"] }
 criterion = { version = "0.5.1", default-features=false }
-cudarc = { version = "0.11.0", features = ["f16", "cuda-version-from-build-system"] }
+cudarc = { version = "0.11.1", features = ["f16", "cuda-version-from-build-system"] }
 fancy-regex = "0.13.0"
 gemm = { version = "0.17.0", features = ["wasm-simd128-enable"] }
 hf-hub = "0.3.0"


### PR DESCRIPTION
### Upgrading cudarc dependency from v0.11.0 to v0.11.1 due to new version having resolved a compile-time bug.

The 0.11.0 release of cudarc (v0.11.0) contains an issue (https://github.com/coreylowman/cudarc/issues/226) that causes an error during compile time.

The cudarc project has resolved this via a recent commit (https://github.com/coreylowman/cudarc/commit/76430d1d6164309af0b9ba27d30711fd709a69b2) and just made a new release v0.11.1 that contains the fix (https://github.com/coreylowman/cudarc/releases/tag/v0.11.1).

See: https://github.com/huggingface/candle/issues/2173