### PR TITLE
Depth Anything v2

### DIFF
--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -26,7 +26,7 @@ image = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
 num-traits = { workspace = true }
 palette = { version = "0.7.6", optional = true }
-enterpolation = "0.2.1"
+enterpolation = { version = "0.2.1", optional = true}
 pyo3 = { version = "0.21.0", features = ["auto-initialize"], optional = true }
 rayon = { workspace = true }
 rubato = { version = "0.15.0", optional = true }
@@ -67,7 +67,7 @@ onnx = ["candle-onnx"]
 metal = ["candle/metal", "candle-nn/metal"]
 microphone = ["cpal"]
 encodec = ["cpal", "symphonia", "rubato"]
-depth_anything_v2 = ["palette"]
+depth_anything_v2 = ["palette", "enterpolation"]
 
 [[example]]
 name = "llama_multiprocess"

--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -25,6 +25,8 @@ hf-hub = { workspace = true, features = ["tokio"] }
 image = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
 num-traits = { workspace = true }
+palette = { version = "0.7.6", optional = true }
+enterpolation = "0.2.1"
 pyo3 = { version = "0.21.0", features = ["auto-initialize"], optional = true }
 rayon = { workspace = true }
 rubato = { version = "0.15.0", optional = true }
@@ -65,6 +67,7 @@ onnx = ["candle-onnx"]
 metal = ["candle/metal", "candle-nn/metal"]
 microphone = ["cpal"]
 encodec = ["cpal", "symphonia", "rubato"]
+depth_anything_v2 = ["palette"]
 
 [[example]]
 name = "llama_multiprocess"
@@ -101,3 +104,7 @@ required-features = ["candle-datasets"]
 [[example]]
 name = "encodec"
 required-features = ["encodec"]
+
+[[example]]
+name = "depth_anything_v2"
+required-features = ["depth_anything_v2"]

