### PR TITLE
Add get_ids to GradStore (Discussion #2377)

### DIFF
--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -756,4 +756,9 @@ impl GradStore {
         };
         Ok(grad)
     }
+
+    /// Get the tensor ids of the stored gradient tensors
+    pub fn get_ids(&self) -> impl Iterator<Item = &TensorId> {
+        self.0.keys()
+    }
 }


### PR DESCRIPTION
Discussion in https://github.com/huggingface/candle/discussions/2377 

This PR adds `get_ids` function to `GradStore` that returns the list of `TensorId` in the store. It can be used to implement optimizers that only update relevant variables stored in the store. The typical use case is the word2vec model, which has many embeddings for the words but updates only a few in each iteration.