### PR TITLE
Improve `candle_core::Error` to make it more ergonomic

### DIFF
--- a/candle-core/src/error.rs
+++ b/candle-core/src/error.rs
@@ -235,7 +235,7 @@ impl Error {
     /// Create a new error based on a printable error message.
     ///
     /// If the message implements `std::error::Error`, prefer using [`Error::wrap`] instead.
-    pub fn msg<M: Display + Send + Sync>(msg: M) -> Self {
+    pub fn msg<M: Display>(msg: M) -> Self {
         Self::Msg(msg.to_string()).bt()
     }
 

--- a/candle-core/src/error.rs
+++ b/candle-core/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Debug, Display};
+
 use crate::{DType, DeviceLocation, Layout, MetalError, Shape};
 
 #[derive(Debug, Clone)]
@@ -215,14 +217,21 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl Error {
+    /// Create a new error by wrapping another.
     pub fn wrap(err: impl std::error::Error + Send + Sync + 'static) -> Self {
         Self::Wrapped(Box::new(err)).bt()
     }
 
-    pub fn msg(err: impl std::error::Error) -> Self {
-        Self::Msg(err.to_string()).bt()
+    /// Create a new error based on a printable error message.
+    ///
+    /// If the message implements `std::error::Error`, prefer using [`Error::wrap`] instead.
+    pub fn msg<M: Display + Debug + Send + Sync>(msg: M) -> Self {
+        Self::Msg(msg.to_string()).bt()
     }
 
+    /// Create a new error based on a debuggable error message.
+    ///
+    /// If the message implements `std::error::Error`, prefer using [`Error::wrap`] instead.
     pub fn debug(err: impl std::fmt::Debug) -> Self {
         Self::Msg(format!("{err:?}")).bt()
     }

--- a/candle-core/src/lib.rs
+++ b/candle-core/src/lib.rs
@@ -80,7 +80,7 @@ pub use cpu_backend::{CpuStorage, CpuStorageRef};
 pub use custom_op::{CustomOp1, CustomOp2, CustomOp3, InplaceOp1, InplaceOp2, InplaceOp3};
 pub use device::{Device, DeviceLocation, NdArray};
 pub use dtype::{DType, DTypeParseError, FloatDType, IntDType, WithDType};
-pub use error::{Error, Result};
+pub use error::{Error, Result, Context};
 pub use indexer::IndexOp;
 pub use layout::Layout;
 pub use shape::{Shape, D};


### PR DESCRIPTION
Currently, our Error type is already useful but could benefit from some of the QoL features which the anyhow crate has.

This PR adds the following:
- Make `Error::msg` more in line with `anyhow::Error::msg`. Although the type bound changes, this *is not* a breaking change because `std::error::Error: Display` already.
- Add the `Context` trait. Inspired by anyhow's Context trait which allows for `.with_context` and `.context` on Options and Results. Very useful!