### PR TITLE
Add Llama 3.3 70B to llama example

### DIFF
--- a/candle-examples/examples/llama/main.rs
+++ b/candle-examples/examples/llama/main.rs
@@ -39,6 +39,7 @@ enum Which {
     V32_1bInstruct,
     V32_3b,
     V32_3bInstruct,
+    V33_70bInstruct,
     #[value(name = "solar-10.7b")]
     Solar10_7B,
     #[value(name = "tiny-llama-1.1b-chat")]
@@ -158,6 +159,7 @@ fn main() -> Result<()> {
                 Which::V32_1bInstruct => "meta-llama/Llama-3.2-1B-Instruct",
                 Which::V32_3b => "meta-llama/Llama-3.2-3B",
                 Which::V32_3bInstruct => "meta-llama/Llama-3.2-3B-Instruct",
+                Which::V33_70bInstruct => "meta-llama/Llama-3.3-70B-Instruct",
                 Which::Solar10_7B => "upstage/SOLAR-10.7B-v1.0",
                 Which::TinyLlama1_1BChat => "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
                 Which::SmolLM2_135M => "HuggingFaceTB/SmolLM2-135M",
@@ -187,6 +189,7 @@ fn main() -> Result<()> {
             | Which::V31Instruct
             | Which::V32_3b
             | Which::V32_3bInstruct
+            | Which::V33_70bInstruct
             | Which::Solar10_7B => {
                 candle_examples::hub_load_safetensors(&api, "model.safetensors.index.json")?
             }


### PR DESCRIPTION
In the llama example update the list of models and urls to include the new 3.3 70B