### PR TITLE
Add/lstm state from tensors

### DIFF
--- a/candle-nn/src/rnn.rs
+++ b/candle-nn/src/rnn.rs
@@ -199,6 +199,13 @@ impl RNN for LSTM {
         let states = states.iter().map(|s| s.h.clone()).collect::<Vec<_>>();
         Tensor::stack(&states, 1)
     }
+
+    fn states_from_tensor(&self, h0: &Tensor, c0: &Tensor) -> Result<Self::State> {
+        Ok(LSTMState {
+            h: h0.clone(),
+            c: c0.clone(),
+        })
+    }
 }
 
 /// The state for a GRU network, this contains a single tensor.

--- a/candle-nn/src/rnn.rs
+++ b/candle-nn/src/rnn.rs
@@ -44,6 +44,9 @@ pub trait RNN {
 
     /// Converts a sequence of state to a tensor.
     fn states_to_tensor(&self, states: &[Self::State]) -> Result<Tensor>;
+
+    /// Converts a tensor to a sequence of state.
+    fn states_from_tensor(&self, h0: &Tensor, c0: &Tensor) -> Result<Self::State>;
 }
 
 /// The state for a LSTM network, this contains two tensors.
@@ -339,5 +342,9 @@ impl RNN for GRU {
     fn states_to_tensor(&self, states: &[Self::State]) -> Result<Tensor> {
         let states = states.iter().map(|s| s.h.clone()).collect::<Vec<_>>();
         Tensor::cat(&states, 1)
+    }
+
+    fn states_from_tensor(&self, h0: &Tensor, _c0: &Tensor) -> Result<Self::State> {
+        Ok(GRUState { h: h0.clone() })
     }
 }


### PR DESCRIPTION
I added a method to retrieve an LSTM state based on a given tensor of the hidden and cell state vectors. This is useful when loading a pretrained PyTorch models weights, to initialize the state using the hidden and cell state vectors from the pretrained model.

I initially tried other ways of initializing an LSTM state when given a hidden and cell state vector using `assign_elem` on the `state.h()` method (i.e. `state_forward.h().assign_elem(&h0_forward);`, but that did not seem to work. Which is why I'm adding this method. If there is an actual existing way to do this without the added method, please let me know.

Best,

Justin