### PR TITLE
Expand split ops

### DIFF
--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -616,12 +616,12 @@ fn simple_eval_(
             "Clip" => {
                 let xs = get(&node.input[0])?;
                 let xs = if let Some(mins) = get_opt(1) {
-                    xs.broadcast_maximum(mins)?
+                    xs.broadcast_maximum(mins?)?
                 } else {
                     xs.clone()
                 };
                 let xs = if let Some(maxs) = get_opt(2) {
-                    xs.broadcast_minimum(maxs)?
+                    xs.broadcast_minimum(maxs?)?
                 } else {
                     xs.clone()
                 };
@@ -1301,7 +1301,7 @@ fn simple_eval_(
                     .unwrap_or(0);
 
                 let axes = match axes {
-                    Some(axes) => axes
+                    Some(axes) => axes?
                         .to_vec1::<i64>()?
                         .into_iter()
                         .map(|x| x as usize)
@@ -1336,7 +1336,7 @@ fn simple_eval_(
                 let input_sq = input.sqr()?;
 
                 let axes = match axes {
-                    Some(axes) => axes
+                    Some(axes) => axes?
                         .to_vec1::<i64>()?
                         .into_iter()
                         .map(|x| x as usize)

--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -1225,7 +1225,9 @@ fn simple_eval_(
                     let split_tensor = get(&node.input[1])?.to_vec1::<i64>()?;
                     split_tensor.iter().map(|&x| x as usize).collect::<Vec<_>>()
                 } else {
-                    let num_outputs = if let Some(&num_outputs_attrib) = get_attr_opt::<i64>(node, "num_outputs")? {
+                    let num_outputs = if let Some(&num_outputs_attrib) =
+                        get_attr_opt::<i64>(node, "num_outputs")?
+                    {
                         num_outputs_attrib as usize
                     } else {
                         node.output.len()
@@ -1281,7 +1283,8 @@ fn simple_eval_(
                     .map(|x| x as usize)
                     .collect::<Vec<_>>();
 
-                let target_shape = broadcast_shape(&input_tensor_dims, input_shape_dims.as_slice())?;
+                let target_shape =
+                    broadcast_shape(&input_tensor_dims, input_shape_dims.as_slice())?;
 
                 let expanded_tensor = input_tensor.broadcast_as(target_shape)?;
 
@@ -1293,16 +1296,20 @@ fn simple_eval_(
                 let input = get(&node.input[0])?;
                 let axes = get_opt(1);
                 let keepdims = get_attr_opt::<i64>(node, "keepdims")?.copied().unwrap_or(1);
-                let noop_with_empty_axes = get_attr_opt::<i64>(node, "noop_with_empty_axes")?.copied().unwrap_or(0);
+                let noop_with_empty_axes = get_attr_opt::<i64>(node, "noop_with_empty_axes")?
+                    .copied()
+                    .unwrap_or(0);
 
                 let axes = match axes {
-                    Some(axes) => {
-                        axes.to_vec1::<i64>()?.into_iter().map(|x| x as usize).collect::<Vec<_>>()
-                    }
+                    Some(axes) => axes
+                        .to_vec1::<i64>()?
+                        .into_iter()
+                        .map(|x| x as usize)
+                        .collect::<Vec<_>>(),
                     None => {
                         if noop_with_empty_axes == 1 {
                             vec![]
-                        }else{
+                        } else {
                             (0..input.rank()).collect()
                         }
                     }
@@ -1322,18 +1329,22 @@ fn simple_eval_(
                 let input = get(&node.input[0])?;
                 let axes = get_opt(1);
                 let keepdims = get_attr_opt::<i64>(node, "keepdims")?.copied().unwrap_or(1);
-                let noop_with_empty_axes = get_attr_opt::<i64>(node, "noop_with_empty_axes")?.copied().unwrap_or(0);
+                let noop_with_empty_axes = get_attr_opt::<i64>(node, "noop_with_empty_axes")?
+                    .copied()
+                    .unwrap_or(0);
 
                 let input_sq = input.sqr()?;
 
                 let axes = match axes {
-                    Some(axes) => {
-                        axes.to_vec1::<i64>()?.into_iter().map(|x| x as usize).collect::<Vec<_>>()
-                    }
+                    Some(axes) => axes
+                        .to_vec1::<i64>()?
+                        .into_iter()
+                        .map(|x| x as usize)
+                        .collect::<Vec<_>>(),
                     None => {
                         if noop_with_empty_axes == 1 {
                             vec![]
-                        }else{
+                        } else {
                             (0..input_sq.rank()).collect()
                         }
                     }
@@ -1734,7 +1745,11 @@ fn broadcast_shape(shape_a: &[usize], shape_b: &[usize]) -> Result<Vec<usize>> {
         if *dim1 == *dim2 || *dim2 == 1 || *dim1 == 1 {
             target_shape.push(usize::max(*dim1, *dim2));
         } else {
-            bail!("Expand: incompatible shapes for broadcast, {:?} and {:?}", shape_a, shape_b);
+            bail!(
+                "Expand: incompatible shapes for broadcast, {:?} and {:?}",
+                shape_a,
+                shape_b
+            );
         }
     }
     Ok(target_shape)

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -3980,3 +3980,207 @@ fn test_lstm() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_expand_dim_changed() -> Result<()> {
+    // Create a manual graph for the Expand operation
+    let manual_graph = create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "Expand".to_string(),
+            domain: "".to_string(),
+            attribute: vec![],
+            input: vec!["data".to_string(), "new_shape".to_string()],
+            output: vec!["expanded".to_string()],
+            name: "".to_string(),
+            doc_string: "".to_string(),
+        }],
+        input: vec![
+            ValueInfoProto {
+                name: "data".to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            },
+            ValueInfoProto {
+                name: "new_shape".to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            },
+        ],
+        output: vec![ValueInfoProto {
+            name: "expanded".to_string(),
+            doc_string: "".to_string(),
+            r#type: None,
+        }],
+        ..GraphProto::default()
+    }));
+
+    // Input tensor with shape [3, 1]
+    let data = Tensor::from_vec(vec![1.0f32, 2.0f32, 3.0f32], (3, 1), &Device::Cpu)?;
+
+    // New shape tensor: [2, 1, 6]
+    let new_shape = Tensor::from_vec(vec![2i64, 1, 6], (3,), &Device::Cpu)?;
+
+    // Expected output after expansion
+    let expected = Tensor::from_vec(
+        vec![
+            1.0f32, 1.0f32, 1.0f32, 1.0f32, 1.0f32, 1.0f32, 2.0f32, 2.0f32, 2.0f32, 2.0f32, 2.0f32,
+            2.0f32, 3.0f32, 3.0f32, 3.0f32, 3.0f32, 3.0f32, 3.0f32, 1.0f32, 1.0f32, 1.0f32, 1.0f32,
+            1.0f32, 1.0f32, 2.0f32, 2.0f32, 2.0f32, 2.0f32, 2.0f32, 2.0f32, 3.0f32, 3.0f32, 3.0f32,
+            3.0f32, 3.0f32, 3.0f32,
+        ],
+        (2, 3, 6),
+        &Device::Cpu,
+    )?;
+
+    // Execute the model evaluation
+    let inputs = HashMap::from_iter([
+        ("data".to_string(), data),
+        ("new_shape".to_string(), new_shape),
+    ]);
+    let result = candle_onnx::simple_eval(&manual_graph, inputs)?;
+
+    // Retrieve and compare the result
+    let expanded = result.get("expanded").expect("Output 'expanded' not found");
+
+    assert_eq!(expanded.to_vec3::<f32>()?, expected.to_vec3::<f32>()?);
+
+    Ok(())
+}
+
+#[test]
+fn test_expand_dim_unchanged() -> Result<()> {
+    // Create a manual graph for the Expand operation
+    let manual_graph = create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "Expand".to_string(),
+            domain: "".to_string(),
+            attribute: vec![],
+            input: vec!["data".to_string(), "new_shape".to_string()],
+            output: vec!["expanded".to_string()],
+            name: "".to_string(),
+            doc_string: "".to_string(),
+        }],
+        input: vec![
+            ValueInfoProto {
+                name: "data".to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            },
+            ValueInfoProto {
+                name: "new_shape".to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            },
+        ],
+        output: vec![ValueInfoProto {
+            name: "expanded".to_string(),
+            doc_string: "".to_string(),
+            r#type: None,
+        }],
+        ..GraphProto::default()
+    }));
+
+    // Input tensor with shape [3, 1] and dtype f32
+    let data = Tensor::from_vec(vec![1.0f32, 2.0f32, 3.0f32], (3, 1), &Device::Cpu)?;
+
+    // New shape tensor: [3, 4]
+    let new_shape = Tensor::from_vec(vec![3i64, 4], (2,), &Device::Cpu)?;
+
+    // Expected output after expansion, dtype f32
+    let expected = Tensor::from_vec(
+        vec![
+            1.0f32, 1.0f32, 1.0f32, 1.0f32, 2.0f32, 2.0f32, 2.0f32, 2.0f32, 3.0f32, 3.0f32, 3.0f32,
+            3.0f32,
+        ],
+        (3, 4),
+        &Device::Cpu,
+    )?;
+
+    // Execute the model evaluation
+    let inputs = HashMap::from_iter([
+        ("data".to_string(), data),
+        ("new_shape".to_string(), new_shape),
+    ]);
+    let result = candle_onnx::simple_eval(&manual_graph, inputs)?;
+
+    // Retrieve and compare the result
+    let expanded = result.get("expanded").expect("Output 'expanded' not found");
+    assert_eq!(expanded.to_vec2::<f32>()?, expected.to_vec2::<f32>()?);
+
+    Ok(())
+}
+
+fn make_split_graph_helper(inputs: &[&str], outputs: &[&str], axis: i64) -> ModelProto {
+    create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "Split".to_string(),
+            input: inputs.iter().map(|s| s.to_string()).collect(),
+            output: outputs.iter().map(|s| s.to_string()).collect(),
+            attribute: vec![AttributeProto {
+                name: "axis".to_string(),
+                r#type: AttributeType::Int.into(),
+                i: axis,
+                ..AttributeProto::default()
+            }],
+            ..NodeProto::default()
+        }],
+        input: inputs
+            .into_iter()
+            .map(|name| ValueInfoProto {
+                name: name.to_string(),
+                ..ValueInfoProto::default()
+            })
+            .collect(),
+
+        output: outputs
+            .into_iter()
+            .map(|name| ValueInfoProto {
+                name: name.to_string(),
+                ..ValueInfoProto::default()
+            })
+            .collect(),
+
+        ..GraphProto::default()
+    }))
+}
+
+#[test]
+fn test_split_equal_parts_1d_opset13() -> Result<()> {
+    let input = Tensor::from_vec(
+        vec![1.0f32, 2.0f32, 3.0f32, 4.0f32, 5.0f32, 6.0f32],
+        (6,),
+        &Device::Cpu,
+    )?;
+    let mut inputs = HashMap::new();
+    inputs.insert("input".to_string(), input);
+
+    {
+        let manual_graph = make_split_graph_helper(&["input"], &["output_1", "output_2", "output_3"], 0);
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs.clone())?;
+        assert_eq!(eval.len(), 3);
+
+        let out1 = eval.get("output_1").expect("Output 'output_1' not found");
+        let out2 = eval.get("output_2").expect("Output 'output_2' not found");
+        let out3 = eval.get("output_3").expect("Output 'output_3' not found");
+
+        assert_eq!(out1.to_vec1::<f32>()?, vec![1.0f32, 2.0f32]);
+        assert_eq!(out2.to_vec1::<f32>()?, vec![3.0f32, 4.0f32]);
+        assert_eq!(out3.to_vec1::<f32>()?, vec![5.0f32, 6.0f32]);
+    }
+
+    {
+        let splits = Tensor::from_vec(vec![2i64, 4], (2,), &Device::Cpu)?;
+        inputs.insert("split".to_string(), splits);
+
+        let manual_graph = make_split_graph_helper(&["input", "split"], &["output_1", "output_2"], 0);
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        assert_eq!(eval.len(), 2);
+
+        let out1 = eval.get("output_1").expect("Output 'output_1' not found");
+        let out2 = eval.get("output_2").expect("Output 'output_2' not found");
+
+        assert_eq!(out1.to_vec1::<f32>()?, vec![1.0f32, 2.0f32]);
+        assert_eq!(out2.to_vec1::<f32>()?, vec![3.0f32, 4.0f32, 5.0f32, 6.0f32]);
+    }
+    Ok(())
+}

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -4047,7 +4047,12 @@ fn test_expand_dim_changed() -> Result<()> {
     Ok(())
 }
 
