### PR TITLE
Abstract the `Scheduler` from the `Optimizer`

### DIFF
--- a/candle-nn/src/optim.rs
+++ b/candle-nn/src/optim.rs
@@ -1,20 +1,34 @@
 //! Various optimization algorithms.
+//!
+//! This contains to major traits: `Optimizer` and `Scheduler`. The `Optimizer` is designed to contain
+//! the `Scheduler`, and handles the process of actually doing the optimization. In contrast,
+//! the `Scheduler` purely focuses on the learning rate.
+
+use std::{
+    fmt::Debug,
+    sync::{Arc, Mutex},
+};
+
 use candle::{Result, Tensor, Var};
 
-/// The interface optimizers should implement.
+/// The trait optimizers should implement.
 pub trait Optimizer: Sized {
+    type SchedulerOutput: Sized;
     type Config: Sized;
 
-    fn new(vars: Vec<Var>, config: Self::Config) -> Result<Self>;
+    fn new(
+        vars: Vec<Var>,
+        scheduler: Arc<Mutex<dyn Scheduler<Output = Self::SchedulerOutput>>>,
+        config: Self::Config,
+    ) -> Result<Self>;
 
     fn step(&mut self, grads: &candle::backprop::GradStore) -> Result<()>;
 
-    fn learning_rate(&self) -> f64;
-
-    fn set_learning_rate(&mut self, lr: f64);
-
-    fn empty(config: Self::Config) -> Result<Self> {
-        Self::new(vec![], config)
+    fn empty(
+        scheduler: Arc<Mutex<dyn Scheduler<Output = Self::SchedulerOutput>>>,
+        config: Self::Config,
+    ) -> Result<Self> {
+        Self::new(vec![], scheduler, config)
     }
 
     fn backward_step(&mut self, loss: &Tensor) -> Result<()> {
@@ -22,9 +36,61 @@ pub trait Optimizer: Sized {
         self.step(&grads)
     }
 
-    fn from_slice(vars: &[&Var], config: Self::Config) -> Result<Self> {
+    fn from_slice(
+        vars: &[&Var],
+        scheduler: Arc<Mutex<dyn Scheduler<Output = Self::SchedulerOutput>>>,
+        config: Self::Config,
+    ) -> Result<Self> {
         let vars: Vec<_> = vars.iter().map(|&v| v.clone()).collect();
-        Self::new(vars, config)
+        Self::new(vars, scheduler, config)
+    }
+}
+
+/// A trait to abstract schedulers.
+pub trait Scheduler: Debug {
+    type Output: Sized;
+
+    fn step(&mut self) -> Result<Self::Output>;
+}
+
+/// A trait to simplify construction of schedulers.
+pub trait SchedulerCreator: Debug {
+    type Config: Sized;
+    type Output: Sized;
+
+    fn new(config: Self::Config) -> Result<Arc<Mutex<dyn Scheduler<Output = Self::Output>>>>;
+}
+
+macro_rules! get_scheduler {
+    ($thing:expr) => {
+        loop {
+            if let Ok(inner) = $thing.try_lock() {
+                break inner;
+            }
+        }
+    };
+}
+
+/// A scheduler which maintains a static learning rate.
+#[derive(Debug)]
+pub struct StaticScheduler {
+    lr: f64,
+}
+
+impl Scheduler for StaticScheduler {
+    type Output = f64;
+
+    fn step(&mut self) -> Result<f64> {
+        Ok(self.lr)
+    }
+}
+
+impl SchedulerCreator for StaticScheduler {
+    type Config = f64;
+    type Output = f64;
+
+    fn new(lr: Self::Config) -> Result<Arc<Mutex<dyn Scheduler<Output = Self::Output>>>> {
+        Ok(Arc::new(Mutex::new(Self { lr })))
     }
 }
 
@@ -34,38 +100,34 @@ pub trait Optimizer: Sized {
 #[derive(Debug)]
 pub struct SGD {
     vars: Vec<Var>,
-    learning_rate: f64,
+    scheduler: Arc<Mutex<dyn Scheduler<Output = f64>>>,
 }
 
 impl Optimizer for SGD {
-    type Config = f64;
+    type SchedulerOutput = f64;
+    type Config = ();
 
-    fn new(vars: Vec<Var>, learning_rate: f64) -> Result<Self> {
+    fn new(
+        vars: Vec<Var>,
+        scheduler: Arc<Mutex<dyn Scheduler<Output = f64>>>,
+        _: (),
+    ) -> Result<Self> {
         let vars = vars
             .into_iter()
             .filter(|var| var.dtype().is_float())
             .collect();
-        Ok(Self {
-            vars,
-            learning_rate,
-        })
-    }
-
-    fn learning_rate(&self) -> f64 {
-        self.learning_rate
+        Ok(Self { vars, scheduler })
     }
 
     fn step(&mut self, grads: &candle::backprop::GradStore) -> Result<()> {
+        let mut scheduler = get_scheduler!(self.scheduler);
+        let lr = scheduler.step()?;
         for var in self.vars.iter() {
             if let Some(grad) = grads.get(var) {
-                var.set(&var.sub(&(grad * self.learning_rate)?)?)?;
+                var.set(&var.sub(&(grad * lr)?)?)?;
             }
         }
         Ok(())
-    }
-
-    fn set_learning_rate(&mut self, lr: f64) {
-        self.learning_rate = lr
     }
 }
 
@@ -79,24 +141,76 @@ impl SGD {
     }
 }
 
+/// Parameters for the AdamW scheduler.
 #[derive(Clone, Debug)]
-pub struct ParamsAdamW {
+pub struct SchedulerParamsAdamW {
     pub lr: f64,
     pub beta1: f64,
     pub beta2: f64,
-    pub eps: f64,
     pub weight_decay: f64,
 }
 
-impl Default for ParamsAdamW {
+impl Default for SchedulerParamsAdamW {
     fn default() -> Self {
         Self {
             lr: 0.001,
             beta1: 0.9,
             beta2: 0.999,
-            eps: 1e-8,
             weight_decay: 0.01,
         }
+    }
+}
+
+/// Parameters for the AdamW optimizer.
+#[derive(Clone, Debug)]
+pub struct ParamsAdamW {
+    pub eps: f64,
+}
+
+impl Default for ParamsAdamW {
+    fn default() -> Self {
+        Self { eps: 1e-8 }
+    }
+}
+
+/// A scheduler for AdamW.
+#[derive(Debug)]
+pub struct AdamWScheduler {
+    params: SchedulerParamsAdamW,
+}
+
+#[derive(Debug)]
+pub struct AdamWSchedulerOutput {
+    pub lr: f64,
+    pub lr_lambda: f64,
+    pub beta1: f64,
+    pub beta2: f64,
+}
+
+impl Scheduler for AdamWScheduler {
+    type Output = AdamWSchedulerOutput;
+
+    fn step(&mut self) -> Result<AdamWSchedulerOutput> {
+        let lr = self.params.lr;
+        let lambda = self.params.weight_decay;
+        let lr_lambda = lr * lambda;
+        let beta1 = self.params.beta1;
+        let beta2 = self.params.beta2;
+        Ok(AdamWSchedulerOutput {
+            lr,
+            lr_lambda,
+            beta1,
+            beta2,
+        })
+    }
+}
+
+impl SchedulerCreator for AdamWScheduler {
+    type Config = SchedulerParamsAdamW;
+    type Output = AdamWSchedulerOutput;
+
+    fn new(params: Self::Config) -> Result<Arc<Mutex<dyn Scheduler<Output = Self::Output>>>> {
+        Ok(Arc::new(Mutex::new(Self { params })))
     }
 }
 
@@ -111,13 +225,19 @@ struct VarAdamW {
 pub struct AdamW {
     vars: Vec<VarAdamW>,
     step_t: usize,
+    scheduler: Arc<Mutex<dyn Scheduler<Output = AdamWSchedulerOutput>>>,
     params: ParamsAdamW,
 }
 
 impl Optimizer for AdamW {
+    type SchedulerOutput = AdamWSchedulerOutput;
     type Config = ParamsAdamW;
 
-    fn new(vars: Vec<Var>, params: ParamsAdamW) -> Result<Self> {
+    fn new(
+        vars: Vec<Var>,
+        scheduler: Arc<Mutex<dyn Scheduler<Output = AdamWSchedulerOutput>>>,
+        params: ParamsAdamW,
+    ) -> Result<Self> {
         let vars = vars
             .into_iter()
             .filter(|var| var.dtype().is_float())
@@ -136,26 +256,20 @@ impl Optimizer for AdamW {
             .collect::<Result<Vec<_>>>()?;
         Ok(Self {
             vars,
-            params,
             step_t: 0,
+            scheduler,
+            params,
         })
-    }
-
-    fn learning_rate(&self) -> f64 {
-        self.params.lr
-    }
-
-    fn set_learning_rate(&mut self, lr: f64) {
-        self.params.lr = lr
     }
 
     fn step(&mut self, grads: &candle::backprop::GradStore) -> Result<()> {
         self.step_t += 1;
-        let lr = self.params.lr;
-        let lambda = self.params.weight_decay;
-        let lr_lambda = lr * lambda;
-        let beta1 = self.params.beta1;
-        let beta2 = self.params.beta2;
+        let AdamWSchedulerOutput {
+            lr,
+            lr_lambda,
+            beta1,
+            beta2,
+        } = get_scheduler!(self.scheduler).step()?;
         let scale_m = 1f64 / (1f64 - beta1.powi(self.step_t as i32));
         let scale_v = 1f64 / (1f64 - beta2.powi(self.step_t as i32));
         for var in self.vars.iter() {
@@ -184,11 +298,18 @@ impl Optimizer for AdamW {
 
 impl AdamW {
     pub fn new_lr(vars: Vec<Var>, learning_rate: f64) -> Result<Self> {
-        let params = ParamsAdamW {
+        let params = ParamsAdamW::default();
+        let scheduler_params = SchedulerParamsAdamW {
             lr: learning_rate,
-            ..ParamsAdamW::default()
+            ..SchedulerParamsAdamW::default()
         };
-        Self::new(vars, params)
+        Self::new(
+            vars,
+            Arc::new(Mutex::new(AdamWScheduler {
+                params: scheduler_params,
+            })),
+            params,
+        )
     }
 
     pub fn params(&self) -> &ParamsAdamW {

--- a/candle-nn/tests/optim.rs
+++ b/candle-nn/tests/optim.rs
@@ -8,12 +8,15 @@ use candle::test_utils::{to_vec0_round, to_vec2_round};
 
 use anyhow::Result;
 use candle::{DType, Device, Tensor, Var};
-use candle_nn::{AdamW, Linear, Module, Optimizer, ParamsAdamW, SGD};
+use candle_nn::{
+    optim::{AdamWScheduler, SchedulerCreator, SchedulerParamsAdamW, StaticScheduler},
+    AdamW, Linear, Module, Optimizer, ParamsAdamW, SGD,
+};
 
 #[test]
 fn sgd_optim() -> Result<()> {
     let x = Var::new(0f32, &Device::Cpu)?;
-    let mut sgd = SGD::new(vec![x.clone()], 0.1)?;
+    let mut sgd = SGD::new(vec![x.clone()], StaticScheduler::new(0.1)?, ())?;
     let xt = x.as_tensor();
     for _step in 0..100 {
         let loss = ((xt - 4.2)? * (xt - 4.2)?)?;
@@ -59,7 +62,9 @@ fn sgd_linear_regression() -> Result<()> {
     // Now use backprop to run a linear regression between samples and get the coefficients back.
     let w = Var::new(&[[0f32, 0.]], &Device::Cpu)?;
     let b = Var::new(0f32, &Device::Cpu)?;
-    let mut sgd = SGD::new(vec![w.clone(), b.clone()], 0.004)?;
+
+    let mut sgd = SGD::new(vec![w.clone(), b.clone()], StaticScheduler::new(0.004)?, ())?;
+
     let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
     for _step in 0..1000 {
         let ys = lin.forward(&sample_xs)?;
@@ -106,11 +111,17 @@ fn adamw_linear_regression() -> Result<()> {
     // Now use backprop to run a linear regression between samples and get the coefficients back.
     let w = Var::new(&[[0f32, 0.]], &Device::Cpu)?;
     let b = Var::new(0f32, &Device::Cpu)?;
-    let params = ParamsAdamW {
+
+    let scheduler_params = SchedulerParamsAdamW {
         lr: 0.1,
         ..Default::default()
     };
-    let mut opt = AdamW::new(vec![w.clone(), b.clone()], params)?;
+    let mut opt = AdamW::new(
+        vec![w.clone(), b.clone()],
+        AdamWScheduler::new(scheduler_params)?,
+        ParamsAdamW::default(),
+    )?;
+
     let lin = Linear::new(w.as_tensor().clone(), Some(b.as_tensor().clone()));
     for _step in 0..100 {
         let ys = lin.forward(&sample_xs)?;
@@ -137,11 +148,17 @@ fn adamw_linear_regression_varmap() -> Result<()> {
 
     let w = var_map.get((1, 2), "w", Const(0.), DType::F32, &Device::Cpu)?;
     let b = var_map.get((), "b", Const(0.), DType::F32, &Device::Cpu)?;
-    let params = ParamsAdamW {
+
+    let scheduler_params = SchedulerParamsAdamW {
         lr: 0.1,
         ..Default::default()
     };
-    let mut opt = AdamW::new(var_map.all_vars(), params)?;
+    let mut opt = AdamW::new(
+        var_map.all_vars(),
+        AdamWScheduler::new(scheduler_params)?,
+        ParamsAdamW::default(),
+    )?;
+
     let lin = Linear::new(w, Some(b));
     for _step in 0..100 {
         let ys = lin.forward(&sample_xs)?;


### PR DESCRIPTION
This PR introduces the `Scheduler` trait, which abstracts learning rate control from the `Optimizer`, to allow development of various scheduler algorithms (refs #2224).

Each optimizer takes a trait object scheduler with a specific output type, so it should be easy to mix-and-match different but compatible schedulers and optimizers. I have converted the SGD and AdamW optimizer code. I would appreciate any thoughts on how this design can be improved!