### PR TITLE
make up for the missing last token output of phi2 example

### DIFF
--- a/candle-examples/examples/phi/main.rs
+++ b/candle-examples/examples/phi/main.rs
@@ -114,6 +114,10 @@ impl TextGeneration {
             tokens.push(next_token);
             generated_tokens += 1;
             if next_token == eos_token {
+                if let Some(t) = self.tokenizer.decode_rest()? {
+                    print!("{t}");
+                    std::io::stdout().flush()?;
+                }
                 break;
             }
             if let Some(t) = self.tokenizer.next_token(next_token)? {


### PR DESCRIPTION
I tried out the sample command provided in the README.md file:
```
$ cargo run --example phi --release -- --model 2 \
  --prompt "A skier slides down a frictionless slope of height 40m and length 80m. What's the skier speed at the bottom?"

...

loaded the model in 12.820701458s
starting the inference loop
A skier slides down a frictionless slope of height 40m and length 80m. What's the skier speed at the bottom?

Solution:
The potential energy of the skier is converted into kinetic energy as it slides down the slope. The formula for potential energy is mgh, where m is mass, g is acceleration due to gravity (9.8 m/s^2), and h is height. Since there's no friction, all the potential energy is converted into kinetic energy at the bottom of the slope. The formula for kinetic energy is 1/2mv^2, where v is velocity. We can equate these two formulas:
mgh = 1/2mv^2
Solving for v, we get:
v = sqrt(2gh)
Substituting the given values, we get:
v = sqrt(2*9.8*40) = 28 m/s
Therefore, the skier speed at the bottom of the slope is 28 m/s
188 tokens generated (2.49 token/s)
```

... and noticed the last line of the LLM output lacks the concluding period, which is not consistent with the README.md example's output:

https://github.com/huggingface/candle/blob/e27aac0a062a6de125e2984eacdb7841664e86fd/candle-examples/examples/phi/README.md?plain=1#L28

Apparently, when the EOS token is encountered, the existing source code of the example doesn't invoke the decode_rest function to make use of the pending undecoded tokens. This PR adds this back to fix the problem and matches the output with what's shown in the example README.