### PR TITLE
Add `Device::best_device`, `Device::metal_if_available`

### DIFF
--- a/candle-core/src/device.rs
+++ b/candle-core/src/device.rs
@@ -195,6 +195,25 @@ impl Device {
         }
     }
 
+    pub fn metal_if_available(ordinal: usize) -> Result<Self> {
+        if crate::utils::metal_is_available() {
+            Self::new_metal(ordinal)
+        } else {
+            Ok(Self::Cpu)
+        }
+    }
+
+    /// Get the best (fastest) device, with the given accelerator ordinal.
+    pub fn best_device(ordinal: usize) -> Result<Self> {
+        if crate::utils::cuda_is_available() {
+            Self::new_cuda(ordinal)
+        } else if crate::utils::metal_is_available() {
+            Self::new_metal(ordinal)
+        } else {
+            Ok(Self::Cpu)
+        }
+    }
+
     pub(crate) fn rand_uniform_f64(
         &self,
         lo: f64,

--- a/candle-examples/src/lib.rs
+++ b/candle-examples/src/lib.rs
@@ -5,17 +5,11 @@ pub mod imagenet;
 pub mod token_output_stream;
 pub mod wav;
 
-use candle::utils::{cuda_is_available, metal_is_available};
 use candle::{Device, Result, Tensor};
 
 pub fn device(cpu: bool) -> Result<Device> {
-    if cpu {
-        Ok(Device::Cpu)
-    } else if cuda_is_available() {
-        Ok(Device::new_cuda(0)?)
-    } else if metal_is_available() {
-        Ok(Device::new_metal(0)?)
-    } else {
+    let device = Device::best_device(0)?;
+    if !cpu && device.is_cpu() {
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {
             println!(
@@ -26,8 +20,8 @@ pub fn device(cpu: bool) -> Result<Device> {
         {
             println!("Running on CPU, to run on GPU, build this example with `--features cuda`");
         }
-        Ok(Device::Cpu)
     }
+    Ok(device)
 }
 
 pub fn load_image<P: AsRef<std::path::Path>>(


### PR DESCRIPTION
Adds the aforementioned methods to Device. The `Device::best_device` has the same functionality as `candle_examples::device`, and this PR changes `candle_examples::device` to use `best_device`. `metal_if_available` has been added for parity with `cuda_if_available`.