--- a/candle-examples/examples/depth_anything_v2/README.md
+++ b/candle-examples/examples/depth_anything_v2/README.md
@@ -1,0 +1,13 @@
+# candle-dinov2
+
+[Depth Anything V2] is a  model for Monocular depth estimation which builds on the [DINOv2](https://github.com/facebookresearch/dinov2) vision transformer.
+
+This example first instantiates the DINOv2 model and then proceeds to create DepthAnythingV2 and run it. 
+
+## Running some example
+
+```bash
+cargo run --example depth_anything_v2 --release -- --image candle-examples/examples/yolo-v8/assets/bike.jpg
+
+```
+

--- a/candle-examples/examples/depth_anything_v2/README.md
+++ b/candle-examples/examples/depth_anything_v2/README.md
@@ -1,13 +1,13 @@
 # candle-dinov2
 
-[Depth Anything V2] is a  model for Monocular depth estimation which builds on the [DINOv2](https://github.com/facebookresearch/dinov2) vision transformer.
+[Depth Anything V2] is a model for Monocular Depth Estimation (MDE, i.e. just using a single image) which
+builds on the [DINOv2](https://github.com/facebookresearch/dinov2) vision transformer.
 
-This example first instantiates the DINOv2 model and then proceeds to create DepthAnythingV2 and run it. 
+This example first instantiates the DINOv2 model and then proceeds to create DepthAnythingV2 and run it.
 
-## Running some example
+## Running an example with color map and CUDA
 
 ```bash
-cargo run --example depth_anything_v2 --release -- --image candle-examples/examples/yolo-v8/assets/bike.jpg
-
+cargo run --features cuda,depth_anything_v2 --package candle-examples --example depth_anything_v2 -- --color-map --image candle-examples/examples/yolo-v8/assets/bike.jpg 
 ```
 

--- a/candle-examples/examples/depth_anything_v2/color_map.rs
+++ b/candle-examples/examples/depth_anything_v2/color_map.rs
@@ -1,5 +1,5 @@
-use enterpolation::Generator;
 use enterpolation::linear::ConstEquidistantLinear;
+use enterpolation::Generator;
 use palette::LinSrgb;
 
 use candle::Tensor;

--- a/candle-examples/examples/depth_anything_v2/color_map.rs
+++ b/candle-examples/examples/depth_anything_v2/color_map.rs
@@ -1,7 +1,8 @@
-use candle::{Shape, Tensor};
-use enterpolation::linear::ConstEquidistantLinear;
 use enterpolation::Generator;
+use enterpolation::linear::ConstEquidistantLinear;
 use palette::LinSrgb;
+
+use candle::Tensor;
 
 pub struct SpectralRColormap {
     gradient: ConstEquidistantLinear<f32, LinSrgb, 9>,
@@ -42,7 +43,7 @@ impl SpectralRColormap {
             candle::bail!("Not enough dims!")
         };
 
-        let color = Tensor::from_vec(rgb_values, Shape::from((*height, *width, 3)), gray.device())?;
+        let color = Tensor::from_vec(rgb_values, (*height, *width, 3), gray.device())?;
 
         color.permute((2, 0, 1))
     }

--- a/candle-examples/examples/depth_anything_v2/color_map.rs
+++ b/candle-examples/examples/depth_anything_v2/color_map.rs
@@ -1,0 +1,49 @@
+use candle::{Shape, Tensor};
+use enterpolation::linear::ConstEquidistantLinear;
+use enterpolation::Generator;
+use palette::LinSrgb;
+
+pub struct SpectralRColormap {
+    gradient: ConstEquidistantLinear<f32, LinSrgb, 9>,
+}
+
+impl SpectralRColormap {
+    pub(crate) fn new() -> Self {
+        // Define a colormap similar to 'Spectral_r' by specifying key colors.
+        // got the colors from ChatGPT-4o
+        let gradient = ConstEquidistantLinear::<f32, _, 9>::equidistant_unchecked([
+            LinSrgb::new(0.3686, 0.3098, 0.6353), // Dark blue
+            LinSrgb::new(0.1961, 0.5333, 0.7412), // Blue
+            LinSrgb::new(0.4000, 0.7608, 0.6471), // Cyan
+            LinSrgb::new(0.6706, 0.8667, 0.6431), // Green
+            LinSrgb::new(0.9020, 0.9608, 0.5961), // Yellow
+            LinSrgb::new(0.9961, 0.8784, 0.5451), // Orange
+            LinSrgb::new(0.9922, 0.6824, 0.3804), // Red
+            LinSrgb::new(0.9569, 0.4275, 0.2627), // Dark red
+            LinSrgb::new(0.8353, 0.2431, 0.3098), // Dark purple
+        ]);
+        Self { gradient }
+    }
+
+    fn get_color(&self, value: f32) -> LinSrgb {
+        self.gradient.gen(value)
+    }
+
+    pub fn gray2color(&self, gray: &Tensor) -> candle::Result<Tensor> {
+        println!("Gray: {:?}", gray.dims());
+        let gray_values: Vec<f32> = gray.flatten_all()?.to_vec1()?;
+        let rgb_values: Vec<f32> = gray_values
+            .iter()
+            .map(|g| self.get_color(*g))
+            .flat_map(|rgb| [rgb.red, rgb.green, rgb.blue])
+            .collect();
+
+        let [.., height, width] = gray.dims() else {
+            panic!("Not enough dims!")
+        };
+
+        let color = Tensor::from_vec(rgb_values, Shape::from((*height, *width, 3)), gray.device())?;
+
+        color.permute((2, 0, 1))
+    }
+}

--- a/candle-examples/examples/depth_anything_v2/color_map.rs
+++ b/candle-examples/examples/depth_anything_v2/color_map.rs
@@ -39,7 +39,7 @@ impl SpectralRColormap {
             .collect();
 
         let [.., height, width] = gray.dims() else {
-            panic!("Not enough dims!")
+            candle::bail!("Not enough dims!")
         };
 
         let color = Tensor::from_vec(rgb_values, Shape::from((*height, *width, 3)), gray.device())?;

--- a/candle-examples/examples/depth_anything_v2/main.rs
+++ b/candle-examples/examples/depth_anything_v2/main.rs
@@ -1,0 +1,122 @@
+//! Depth Anything V2
+//! https://huggingface.co/spaces/depth-anything/Depth-Anything-V2
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+use clap::Parser;
+
+use candle::{DType, Module, Result, Tensor};
+use candle::DType::F32;
+use candle_examples::{load_image, load_image_and_resize, save_image};
+use candle_nn::VarBuilder;
+use candle_transformers::models::depth_anything_v2::DepthAnythingV2;
+use candle_transformers::models::dinov2;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(long)]
+    dinov2_model: Option<String>,
+
+    #[arg(long)]
+    depth_anything_v2_model: Option<String>,
+
+    #[arg(long)]
+    image: String,
+
+    /// Run on CPU rather than on GPU.
+    #[arg(long)]
+    cpu: bool,
+}
+
+const DINO_IMG_SIZE: usize = 518; // multiple of 14: 37
+
+pub fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let device = candle_examples::device(args.cpu)?;
+
+    let (_original_image, original_height, original_width) = load_image(&args.image, None)?;
+    let image = load_image_and_resize(&args.image, DINO_IMG_SIZE, DINO_IMG_SIZE)?
+        .unsqueeze(0)?
+        .to_dtype(F32)?
+        .to_device(&device)?;
+    println!("Loaded image {image:?}");
+
+    let dinov2_model_file = match args.dinov2_model {
+        None => {
+            let api = hf_hub::api::sync::Api::new()?;
+            let api = api.model("lmz/candle-dino-v2".into());
+            api.get("dinov2_vits14.safetensors")?
+        }
+        Some(dinov2_model) => dinov2_model.into(),
+    };
+    println!("Using file {:?}", dinov2_model_file);
+
+    let vb =
+        unsafe { VarBuilder::from_mmaped_safetensors(&[dinov2_model_file], F32, &device)? };
+    let dinov2 = dinov2::vit_small(vb)?;
+    println!("DinoV2 model built");
+
+    let depth_anything_model_file = match args.depth_anything_v2_model {
+        None => {
+            let api = hf_hub::api::sync::Api::new()?;
+            let api = api.model("jeroenvlek/depth-anything-v2-safetensors".into());
+            api.get("depth_anything_v2_vits.safetensors")?
+        }
+        Some(depth_anything_model) => depth_anything_model.into(),
+    };
+
+    println!("Using file {:?}", depth_anything_model_file);
+
+    let vb = unsafe {
+        VarBuilder::from_mmaped_safetensors(&[depth_anything_model_file], DType::F32, &device)?
+    };
+
+    let out_channel_sizes = vec![48, 96, 192, 384];
+    const IN_CHANNEL_SIZE: usize = 384;
+    const NUM_FEATURES: usize = 64;
+    let depth_anything = DepthAnythingV2::new(
+        &dinov2,
+        IN_CHANNEL_SIZE,
+        out_channel_sizes,
+        NUM_FEATURES,
+        vb,
+    )?;
+
+    let depth = depth_anything.forward(&image)?;
+
+    println!("Got image {:?}", depth.shape());
+
+    let depth = post_process_image(&depth, original_height, original_width)?;
+
+    save_image(&depth, "depth_output")?;
+
+    Ok(())
+}
+
+fn post_process_image(
+    image: &Tensor,
+    original_height: usize,
+    original_width: usize,
+) -> Result<Tensor> {
+    let out = image.interpolate2d(original_height, original_width);
+    // let out = normalize_and_scale(&out);
+    out
+}
+
+// fn normalize_and_scale(depth: &Tensor) -> Result<Tensor> {
+//
+//     let min_val = depth.min(0)?;
+//     let max_val = depth.max(0)?;
+//
+//     let depth = depth - &min_val;
+//
+//     let range = &max_val - &min_val;
+//     let depth = depth / &range;
+//
+//     let depth = depth * 255.0;
+//
+//     Ok(depth)
+// }

--- a/candle-examples/examples/depth_anything_v2/main.rs
+++ b/candle-examples/examples/depth_anything_v2/main.rs
@@ -88,20 +88,26 @@ pub fn main() -> anyhow::Result<()> {
 
     let depth = post_process_image(&depth, original_height, original_width)?;
 
-    let input_file_name = args.image.file_name().unwrap();
-    let mut output_file_name = OsString::from("depth_");
-    output_file_name.push(input_file_name);
-    let mut output_path = match args.output_dir {
-        None => args.image.parent().unwrap().to_path_buf(),
-        Some(output_path) => output_path,
-    };
-    output_path.push(output_file_name);
+    let output_path = full_output_path(&args.image, &args.output_dir);
     println!("Saving image to {}", output_path.to_string_lossy());
-
     save_image(&depth, output_path)?;
 
     Ok(())
 }
+
+fn full_output_path(image_path: &PathBuf, output_dir: &Option<PathBuf>) -> PathBuf {
+    let input_file_name = image_path.file_name().unwrap();
+    let mut output_file_name = OsString::from("depth_");
+    output_file_name.push(input_file_name);
+    let mut output_path = match output_dir {
+        None => image_path.parent().unwrap().to_path_buf(),
+        Some(output_path) => output_path.clone(),
+    };
+    output_path.push(output_file_name);
+
+    output_path
+}
+
 
 fn load_and_prep_image(image_path: &PathBuf, device: &Device) -> anyhow::Result<(usize, usize, Tensor)> {
     let (_original_image, original_height, original_width) = load_image(&image_path, None)?;

--- a/candle-examples/examples/depth_anything_v2/main.rs
+++ b/candle-examples/examples/depth_anything_v2/main.rs
@@ -178,8 +178,6 @@ fn scale_image(depth: &Tensor) -> Result<Tensor> {
 
     let min_val = flat_values.iter().min_by(|a, b| a.total_cmp(b)).unwrap();
     let max_val = flat_values.iter().max_by(|a, b| a.total_cmp(b)).unwrap();
-    println!("Min: {min_val}");
-    println!("Max: {max_val}");
 
     let min_val_tensor = Tensor::try_from(*min_val)?
         .to_device(depth.device())?

--- a/candle-examples/examples/depth_anything_v2/main.rs
+++ b/candle-examples/examples/depth_anything_v2/main.rs
@@ -113,6 +113,8 @@ fn normalize_and_scale(depth: &Tensor) -> Result<Tensor> {
 
     let min_val = flat_values.iter().min_by(|a, b| a.total_cmp(b)).unwrap();
     let max_val = flat_values.iter().max_by(|a, b| a.total_cmp(b)).unwrap();
+    println!("Min: {}", min_val);
+    println!("Max: {}", max_val);
 
     let min_val_tensor = Tensor::try_from(*min_val)?
         .to_device(depth.device())?

--- a/candle-examples/examples/depth_anything_v2/main.rs
+++ b/candle-examples/examples/depth_anything_v2/main.rs
@@ -84,6 +84,12 @@ pub fn main() -> anyhow::Result<()> {
         .unsqueeze(0)?
         .to_dtype(F32)?
         .to_device(&device)?;
+
+    let max_pixel_val = Tensor::try_from(255.0f32)?
+        .to_device(&device)?
+        .broadcast_as(image.shape())?;
+    let image = (image / max_pixel_val)?;
+
     println!("Loaded image {image:?}");
 
     let depth = depth_anything.forward(&image)?;

--- a/candle-examples/examples/depth_anything_v2/main.rs
+++ b/candle-examples/examples/depth_anything_v2/main.rs
@@ -162,10 +162,8 @@ fn post_process_image(
         spectral_r.gray2color(&out)?
     } else {
         let rgb_slice = [&out, &out, &out];
-        Tensor::cat(&rgb_slice, 0)?
+        Tensor::cat(&rgb_slice, 0)?.squeeze(1)?
     };
-
-    let out = out.squeeze(1)?;
 
     let max_pixel_val = Tensor::try_from(255.0f32)?
         .to_device(out.device())?

--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -932,7 +932,13 @@ pub struct Identity;
 
 impl Identity {
     pub fn new() -> Identity {
-        Self {}
+        Self
+    }
+}
+
+impl Default for Identity {
+    fn default() -> Self {
+        Self
     }
 }
 

--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -926,3 +926,22 @@ pub fn replication_pad2d(xs: &Tensor, pad: usize) -> Result<Tensor> {
         n => candle::bail!("replication-pad with a size of {n} is not supported"),
     }
 }
+
+#[derive(Clone, Debug)]
+pub struct Identity {}
+
+impl Identity {
+    pub fn new() -> Identity {
+        Self { }
+    }
+
+    pub fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        Ok(xs.clone())
+    }
+}
+
+impl candle::ModuleT for Identity {
+    fn forward_t(&self, xs: &Tensor, _train: bool) -> Result<Tensor> {
+        Ok(xs.clone())
+    }
+}

--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -1,4 +1,4 @@
-use candle::{CpuStorage, DType, Layout, Result, Shape, Tensor, D, Module};
+use candle::{CpuStorage, DType, Layout, Module, Result, Shape, Tensor, D};
 use rayon::prelude::*;
 
 /// Applies the softmax function to the input tensor, rescaling the element so that elements on
@@ -932,9 +932,8 @@ pub struct Identity;
 
 impl Identity {
     pub fn new() -> Identity {
-        Self { }
+        Self {}
     }
-
 }
 
 impl Module for Identity {

--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -928,7 +928,7 @@ pub fn replication_pad2d(xs: &Tensor, pad: usize) -> Result<Tensor> {
 }
 
 #[derive(Clone, Debug)]
-pub struct Identity {}
+pub struct Identity;
 
 impl Identity {
     pub fn new() -> Identity {

--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -1,4 +1,4 @@
-use candle::{CpuStorage, DType, Layout, Result, Shape, Tensor, D};
+use candle::{CpuStorage, DType, Layout, Result, Shape, Tensor, D, Module};
 use rayon::prelude::*;
 
 /// Applies the softmax function to the input tensor, rescaling the element so that elements on
@@ -935,13 +935,10 @@ impl Identity {
         Self { }
     }
 
-    pub fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        Ok(xs.clone())
-    }
 }
 
-impl candle::ModuleT for Identity {
-    fn forward_t(&self, xs: &Tensor, _train: bool) -> Result<Tensor> {
+impl Module for Identity {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         Ok(xs.clone())
     }
 }

--- a/candle-transformers/src/models/depth_anything_v2.rs
+++ b/candle-transformers/src/models/depth_anything_v2.rs
@@ -1,4 +1,5 @@
-use candle_nn::{Activation, BatchNorm, Conv2d, Sequential};
+use candle::Result;
+use candle_nn::{Activation, batch_norm, BatchNorm, BatchNormConfig, Conv2d, conv2d, Conv2dConfig, Sequential, VarBuilder};
 
 use crate::models::dinov2::DinoVisionTransformer;
 
@@ -8,6 +9,43 @@ pub struct ResidualConvUnit {
     conv2: Conv2d,
     batch_norm1: Option<BatchNorm>,
     batch_norm2: Option<BatchNorm>,
+}
+
+impl ResidualConvUnit {
+    pub fn new(num_features: usize, activation: Activation, use_batch_norm: bool, var_builder: VarBuilder) -> Result<Self> {
+        const KERNEL_SIZE: usize = 3;
+        let conv_cfg = Conv2dConfig {
+            padding: 1,
+            stride: 1,
+            dilation: 1,
+            groups: 1,
+        };
+        let conv1 = conv2d(num_features, num_features, KERNEL_SIZE, conv_cfg, var_builder.push_prefix("conv1"))?;
+        let conv2 = conv2d(num_features, num_features, KERNEL_SIZE, conv_cfg, var_builder.push_prefix("conv2"))?;
+
+        
+        let (batch_norm1, batch_norm2) = match use_batch_norm {
+            true => {
+                let batch_norm_cfg = BatchNormConfig {
+                    eps: 1e-05,
+                    remove_mean: false,
+                    affine: true,
+                    momentum: 0.1,
+                };
+                (Some(batch_norm(num_features, batch_norm_cfg, var_builder.push_prefix("batch_norm1"))?), Some(batch_norm(num_features, batch_norm_cfg, var_builder.push_prefix("batch_norm2"))?))
+            },
+            false => (None, None)
+        };
+
+        Ok(Self {
+          activation,
+            conv1,
+            conv2,
+            batch_norm1,
+            batch_norm2
+        })
+
+    }
 }
 
 pub struct FeatureFusionBlock {

--- a/candle-transformers/src/models/depth_anything_v2.rs
+++ b/candle-transformers/src/models/depth_anything_v2.rs
@@ -1,5 +1,5 @@
 use candle::{Module, Result, Tensor};
-use candle_nn::{Activation, batch_norm, BatchNorm, BatchNormConfig, Conv2d, conv2d, Conv2dConfig, Sequential, VarBuilder};
+use candle_nn::{Activation, batch_norm, BatchNorm, BatchNormConfig, Conv2d, conv2d, Conv2dConfig, Sequential, sequential, VarBuilder};
 
 use crate::models::dinov2::DinoVisionTransformer;
 
@@ -73,11 +73,11 @@ pub struct FeatureFusionBlock {
     res_conv_unit1: ResidualConvUnit,
     res_conv_unit2: ResidualConvUnit,
     output_conv: Conv2d,
-    size: (usize, usize),
+    use_scaling: bool,
 }
 
 impl FeatureFusionBlock {
-    pub fn new(num_features: usize, activation: Activation, use_batch_norm: bool, size: (usize, usize), var_builder: VarBuilder) -> Result<Self> {
+    pub fn new(num_features: usize, activation: Activation, use_batch_norm: bool, use_scaling: bool, var_builder: VarBuilder) -> Result<Self> {
         const KERNEL_SIZE: usize = 1;
         let conv_cfg = Conv2dConfig {
             padding: 1,
@@ -85,7 +85,7 @@ impl FeatureFusionBlock {
             dilation: 1,
             groups: 1,
         };
-        let output_conv = conv2d(num_features, num_features, KERNEL_SIZE, conv_cfg, var_builder.push_prefix("output_conf"))?;
+        let output_conv = conv2d(num_features, num_features, KERNEL_SIZE, conv_cfg, var_builder.push_prefix("output_conv"))?;
         let res_conv_unit1 = ResidualConvUnit::new(num_features, activation, use_batch_norm, var_builder.push_prefix("res_conv_unit1"))?;
         let res_conv_unit2 = ResidualConvUnit::new(num_features, activation, use_batch_norm, var_builder.push_prefix("res_conv_unit2"))?;
 
@@ -94,37 +94,136 @@ impl FeatureFusionBlock {
             res_conv_unit1,
             res_conv_unit2,
             output_conv,
-            size,
+            use_scaling,
         })
     }
 }
 
 impl Module for FeatureFusionBlock {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let out = xs.get(0)?;
-        let out = match xs.elem_count() {
-            2 => self.res_conv_unit1.forward(&xs.get(1)?)?,
-            _ => out
-        };
+        // TODO for now this call is moved to Scratch. Not great....
+        // let out = xs.get(0)?;
+        // let out = match xs.elem_count() {
+        //     2 => self.res_conv_unit1.forward(&xs.get(1)?)?,
+        //     _ => out
+        // };
 
-        let out = self.res_conv_unit2.forward(&out)?;
-        let out = out.interpolate2d(self.size.1, self.size.0)?;
+        let out = self.res_conv_unit2.forward(&xs)?;
+        let size = xs.shape();
+        let dims = size.dims();
+        let target_h = if self.use_scaling { dims[-1] * 2 } else { dims[-1] };
+        let target_w = if self.use_scaling { dims[-2] * 2 } else { dims[-2] };
+
+        let out = out.interpolate2d(target_h, target_w)?;
 
         self.output_conv.forward(&out)
     }
 }
 
 pub struct Scratch {
-    layer1_rn: Conv2d,
-    layer2_rn: Conv2d,
-    layer3_rn: Conv2d,
-    layer4_rn: Option<Conv2d>,
+    conv1: Conv2d,
+    conv2: Conv2d,
+    conv3: Conv2d,
+    conv4: Option<Conv2d>,
     refine_net1: FeatureFusionBlock,
     refine_net2: FeatureFusionBlock,
     refine_net3: FeatureFusionBlock,
     refine_net4: FeatureFusionBlock,
     output_conv1: Conv2d,
     output_conv2: Sequential,
+}
+
+impl Scratch {
+    pub fn new(num_channels: Vec<usize>, num_features: usize, use_batch_norm: bool, var_builder: VarBuilder) -> Result<Self> {
+        const KERNEL_SIZE: usize = 3;
+        let conv_cfg = Conv2dConfig {
+            padding: 1,
+            stride: 1,
+            dilation: 1,
+            groups: 1,
+        };
+
+        let conv1 = conv2d(*num_channels.get(0)?, num_features, KERNEL_SIZE, conv_cfg, var_builder.push_prefix("conv1"))?;
+        let conv2 = conv2d(*num_channels.get(1)?, num_features, KERNEL_SIZE, conv_cfg, var_builder.push_prefix("conv2"))?;
+        let conv3 = conv2d(*num_channels.get(2)?, num_features, KERNEL_SIZE, conv_cfg, var_builder.push_prefix("conv3"))?;
+        let conv4 = num_channels.get(3).map(
+            |in_shape|
+                conv2d(*num_channels.get(2)?, num_features, KERNEL_SIZE, conv_cfg, var_builder.push_prefix("conv4"))?
+        );
+
+        let refine_net1 = FeatureFusionBlock::new(num_features, Activation::Relu, use_batch_norm, true, var_builder.push_prefix("refine_net1"))?;
+        let refine_net2 = FeatureFusionBlock::new(num_features, Activation::Relu, use_batch_norm, false, var_builder.push_prefix("refine_net2"))?;
+        let refine_net3 = FeatureFusionBlock::new(num_features, Activation::Relu, use_batch_norm, false, var_builder.push_prefix("refine_net3"))?;
+        let refine_net4 = FeatureFusionBlock::new(num_features, Activation::Relu, use_batch_norm, false, var_builder.push_prefix("refine_net4"))?;
+
+        let conv_cfg = Conv2dConfig {
+            padding: 1,
+            stride: 1,
+            dilation: 1,
+            groups: 1,
+        };
+        let output_conv1 = conv2d(num_features, num_features / 2, KERNEL_SIZE, conv_cfg, var_builder.push_prefix("output_conv1"))?;
+
+        let output_conv2 = sequential::seq();
+        const HEAD_FEATURES_2: usize = 32;
+        const OUT_CHANNELS_2: usize = 1;
+        const KERNEL_SIZE_2: usize = 1;
+        let output_conv2 = output_conv2.add(conv2d(num_features / 2, HEAD_FEATURES_2, KERNEL_SIZE, conv_cfg, var_builder.push_prefix("output_conv2_conv1"))?);
+        let output_conv2 = output_conv2.add(Activation::Relu);
+        let output_conv2 = output_conv2.add(conv2d(HEAD_FEATURES_2, OUT_CHANNELS_2, KERNEL_SIZE_2, conv_cfg, var_builder.push_prefix("output_conv2_conv2"))?);
+        let output_conv2 = output_conv2.add(Activation::Relu);
+
+        Ok(Self {
+            conv1,
+            conv2,
+            conv3,
+            conv4,
+            refine_net1,
+            refine_net2,
+            refine_net3,
+            refine_net4,
+            output_conv1,
+            output_conv2,
+        })
+    }
+}
+
+impl Module for Scratch {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+
+
+        // these are called layer_*_rn in the Python impl
+        let conv1_out = self.conv1.forward(&xs.get(0)?)?;
+        let conv2_out = self.conv2.forward(&xs.get(1)?)?;
+        let conv3_out = self.conv3.forward(&xs.get(2)?)?;
+        let conv4_out = self.conv4.forward(&xs.get(3)?)?;
+
+        let path4 = self.refine_net4.forward(&conv4_out)?;
+
+        let res3_out = self.refine_net3.res_conv_unit1.forward(&conv3_out)?;
+        let res3_out = path4.add(&res3_out)?;
+        let path3 = self.refine_net3.forward(&res3_out)?;
+
+        let res2_out = self.refine_net2.res_conv_unit1.forward(&conv2_out)?;
+        let res2_out = path3.add(&res2_out)?;
+        let path2 = self.refine_net2.forward(&res2_out)?;
+
+        let res1_out = self.refine_net1.res_conv_unit1.forward(&conv1_out)?;
+        let res1_out = path2.add(&res1_out)?;
+        let path1 = self.refine_net1.forward(&res1_out)?;
+
+        let out = self.output_conv1.forward(&path1)?;
+
+        // TODO this needs to be scaled to the correct width and height
+        // which the Python implementation does somewhere else
+        let dims = xs.shape().dims()?;
+        println!("Got dims: {:?}", dims);
+        let [height, width] = dims[-2..];
+
+        let out = out.interpolate2d(height, width)?;
+
+        self.output_conv2.forward(&out)
+    }
 }
 
 pub struct DPTHead {

--- a/candle-transformers/src/models/depth_anything_v2.rs
+++ b/candle-transformers/src/models/depth_anything_v2.rs
@@ -1,0 +1,44 @@
+use candle_nn::{Activation, BatchNorm, Conv2d, Sequential};
+
+use crate::models::dinov2::DinoVisionTransformer;
+
+pub struct ResidualConvUnit {
+    activation: Activation,
+    conv1: Conv2d,
+    conv2: Conv2d,
+    batch_norm1: Option<BatchNorm>,
+    batch_norm2: Option<BatchNorm>,
+}
+
+pub struct FeatureFusionBlock {
+    res_conv_unit1: ResidualConvUnit,
+    res_conv_unit2: ResidualConvUnit,
+    output_conv: Conv2d,
+
+}
+
+pub struct Scratch {
+    layer1_rn: Conv2d,
+    layer2_rn: Conv2d,
+    layer3_rn: Conv2d,
+    layer4_rn: Option<Conv2d>,
+    refine_net1: FeatureFusionBlock,
+    refine_net2: FeatureFusionBlock,
+    refine_net3: FeatureFusionBlock,
+    refine_net4: FeatureFusionBlock,
+    output_conv1: Conv2d,
+    output_conv2: Sequential,
+}
+
+pub struct DPTHead {
+    num_classes: usize,
+    use_class_token: bool,
+    projections: Sequential,
+    resize_layers: Sequential,
+    readout_projections: Option<Sequential>,
+}
+
+pub struct DepthAnythingV2 {
+    pretrained: DinoVisionTransformer,
+    depth_head: DPTHead,
+}

--- a/candle-transformers/src/models/depth_anything_v2.rs
+++ b/candle-transformers/src/models/depth_anything_v2.rs
@@ -20,6 +20,7 @@ pub struct DepthAnythingV2Config {
 }
 
 impl DepthAnythingV2Config {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         out_channel_sizes: Vec<usize>,
         in_channel_size: usize,
@@ -221,7 +222,7 @@ impl FeatureFusionBlock {
 
 impl Module for FeatureFusionBlock {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let out = self.res_conv_unit2.forward(&xs)?;
+        let out = self.res_conv_unit2.forward(xs)?;
         let out = out.interpolate2d(self.target_patch_size, self.target_patch_size)?;
 
         self.output_conv.forward(&out)
@@ -252,7 +253,7 @@ impl Scratch {
         };
 
         let layer1_rn = conv2d_no_bias(
-            *conf.out_channel_sizes.get(0).unwrap(),
+            *conf.out_channel_sizes.first().unwrap(),
             conf.num_features,
             KERNEL_SIZE,
             conv_cfg,

--- a/candle-transformers/src/models/dinov2.rs
+++ b/candle-transformers/src/models/dinov2.rs
@@ -268,7 +268,9 @@ impl DinoVisionTransformer {
                 output.push(xs.clone());
             }
         }
-        assert_eq!(output.len(), blocks_to_take.len(), "only {} / {} blocks found", output.len(), blocks_to_take.len());
+        if output.len() != blocks_to_take.len() {
+            candle::bail!("only {} / {} blocks found", output.len(), blocks_to_take.len());
+        }
         Ok(output)
     }
 

--- a/candle-transformers/src/models/dinov2.rs
+++ b/candle-transformers/src/models/dinov2.rs
@@ -259,7 +259,7 @@ impl DinoVisionTransformer {
         &xs + &self.interpolate_pos_encoding(&xs, w, h)?
     }
 
-    fn get_intermediate_layers_not_chunked(&self, xs: &Tensor, blocks_to_take: Vec<usize>) -> Result<Vec<Tensor>> {
+    fn get_intermediate_layers_not_chunked(&self, xs: &Tensor, blocks_to_take: &Vec<usize>) -> Result<Vec<Tensor>> {
         let mut xs = self.prepare_tokens_with_mask(xs)?;
         let mut output = Vec::new();
         for (i, blk) in self.blocks.iter().enumerate() {
@@ -278,7 +278,7 @@ impl DinoVisionTransformer {
     pub fn get_intermediate_layers(
         &self,
         xs: &Tensor,
-        blocks_to_take: Vec<usize>,
+        blocks_to_take: &Vec<usize>,
         reshape: bool,
         return_class_token: bool,
         norm: bool,

--- a/candle-transformers/src/models/dinov2.rs
+++ b/candle-transformers/src/models/dinov2.rs
@@ -262,7 +262,7 @@ impl DinoVisionTransformer {
     fn get_intermediate_layers_not_chunked(
         &self,
         xs: &Tensor,
-        blocks_to_take: &Vec<usize>,
+        blocks_to_take: &[usize],
     ) -> Result<Vec<Tensor>> {
         let mut xs = self.prepare_tokens_with_mask(xs)?;
         let mut output = Vec::new();
@@ -285,7 +285,7 @@ impl DinoVisionTransformer {
     pub fn get_intermediate_layers(
         &self,
         xs: &Tensor,
-        blocks_to_take: &Vec<usize>,
+        blocks_to_take: &[usize],
         reshape: bool,
         return_class_token: bool,
         norm: bool,
@@ -305,7 +305,7 @@ impl DinoVisionTransformer {
             .collect::<Result<Vec<_>>>()?;
         let outputs = outputs
             .iter()
-            .map(|out| out.i((.., 1..)).map(|out| out.clone()))
+            .map(|out| out.i((.., 1..)))
             .collect::<Result<Vec<_>>>()?;
 
         let outputs = if reshape {

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -67,3 +67,4 @@ pub mod whisper;
 pub mod with_tracing;
 pub mod wuerstchen;
 pub mod yi;
+mod depth_anything_v2;

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod chatglm;
 pub mod clip;
 pub mod convmixer;
 pub mod convnext;
+pub mod depth_anything_v2;
 pub mod dinov2;
 pub mod distilbert;
 pub mod efficientnet;
@@ -67,4 +68,4 @@ pub mod whisper;
 pub mod with_tracing;
 pub mod wuerstchen;
 pub mod yi;
-mod depth_anything_v2;
+

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -68,4 +68,3 @@ pub mod whisper;
 pub mod with_tracing;
 pub mod wuerstchen;
 pub mod yi;
-


### PR DESCRIPTION
This PR adds [Depth Anything V2](https://depth-anything-v2.github.io/), which is based on the already present DinoVisionTransformer.  I'm still adding the [Spectral-R coloring](https://huggingface.co/spaces/depth-anything/Depth-Anything-V2/blob/main/run.py#L51), but this led me to another question on the list, so I thought it wise to open a (preliminary) PR to get some early answers and feedback. So here goes:

1. Currently the port is following the Python code very closely. However, the separation of concerns in the original code is not necessarily the level of encapsulation I would have chosen (e.g. the scratch layer is accessed from the head). What is your standpoint here: Stick to the original code as closely as makes sense, or improve it where you can?
2. Can I add palette as a dep to candle-examples for the spectral coloring (or use an alternative)?
3. Currently the module is named depth_anything_v2, is that ok or do you prefer a different scheme (no/less underscores)?
4. Developing this model it was very useful for me to print the list of safetensor names, shall I add that functionality to candle-examples/src/lib.rs, or maybe even the safetensors related code? (It's only a few lines, but I'm guessing more people could benefit)
5. I've added an Identity() op, analog to the one in [PyTorch](https://pytorch.org/docs/stable/generated/torch.nn.Identity.html), there's other ways to deal with a no-op though, so is this ok?

### Example:

```rust
    let out_channel_sizes = vec![48, 96, 192, 384];
    const IN_CHANNEL_SIZE: usize = 384;
    const NUM_FEATURES: usize = 64;
    let depth_anything = DepthAnythingV2::new(
        &dinov2,
        IN_CHANNEL_SIZE,
        out_channel_sizes,
        NUM_FEATURES,
        vb,
    )?;
    let (original_height, original_width, image) = load_and_prep_image(&args.image, &device)?;

    let depth = depth_anything.forward(&image)?;

    let depth = post_process_image(&depth, original_height, original_width)?;

    save_image(&depth, output_path)?;
