### PR TITLE
Bump image crate version so ImageReader is available without aliasing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ gemm = { version = "0.17.0", features = ["wasm-simd128-enable"] }
 hf-hub = "0.3.0"
 half = { version = "2.3.1", features = ["num-traits", "use-intrinsics", "rand_distr"] }
 hound = "3.5.1"
-image = { version = "0.25.0", default-features = false, features = ["jpeg", "png"] }
+image = { version = "0.25.2", default-features = false, features = ["jpeg", "png"] }
 imageproc = { version = "0.24.0", default-features = false }
 intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"] }
 libc = { version = "0.2.147" }


### PR DESCRIPTION
In the image crate [v0.25.0](https://docs.rs/image/0.25.0/image/index.html#high-level-api) it seems you're expected to alias the reader ala `use image::io::Reader as ImageReader;`, while in [0.25.2 (latest)](https://docs.rs/image/latest/image/index.html#high-level-api) it is available directly.

This resolves these errors:

> error[E0433]: failed to resolve: could not find `ImageReader` in `image`
 --> candle-examples/src/imagenet.rs:6:22
  |
6 |     let img = image::ImageReader::open(p)?
  |                      ^^^^^^^^^^^
  |                      |
  |                      could not find `ImageReader` in `image`
  |                      help: a trait with a similar name exists: `ImageDecoder`
  
 