### PR TITLE
Optimize gradient for silu a bit

### DIFF
--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -623,9 +623,9 @@ impl Tensor {
                     }
                     Op::Unary(arg, UnaryOp::Silu) => {
                         let sum_grad = grads.or_insert(arg)?;
-                        // d/dx silu = sigmoid(x) * (1 + x * (1 - sigmoid(x)))
+                        // d/dx silu = sigmoid(x) * (1 + x * (1 - sigmoid(x))) = sigmoid(x) * (1 - node) + node
                         let sigmoid_arg = (arg.neg()?.exp()? + 1.)?.recip()?;
-                        let silu_grad = (&sigmoid_arg * (1. + (arg * (1. - &sigmoid_arg)?)?)?)?;
+                        let silu_grad = &sigmoid_arg * (1. - *node) + *node;
                         *sum_grad = sum_grad.add(&(&grad * silu_grad)?)?
                     }
                     Op::Elu(arg, alpha) => {


### PR DESCRIPTION
This pull request exploits some mathematical properties of the `silu` operation. By reusing the computed forward pass results as much as possible, the optimized code reduces the running time for a sliver of a millisecond.

Ideally, since the forward pass also calculates the sigmoid of the input, if we could cache that intermediate result somehow, we can avoid computing that again, further cutting down some time.

By the way, the type of `silu_grad` is `Result<Tensor, Error>`, yet the compiler still accepts the code. Perhaps we don't need so many `?` operators after all.