### PR TITLE
Add method to access a sub-layer in Sequential.

### DIFF
--- a/candle-nn/src/sequential.rs
+++ b/candle-nn/src/sequential.rs
@@ -21,6 +21,11 @@ impl Sequential {
     pub fn is_empty(&self) -> bool {
         self.layers.is_empty()
     }
+
+    /// Returns a reference to the specified sub-layer.
+    pub fn layer(&self, index: i64) -> Option<&dyn Module> {
+        self.layers.get(index as usize).map(|l| &**l)
+    }
 }
 
 impl Module for Sequential {


### PR DESCRIPTION
Trivial addition to [Sequential](https://docs.rs/candle-nn/latest/candle_nn/sequential/struct.Sequential.html) that allows obtaining a reference to a sublayer.

I used an index type of `i64` because that's what `len()` currently returns, I'm not sure why it is using an `i64` and not an `usize`?