### PR TITLE
Fix position encodings for Pixtral

### DIFF
--- a/candle-transformers/src/models/pixtral/vision_model.rs
+++ b/candle-transformers/src/models/pixtral/vision_model.rs
@@ -342,8 +342,8 @@ impl Model {
         let idx = Tensor::arange(0, num_patches_h as u32, device)?;
         let idy = Tensor::arange(0, num_patches_w as u32, device)?;
         let mesh = Tensor::meshgrid(&[idx, idy], false)?;
-        let ids = (&mesh[0] * (self.max_image_width as f64) + &mesh[1])?;
-        Ok(ids.flatten_all())
+        let ids = (&mesh[0] * (self.max_image_width as f64) + &mesh[1])?.flatten_all()?;
+        Ok(ids)
     }
 }
 

--- a/candle-transformers/src/models/pixtral/vision_model.rs
+++ b/candle-transformers/src/models/pixtral/vision_model.rs
@@ -343,7 +343,7 @@ impl Model {
         let idy = Tensor::arange(0, num_patches_w as u32, device)?;
         let mesh = Tensor::meshgrid(&[idx, idy], false)?;
         let ids = (&mesh[0] * (self.max_image_width as f64) + &mesh[1])?;
-        Ok(ids.flatten_all()?)
+        Ok(ids.flatten_all())
     }
 }
 

--- a/candle-transformers/src/models/pixtral/vision_model.rs
+++ b/candle-transformers/src/models/pixtral/vision_model.rs
@@ -2,7 +2,7 @@ use candle::{DType, Device, Module, Result, Tensor, D};
 use candle_nn::{linear_b, rms_norm, Linear, RmsNorm, VarBuilder};
 
 fn default_act() -> candle_nn::Activation {
-    candle_nn::Activation::Gelu
+    candle_nn::Activation::Silu
 }
 
 fn default_hidden_size() -> usize {
@@ -58,7 +58,7 @@ impl Config {
             num_attention_heads: 16,
             head_dim: None,
             // Default
-            hidden_act: candle_nn::Activation::Gelu,
+            hidden_act: candle_nn::Activation::Silu,
         }
     }
 


### PR DESCRIPTION
For Pixtral models, the position encodings are resampled on-the-fly when dealing with images which are smaller than the default model's config (1024x1024px images, or 64x64 patches of size 16px x 16px). Doing so seems to slightly improve generations (in particular when it comes to the number of objects).

  * [link](https://github.com/huggingface/transformers/blob/05260a1fc1c8571a2b421ce72b680d5f1bc3e5a4/src/transformers/models/pixtral/modeling_pixtral.py#L501) to ref in Huggingface code
  * [testing the fix](https://gist.github.com/ameroyer/fb565b817291e0e848a6d920ff93b8fc) : mainly looking at the model outputs for different image size