### PR TITLE
WIP: Precompile metal kernels into `.metallib` files

### DIFF
--- a/candle-metal-kernels/Cargo.toml
+++ b/candle-metal-kernels/Cargo.toml
@@ -23,3 +23,7 @@ half = { version = "2.3.1", features = [
   "rand_distr",
 ] }
 rand = "0.8.5"
+
+[build-dependencies]
+anyhow = "1.0.44"
+convert_case = "0.6.0"

--- a/candle-metal-kernels/build.rs
+++ b/candle-metal-kernels/build.rs
@@ -1,0 +1,117 @@
+use anyhow::Result;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::{env, fs};
+
+fn main() -> Result<()> {
+    let kernel_files: Vec<PathBuf> = kernel_source_files()?;
+    let mut metallib_files: Vec<PathBuf> = Vec::with_capacity(kernel_files.len());
+
+    for kernel_file in kernel_files {
+        let ir_path = compile_kernel(kernel_file)?;
+        let metallib_path = link_kernel(ir_path)?;
+        metallib_files.push(metallib_path);
+    }
+
+    gen_metallibs_rs(metallib_files)?;
+
+    Ok(())
+}
+
+fn kernel_source_files() -> Result<Vec<PathBuf>> {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR")?;
+    let src_dir = Path::new(&manifest_dir).join("src");
+
+    let mut paths = Vec::new();
+    for entry in fs::read_dir(src_dir)? {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.extension().map(|ext| ext.to_str().unwrap()) == Some("metal") {
+            paths.push(path);
+        }
+    }
+
+    Ok(paths)
+}
+
+fn compile_kernel(kernel_path: impl AsRef<Path>) -> Result<PathBuf> {
+    let out_dir = std::env::var("OUT_DIR")?;
+
+    let ir_file_name = format!(
+        "{}.ir",
+        kernel_path.as_ref().file_stem().unwrap().to_str().unwrap()
+    );
+
+    let output_file = Path::new(&out_dir).join(ir_file_name);
+
+    let mut command = std::process::Command::new("xcrun");
+    command.arg("metal");
+    command.arg("-c");
+    command.arg(format!("{}", kernel_path.as_ref().display()));
+    command.arg("-o");
+    command.arg(format!("{}", output_file.display()));
+
+    let status = command.status()?;
+
+    if !status.success() {
+        return Err(anyhow::anyhow!(
+            "Failed to compile kernel file: {:?}",
+            kernel_path.as_ref()
+        ));
+    }
+
+    Ok(output_file)
+}
+
+fn link_kernel(ir_path: impl AsRef<Path>) -> Result<PathBuf> {
+    let out_dir = std::env::var("OUT_DIR")?;
+
+    let metallib_file_name = format!(
+        "{}.metallib",
+        ir_path.as_ref().file_stem().unwrap().to_str().unwrap()
+    );
+
+    let output_file = Path::new(&out_dir).join(metallib_file_name);
+
+    let mut command = std::process::Command::new("xcrun");
+    command.arg("metallib");
+    command.arg(format!("{}", ir_path.as_ref().display()));
+    command.arg("-o");
+    command.arg(format!("{}", output_file.display()));
+
+    let status = command.status()?;
+
+    if !status.success() {
+        return Err(anyhow::anyhow!(
+            "Failed to link kernel file: {:?}",
+            ir_path.as_ref()
+        ));
+    }
+
+    Ok(output_file)
+}
+
+fn gen_metallibs_rs(metallibs: Vec<PathBuf>) -> Result<()> {
+    use convert_case::{Case, Casing};
+
+    // generate a rust source file that contains an include_bytes constant
+    // for every metallib file
+    let out_dir = std::env::var("OUT_DIR")?;
+    let out_file = Path::new(&out_dir).join("candle_metallibs.rs");
+
+    let mut file = fs::File::create(&out_file)?;
+
+    // writeln!(file, "pub mod metallibs {{")?;
+    for metallib in metallibs {
+        let name = metallib.file_stem().unwrap().to_str().unwrap();
+        writeln!(
+            file,
+            "    pub const {}: &'static [u8] = include_bytes!(\"{}\");",
+            name.to_case(Case::ScreamingSnake),
+            metallib.display()
+        )?;
+    }
+    // writeln!(file, "}}")?;
+
+    Ok(())
+}


### PR DESCRIPTION
I'm running into an issue where the first time I call `apply_repeat_penalty`, it takes a very long time (in excess of 6 seconds). It seems to be coming from the `Tensor::to_vec1d` call to move the logits into a `Vec<f32>`. It seems like a simple copy like this would be very fast. 

It was suggested on Discord that this slowness might be due to some other async stuff happening in Metal, maybe the compilation of the kernels on first load. 

This PR precompiles the kernels at build time instead of on every run. Unfortunately, it doesn't seem to solve my problem but it might be useful for other reasons. 