### PR TITLE
Depth Anything V2: Bigger Models

### DIFF
--- a/candle-examples/examples/depth_anything_v2/main.rs
+++ b/candle-examples/examples/depth_anything_v2/main.rs
@@ -80,7 +80,7 @@ pub fn main() -> anyhow::Result<()> {
 
     let vb_head = unsafe { VarBuilder::from_mmaped_safetensors(&[head_path], F32, &device)? };
 
-    let dinov2 = dinov2::vit_small(vb, vb_head)?;
+    let dinov2 = dinov2::vit_small(vb, Some(vb_head))?;
     println!("DinoV2 model built");
 
     let depth_anything_path = match args.depth_anything_v2_model {

--- a/candle-examples/examples/dinov2/main.rs
+++ b/candle-examples/examples/dinov2/main.rs
@@ -10,6 +10,7 @@ extern crate accelerate_src;
 use clap::Parser;
 
 use candle::{DType, IndexOp, D};
+use candle::DType::F32;
 use candle_nn::{Module, VarBuilder};
 use candle_transformers::models::dinov2;
 
@@ -17,6 +18,9 @@ use candle_transformers::models::dinov2;
 struct Args {
     #[arg(long)]
     model: Option<String>,
+
+    #[arg(long)]
+    head: Option<String>,
 
     #[arg(long)]
     image: String,
@@ -34,17 +38,34 @@ pub fn main() -> anyhow::Result<()> {
     let image = candle_examples::imagenet::load_image224(args.image)?.to_device(&device)?;
     println!("loaded image {image:?}");
 
-    let model_file = match args.model {
+    let dinov2_model_file = match args.model {
         None => {
             let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("lmz/candle-dino-v2".into());
-            api.get("dinov2_vits14.safetensors")?
+            let api = api.model("facebook/dinov2-small".into());
+            api.get("model.safetensors")?
         }
-        Some(model) => model.into(),
+        Some(dinov2_model) => dinov2_model.into(),
     };
-    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], DType::F32, &device)? };
-    let model = dinov2::vit_small(vb)?;
-    println!("model built");
+    println!("Using dinov2 file {:?}", dinov2_model_file);
+
+    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[dinov2_model_file], F32, &device)? };
+
+    let dinov2_head_file = match args.head {
+        None => {
+            let api = hf_hub::api::sync::Api::new()?;
+            let api = api.model("jeroenvlek/dinov2-linear-heads-safetensors".into());
+            api.get("dinov2_vits14_linear_head.safetensors")?
+        }
+        Some(dinov2_head) => dinov2_head.into(),
+    };
+    println!("Using dinov2 head file {:?}", dinov2_head_file);
+
+    let vb_head =
+        unsafe { VarBuilder::from_mmaped_safetensors(&[dinov2_head_file], F32, &device)? };
+
+    let model = dinov2::vit_small(vb, vb_head)?;
+    println!("DinoV2 model built");
+
     let logits = model.forward(&image.unsqueeze(0)?)?;
     let prs = candle_nn::ops::softmax(&logits, D::Minus1)?
         .i(0)?

--- a/candle-examples/examples/dinov2/main.rs
+++ b/candle-examples/examples/dinov2/main.rs
@@ -9,8 +9,8 @@ extern crate accelerate_src;
 
 use clap::Parser;
 
-use candle::{DType, IndexOp, D};
 use candle::DType::F32;
+use candle::{DType, IndexOp, D};
 use candle_nn::{Module, VarBuilder};
 use candle_transformers::models::dinov2;
 
@@ -46,7 +46,7 @@ pub fn main() -> anyhow::Result<()> {
         }
         Some(dinov2_model) => dinov2_model.into(),
     };
-    println!("Using dinov2 file {:?}", dinov2_model_file);
+    println!("Using Dinov2 file {:?}", dinov2_model_file);
 
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[dinov2_model_file], F32, &device)? };
 
@@ -58,12 +58,12 @@ pub fn main() -> anyhow::Result<()> {
         }
         Some(dinov2_head) => dinov2_head.into(),
     };
-    println!("Using dinov2 head file {:?}", dinov2_head_file);
+    println!("Using Dinov2 head file {:?}", dinov2_head_file);
 
     let vb_head =
         unsafe { VarBuilder::from_mmaped_safetensors(&[dinov2_head_file], F32, &device)? };
 
-    let model = dinov2::vit_small(vb, vb_head)?;
+    let model = dinov2::vit_small(vb, Some(vb_head))?;
     println!("DinoV2 model built");
 
     let logits = model.forward(&image.unsqueeze(0)?)?;


### PR DESCRIPTION
Sorry to open a draft again, but while adding more models I found out why the DinoV2 example loads its safetensors from a different location than Facebook's own HF space: Facebook's safetensors have the query, key and value layers separate, whereas the original Python code, and thus the Candle implementation, have a single QKV layer. Furthermore, the original model file relies on separate head weights (guessing the head is not even necessary for DepthAnything, so might remove from example)

**So what I've done here:**

* Load the weights from Facebook's HF space and pack them together into a linear QKV layer
* Make the head optional with an optional VarBuilder
* Downloaded all head files from Facebook's GitHub and converted them to safetensors in my [own HF space](https://huggingface.co/jeroenvlek/dinov2-linear-heads-safetensors/tree/main)


**Question:** Do you agree with this approach? 

Happy to adapt to other ideas, but if you agree, I will continue adding the base, large and giant models.

PS: I saw you also did some formatting on my previous PR and fixed some Clippy warnings. Maybe it's an idea to have a Contributor page that details the formatting requirements and other conventions?
