### PR TITLE
add top_k option to `LogitsProcessor` new method

### DIFF
--- a/candle-examples/examples/blip/main.rs
+++ b/candle-examples/examples/blip/main.rs
@@ -102,7 +102,7 @@ pub fn main() -> anyhow::Result<()> {
     let tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;
     let mut tokenizer = TokenOutputStream::new(tokenizer);
     let mut logits_processor =
-        candle_transformers::generation::LogitsProcessor::new(1337, None, None);
+        candle_transformers::generation::LogitsProcessor::new(1337, None, None, None);
 
     let config = blip::Config::image_captioning_large();
 

--- a/candle-examples/examples/llama2-c/main.rs
+++ b/candle-examples/examples/llama2-c/main.rs
@@ -319,7 +319,7 @@ fn run_inference(args: &InferenceCmd, common_args: &Args) -> Result<()> {
     };
 
     println!("starting the inference loop");
-    let mut logits_processor = LogitsProcessor::new(299792458, args.temperature, args.top_p);
+    let mut logits_processor = LogitsProcessor::new(299792458, args.temperature, args.top_p, None);
     let mut index_pos = 0;
 
     print!("{}", args.prompt);

--- a/candle-examples/examples/llama_multiprocess/main.rs
+++ b/candle-examples/examples/llama_multiprocess/main.rs
@@ -199,7 +199,7 @@ fn main() -> Result<()> {
     } else {
         Some(args.temperature)
     };
-    let mut logits_processor = LogitsProcessor::new(args.seed, temperature, args.top_p);
+    let mut logits_processor = LogitsProcessor::new(args.seed, temperature, args.top_p, None);
     let mut new_tokens = vec![];
     let mut start_gen = std::time::Instant::now();
     let mut index_pos = 0;

--- a/candle-examples/examples/marian-mt/main.rs
+++ b/candle-examples/examples/marian-mt/main.rs
@@ -112,7 +112,7 @@ pub fn main() -> anyhow::Result<()> {
     let mut model = marian::MTModel::new(&config, vb)?;
 
     let mut logits_processor =
-        candle_transformers::generation::LogitsProcessor::new(1337, None, None);
+        candle_transformers::generation::LogitsProcessor::new(1337, None, None, None);
 
     let encoder_xs = {
         let mut tokens = tokenizer

--- a/candle-examples/examples/metavoice/main.rs
+++ b/candle-examples/examples/metavoice/main.rs
@@ -192,7 +192,8 @@ fn main() -> Result<()> {
         Some(spk_emb) => spk_emb.to_dtype(dtype)?,
     };
     let spk_emb = spk_emb.to_device(&device)?;
-    let mut logits_processor = LogitsProcessor::new(args.seed, Some(args.temperature), Some(0.95));
+    let mut logits_processor =
+        LogitsProcessor::new(args.seed, Some(args.temperature), Some(0.95), None);
 
     // First stage generation.
     for index in 0..args.max_tokens {

--- a/candle-examples/examples/quantized-t5/main.rs
+++ b/candle-examples/examples/quantized-t5/main.rs
@@ -184,7 +184,7 @@ fn main() -> Result<()> {
     } else {
         Some(args.temperature)
     };
-    let mut logits_processor = LogitsProcessor::new(299792458, temperature, args.top_p);
+    let mut logits_processor = LogitsProcessor::new(299792458, temperature, args.top_p, None);
     let encoder_output = model.encode(&input_token_ids)?;
     let start = std::time::Instant::now();
 

--- a/candle-examples/examples/t5/main.rs
+++ b/candle-examples/examples/t5/main.rs
@@ -242,7 +242,8 @@ fn main() -> Result<()> {
                 } else {
                     Some(args.temperature)
                 };
-                let mut logits_processor = LogitsProcessor::new(299792458, temperature, args.top_p);
+                let mut logits_processor =
+                    LogitsProcessor::new(299792458, temperature, args.top_p, None);
                 let encoder_output = model.encode(&input_token_ids)?;
                 let start = std::time::Instant::now();
 

--- a/candle-examples/examples/trocr/main.rs
+++ b/candle-examples/examples/trocr/main.rs
@@ -120,7 +120,7 @@ pub fn main() -> anyhow::Result<()> {
     let encoder_xs = model.encoder().forward(&image)?;
 
     let mut logits_processor =
-        candle_transformers::generation::LogitsProcessor::new(1337, None, None);
+        candle_transformers::generation::LogitsProcessor::new(1337, None, None, None);
 
     let mut token_ids: Vec<u32> = vec![decoder_config.decoder_start_token_id];
     for index in 0..1000 {

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -21,12 +21,20 @@ impl LogitsProcessor {
         Self { rng, sampling }
     }
 
-    pub fn new(seed: u64, temperature: Option<f64>, top_p: Option<f64>) -> Self {
+    pub fn new(
+        seed: u64,
+        temperature: Option<f64>,
+        top_p: Option<f64>,
+        top_k: Option<usize>,
+    ) -> Self {
         let temperature = temperature.and_then(|v| if v < 1e-7 { None } else { Some(v) });
         let sampling = match temperature {
             None => Sampling::ArgMax,
             Some(temperature) => match top_p {
-                None => Sampling::All { temperature },
+                None => match top_k {
+                    Some(k) => Sampling::TopK { k, temperature },
+                    None => Sampling::All { temperature },
+                },
                 Some(p) => Sampling::TopP { p, temperature },
             },
         };

--- a/candle-wasm-examples/blip/src/bin/m.rs
+++ b/candle-wasm-examples/blip/src/bin/m.rs
@@ -88,7 +88,7 @@ impl Model {
             SelectedModel::Q(m) => image.unsqueeze(0)?.apply(m.vision_model())?,
         };
         console_log!("image embedded in {:?}s", (Date::now() - start) / 1000.);
-        let mut logits_processor = LogitsProcessor::new(299792458, None, None);
+        let mut logits_processor = LogitsProcessor::new(299792458, None, None, None);
         let mut token_ids = vec![30522u32];
         let mut text: String = "".to_string();
 

--- a/candle-wasm-examples/llama2-c/src/bin/m.rs
+++ b/candle-wasm-examples/llama2-c/src/bin/m.rs
@@ -47,7 +47,7 @@ impl Model {
             tokenizer,
             model: weights,
         });
-        let logits_processor = LogitsProcessor::new(299792458, None, None);
+        let logits_processor = LogitsProcessor::new(299792458, None, None, None);
         match model {
             Ok(inner) => Ok(Self {
                 inner,
@@ -86,7 +86,7 @@ impl Model {
         } else {
             Some(top_p)
         };
-        self.logits_processor = LogitsProcessor::new(seed, temp, top_p);
+        self.logits_processor = LogitsProcessor::new(seed, temp, top_p, None);
         self.repeat_penalty = repeat_penalty;
         self.tokens.clear();
         let tokens = self

--- a/candle-wasm-examples/llama2-c/src/worker.rs
+++ b/candle-wasm-examples/llama2-c/src/worker.rs
@@ -73,7 +73,7 @@ impl Model {
             Some(top_p)
         };
         console_log!("temp: {temp:?} top_p: {top_p:?} prompt: {prompt}");
-        let mut logits_processor = LogitsProcessor::new(299792458, temp, top_p);
+        let mut logits_processor = LogitsProcessor::new(299792458, temp, top_p, None);
         let mut index_pos = 0;
         let mut tokens = self
             .tokenizer

--- a/candle-wasm-examples/moondream/src/bin/m.rs
+++ b/candle-wasm-examples/moondream/src/bin/m.rs
@@ -72,7 +72,7 @@ impl Model {
             SelectedModel::Moondream(model)
         };
         console_log!("model loaded in {:?}s", (Date::now() - start) / 1000.);
-        let logits_processor = LogitsProcessor::new(299792458, None, None);
+        let logits_processor = LogitsProcessor::new(299792458, None, None, None);
         Ok(Self {
             model,
             tokenizer,
@@ -132,7 +132,7 @@ impl Model {
         } else {
             Some(top_p)
         };
-        self.logits_processor = LogitsProcessor::new(seed, temp, top_p);
+        self.logits_processor = LogitsProcessor::new(seed, temp, top_p, None);
         self.repeat_penalty = repeat_penalty;
         self.repeat_last_n = repeat_last_n;
         self.tokens.clear();

--- a/candle-wasm-examples/phi/src/bin/m.rs
+++ b/candle-wasm-examples/phi/src/bin/m.rs
@@ -69,7 +69,7 @@ impl Model {
             SelectedModel::MixFormer(model)
         };
         console_log!("model loaded in {:?}s", (Date::now() - start) / 1000.);
-        let logits_processor = LogitsProcessor::new(299792458, None, None);
+        let logits_processor = LogitsProcessor::new(299792458, None, None, None);
         Ok(Self {
             model,
             tokenizer,
@@ -99,7 +99,7 @@ impl Model {
         } else {
             Some(top_p)
         };
-        self.logits_processor = LogitsProcessor::new(seed, temp, top_p);
+        self.logits_processor = LogitsProcessor::new(seed, temp, top_p, None);
         self.repeat_penalty = repeat_penalty;
         self.repeat_last_n = repeat_last_n;
         self.tokens.clear();

--- a/candle-wasm-examples/t5/src/bin/m-quantized.rs
+++ b/candle-wasm-examples/t5/src/bin/m-quantized.rs
@@ -65,7 +65,7 @@ impl ModelConditionalGeneration {
         } else {
             Some(input.top_p)
         };
-        let mut logits_processor = LogitsProcessor::new(seed, temperature, top_p);
+        let mut logits_processor = LogitsProcessor::new(seed, temperature, top_p, None);
         let tokens = self
             .tokenizer
             .encode(prompt, true)

--- a/candle-wasm-examples/t5/src/bin/m.rs
+++ b/candle-wasm-examples/t5/src/bin/m.rs
@@ -62,7 +62,7 @@ impl ModelConditionalGeneration {
         } else {
             Some(input.top_p)
         };
-        let mut logits_processor = LogitsProcessor::new(seed, temperature, top_p);
+        let mut logits_processor = LogitsProcessor::new(seed, temperature, top_p, None);
         let tokens = self
             .tokenizer
             .encode(prompt, true)


### PR DESCRIPTION
Adds an optional `top_k` parameter to `LogitsProcessor`, so we allow `top_k` sampling externally.