### PR TITLE
update: LSTMState and GRUState fields to be public

### DIFF
--- a/candle-nn/src/rnn.rs
+++ b/candle-nn/src/rnn.rs
@@ -50,8 +50,8 @@ pub trait RNN {
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone)]
 pub struct LSTMState {
-    h: Tensor,
-    c: Tensor,
+    pub h: Tensor,
+    pub c: Tensor,
 }
 
 impl LSTMState {
@@ -205,7 +205,7 @@ impl RNN for LSTM {
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone)]
 pub struct GRUState {
-    h: Tensor,
+    pub h: Tensor,
 }
 
 impl GRUState {


### PR DESCRIPTION
I added the `pub`  keyword to the fields in `LSTMState` and `GRUState` to make the states public, so that a state can be created using a predefined initial state tensor from a pretrained model.

See previous related closed [PR #2368 ](https://github.com/huggingface/candle/pull/2368).