### PR TITLE
Fix the guide to gain access to Stable Diffusion 3 Medium

### DIFF
--- a/candle-examples/examples/stable-diffusion-3/README.md
+++ b/candle-examples/examples/stable-diffusion-3/README.md
@@ -12,9 +12,16 @@ Stable Diffusion 3 Medium is a text-to-image model based on Multimodal Diffusion
 
 ## Getting access to the weights
 
-The weights of Stable Diffusion 3 Medium is released by Stability AI under the Stability Community License. You will need to accept the conditions and acquire a license by visiting the [repo on HuggingFace Hub](https://huggingface.co/stabilityai/stable-diffusion-3-medium) to gain access to the weights for your HuggingFace account.
+The weights of Stable Diffusion 3 Medium is released by Stability AI under the Stability Community License. You will need to accept the conditions and acquire a license by visiting [the repo on HuggingFace Hub](https://huggingface.co/stabilityai/stable-diffusion-3-medium) to gain access to the weights for your HuggingFace account.
 
-On the first run, the weights will be automatically downloaded from the Huggingface Hub. You might be prompted to configure a [Huggingface User Access Tokens](https://huggingface.co/docs/hub/en/security-tokens) (recommended) on your computer if you haven't done that before. After the download, the weights will be [cached](https://huggingface.co/docs/datasets/en/cache) and remain accessible locally.
+To allow your computer to gain access to the public-gated repos on HuggingFace, you might need to create a [HuggingFace User Access Tokens](https://huggingface.co/docs/hub/en/security-tokens) (recommended) and log in on your computer if you haven't done that before. A convenient way to do the login is to use [huggingface-cli](https://huggingface.co/docs/huggingface_hub/en/guides/cli):
+
+```shell
+huggingface-cli login
+```
+and you will be prompted to enter your token.
+
+On the first run, the weights will be automatically downloaded from the Huggingface Hub. After the download, the weights will be [cached](https://huggingface.co/docs/datasets/en/cache) and remain accessible locally.
 
 ## Running the model
 


### PR DESCRIPTION
This follows and completes #2558 . 

@LaurentMazare I just realized the user needs to login to HuggingFace via Access Token separately by running huggingface-cli. Rust's `hf_hub` doesn't seem to prompt that automatically.