### PR TITLE
Dep Version Bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ categories = ["science"]
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-ab_glyph = "0.2.23"
+ab_glyph = "0.2.29"
 accelerate-src = { version = "0.3.2" }
 anyhow = { version = "1", features = ["backtrace"] }
-byteorder = "1.4.3"
+byteorder = "1.5.0"
 candle = { path = "./candle-core", package = "candle-core", version = "0.8.1" }
 candle-datasets = { path = "./candle-datasets", version = "0.8.1" }
 candle-flash-attn = { path = "./candle-flash-attn", version = "0.8.1" }
@@ -41,40 +41,40 @@ candle-metal-kernels = { path = "./candle-metal-kernels", version = "0.8.1" }
 candle-nn = { path = "./candle-nn", version = "0.8.1" }
 candle-onnx = { path = "./candle-onnx", version = "0.8.1" }
 candle-transformers = { path = "./candle-transformers", version = "0.8.1" }
-clap = { version = "4.2.4", features = ["derive"] }
+clap = { version = "4.5.23", features = ["derive"] }
 criterion = { version = "0.5.1", default-features=false }
 cudarc = { version = "0.12.1", features = ["std", "cublas", "cublaslt", "curand", "driver", "nvrtc", "f16", "cuda-version-from-build-system", "dynamic-linking"], default-features=false }
 fancy-regex = "0.13.0"
-gemm = { version = "0.17.0", features = ["wasm-simd128-enable"] }
+gemm = { version = "0.17.1", features = ["wasm-simd128-enable"] }
 hf-hub = { version = "0.3.3", package = "candle-hf-hub" }
-half = { version = "2.3.1", features = ["num-traits", "use-intrinsics", "rand_distr"] }
+half = { version = "2.4.1", features = ["num-traits", "use-intrinsics", "rand_distr"] }
 hound = "3.5.1"
-image = { version = "0.25.2", default-features = false, features = ["jpeg", "png"] }
+image = { version = "0.25.5", default-features = false, features = ["jpeg", "png"] }
 imageproc = { version = "0.24.0", default-features = false }
 intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"] }
-libc = { version = "0.2.147" }
+libc = { version = "0.2.167" }
 log = "0.4"
-memmap2 = { version = "0.9.3", features = ["stable_deref_trait"] }
-num_cpus = "1.15.0"
-num-traits = "0.2.15"
+memmap2 = { version = "0.9.5", features = ["stable_deref_trait"] }
+num_cpus = "1.16.0"
+num-traits = "0.2.19"
 parquet = { version = "51.0.0" }
 rand = "0.8.5"
 rand_distr = "0.4.3"
-rayon = "1.7.0"
-safetensors = "0.4.1"
-serde = { version = "1.0.171", features = ["derive"] }
+rayon = "1.10.0"
+safetensors = "0.4.5"
+serde = { version = "1.0.215", features = ["derive"] }
 serde_plain = "1.0.2"
-serde_json = "1.0.99"
+serde_json = "1.0.133"
 thiserror = "1"
 tokenizers = { version = "0.19.1", default-features = false }
-tracing = "0.1.37"
-tracing-chrome = "0.7.1"
-tracing-subscriber = "0.3.7"
+tracing = "0.1.41"
+tracing-chrome = "0.7.2"
+tracing-subscriber = "0.3.19"
 ug = "0.0.2"
 ug-cuda = "0.0.2"
 ug-metal = "0.0.2"
-yoke = { version = "0.7.2", features = ["derive"] }
-zip = { version = "1.1.1", default-features = false }
+yoke = { version = "0.7.5", features = ["derive"] }
+zip = { version = "1.1.4", default-features = false }
 metal = { version = "0.27.0", features = ["mps"]}
 
 [profile.release-with-debug]

--- a/candle-book/Cargo.toml
+++ b/candle-book/Cargo.toml
@@ -25,7 +25,7 @@ cudarc = { workspace = true, optional = true }
 half = { workspace = true, optional = true }
 image = { workspace = true, optional = true }
 anyhow = { workspace = true }
-tokio = "1.29.1"
+tokio = "1.42.0"
 
 [dev-dependencies]
 byteorder = { workspace = true }

