### PR TITLE
Bump the crate version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 description = "Minimalist ML framework."
 repository = "https://github.com/huggingface/candle"
@@ -33,14 +33,14 @@ ab_glyph = "0.2.23"
 accelerate-src = { version = "0.3.2" }
 anyhow = { version = "1", features = ["backtrace"] }
 byteorder = "1.4.3"
-candle = { path = "./candle-core", package = "candle-core", version = "0.6.1" }
-candle-datasets = { path = "./candle-datasets", version = "0.6.1" }
-candle-flash-attn = { path = "./candle-flash-attn", version = "0.6.1" }
-candle-kernels = { path = "./candle-kernels", version = "0.6.1" }
-candle-metal-kernels = { path = "./candle-metal-kernels", version = "0.6.1" }
-candle-nn = { path = "./candle-nn", version = "0.6.1" }
-candle-onnx = { path = "./candle-onnx", version = "0.6.1" }
-candle-transformers = { path = "./candle-transformers", version = "0.6.1" }
+candle = { path = "./candle-core", package = "candle-core", version = "0.7.0" }
+candle-datasets = { path = "./candle-datasets", version = "0.7.0" }
+candle-flash-attn = { path = "./candle-flash-attn", version = "0.7.0" }
+candle-kernels = { path = "./candle-kernels", version = "0.7.0" }
+candle-metal-kernels = { path = "./candle-metal-kernels", version = "0.7.0" }
+candle-nn = { path = "./candle-nn", version = "0.7.0" }
+candle-onnx = { path = "./candle-onnx", version = "0.7.0" }
+candle-transformers = { path = "./candle-transformers", version = "0.7.0" }
 clap = { version = "4.2.4", features = ["derive"] }
 criterion = { version = "0.5.1", default-features=false }
 cudarc = { version = "0.12.0", features = ["std", "cublas", "cublaslt", "curand", "driver", "nvrtc", "f16", "cuda-version-from-build-system", "dynamic-linking"], default-features=false }

--- a/candle-flash-attn/Cargo.toml
+++ b/candle-flash-attn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candle-flash-attn"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 
 description = "Flash attention layer for the candle ML framework."
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-candle = { path = "../candle-core", features = ["cuda"], package = "candle-core", version = "0.6.1" }
+candle = { path = "../candle-core", features = ["cuda"], package = "candle-core", version = "0.7.0" }
 half = { version = "2.3.1", features = ["num-traits"] }
 
 [build-dependencies]

--- a/candle-kernels/Cargo.toml
+++ b/candle-kernels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candle-kernels"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 
 description = "CUDA kernels for Candle"

--- a/candle-metal-kernels/Cargo.toml
+++ b/candle-metal-kernels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candle-metal-kernels"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 
 description = "Metal kernels for Candle"

--- a/candle-onnx/Cargo.toml
+++ b/candle-onnx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "candle-onnx"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 
 description = "ONNX support for Candle"
@@ -10,8 +10,8 @@ categories = ["science"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-candle = { path = "../candle-core", package = "candle-core", version = "0.6.1" }
-candle-nn = { path = "../candle-nn", version = "0.6.1" }
+candle = { path = "../candle-core", package = "candle-core", version = "0.7.0" }
+candle-nn = { path = "../candle-nn", version = "0.7.0" }
 prost = "0.12.1"
 
 [build-dependencies]


### PR DESCRIPTION
Bump to a new major version as the previous metal changes break the existing api.