### PR TITLE
Change DTypes in candle-wasm-examples/bert (fixes #2355)

### DIFF
--- a/candle-wasm-examples/bert/src/bin/m.rs
+++ b/candle-wasm-examples/bert/src/bin/m.rs
@@ -18,7 +18,7 @@ impl Model {
         console_error_panic_hook::set_once();
         console_log!("loading model");
         let device = &Device::Cpu;
-        let vb = VarBuilder::from_buffered_safetensors(weights, DType::F64, device)?;
+        let vb = VarBuilder::from_buffered_safetensors(weights, DType::F32, device)?;
         let config: Config = serde_json::from_slice(&config)?;
         let tokenizer =
             Tokenizer::from_bytes(&tokenizer).map_err(|m| JsError::new(&m.to_string()))?;
@@ -78,7 +78,7 @@ impl Model {
 
 #[derive(serde::Serialize, serde::Deserialize)]
 struct Embeddings {
-    data: Vec<Vec<f64>>,
+    data: Vec<Vec<f32>>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
This PR changes DTypes from F64 to F32 to allow the example to run and to match the DTypes in candle-transformers. Fixes #2355.