### PR TITLE
Pinning cudarc to 0.11.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ candle-onnx = { path = "./candle-onnx", version = "0.6.0" }
 candle-transformers = { path = "./candle-transformers", version = "0.6.0" }
 clap = { version = "4.2.4", features = ["derive"] }
 criterion = { version = "0.5.1", default-features=false }
-cudarc = { version = "0.11.4", features = ["std", "cublas", "cublaslt", "curand", "driver", "nvrtc", "f16", "cuda-version-from-build-system", "dynamic-linking"], default-features=false }
+cudarc = { version = "=0.11.6", features = ["std", "cublas", "cublaslt", "curand", "driver", "nvrtc", "f16", "cuda-version-from-build-system", "dynamic-linking"], default-features=false }
 fancy-regex = "0.13.0"
 gemm = { version = "0.17.0", features = ["wasm-simd128-enable"] }
 hf-hub = "0.3.0"


### PR DESCRIPTION
This PR pins `cudarc` to a known working version and resolves #2331. I have tested this change across two official nvidia cuda containers. One with a version prior to support (`nvidia/cuda:12.0.0-cudnn8-devel-ubuntu20.04`) and one post (`nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04`) and the examples I tested work as expected.