### PR TITLE
Allow the threshold argumet to be negative in the segment-anything example

### DIFF
--- a/candle-examples/examples/segment-anything/main.rs
+++ b/candle-examples/examples/segment-anything/main.rs
@@ -39,7 +39,7 @@ struct Args {
 
     /// The detection threshold for the mask, 0 is the default value, negative values mean a larger
     /// mask, positive makes the mask more selective.
-    #[arg(long, default_value_t = 0.)]
+    #[arg(long, allow_hyphen_values = true, default_value_t = 0.)]
     threshold: f32,
 
     /// Enable tracing (generates a trace-timestamp.json file).


### PR DESCRIPTION
Threshold is 0.0 by default, negative values make more points included, expanding the mask. Positive values make it more picky, making the mask smaller.

Negative numbers start with a minus sign, which normally makes clap consider it a flag.

Without this change:
```
$ cargo run --example segment-anything -- --image assets/single_pt_prompt.jpg --point 0.5,0.5 --threshold -0.5
error: unexpected argument '-0' found

Usage: segment-anything [OPTIONS] --image <IMAGE>

For more information, try '--help'.
```