### PR TITLE
onnx: workaround pow with negative base

### DIFF
--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -352,11 +352,10 @@ fn simple_eval_(
             "Pow" => {
                 let input0 = get(&node.input[0])?;
                 let input1 = get(&node.input[1])?;
-                // HACK: current implementation of (broadcast_)pow cannot handle negative base;
-                // this is rarely an issue, but blocked support of silero-vad which uses x^2.
-                // Rather than fix pow for all negative base, we choose to handle just x^2.
-                if let Ok(2.0) = (|| input1.flatten_all()?.to_scalar::<f32>())() {
-                    let output = input0.mul(input0)?;
+                // HACK: current implementation of broadcast_pow cannot handle negative base,
+                // so we use powf where we can, which *does* correctly handle negative base.
+                if let Ok(exp) = (|| input1.to_dtype(DType::F64)?.to_scalar::<f64>())() {
+                    let output = input0.powf(exp as f64)?;
                     values.insert(node.output[0].clone(), output);
                 } else {
                     let output = input0.broadcast_pow(input1)?;


### PR DESCRIPTION
rather than fully defining pow in the cpu backend (as in #2318), this implements a much smaller change which is sufficient to evaluate silero-vad onnx models. Specifically, checking if we can use `Tensor::powf` which is defined for negative base.