-fn make_graph_helper(op_name: &str, inputs: &[&str], outputs: &[&str], attribs : Vec<AttributeProto>) -> ModelProto {
+fn make_graph_helper(
+    op_name: &str,
+    inputs: &[&str],
+    outputs: &[&str],
+    attribs: Vec<AttributeProto>,
+) -> ModelProto {
     create_model_proto_with_graph(Some(GraphProto {
         node: vec![NodeProto {
             op_type: op_name.to_string(),
@@ -4133,7 +4138,8 @@ fn test_split_equal_parts_1d_opset13() -> Result<()> {
     inputs.insert("input".to_string(), input);
 
     {
-        let manual_graph = make_split_graph_helper(&["input"], &["output_1", "output_2", "output_3"], 0);
+        let manual_graph =
+            make_split_graph_helper(&["input"], &["output_1", "output_2", "output_3"], 0);
         let eval = candle_onnx::simple_eval(&manual_graph, inputs.clone())?;
         assert_eq!(eval.len(), 3);
 
@@ -4150,7 +4156,8 @@ fn test_split_equal_parts_1d_opset13() -> Result<()> {
         let splits = Tensor::from_vec(vec![2i64, 4], (2,), &Device::Cpu)?;
         inputs.insert("split".to_string(), splits);
 
-        let manual_graph = make_split_graph_helper(&["input", "split"], &["output_1", "output_2"], 0);
+        let manual_graph =
+            make_split_graph_helper(&["input", "split"], &["output_1", "output_2"], 0);
         let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
         assert_eq!(eval.len(), 2);
 
@@ -4163,7 +4170,12 @@ fn test_split_equal_parts_1d_opset13() -> Result<()> {
     Ok(())
 }
 
-fn make_reduce_sum_graph_helper(inputs: &[&str], outputs: &[&str], keepdims: Option<i64>, noop_with_empty_axes: Option<i64>) -> ModelProto {
+fn make_reduce_sum_graph_helper(
+    inputs: &[&str],
+    outputs: &[&str],
+    keepdims: Option<i64>,
+    noop_with_empty_axes: Option<i64>,
+) -> ModelProto {
     let mut attribs = vec![];
     if let Some(keepdims) = keepdims {
         attribs.push(AttributeProto {
@@ -4186,13 +4198,13 @@ fn make_reduce_sum_graph_helper(inputs: &[&str], outputs: &[&str], keepdims: Opt
 
 #[test]
 fn test_reduce_sum_default_axes_keepdims() -> Result<()> {
-    let manual_graph =  make_reduce_sum_graph_helper(&["data","axes"], &["reduced"], Some(1), None);
+    let manual_graph = make_reduce_sum_graph_helper(&["data", "axes"], &["reduced"], Some(1), None);
 
     // Test with example data
     {
         let data = Tensor::from_vec(
             vec![
-                1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0
+                1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
             ],
             (3, 2, 2),
             &Device::Cpu,
@@ -4215,9 +4227,7 @@ fn test_reduce_sum_default_axes_keepdims() -> Result<()> {
     {
         let data = Tensor::from_vec(
             vec![
-                -5.2f32, 7.8, -3.1, 9.4,
-                2.6, -8.7, 4.3, -1.9,
-                6.5, -0.8, -7.2, 3.6
+                -5.2f32, 7.8, -3.1, 9.4, 2.6, -8.7, 4.3, -1.9, 6.5, -0.8, -7.2, 3.6,
             ],
             (3, 2, 2),
             &Device::Cpu,
@@ -4238,7 +4248,6 @@ fn test_reduce_sum_default_axes_keepdims() -> Result<()> {
     Ok(())
 }
 
-
 #[test]
 fn test_reduce_sum_do_not_keep_dims() -> Result<()> {
     let manual_graph = make_reduce_sum_graph_helper(&["data", "axes"], &["reduced"], Some(0), None);
@@ -4247,9 +4256,7 @@ fn test_reduce_sum_do_not_keep_dims() -> Result<()> {
     {
         let data = Tensor::from_vec(
             vec![
-                1.0f32, 2.0, 3.0, 4.0,
-                5.0, 6.0, 7.0, 8.0,
-                9.0, 10.0, 11.0, 12.0
+                1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
             ],
             (3, 2, 2),
             &Device::Cpu,
@@ -4278,9 +4285,7 @@ fn test_reduce_sum_do_not_keep_dims() -> Result<()> {
         let shape = (3, 2, 2);
         let data = Tensor::from_vec(
             vec![
-                -5.2f32, 7.8, -3.1, 9.4,
-                2.6, -8.7, 4.3, -1.9,
-                6.5, -0.8, -7.2, 3.6
+                -5.2f32, 7.8, -3.1, 9.4, 2.6, -8.7, 4.3, -1.9, 6.5, -0.8, -7.2, 3.6,
             ],
             (3, 2, 2),
             &Device::Cpu,

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -4047,38 +4047,39 @@ fn test_expand_dim_changed() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_expand_dim_unchanged() -> Result<()> {
-    // Create a manual graph for the Expand operation
-    let manual_graph = create_model_proto_with_graph(Some(GraphProto {
+fn make_graph_helper(op_name: &str, inputs: &[&str], outputs: &[&str], attribs : Vec<AttributeProto>) -> ModelProto {
+    create_model_proto_with_graph(Some(GraphProto {
         node: vec![NodeProto {
-            op_type: "Expand".to_string(),
+            op_type: op_name.to_string(),
             domain: "".to_string(),
-            attribute: vec![],
-            input: vec!["data".to_string(), "new_shape".to_string()],
-            output: vec!["expanded".to_string()],
+            attribute: attribs,
+            input: inputs.iter().map(|s| s.to_string()).collect(),
+            output: outputs.iter().map(|s| s.to_string()).collect(),
             name: "".to_string(),
             doc_string: "".to_string(),
         }],
-        input: vec![
-            ValueInfoProto {
-                name: "data".to_string(),
-                doc_string: "".to_string(),
-                r#type: None,
-            },
-            ValueInfoProto {
-                name: "new_shape".to_string(),
-                doc_string: "".to_string(),
-                r#type: None,
-            },
-        ],
-        output: vec![ValueInfoProto {
-            name: "expanded".to_string(),
-            doc_string: "".to_string(),
-            r#type: None,
-        }],
+        input: inputs
+            .into_iter()
+            .map(|name| ValueInfoProto {
+                name: name.to_string(),
+                ..ValueInfoProto::default()
+            })
+            .collect(),
+        output: outputs
+            .into_iter()
+            .map(|name| ValueInfoProto {
+                name: name.to_string(),
+                ..ValueInfoProto::default()
+            })
+            .collect(),
         ..GraphProto::default()
-    }));
+    }))
+}
+
+#[test]
+fn test_expand_dim_unchanged() -> Result<()> {
+    // Create a manual graph for the Expand operation
+    let manual_graph = make_graph_helper("Expand", &["data", "new_shape"], &["expanded"], vec![]);
 
     // Input tensor with shape [3, 1] and dtype f32
     let data = Tensor::from_vec(vec![1.0f32, 2.0f32, 3.0f32], (3, 1), &Device::Cpu)?;
@@ -4111,37 +4112,14 @@ fn test_expand_dim_unchanged() -> Result<()> {
 }
 
 fn make_split_graph_helper(inputs: &[&str], outputs: &[&str], axis: i64) -> ModelProto {
-    create_model_proto_with_graph(Some(GraphProto {
-        node: vec![NodeProto {
-            op_type: "Split".to_string(),
-            input: inputs.iter().map(|s| s.to_string()).collect(),
-            output: outputs.iter().map(|s| s.to_string()).collect(),
-            attribute: vec![AttributeProto {
-                name: "axis".to_string(),
-                r#type: AttributeType::Int.into(),
-                i: axis,
-                ..AttributeProto::default()
-            }],
-            ..NodeProto::default()
-        }],
-        input: inputs
-            .into_iter()
-            .map(|name| ValueInfoProto {
-                name: name.to_string(),
-                ..ValueInfoProto::default()
-            })
-            .collect(),
+    let attribs = vec![AttributeProto {
+        name: "axis".to_string(),
+        r#type: AttributeType::Int.into(),
+        i: axis,
+        ..AttributeProto::default()
+    }];
 
-        output: outputs
-            .into_iter()
-            .map(|name| ValueInfoProto {
-                name: name.to_string(),
-                ..ValueInfoProto::default()
-            })
-            .collect(),
-
-        ..GraphProto::default()
-    }))
+    make_graph_helper("Split", inputs, outputs, attribs)
 }
 
 #[test]
@@ -4182,5 +4160,147 @@ fn test_split_equal_parts_1d_opset13() -> Result<()> {
         assert_eq!(out1.to_vec1::<f32>()?, vec![1.0f32, 2.0f32]);
         assert_eq!(out2.to_vec1::<f32>()?, vec![3.0f32, 4.0f32, 5.0f32, 6.0f32]);
     }
+    Ok(())
+}
+
+fn make_reduce_sum_graph_helper(inputs: &[&str], outputs: &[&str], keepdims: Option<i64>, noop_with_empty_axes: Option<i64>) -> ModelProto {
+    let mut attribs = vec![];
+    if let Some(keepdims) = keepdims {
+        attribs.push(AttributeProto {
+            name: "keepdims".to_string(),
+            r#type: AttributeType::Int.into(),
+            i: keepdims,
+            ..AttributeProto::default()
+        });
+    }
+    if let Some(noop_with_empty_axes) = noop_with_empty_axes {
+        attribs.push(AttributeProto {
+            name: "noop_with_empty_axes".to_string(),
+            r#type: AttributeType::Ints.into(),
+            i: noop_with_empty_axes,
+            ..AttributeProto::default()
+        });
+    }
+    make_graph_helper("ReduceSum", inputs, outputs, attribs)
+}
+
+#[test]
+fn test_reduce_sum_default_axes_keepdims() -> Result<()> {
+    let manual_graph =  make_reduce_sum_graph_helper(&["data","axes"], &["reduced"], Some(1), None);
+
+    // Test with example data
+    {
+        let data = Tensor::from_vec(
+            vec![
+                1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0
+            ],
+            (3, 2, 2),
+            &Device::Cpu,
+        )?;
+        // let axes = Tensor::from_vec(Vec::<i64>::new(), (0,), &Device::Cpu)?;
+
+        let mut inputs = HashMap::new();
+        inputs.insert("data".to_string(), data);
+        // inputs.insert("axes".to_string(), axes);
+
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        assert_eq!(eval.len(), 1);
+
+        let reduced = eval.get("reduced").expect("Output 'reduced' not found");
+        let expected = Tensor::from_vec(vec![78.0f32], (1, 1, 1), &Device::Cpu)?;
+
+        assert_eq!(reduced.to_vec3::<f32>()?, expected.to_vec3::<f32>()?);
+    }
+
+    {
+        let data = Tensor::from_vec(
+            vec![
+                -5.2f32, 7.8, -3.1, 9.4,
+                2.6, -8.7, 4.3, -1.9,
+                6.5, -0.8, -7.2, 3.6
+            ],
+            (3, 2, 2),
+            &Device::Cpu,
+        )?;
+
+        let mut inputs = HashMap::new();
+        inputs.insert("data".to_string(), data.clone());
+
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        assert_eq!(eval.len(), 1);
+
+        let reduced = eval.get("reduced").expect("Output 'reduced' not found");
+        let expected = data.sum_all()?.reshape((1, 1, 1))?;
+
+        assert_eq!(reduced.to_vec3::<f32>()?, expected.to_vec3::<f32>()?);
+    }
+
+    Ok(())
+}
+
+
+#[test]
+fn test_reduce_sum_do_not_keep_dims() -> Result<()> {
+    let manual_graph = make_reduce_sum_graph_helper(&["data", "axes"], &["reduced"], Some(0), None);
+
+    // Test with example data
+    {
+        let data = Tensor::from_vec(
+            vec![
+                1.0f32, 2.0, 3.0, 4.0,
+                5.0, 6.0, 7.0, 8.0,
+                9.0, 10.0, 11.0, 12.0
+            ],
+            (3, 2, 2),
+            &Device::Cpu,
+        )?;
+        let axes = Tensor::from_vec(vec![1i64], (1,), &Device::Cpu)?;
+
+        let mut inputs = HashMap::new();
+        inputs.insert("data".to_string(), data);
+        inputs.insert("axes".to_string(), axes);
+
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        assert_eq!(eval.len(), 1);
+
+        let reduced = eval.get("reduced").expect("Output 'reduced' not found");
+        let expected = Tensor::from_vec(
+            vec![4.0f32, 6.0, 12.0, 14.0, 20.0, 22.0],
+            (3, 2),
+            &Device::Cpu,
+        )?;
+
+        assert_eq!(reduced.to_vec2::<f32>()?, expected.to_vec2::<f32>()?);
+    }
+
+    // Test with random data
+    {
+        let shape = (3, 2, 2);
+        let data = Tensor::from_vec(
+            vec![
+                -5.2f32, 7.8, -3.1, 9.4,
+                2.6, -8.7, 4.3, -1.9,
+                6.5, -0.8, -7.2, 3.6
+            ],
+            (3, 2, 2),
+            &Device::Cpu,
+        )?;
+        let axes = Tensor::from_vec(vec![1i64], (1,), &Device::Cpu)?;
+
+        let mut inputs = HashMap::new();
+        inputs.insert("data".to_string(), data.clone());
+        inputs.insert("axes".to_string(), axes);
+
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        assert_eq!(eval.len(), 1);
+
+        let reduced = eval.get("reduced").expect("Output 'reduced' not found");
+
+        // Calculate expected result
+        let expected = data.sum(1)?;
+
+        assert_eq!(reduced.to_vec2::<f32>()?, expected.to_vec2::<f32>()?);
+    }
+
     Ok(())
 }


### PR DESCRIPTION
- Added 4 ONNX operators, Expand, Split, ReduceSum and ReduceL2
- Fix small issues in Where and Clip operators
- Add some associated tests

There are some more tests that could be added based on the onnx documentation examples, but I wanted to open this PR to get any feedback first, since this would be my first contribution to candle.

My motivation for the changes was to support running a few onnx models (such as https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2).