### PR TITLE
Allow marian configs to deserialize from json.

### DIFF
--- a/candle-transformers/src/models/marian.rs
+++ b/candle-transformers/src/models/marian.rs
@@ -1,8 +1,9 @@
 use super::with_tracing::{linear, Embedding, Linear};
 use candle::{Result, Tensor};
 use candle_nn::{layer_norm, LayerNorm, VarBuilder};
+use serde::Deserialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     pub vocab_size: usize,
     pub decoder_vocab_size: Option<usize>,


### PR DESCRIPTION
Currently, there is no way to use a Marian model that isn't `opus_mt_tc_big_fr_en` or `opus_mt_tc_big_fr_en`, because the only way to get a Marian config is by calling the functions for those two models configs which are hard coded into the library. This change simply allows you to use serde to deserialize a Marian model's `config.json`, just like how other model types in candle already do (see the bert.rs file for example).