### PR TITLE
Add support for argsort with no shared memory usage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,14 @@
         "candle-pyo3"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "rust-analyzer.cargo.features": [
+        "cuda"
+    ],
+    "files.associations": {
+        "array": "cpp",
+        "string": "cpp",
+        "string_view": "cpp",
+        "ranges": "cpp"
+    }
 }

--- a/candle-core/src/sort.rs
+++ b/candle-core/src/sort.rs
@@ -109,26 +109,23 @@ impl crate::CustomOp1 for ArgSort {
                 const MAX_SMEM_BYTES: u32 = 48 * 1024; // 48 KB threshold
 
                 //if shared_mem_bytes >= MAX_SMEM_BYTES {
-                    let func = if self.asc {
-                        dev.get_or_load_func(&kernel_name::<T>("asort_asc_no_smem"), kernels::SORT)?
-                    } else {
-                        dev.get_or_load_func(
-                            &kernel_name::<T>("asort_desc_no_smem"),
-                            kernels::SORT,
-                        )?
-                    };
+                let func = if self.asc {
+                    dev.get_or_load_func(&kernel_name::<T>("asort_asc_no_smem"), kernels::SORT)?
+                } else {
+                    dev.get_or_load_func(&kernel_name::<T>("asort_desc_no_smem"), kernels::SORT)?
+                };
 
-                    let params = (&slice, &dst, nrows as i32, ncols as i32);
+                let params = (&slice, &dst, nrows as i32, ncols as i32);
 
-                    const BLOCK_SIZE: u32 = 256;
+                const BLOCK_SIZE: u32 = 256;
 
-                    let cfg = LaunchConfig {
-                        grid_dim: ((nrows as u32 + BLOCK_SIZE - 1) / BLOCK_SIZE, 1, 1),
-                        block_dim: (BLOCK_SIZE, 1, 1),
-                        shared_mem_bytes: 0,
-                    };
-                    unsafe { func.launch(cfg, params) }.w()?;
-                    Ok(S::U32(dst))
+                let cfg = LaunchConfig {
+                    grid_dim: ((nrows as u32 + BLOCK_SIZE - 1) / BLOCK_SIZE, 1, 1),
+                    block_dim: (BLOCK_SIZE, 1, 1),
+                    shared_mem_bytes: 0,
+                };
+                unsafe { func.launch(cfg, params) }.w()?;
+                Ok(S::U32(dst))
                 // } else {
                 //     let func = if self.asc {
                 //         dev.get_or_load_func(&kernel_name::<T>("asort_asc"), kernels::SORT)?

--- a/candle-core/src/sort.rs
+++ b/candle-core/src/sort.rs
@@ -101,22 +101,50 @@ impl crate::CustomOp1 for ArgSort {
                 };
                 let elem_count = layout.shape().elem_count();
                 let dst = unsafe { dev.alloc::<u32>(elem_count) }.w()?;
-                let func = if self.asc {
-                    dev.get_or_load_func(&kernel_name::<T>("asort_asc"), kernels::SORT)?
-                } else {
-                    dev.get_or_load_func(&kernel_name::<T>("asort_desc"), kernels::SORT)?
-                };
                 let ncols = self.last_dim;
                 let nrows = elem_count / ncols;
                 let ncols_pad = next_power_of_2(ncols);
-                let params = (&slice, &dst, ncols as i32, ncols_pad as i32);
-                let cfg = LaunchConfig {
-                    grid_dim: (1, nrows as u32, 1),
-                    block_dim: (ncols_pad as u32, 1, 1),
-                    shared_mem_bytes: (ncols_pad * std::mem::size_of::<u32>()) as u32,
-                };
-                unsafe { func.launch(cfg, params) }.w()?;
-                Ok(S::U32(dst))
+                let shared_mem_bytes = (ncols_pad * std::mem::size_of::<u32>()) as u32;
+
+                const MAX_SMEM_BYTES: u32 = 48 * 1024; // 48 KB threshold
+
+                //if shared_mem_bytes >= MAX_SMEM_BYTES {
+                    let func = if self.asc {
+                        dev.get_or_load_func(&kernel_name::<T>("asort_asc_no_smem"), kernels::SORT)?
+                    } else {
+                        dev.get_or_load_func(
+                            &kernel_name::<T>("asort_desc_no_smem"),
+                            kernels::SORT,
+                        )?
+                    };
+
+                    let params = (&slice, &dst, nrows as i32, ncols as i32);
+
+                    const BLOCK_SIZE: u32 = 256;
+
+                    let cfg = LaunchConfig {
+                        grid_dim: ((nrows as u32 + BLOCK_SIZE - 1) / BLOCK_SIZE, 1, 1),
+                        block_dim: (BLOCK_SIZE, 1, 1),
+                        shared_mem_bytes: 0,
+                    };
+                    unsafe { func.launch(cfg, params) }.w()?;
+                    Ok(S::U32(dst))
+                // } else {
+                //     let func = if self.asc {
+                //         dev.get_or_load_func(&kernel_name::<T>("asort_asc"), kernels::SORT)?
+                //     } else {
+                //         dev.get_or_load_func(&kernel_name::<T>("asort_desc"), kernels::SORT)?
+                //     };
+
+                //     let params = (&slice, &dst, ncols as i32, ncols_pad as i32);
+                //     let cfg = LaunchConfig {
+                //         grid_dim: (1, nrows as u32, 1),
+                //         block_dim: (ncols_pad as u32, 1, 1),
+                //         shared_mem_bytes,
+                //     };
+                //     unsafe { func.launch(cfg, params) }.w()?;
+                //     Ok(S::U32(dst))
+                // }
             }
         }
 

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -133,16 +133,16 @@ fn asort(device: &Device) -> Result<()> {
 fn asort_very_big(device: &Device) -> Result<()> {
     // This would require a lot of shared memory, as we're testing the other kernel
     // smem is calculated as (ncols * sizeof(u32)), so in this case, 393216 bytes.
-    let ncols = 32;//96u32 * 1024;
+    let ncols = 32; //96u32 * 1024;
     // Descending data.
-    let data_des = vec![(0..ncols).into_iter().rev().collect::<Vec<_>>(); 2];
+    let data_des = vec![(0..ncols).into_iter().rev().collect::<Vec<_>>(); 256];
 
     let tensor = Tensor::new(data_des, device)?;
-    assert_eq!(tensor.dims2()?, (2, ncols as usize));
+    assert_eq!(tensor.dims2()?, (256, ncols as usize));
     let indexes = tensor.arg_sort_last_dim(true)?;
     assert_eq!(
         indexes.to_vec2::<u32>()?,
-        vec![(0..ncols).into_iter().rev().collect::<Vec<_>>(); 2]
+        vec![(0..ncols).into_iter().rev().collect::<Vec<_>>(); 256]
     );
     Ok(())
 }

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -130,6 +130,23 @@ fn asort(device: &Device) -> Result<()> {
     Ok(())
 }
 
+fn asort_very_big(device: &Device) -> Result<()> {
+    // This would require a lot of shared memory, as we're testing the other kernel
+    // smem is calculated as (ncols * sizeof(u32)), so in this case, 393216 bytes.
+    let ncols = 32;//96u32 * 1024;
+    // Descending data.
+    let data_des = vec![(0..ncols).into_iter().rev().collect::<Vec<_>>(); 2];
+
+    let tensor = Tensor::new(data_des, device)?;
+    assert_eq!(tensor.dims2()?, (2, ncols as usize));
+    let indexes = tensor.arg_sort_last_dim(true)?;
+    assert_eq!(
+        indexes.to_vec2::<u32>()?,
+        vec![(0..ncols).into_iter().rev().collect::<Vec<_>>(); 2]
+    );
+    Ok(())
+}
+
 fn unary_op(device: &Device) -> Result<()> {
     let data = &[[-3f32, 1., 4., -0.1, 0.5], [2.7, -1.8, -0.28, 1.8, 2.8]];
     let tensor = Tensor::new(data, device)?;
@@ -1211,6 +1228,12 @@ test_device!(
 test_device!(randn, randn_cpu, randn_gpu, randn_metal);
 test_device!(clamp, clamp_cpu, clamp_gpu, clamp_metal);
 test_device!(asort, asort_cpu, asort_gpu, asort_metal);
+test_device!(
+    asort_very_big,
+    asort_very_big_cpu,
+    asort_very_big_gpu,
+    asort_very_big_metal
+);
 test_device!(var, var_cpu, var_gpu, var_metal);
 test_device!(zero_dim, zero_dim_cpu, zero_dim_gpu, zero_dim_metal);
 


### PR DESCRIPTION
As discussed in #2361, our current argsort implementation does not work on CUDA for large vectors because we use a bitonic sort implementation, which requires shared memory. For some n x m matrix (or really anything x m), shared memory scales with `m` in our bitonic sort implementation. In fact, it is calculated as `sizeof(u32) * m`. However, CUDA imposes a limit on shared memory size (depends on the architecture, but is clearly a limiting factor).

This PR sketches an argsort which runs only in global memory. However, I haven't found a way to implement something more parallel because of the limitation of no shared memory. As a result, we use a simple bubble sort, which gives horrible performance, especially when using argsort in sampling where `m` is large.

@gabrielmbmb, I was wondering if you could review and may know of a fasterway to do this? I considered implementing a merge sort so that each thread will merge sort one row, but that still gives $n \log{n}$ VS the bitonic sort's  ${\log}^{2}{n}$.

The PR can be tested with:
```
cargo test --features cuda --test tensor_tests -- asort_very_big
```
There is still some cleanup to do before merge (for example, I modified the settings.json for testing and some other things).