### PR TITLE
Fix CLIP example README title

### DIFF
--- a/candle-examples/examples/clip/README.md
+++ b/candle-examples/examples/clip/README.md
@@ -1,4 +1,4 @@
-Contrastive Language-Image Pre-Training
+# candle-clip
 
 Contrastive Language-Image Pre-Training (CLIP) is an architecture trained on
 pairs of images with related texts.


### PR DESCRIPTION
I going through examples in the project and I noticed that the CLIP example README title was different (probably a mistake) than other examples.

I tried following the same standard as done in these files:
- `./candle-examples/examples/blip/README.md`
- `./candle-examples/examples/trocr/README.md`
- `./candle-examples/examples/marian-mt/README.md`
- `./candle-examples/examples/segformer/README.md`