### PR TITLE
Export ``TensorIndexer` to candle users

### DIFF
--- a/candle-core/src/lib.rs
+++ b/candle-core/src/lib.rs
@@ -81,7 +81,7 @@ pub use custom_op::{CustomOp1, CustomOp2, CustomOp3, InplaceOp1, InplaceOp2, Inp
 pub use device::{Device, DeviceLocation, NdArray};
 pub use dtype::{DType, DTypeParseError, FloatDType, IntDType, WithDType};
 pub use error::{Error, Result};
-pub use indexer::IndexOp;
+pub use indexer::{IndexOp, TensorIndexer};
 pub use layout::Layout;
 pub use shape::{Shape, D};
 pub use storage::Storage;


### PR DESCRIPTION
This pull request exports `TensorIndexer` to candle lib users, which allows users to implement the `IndexOp` trait with `TensorIndexer` specified as a part of the constraints.

```rust
pub struct CustomStruct {
    data: Tensor,
    // ...
}

impl<A> IndexOp<A> for CustomStruct
where
    A: Into<TensorIndexer>,
{
    fn i(&self, index: A) -> Result<Tensor, Error> {
        self.data.i(index)
    }
}
```