### PR TITLE
fix FLUX.1 weights

### DIFF
--- a/candle-examples/examples/flux/main.rs
+++ b/candle-examples/examples/flux/main.rs
@@ -147,7 +147,8 @@ fn run(args: Args) -> Result<()> {
             println!("CLIP\n{clip_emb}");
             let img = {
                 let model_file = match model {
-                    Model::Schnell => bf_repo.get("flux1-schnell.sft")?,
+                    // Model::Schnell => bf_repo.get("flux1-schnell.sft")?,
+                    Model::Schnell => bf_repo.get("flux1-schnell.safetensors")?,
                     Model::Dev => bf_repo.get("flux1-dev.sft")?,
                 };
                 let vb =
@@ -189,7 +190,8 @@ fn run(args: Args) -> Result<()> {
     println!("latent img\n{img}");
 
     let img = {
-        let model_file = bf_repo.get("ae.sft")?;
+        // let model_file = bf_repo.get("ae.sft")?;
+        let model_file = bf_repo.get("ae.safetensors")?;
         let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], dtype, &device)? };
         let cfg = match model {
             Model::Dev => flux::autoencoder::Config::dev(),

--- a/candle-examples/examples/flux/main.rs
+++ b/candle-examples/examples/flux/main.rs
@@ -147,9 +147,8 @@ fn run(args: Args) -> Result<()> {
             println!("CLIP\n{clip_emb}");
             let img = {
                 let model_file = match model {
-                    // Model::Schnell => bf_repo.get("flux1-schnell.sft")?,
                     Model::Schnell => bf_repo.get("flux1-schnell.safetensors")?,
-                    Model::Dev => bf_repo.get("flux1-dev.sft")?,
+                    Model::Dev => bf_repo.get("flux1-dev.safetensors")?,
                 };
                 let vb =
                     unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], dtype, &device)? };
@@ -190,7 +189,6 @@ fn run(args: Args) -> Result<()> {
     println!("latent img\n{img}");
 
     let img = {
-        // let model_file = bf_repo.get("ae.sft")?;
         let model_file = bf_repo.get("ae.safetensors")?;
         let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], dtype, &device)? };
         let cfg = match model {


### PR DESCRIPTION
FLUX repo changed extension for the filenames, this PR addresses this:

`flux1-schnell.sft` -> `flux1-schnell.safetensors`
`flux1-dev.sft` -> `flux1-dev.safetensors`
`ae.sft` -> `ae.safetensors`