### PR TITLE
Fix dataset id for MNIST

### DIFF
--- a/candle-datasets/src/vision/mnist.rs
+++ b/candle-datasets/src/vision/mnist.rs
@@ -89,7 +89,7 @@ fn load_parquet(parquet: SerializedFileReader<std::fs::File>) -> Result<(Tensor,
 
 pub fn load() -> Result<crate::vision::Dataset> {
     let api = Api::new().map_err(|e| Error::Msg(format!("Api error: {e}")))?;
-    let dataset_id = "mnist".to_string();
+    let dataset_id = "ylecun/mnist".to_string();
     let repo = Repo::with_revision(
         dataset_id,
         RepoType::Dataset,


### PR DESCRIPTION
Attempting to load the MNIST dataset currently results in a somewhat confusing error `Api error: Header etag is missing`, which seems to be a symptom of the dataset simply not existing. 

This can be reproduced with
```
use candle_datasets::vision::mnist;

fn main() {
    mnist::load().unwrap();
}
```