### PR TITLE
[chore] Fix small typo in doc string of `Tensor::zeros_like`

### DIFF
--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -242,7 +242,7 @@ impl Tensor {
         Self::zeros_impl(shape, dtype, device, false)
     }
 
-    /// Creates a new tensor filled with ones with same shape, dtype, and device as the other
+    /// Creates a new tensor filled with zeros with same shape, dtype, and device as the other
     /// tensor.
     ///
     /// ```rust


### PR DESCRIPTION
The doc string for `zeros_like` mistakenly says that the resulting `Tensor` will be filled with "ones" as opposed to "zeros".