### PR TITLE
Soft Non-Maximum Suppression

### DIFF
--- a/candle-transformers/src/object_detection.rs
+++ b/candle-transformers/src/object_detection.rs
@@ -65,7 +65,9 @@ pub fn soft_non_maximum_suppression<D>(
 
     for bboxes_for_class in bboxes.iter_mut() {
         bboxes_for_class.sort_by(|b1, b2| b2.confidence.partial_cmp(&b1.confidence).unwrap());
-        let mut updated_confidences = vec![0.0; bboxes_for_class.len()]; // Mutable confidence
+        let mut updated_confidences = bboxes_for_class.iter()
+            .map(|bbox| bbox.confidence)
+            .collect::<Vec<_>>();
         let mut current_index = 0;
         while current_index < bboxes_for_class.len() {
             let current_bbox = &bboxes_for_class[current_index];
@@ -86,7 +88,7 @@ pub fn soft_non_maximum_suppression<D>(
         for (i, &confidence) in updated_confidences.iter().enumerate() {
             if confidence < score_threshold {
                 bboxes_for_class[i].confidence = 0.0;
-            } else
+            } else {
                 bboxes_for_class[i].confidence = confidence;
             }
         }

--- a/candle-transformers/src/object_detection.rs
+++ b/candle-transformers/src/object_detection.rs
@@ -61,13 +61,15 @@ fn update_confidences<D>(
     let len = bboxes_for_class.len();
     for current_index in 0..len {
         let current_bbox = &bboxes_for_class[current_index];
-        for index in (current_index + 1)..len {
-            let iou_val = iou(current_bbox, &bboxes_for_class[index]);
-            if iou_val > iou_threshold {
-                // Decay calculation from page 4 of: https://arxiv.org/pdf/1704.04503
-                let decay = (-iou_val * iou_val / sigma).exp();
-                let updated_confidence = bboxes_for_class[index].confidence * decay;
-                updated_confidences[index] = updated_confidence;
+        for index in 0..len {
+            if current_index != index {
+                let iou_val = iou(current_bbox, &bboxes_for_class[index]);
+                if iou_val > iou_threshold {
+                    // Decay calculation from page 4 of: https://arxiv.org/pdf/1704.04503
+                    let decay = (-iou_val * iou_val / sigma).exp();
+                    let updated_confidence = bboxes_for_class[index].confidence * decay;
+                    updated_confidences[index] = updated_confidence;
+                }
             }
         }
     }
@@ -92,7 +94,7 @@ pub fn soft_non_maximum_suppression<D>(
             .map(|bbox| bbox.confidence)
             .collect::<Vec<_>>();
         update_confidences(bboxes_for_class, &mut updated_confidences, iou_threshold, sigma);
-        // Update confidences based on score threshold
+        // Update confidences based on score threshold, TODO: Refactor to be idiomatic
         for (i, &confidence) in updated_confidences.iter().enumerate() {
             if confidence < confidence_threshold {
                 bboxes_for_class.remove(i);
@@ -102,4 +104,3 @@ pub fn soft_non_maximum_suppression<D>(
         }
     }
 }
-

--- a/candle-transformers/src/object_detection.rs
+++ b/candle-transformers/src/object_detection.rs
@@ -79,11 +79,11 @@ fn update_confidences<D>(
 pub fn soft_non_maximum_suppression<D>(
     bboxes: &mut [Vec<Bbox<D>>],
     iou_threshold: Option<f32>,
-    score_threshold: Option<f32>,
+    confidence_threshold: Option<f32>,
     sigma: Option<f32>,
 ) {
     let iou_threshold = iou_threshold.unwrap_or(0.5);
-    let score_threshold = score_threshold.unwrap_or(0.1);
+    let confidence_threshold = score_threshold.unwrap_or(0.1);
     let sigma = sigma.unwrap_or(0.5);
 
     for bboxes_for_class in bboxes.iter_mut() {
@@ -94,7 +94,7 @@ pub fn soft_non_maximum_suppression<D>(
         update_confidences(bboxes_for_class, &mut updated_confidences, iou_threshold, sigma);
         // Update confidences based on score threshold
         for (i, &confidence) in updated_confidences.iter().enumerate() {
-            if confidence < score_threshold {
+            if confidence < confidence_threshold {
                 bboxes_for_class[i].confidence = 0.0;
             } else {
                 bboxes_for_class[i].confidence = confidence;

--- a/candle-transformers/src/object_detection.rs
+++ b/candle-transformers/src/object_detection.rs
@@ -65,48 +65,29 @@ pub fn soft_non_maximum_suppression<D>(
 
     for bboxes_for_class in bboxes.iter_mut() {
         bboxes_for_class.sort_by(|b1, b2| b2.confidence.partial_cmp(&b1.confidence).unwrap());
-
-        let mut to_remove = vec![];
         let mut updated_confidences = vec![0.0; bboxes_for_class.len()]; // Mutable confidence
-        // storage 
-
         let mut current_index = 0;
-
         while current_index < bboxes_for_class.len() {
             let current_bbox = &bboxes_for_class[current_index];
             let mut index = current_index + 1;
-
             while index < bboxes_for_class.len() {
                 let iou_val = iou(current_bbox, &bboxes_for_class[index]);
                 if iou_val > iou_threshold {
                     // Decay calculation from page 4 of: https://arxiv.org/pdf/1704.04503
                     let decay = (-iou_val * iou_val / sigma).exp();
                     let updated_confidence = bboxes_for_class[index].confidence * decay;
-
-                    if updated_confidence < score_threshold {
-                        to_remove.push(index);
-                    } else {
-                        updated_confidences[index] = updated_confidence;
-                    }
+                    updated_confidences[index] = updated_confidence;
                 }
                 index += 1;
             }
-
             current_index += 1;
         }
-
         // Update confidences
         for (i, &confidence) in updated_confidences.iter().enumerate() {
-            if confidence > 0.0 {
+            if confidence < score_threshold {
+                bboxes_for_class[i].confidence = 0.0;
+            } else
                 bboxes_for_class[i].confidence = confidence;
-            }
-        }
-
-        // Remove boxes with low confidence in reverse order
-        to_remove.sort_by(|a, b| b.cmp(a)); // Reverse sort 
-        for &index in to_remove.iter() {
-            if index < bboxes_for_class.len() {
-                bboxes_for_class.remove(index);
             }
         }
     }

--- a/candle-transformers/src/object_detection.rs
+++ b/candle-transformers/src/object_detection.rs
@@ -83,7 +83,7 @@ pub fn soft_non_maximum_suppression<D>(
     sigma: Option<f32>,
 ) {
     let iou_threshold = iou_threshold.unwrap_or(0.5);
-    let confidence_threshold = score_threshold.unwrap_or(0.1);
+    let confidence_threshold = confidence_threshold.unwrap_or(0.1);
     let sigma = sigma.unwrap_or(0.5);
 
     for bboxes_for_class in bboxes.iter_mut() {
@@ -95,7 +95,7 @@ pub fn soft_non_maximum_suppression<D>(
         // Update confidences based on score threshold
         for (i, &confidence) in updated_confidences.iter().enumerate() {
             if confidence < confidence_threshold {
-                bboxes_for_class[i].confidence = 0.0;
+                bboxes_for_class.remove(i);
             } else {
                 bboxes_for_class[i].confidence = confidence;
             }

--- a/candle-transformers/src/object_detection.rs
+++ b/candle-transformers/src/object_detection.rs
@@ -88,10 +88,16 @@ pub fn soft_non_maximum_suppression<D>(
     for bboxes_for_class in bboxes.iter_mut() {
         // Sort boxes by confidence in descending order
         bboxes_for_class.sort_by(|b1, b2| b2.confidence.partial_cmp(&b1.confidence).unwrap());
-        let mut updated_confidences = bboxes_for_class.iter()
+        let mut updated_confidences = bboxes_for_class
+            .iter()
             .map(|bbox| bbox.confidence)
             .collect::<Vec<_>>();
-        update_confidences(bboxes_for_class, &mut updated_confidences, iou_threshold, sigma);
+        update_confidences(
+            bboxes_for_class,
+            &mut updated_confidences,
+            iou_threshold,
+            sigma,
+        );
         // Update confidences, set to 0.0 if below threshold
         for (i, &confidence) in updated_confidences.iter().enumerate() {
             bboxes_for_class[i].confidence = if confidence < confidence_threshold {

--- a/candle-transformers/tests/nms_tests.rs
+++ b/candle-transformers/tests/nms_tests.rs
@@ -65,3 +65,18 @@ fn softnms_confidence_threshold() {
     // Box with confidence below the threshold should be removed
     assert_eq!(bboxes[0].len(), 1);
 }
+
+#[test]
+fn softnms_no_overlap() {
+    let mut bboxes = vec![
+        vec![
+            Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () },
+            Bbox { xmin: 2.0, ymin: 2.0, xmax: 3.0, ymax: 3.0, confidence: 0.8, data: () },
+        ],
+    ];
+
+    soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
+
+    // Both boxes should remain as they do not significantly overlap
+    assert_eq!(bboxes[0].len(), 2);
+}

--- a/candle-transformers/tests/nms_tests.rs
+++ b/candle-transformers/tests/nms_tests.rs
@@ -35,3 +35,19 @@ fn softnms_basic_functionality() {
 
     assert_eq!(bboxes[0].len(), 3);
 }
+
+#[test]
+fn softnms_confidence_decay() {
+    let mut bboxes = vec![
+        vec![
+            Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () }, // Reference box
+            Bbox { xmin: 0.1, ymin: 0.1, xmax: 1.1, ymax: 1.1, confidence: 0.8, data: () }, // Overlapping box
+        ],
+    ];
+
+    soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
+
+    // Check that confidence of the overlapping box is decayed
+    assert!(bboxes[0][1].confidence < 0.8);
+}
+

--- a/candle-transformers/tests/nms_tests.rs
+++ b/candle-transformers/tests/nms_tests.rs
@@ -79,4 +79,6 @@ fn softnms_no_overlap() {
 
     // Both boxes should remain as they do not significantly overlap
     assert_eq!(bboxes[0].len(), 2);
+    assert_eq!(bboxes[0][0].confidence, 0.9);
+    assert_eq!(bboxes[0][1].confidence, 0.8);
 }

--- a/candle-transformers/tests/nms_tests.rs
+++ b/candle-transformers/tests/nms_tests.rs
@@ -82,3 +82,17 @@ fn softnms_no_overlap() {
     assert_eq!(bboxes[0][0].confidence, 0.9);
     assert_eq!(bboxes[0][1].confidence, 0.8);
 }
+#[test]
+fn softnms_no_bbox() {
+    let mut bboxes: Vec<Vec<Bbox<()>>> = vec![];
+    soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
+    assert!(bboxes.is_empty());
+}
+
+#[test]
+fn softnms_single_bbox() {
+    let mut bboxes = vec![vec![Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () }]];
+    soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
+    assert_eq!(bboxes[0].len(), 1);
+}
+

--- a/candle-transformers/tests/nms_tests.rs
+++ b/candle-transformers/tests/nms_tests.rs
@@ -21,3 +21,21 @@ fn test_non_maximum_suppression() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_soft_non_maximum_suppression() -> Result<()> {
+    // Boxes based upon https://thepythoncode.com/article/non-maximum-suppression-using-opencv-in-python
+    let mut bboxes= vec![
+        vec![
+            Bbox { xmin: 245.0, ymin: 305.0, xmax: 575.0, ymax: 490.0, confidence: 0.9, data: () }, // Box 1
+            Bbox { xmin: 235.0, ymin: 300.0, xmax: 485.0, ymax: 515.0, confidence: 0.8, data: () }, // Box 2
+            Bbox { xmin: 305.0, ymin: 270.0, xmax: 540.0, ymax: 500.0, confidence: 0.6, data: () }  // Box 3
+        ]
+    ];
+
+    soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.3), Some(0.5));
+    let bboxes = bboxes.into_iter().next().unwrap();
+    println!("Bboxes: {:?}", bboxes);
+    assert_eq!(bboxes.len(), 2);
+
+    Ok(())
+}

--- a/candle-transformers/tests/nms_tests.rs
+++ b/candle-transformers/tests/nms_tests.rs
@@ -1,17 +1,37 @@
-use candle::{Result};
-use candle_transformers::object_detection::{Bbox, non_maximum_suppression, soft_non_maximum_suppression};
+use candle::Result;
+use candle_transformers::object_detection::{
+    non_maximum_suppression, soft_non_maximum_suppression, Bbox,
+};
 
-
- #[test]
+#[test]
 fn nms_basic() -> Result<()> {
     // Boxes based upon https://thepythoncode.com/article/non-maximum-suppression-using-opencv-in-python
-    let mut bboxes= vec![
-        vec![
-            Bbox { xmin: 245.0, ymin: 305.0, xmax: 575.0, ymax: 490.0, confidence: 0.9, data: () }, // Box 1
-            Bbox { xmin: 235.0, ymin: 300.0, xmax: 485.0, ymax: 515.0, confidence: 0.8, data: () }, // Box 2
-            Bbox { xmin: 305.0, ymin: 270.0, xmax: 540.0, ymax: 500.0, confidence: 0.6, data: () }  // Box 3
-        ]
-    ];
+    let mut bboxes = vec![vec![
+        Bbox {
+            xmin: 245.0,
+            ymin: 305.0,
+            xmax: 575.0,
+            ymax: 490.0,
+            confidence: 0.9,
+            data: (),
+        }, // Box 1
+        Bbox {
+            xmin: 235.0,
+            ymin: 300.0,
+            xmax: 485.0,
+            ymax: 515.0,
+            confidence: 0.8,
+            data: (),
+        }, // Box 2
+        Bbox {
+            xmin: 305.0,
+            ymin: 270.0,
+            xmax: 540.0,
+            ymax: 500.0,
+            confidence: 0.6,
+            data: (),
+        }, // Box 3
+    ]];
 
     non_maximum_suppression(&mut bboxes, 0.5);
     let bboxes = bboxes.into_iter().next().unwrap();
@@ -23,13 +43,32 @@ fn nms_basic() -> Result<()> {
 
 #[test]
 fn softnms_basic_functionality() -> Result<()> {
-    let mut bboxes = vec![
-        vec![
-            Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.5, data: () },
-            Bbox { xmin: 0.1, ymin: 0.1, xmax: 1.1, ymax: 1.1, confidence: 0.9, data: () },
-            Bbox { xmin: 0.2, ymin: 0.2, xmax: 1.2, ymax: 1.2, confidence: 0.6, data: () },
-        ],
-    ];
+    let mut bboxes = vec![vec![
+        Bbox {
+            xmin: 0.0,
+            ymin: 0.0,
+            xmax: 1.0,
+            ymax: 1.0,
+            confidence: 0.5,
+            data: (),
+        },
+        Bbox {
+            xmin: 0.1,
+            ymin: 0.1,
+            xmax: 1.1,
+            ymax: 1.1,
+            confidence: 0.9,
+            data: (),
+        },
+        Bbox {
+            xmin: 0.2,
+            ymin: 0.2,
+            xmax: 1.2,
+            ymax: 1.2,
+            confidence: 0.6,
+            data: (),
+        },
+    ]];
 
     soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
 
@@ -42,12 +81,24 @@ fn softnms_basic_functionality() -> Result<()> {
 
 #[test]
 fn softnms_confidence_decay() -> Result<()> {
-    let mut bboxes = vec![
-        vec![
-            Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () }, // Reference box
-            Bbox { xmin: 0.1, ymin: 0.1, xmax: 1.1, ymax: 1.1, confidence: 0.8, data: () }, // Overlapping box
-        ],
-    ];
+    let mut bboxes = vec![vec![
+        Bbox {
+            xmin: 0.0,
+            ymin: 0.0,
+            xmax: 1.0,
+            ymax: 1.0,
+            confidence: 0.9,
+            data: (),
+        }, // Reference box
+        Bbox {
+            xmin: 0.1,
+            ymin: 0.1,
+            xmax: 1.1,
+            ymax: 1.1,
+            confidence: 0.8,
+            data: (),
+        }, // Overlapping box
+    ]];
 
     soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
 
@@ -59,12 +110,24 @@ fn softnms_confidence_decay() -> Result<()> {
 
 #[test]
 fn softnms_confidence_threshold() -> Result<()> {
-    let mut bboxes = vec![
-        vec![
-            Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () },
-            Bbox { xmin: 0.1, ymin: 0.1, xmax: 1.1, ymax: 1.1, confidence: 0.05, data: () },
-        ],
-    ];
+    let mut bboxes = vec![vec![
+        Bbox {
+            xmin: 0.0,
+            ymin: 0.0,
+            xmax: 1.0,
+            ymax: 1.0,
+            confidence: 0.9,
+            data: (),
+        },
+        Bbox {
+            xmin: 0.1,
+            ymin: 0.1,
+            xmax: 1.1,
+            ymax: 1.1,
+            confidence: 0.05,
+            data: (),
+        },
+    ]];
 
     soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
 
@@ -77,12 +140,24 @@ fn softnms_confidence_threshold() -> Result<()> {
 
 #[test]
 fn softnms_no_overlap() -> Result<()> {
-    let mut bboxes = vec![
-        vec![
-            Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () },
-            Bbox { xmin: 2.0, ymin: 2.0, xmax: 3.0, ymax: 3.0, confidence: 0.8, data: () },
-        ],
-    ];
+    let mut bboxes = vec![vec![
+        Bbox {
+            xmin: 0.0,
+            ymin: 0.0,
+            xmax: 1.0,
+            ymax: 1.0,
+            confidence: 0.9,
+            data: (),
+        },
+        Bbox {
+            xmin: 2.0,
+            ymin: 2.0,
+            xmax: 3.0,
+            ymax: 3.0,
+            confidence: 0.8,
+            data: (),
+        },
+    ]];
 
     soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
 
@@ -102,7 +177,14 @@ fn softnms_no_bbox() -> Result<()> {
 
 #[test]
 fn softnms_single_bbox() -> Result<()> {
-    let mut bboxes = vec![vec![Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () }]];
+    let mut bboxes = vec![vec![Bbox {
+        xmin: 0.0,
+        ymin: 0.0,
+        xmax: 1.0,
+        ymax: 1.0,
+        confidence: 0.9,
+        data: (),
+    }]];
     soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
     assert_eq!(bboxes[0].len(), 1);
     Ok(())
@@ -110,12 +192,24 @@ fn softnms_single_bbox() -> Result<()> {
 
 #[test]
 fn softnms_equal_confidence_overlap() -> Result<()> {
-    let mut bboxes = vec![
-        vec![
-            Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.5, data: () },
-            Bbox { xmin: 0.1, ymin: 0.1, xmax: 1.1, ymax: 1.1, confidence: 0.5, data: () },
-        ],
-    ];
+    let mut bboxes = vec![vec![
+        Bbox {
+            xmin: 0.0,
+            ymin: 0.0,
+            xmax: 1.0,
+            ymax: 1.0,
+            confidence: 0.5,
+            data: (),
+        },
+        Bbox {
+            xmin: 0.1,
+            ymin: 0.1,
+            xmax: 1.1,
+            ymax: 1.1,
+            confidence: 0.5,
+            data: (),
+        },
+    ]];
 
     soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
 

--- a/candle-transformers/tests/nms_tests.rs
+++ b/candle-transformers/tests/nms_tests.rs
@@ -34,6 +34,7 @@ fn softnms_basic_functionality() {
     soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
 
     assert_eq!(bboxes[0].len(), 3);
+    Ok(())
 }
 
 #[test]
@@ -49,6 +50,7 @@ fn softnms_confidence_decay() {
 
     // Check that confidence of the overlapping box is decayed
     assert!(bboxes[0][1].confidence < 0.8);
+    Ok(())
 }
 
 #[test]
@@ -64,6 +66,7 @@ fn softnms_confidence_threshold() {
 
     // Box with confidence below the threshold should be removed
     assert_eq!(bboxes[0].len(), 1);
+    Ok(())
 }
 
 #[test]
@@ -81,12 +84,14 @@ fn softnms_no_overlap() {
     assert_eq!(bboxes[0].len(), 2);
     assert_eq!(bboxes[0][0].confidence, 0.9);
     assert_eq!(bboxes[0][1].confidence, 0.8);
+    Ok(())
 }
 #[test]
 fn softnms_no_bbox() {
     let mut bboxes: Vec<Vec<Bbox<()>>> = vec![];
     soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
     assert!(bboxes.is_empty());
+    Ok(())
 }
 
 #[test]
@@ -94,5 +99,6 @@ fn softnms_single_bbox() {
     let mut bboxes = vec![vec![Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () }]];
     soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
     assert_eq!(bboxes[0].len(), 1);
+    Ok(())
 }
 

--- a/candle-transformers/tests/nms_tests.rs
+++ b/candle-transformers/tests/nms_tests.rs
@@ -101,3 +101,21 @@ fn softnms_single_bbox() -> Result<()> {
     assert_eq!(bboxes[0].len(), 1);
     Ok(())
 }
+
+#[test]
+fn softnms_equal_confidence_overlap() -> Result<()> {
+    let mut bboxes = vec![
+        vec![
+            Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.5, data: () },
+            Bbox { xmin: 0.1, ymin: 0.1, xmax: 1.1, ymax: 1.1, confidence: 0.5, data: () },
+        ],
+    ];
+
+    soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
+
+    // Both boxes should remain as they have equal confidence
+    assert_eq!(bboxes[0].len(), 2);
+    assert_eq!(bboxes[0][0].confidence, 0.5);
+    assert_eq!(bboxes[0][1].confidence, 0.5);
+    Ok(())
+}

--- a/candle-transformers/tests/nms_tests.rs
+++ b/candle-transformers/tests/nms_tests.rs
@@ -51,3 +51,17 @@ fn softnms_confidence_decay() {
     assert!(bboxes[0][1].confidence < 0.8);
 }
 
+#[test]
+fn softnms_confidence_threshold() {
+    let mut bboxes = vec![
+        vec![
+            Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () },
+            Bbox { xmin: 0.1, ymin: 0.1, xmax: 1.1, ymax: 1.1, confidence: 0.05, data: () },
+        ],
+    ];
+
+    soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
+
+    // Box with confidence below the threshold should be removed
+    assert_eq!(bboxes[0].len(), 1);
+}

--- a/candle-transformers/tests/nms_tests.rs
+++ b/candle-transformers/tests/nms_tests.rs
@@ -3,7 +3,7 @@ use candle_transformers::object_detection::{Bbox, non_maximum_suppression, soft_
 
 
  #[test]
-fn test_non_maximum_suppression() -> Result<()> {
+fn nms_basic() -> Result<()> {
     // Boxes based upon https://thepythoncode.com/article/non-maximum-suppression-using-opencv-in-python
     let mut bboxes= vec![
         vec![
@@ -22,20 +22,16 @@ fn test_non_maximum_suppression() -> Result<()> {
 }
 
 #[test]
-fn test_soft_non_maximum_suppression() -> Result<()> {
-    // Boxes based upon https://thepythoncode.com/article/non-maximum-suppression-using-opencv-in-python
-    let mut bboxes= vec![
+fn softnms_basic_functionality() {
+    let mut bboxes = vec![
         vec![
-            Bbox { xmin: 245.0, ymin: 305.0, xmax: 575.0, ymax: 490.0, confidence: 0.9, data: () }, // Box 1
-            Bbox { xmin: 235.0, ymin: 300.0, xmax: 485.0, ymax: 515.0, confidence: 0.8, data: () }, // Box 2
-            Bbox { xmin: 305.0, ymin: 270.0, xmax: 540.0, ymax: 500.0, confidence: 0.6, data: () }  // Box 3
-        ]
+            Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () },
+            Bbox { xmin: 0.1, ymin: 0.1, xmax: 1.1, ymax: 1.1, confidence: 0.8, data: () },
+            Bbox { xmin: 0.2, ymin: 0.2, xmax: 1.2, ymax: 1.2, confidence: 0.7, data: () },
+        ],
     ];
 
-    soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.3), Some(0.5));
-    let bboxes = bboxes.into_iter().next().unwrap();
-    println!("Bboxes: {:?}", bboxes);
-    assert_eq!(bboxes.len(), 2);
+    soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
 
-    Ok(())
+    assert_eq!(bboxes[0].len(), 3);
 }

--- a/candle-transformers/tests/nms_tests.rs
+++ b/candle-transformers/tests/nms_tests.rs
@@ -22,7 +22,7 @@ fn nms_basic() -> Result<()> {
 }
 
 #[test]
-fn softnms_basic_functionality() {
+fn softnms_basic_functionality() -> Result<()> {
     let mut bboxes = vec![
         vec![
             Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () },
@@ -38,7 +38,7 @@ fn softnms_basic_functionality() {
 }
 
 #[test]
-fn softnms_confidence_decay() {
+fn softnms_confidence_decay() -> Result<()> {
     let mut bboxes = vec![
         vec![
             Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () }, // Reference box
@@ -54,7 +54,7 @@ fn softnms_confidence_decay() {
 }
 
 #[test]
-fn softnms_confidence_threshold() {
+fn softnms_confidence_threshold() -> Result<()> {
     let mut bboxes = vec![
         vec![
             Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () },
@@ -70,7 +70,7 @@ fn softnms_confidence_threshold() {
 }
 
 #[test]
-fn softnms_no_overlap() {
+fn softnms_no_overlap() -> Result<()> {
     let mut bboxes = vec![
         vec![
             Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () },
@@ -87,7 +87,7 @@ fn softnms_no_overlap() {
     Ok(())
 }
 #[test]
-fn softnms_no_bbox() {
+fn softnms_no_bbox() -> Result<()> {
     let mut bboxes: Vec<Vec<Bbox<()>>> = vec![];
     soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
     assert!(bboxes.is_empty());
@@ -95,10 +95,9 @@ fn softnms_no_bbox() {
 }
 
 #[test]
-fn softnms_single_bbox() {
+fn softnms_single_bbox() -> Result<()> {
     let mut bboxes = vec![vec![Bbox { xmin: 0.0, ymin: 0.0, xmax: 1.0, ymax: 1.0, confidence: 0.9, data: () }]];
     soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
     assert_eq!(bboxes[0].len(), 1);
     Ok(())
 }
-

--- a/candle-transformers/tests/nms_tests.rs
+++ b/candle-transformers/tests/nms_tests.rs
@@ -1,0 +1,23 @@
+use candle::{Result};
+use candle_transformers::object_detection::{Bbox, non_maximum_suppression, soft_non_maximum_suppression};
+
+
+ #[test]
+fn test_non_maximum_suppression() -> Result<()> {
+    // Boxes based upon https://thepythoncode.com/article/non-maximum-suppression-using-opencv-in-python
+    let mut bboxes= vec![
+        vec![
+            Bbox { xmin: 245.0, ymin: 305.0, xmax: 575.0, ymax: 490.0, confidence: 0.9, data: () }, // Box 1
+            Bbox { xmin: 235.0, ymin: 300.0, xmax: 485.0, ymax: 515.0, confidence: 0.8, data: () }, // Box 2
+            Bbox { xmin: 305.0, ymin: 270.0, xmax: 540.0, ymax: 500.0, confidence: 0.6, data: () }  // Box 3
+        ]
+    ];
+
+    non_maximum_suppression(&mut bboxes, 0.5);
+    let bboxes = bboxes.into_iter().next().unwrap();
+    assert_eq!(bboxes.len(), 1);
+    assert_eq!(bboxes[0].confidence, 0.9);
+
+    Ok(())
+}
+


### PR DESCRIPTION
# Description
Implements soft non-maximum suppression based on the research article https://arxiv.org/pdf/1704.04503, and also creates basic tests for NMS and Soft-NMS. This implementation of Soft-NMS can be given IOU and Score threshold to fine tune confidence decay.
## Related Issue
Implementation of my feature request: #2389 