--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -18,7 +18,7 @@ candle-transformers = { workspace = true }
 candle-flash-attn = { workspace = true, optional = true }
 candle-onnx = { workspace = true, optional = true }
 
-csv = "1.3.0"
+csv = "1.3.1"
 cudarc = { workspace = true, optional = true }
 half = { workspace = true, optional = true }
 hf-hub = { workspace = true, features = ["tokio"] }
@@ -27,15 +27,15 @@ intel-mkl-src = { workspace = true, optional = true }
 num-traits = { workspace = true }
 palette = { version = "0.7.6", optional = true }
 enterpolation = { version = "0.2.1", optional = true}
-pyo3 = { version = "0.22.0", features = ["auto-initialize", "abi3-py311"], optional = true }
+pyo3 = { version = "0.22.6", features = ["auto-initialize", "abi3-py311"], optional = true }
 rayon = { workspace = true }
 rubato = { version = "0.15.0", optional = true }
 safetensors = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-symphonia = { version = "0.5.3", features = ["all"], optional = true }
+symphonia = { version = "0.5.4", features = ["all"], optional = true }
 tokenizers = { workspace = true, features = ["onig"] }
-cpal = { version = "0.15.2", optional = true }
+cpal = { version = "0.15.3", optional = true }
 pdf2image = { version = "0.1.2" , optional = true}
 
 [dev-dependencies]
@@ -50,11 +50,11 @@ tracing = { workspace = true }
 tracing-chrome = { workspace = true }
 tracing-subscriber = { workspace = true }
 # Necessary to disambiguate with tokio in wasm examples which are 1.28.1
-tokio = "1.29.1"
+tokio = "1.42.0"
 
 [build-dependencies]
 anyhow = { workspace = true }
-bindgen_cuda = { version = "0.1.1", optional = true }
+bindgen_cuda = { version = "0.1.5", optional = true }
 
 [features]
 default = []

--- a/candle-metal-kernels/Cargo.toml
+++ b/candle-metal-kernels/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 
 [dependencies]
-metal = { version = "0.27.0", features = ["mps"] }
+metal = { version = "0.30.0", features = ["mps"] }
 once_cell = "1.18.0"
 thiserror = "1"
 tracing = "0.1.37"
@@ -19,9 +19,9 @@ tracing = "0.1.37"
 [dev-dependencies]
 clap = { version = "4.2.4", features = ["derive"] }
 half = { version = "2.3.1", features = [
-  "num-traits",
-  "use-intrinsics",
-  "rand_distr",
+    "num-traits",
+    "use-intrinsics",
+    "rand_distr",
 ] }
 anyhow = "1"
 rand = "0.8.5"

--- a/candle-pyo3/Cargo.toml
+++ b/candle-pyo3/Cargo.toml
@@ -20,7 +20,7 @@ candle-nn = { workspace = true }
 candle-onnx = { workspace = true, optional = true }
 half = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
-pyo3 = { version = "0.22.0", features = ["extension-module", "abi3-py311"] }
+pyo3 = { version = "0.22.6", features = ["extension-module", "abi3-py311"] }
 
 [build-dependencies]
 pyo3-build-config = "0.22"


### PR DESCRIPTION
- metal 0.27-30
- `cargo-upgrade` for core package.


## Test Package

```
cargo test 

# all pass
```

## Test Metal

```sh
(base) zcpowers@Zacharys-MacBook-Air candle-metal-kernels % cargo run --example  metal_benchmarks -- gemm
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/examples/metal_benchmarks gemm`
MFA F16,         512      gflops 265
MLX F16,         512      gflops 319
MFA F16,        1024      gflops 184
MLX F16,        1024      gflops 217
MFA F16,        2048      gflops 191
MLX F16,        2048      gflops 235
MFA F16,        4096      gflops 279
MLX F16,        4096      gflops 351
MFA F32,         512      gflops 90
MLX F32,         512      gflops 180
MFA F32,        1024      gflops 199
MLX F32,        1024      gflops 187
MFA F32,        2048      gflops 120
MLX F32,        2048      gflops 162
MFA F32,        4096      gflops 238
MLX F32,        4096      gflops 162
```