### PR TITLE
Add Support for mixed quantized BitNet Architecture Inference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ serde = { version = "1.0.171", features = ["derive"] }
 serde_plain = "1.0.2"
 serde_json = "1.0.99"
 thiserror = "1"
-tokenizers = { version = "0.19.1", default-features = false }
+tokenizers = { version = "0.21.0", default-features = false }
 tracing = "0.1.37"
 tracing-chrome = "0.7.1"
 tracing-subscriber = "0.3.7"

--- a/candle-core/src/quantized/ggml_file.rs
+++ b/candle-core/src/quantized/ggml_file.rs
@@ -189,6 +189,9 @@ pub fn qtensor_from_ggml(
         GgmlDType::Q2b0 => {
             from_raw_data::<k_quants::BlockQ2b0>(raw_data, size_in_bytes, dims, device)
         }
+        GgmlDType::QI8 => {
+            from_raw_data::<k_quants::BlockQI8>(raw_data, size_in_bytes, dims, device)
+        }
         _ => crate::bail!("quantized type {ggml_dtype:?} is not supported yet"),
     }
 }

--- a/candle-core/src/quantized/ggml_file.rs
+++ b/candle-core/src/quantized/ggml_file.rs
@@ -183,6 +183,12 @@ pub fn qtensor_from_ggml(
         GgmlDType::Q6K => {
             from_raw_data::<k_quants::BlockQ6K>(raw_data, size_in_bytes, dims, device)
         }
+        GgmlDType::Q8K => {
+            from_raw_data::<k_quants::BlockQ8K>(raw_data, size_in_bytes, dims, device)
+        }
+        GgmlDType::Q2b0 => {
+            from_raw_data::<k_quants::BlockQ2b0>(raw_data, size_in_bytes, dims, device)
+        }
         _ => crate::bail!("quantized type {ggml_dtype:?} is not supported yet"),
     }
 }

--- a/candle-core/src/quantized/gguf_file.rs
+++ b/candle-core/src/quantized/gguf_file.rs
@@ -174,6 +174,22 @@ impl Value {
         }
     }
 
+    pub fn from_u8(v: u8) -> Self {
+        Self::U8(v)
+    }
+
+    pub fn from_u64(v: u64) -> Self {
+        Self::U64(v)
+    }
+
+    pub fn from_u32(v: u32) -> Self {
+        Self::U32(v)
+    }
+
+    pub fn from_f32(v: f32) -> Self {
+        Self::F32(v)
+    }
+
     pub fn to_u8(&self) -> Result<u8> {
         match self {
             Self::U8(v) => Ok(*v),
@@ -489,7 +505,7 @@ fn write_string<W: std::io::Write>(w: &mut W, str: &str) -> Result<()> {
 
 pub fn write<W: std::io::Seek + std::io::Write>(
     w: &mut W,
-    metadata: &[(&str, &Value)],
+    metadata: &[(&str, Value)],
     tensors: &[(&str, &QTensor)],
 ) -> Result<()> {
     w.write_u32::<LittleEndian>(0x46554747)?;

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -107,6 +107,10 @@ impl QMetalStorage {
                 let vec: Vec<crate::quantized::BlockQ2b0> = read_to_vec(&buffer, block_len);
                 crate::quantized::BlockQ2b0::to_float(&vec, &mut out)?;
             }
+            GgmlDType::QI8 => {
+                let vec: Vec<crate::quantized::BlockQI8> = read_to_vec(&buffer, block_len);
+                crate::quantized::BlockQI8::to_float(&vec, &mut out)?;
+            }
         }
 
         let buffer = self.device.new_buffer_with_data(&out)?;
@@ -230,6 +234,7 @@ impl From<GgmlDType> for candle_metal_kernels::GgmlDType {
             GgmlDType::F16 => candle_metal_kernels::GgmlDType::F16,
             GgmlDType::F32 => candle_metal_kernels::GgmlDType::F32,
             GgmlDType::Q2b0 => candle_metal_kernels::GgmlDType::Q2b0,
+            GgmlDType::QI8 => todo!(),
         }
     }
 }

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -103,6 +103,10 @@ impl QMetalStorage {
                 let vec: Vec<crate::quantized::BlockQ8K> = read_to_vec(&buffer, block_len);
                 crate::quantized::BlockQ8K::to_float(&vec, &mut out)?;
             }
+            GgmlDType::Q2b0 => {
+                let vec: Vec<crate::quantized::BlockQ2b0> = read_to_vec(&buffer, block_len);
+                crate::quantized::BlockQ2b0::to_float(&vec, &mut out)?;
+            }
         }
 
         let buffer = self.device.new_buffer_with_data(&out)?;
@@ -225,6 +229,7 @@ impl From<GgmlDType> for candle_metal_kernels::GgmlDType {
             GgmlDType::Q8K => candle_metal_kernels::GgmlDType::Q8K,
             GgmlDType::F16 => candle_metal_kernels::GgmlDType::F16,
             GgmlDType::F32 => candle_metal_kernels::GgmlDType::F32,
+            GgmlDType::Q2b0 => candle_metal_kernels::GgmlDType::Q2b0,
         }
     }
 }

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -146,6 +146,7 @@ pub enum GgmlDType {
     Q5K,
     Q6K,
     Q8K,
+    Q2b0,
 }
 
 impl GgmlDType {
@@ -165,6 +166,7 @@ impl GgmlDType {
             13 => Self::Q5K,
             14 => Self::Q6K,
             15 => Self::Q8K,
+            40 => Self::Q2b0,
             _ => crate::bail!("unknown dtype for tensor {u}"),
         };
         Ok(dtype)
@@ -186,6 +188,7 @@ impl GgmlDType {
             Self::Q5K => 13,
             Self::Q6K => 14,
             Self::Q8K => 15,
+            Self::Q2b0 => 40,
         }
     }
 
@@ -206,6 +209,7 @@ impl GgmlDType {
             Self::Q5K => Box::new(vec![BlockQ5K::zeros(); elem_count / BlockQ5K::BLCK_SIZE]),
             Self::Q6K => Box::new(vec![BlockQ6K::zeros(); elem_count / BlockQ6K::BLCK_SIZE]),
             Self::Q8K => Box::new(vec![BlockQ8K::zeros(); elem_count / BlockQ8K::BLCK_SIZE]),
+            Self::Q2b0 => Box::new(vec![BlockQ2b0::zeros(); elem_count / BlockQ2b0::BLCK_SIZE]),
         }
     }
     /// The type size for blocks in bytes.
@@ -227,6 +231,7 @@ impl GgmlDType {
             Self::Q5K => std::mem::size_of::<BlockQ5K>(),
             Self::Q6K => std::mem::size_of::<BlockQ6K>(),
             Self::Q8K => std::mem::size_of::<BlockQ8K>(),
+            Self::Q2b0 => std::mem::size_of::<BlockQ2b0>(),
         }
     }
 
@@ -241,7 +246,7 @@ impl GgmlDType {
             Self::Q5_1 => k_quants::QK5_1,
             Self::Q8_0 => k_quants::QK8_0,
             Self::Q8_1 => k_quants::QK8_1,
-            Self::Q2K | Self::Q3K | Self::Q4K | Self::Q5K | Self::Q6K | Self::Q8K => k_quants::QK_K,
+            Self::Q2b0 | Self::Q2K | Self::Q3K | Self::Q4K | Self::Q5K | Self::Q6K | Self::Q8K => k_quants::QK_K,
         }
     }
 }

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -147,6 +147,7 @@ pub enum GgmlDType {
     Q6K,
     Q8K,
     Q2b0,
+    QI8,
 }
 
 impl GgmlDType {
@@ -167,6 +168,7 @@ impl GgmlDType {
             14 => Self::Q6K,
             15 => Self::Q8K,
             40 => Self::Q2b0,
+            41 => Self::QI8,
             _ => crate::bail!("unknown dtype for tensor {u}"),
         };
         Ok(dtype)
@@ -189,6 +191,7 @@ impl GgmlDType {
             Self::Q6K => 14,
             Self::Q8K => 15,
             Self::Q2b0 => 40,
+            Self::QI8 => 41,
         }
     }
 
@@ -210,6 +213,7 @@ impl GgmlDType {
             Self::Q6K => Box::new(vec![BlockQ6K::zeros(); elem_count / BlockQ6K::BLCK_SIZE]),
             Self::Q8K => Box::new(vec![BlockQ8K::zeros(); elem_count / BlockQ8K::BLCK_SIZE]),
             Self::Q2b0 => Box::new(vec![BlockQ2b0::zeros(); elem_count / BlockQ2b0::BLCK_SIZE]),
+            Self::QI8 => Box::new(vec![BlockQI8::zeros(); elem_count / BlockQI8::BLCK_SIZE]),
         }
     }
     /// The type size for blocks in bytes.
@@ -232,6 +236,7 @@ impl GgmlDType {
             Self::Q6K => std::mem::size_of::<BlockQ6K>(),
             Self::Q8K => std::mem::size_of::<BlockQ8K>(),
             Self::Q2b0 => std::mem::size_of::<BlockQ2b0>(),
+            Self::QI8 => std::mem::size_of::<BlockQI8>(),
         }
     }
 
@@ -246,7 +251,9 @@ impl GgmlDType {
             Self::Q5_1 => k_quants::QK5_1,
             Self::Q8_0 => k_quants::QK8_0,
             Self::Q8_1 => k_quants::QK8_1,
-            Self::Q2b0 | Self::Q2K | Self::Q3K | Self::Q4K | Self::Q5K | Self::Q6K | Self::Q8K => k_quants::QK_K,
+            Self::Q2b0 => k_quants::Q2B_0,
+            Self::QI8 => k_quants::QI8,
+            Self::Q2K | Self::Q3K | Self::Q4K | Self::Q5K | Self::Q6K | Self::Q8K => k_quants::QK_K,
         }
     }
 }

--- a/candle-core/src/quantized/neon.rs
+++ b/candle-core/src/quantized/neon.rs
@@ -1,6 +1,6 @@
-use super::k_quants::{
-    BlockQ2K, BlockQ3K, BlockQ4K, BlockQ4_0, BlockQ5K, BlockQ6K, BlockQ8K, BlockQ8_0, QK8_0, QK_K, BlockQ2b0
-};
+use super::{k_quants::{
+    BlockQ2K, BlockQ2b0, BlockQ3K, BlockQ4K, BlockQ4_0, BlockQ5K, BlockQ6K, BlockQ8K, BlockQ8_0, Q2B_0, QK8_0, QK_K
+}, BlockQI8};
 use crate::Result;
 use byteorder::{ByteOrder, LittleEndian};
 
@@ -518,8 +518,8 @@ pub(crate) fn vec_dot_q3k_q8k(n: usize, xs: &[BlockQ3K], ys: &[BlockQ8K]) -> Res
 }
 
 #[inline(always)]
-pub(crate) fn vec_dot_q2b0_q8k(n: usize, xs: &[BlockQ2b0], ys: &[BlockQ8K]) -> crate::Result<f32> {
-    if n % QK_K != 0 {
+pub(crate) fn vec_dot_q2b0_qi8(n: usize, xs: &[BlockQ2b0], ys: &[BlockQI8]) -> crate::Result<f32> {
+    if n % Q2B_0 != 0 {
         crate::bail!("vec_dot_q2b0_q8k: {n} is not divisible by {QK_K}")
     }
 
@@ -529,7 +529,7 @@ pub(crate) fn vec_dot_q2b0_q8k(n: usize, xs: &[BlockQ2b0], ys: &[BlockQ8K]) -> c
         for (x, y) in xs.iter().zip(ys.iter()) {
             let mut isum = 0_i32;
 
-            for i in 0..(QK_K / 8) {
+            for i in 0..(Q2B_0 / 8) {
                 let qs = x.qs[i];
                 let qd = x.qd[i];
 
@@ -568,7 +568,7 @@ pub(crate) fn vec_dot_q2b0_q8k(n: usize, xs: &[BlockQ2b0], ys: &[BlockQ8K]) -> c
                 isum += pos_sum as i32 - neg_sum as i32;
             }
 
-            sumf += isum as f32 * y.d;
+            sumf += isum as f32;
         }
     }
 

--- a/candle-examples/examples/quantized-bitnet/main.rs
+++ b/candle-examples/examples/quantized-bitnet/main.rs
@@ -13,7 +13,7 @@ use candle::Tensor;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
 
 use candle_examples::token_output_stream::TokenOutputStream;
-use candle_transformers::models::quantized_llama as model;
+use candle_transformers::models::quantized_llama_bitnet as model;
 use model::ModelWeights;
 
 const DEFAULT_PROMPT: &str = "My favorite theorem is ";
@@ -27,170 +27,32 @@ enum Prompt {
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, ValueEnum)]
 enum Which {
-    #[value(name = "7b")]
-    L7b,
-    #[value(name = "13b")]
-    L13b,
-    #[value(name = "70b")]
-    L70b,
-    #[value(name = "7b-chat")]
-    L7bChat,
-    #[value(name = "13b-chat")]
-    L13bChat,
-    #[value(name = "70b-chat")]
-    L70bChat,
-    #[value(name = "7b-code")]
-    L7bCode,
-    #[value(name = "13b-code")]
-    L13bCode,
-    #[value(name = "32b-code")]
-    L34bCode,
-    #[value(name = "7b-leo")]
-    Leo7b,
-    #[value(name = "13b-leo")]
-    Leo13b,
-    #[value(name = "7b-mistral")]
-    Mistral7b,
-    #[value(name = "7b-mistral-instruct")]
-    Mistral7bInstruct,
-    #[value(name = "7b-mistral-instruct-v0.2")]
-    Mistral7bInstructV02,
-    #[value(name = "7b-zephyr-a")]
-    Zephyr7bAlpha,
-    #[value(name = "7b-zephyr-b")]
-    Zephyr7bBeta,
-    #[value(name = "7b-open-chat-3.5")]
-    OpenChat35,
-    #[value(name = "7b-starling-a")]
-    Starling7bAlpha,
-    #[value(name = "mixtral")]
-    Mixtral,
-    #[value(name = "mixtral-instruct")]
-    MixtralInstruct,
-    #[value(name = "llama3-8b")]
-    L8b,
-    #[value(name = "phi3")]
-    Phi3,
-    #[value(name = "SmoLM2-360M-Instruct")]
-    SmolLM2_360MInstruct,
-    #[value(name = "SmoLM2-1.7B-Instruct")]
-    SmolLM2_1BInstruct,
+    #[value(name = "falcon3-1b-1.58")]
+    Falcon3_1b1_58,
 }
 
 impl Which {
     fn is_mistral(&self) -> bool {
         match self {
-            Self::L7b
-            | Self::L13b
-            | Self::L70b
-            | Self::L7bChat
-            | Self::L13bChat
-            | Self::L70bChat
-            | Self::L7bCode
-            | Self::L13bCode
-            | Self::L34bCode
-            | Self::Leo7b
-            | Self::Leo13b
-            | Self::L8b
-            | Self::Phi3
-            | Self::SmolLM2_1BInstruct
-            | Self::SmolLM2_360MInstruct => false,
-            // Zephyr and OpenChat are fine tuned versions of mistral and should be treated in the
-            // same way. Starling is a fine tuned version of OpenChat.
-            Self::OpenChat35
-            | Self::Starling7bAlpha
-            | Self::Zephyr7bAlpha
-            | Self::Zephyr7bBeta
-            | Self::Mixtral
-            | Self::MixtralInstruct
-            | Self::Mistral7b
-            | Self::Mistral7bInstruct
-            | Self::Mistral7bInstructV02 => true,
+            Self::Falcon3_1b1_58 => false,
         }
     }
 
     fn is_zephyr(&self) -> bool {
         match self {
-            Self::L7b
-            | Self::L13b
-            | Self::L70b
-            | Self::L7bChat
-            | Self::L13bChat
-            | Self::L70bChat
-            | Self::L7bCode
-            | Self::L13bCode
-            | Self::L34bCode
-            | Self::Leo7b
-            | Self::Leo13b
-            | Self::Mixtral
-            | Self::MixtralInstruct
-            | Self::Mistral7b
-            | Self::Mistral7bInstruct
-            | Self::Mistral7bInstructV02
-            | Self::OpenChat35
-            | Self::Starling7bAlpha
-            | Self::L8b
-            | Self::SmolLM2_1BInstruct
-            | Self::SmolLM2_360MInstruct
-            | Self::Phi3 => false,
-            Self::Zephyr7bAlpha | Self::Zephyr7bBeta => true,
+            Self::Falcon3_1b1_58 => false,
         }
     }
 
     fn is_open_chat(&self) -> bool {
         match self {
-            Self::L7b
-            | Self::L13b
-            | Self::L70b
-            | Self::L7bChat
-            | Self::L13bChat
-            | Self::L70bChat
-            | Self::L7bCode
-            | Self::L13bCode
-            | Self::L34bCode
-            | Self::Leo7b
-            | Self::Leo13b
-            | Self::Mixtral
-            | Self::MixtralInstruct
-            | Self::Mistral7b
-            | Self::Mistral7bInstruct
-            | Self::Mistral7bInstructV02
-            | Self::Zephyr7bAlpha
-            | Self::Zephyr7bBeta
-            | Self::L8b
-            | Self::SmolLM2_1BInstruct
-            | Self::SmolLM2_360MInstruct
-            | Self::Phi3 => false,
-            Self::OpenChat35 | Self::Starling7bAlpha => true,
+            Self::Falcon3_1b1_58 => false,
         }
     }
 
     fn tokenizer_repo(&self) -> &'static str {
         match self {
-            Self::L7b
-            | Self::L13b
-            | Self::L70b
-            | Self::L7bChat
-            | Self::L13bChat
-            | Self::L70bChat
-            | Self::L7bCode
-            | Self::L13bCode
-            | Self::L34bCode => "hf-internal-testing/llama-tokenizer",
-            Self::Leo7b => "LeoLM/leo-hessianai-7b",
-            Self::Leo13b => "LeoLM/leo-hessianai-13b",
-            Self::Mixtral => "mistralai/Mixtral-8x7B-v0.1",
-            Self::MixtralInstruct => "mistralai/Mixtral-8x7B-Instruct-v0.1",
-            Self::Mistral7b
-            | Self::Mistral7bInstruct
-            | Self::Mistral7bInstructV02
-            | Self::Zephyr7bAlpha
-            | Self::Zephyr7bBeta => "mistralai/Mistral-7B-v0.1",
-            Self::OpenChat35 => "openchat/openchat_3.5",
-            Self::Starling7bAlpha => "berkeley-nest/Starling-LM-7B-alpha",
-            Self::L8b => "meta-llama/Meta-Llama-3-8B",
-            Self::Phi3 => "microsoft/Phi-3-mini-4k-instruct",
-            Self::SmolLM2_360MInstruct => "HuggingFaceTB/SmolLM2-360M-Instruct",
-            Self::SmolLM2_1BInstruct => "HuggingFaceTB/SmolLM2-1.7B-Instruct",
+            Self::Falcon3_1b1_58 => "tiiuae/Falcon3-1B-Instruct-1.58bit",
         }
     }
 }
@@ -258,7 +120,7 @@ struct Args {
     repeat_last_n: usize,
 
     /// The model size to use.
-    #[arg(long, default_value = "7b")]
+    #[arg(long, default_value = "falcon3-1b-1.58")]
     which: Which,
 
     /// Group-Query Attention, use 8 for the 70B version of LLaMAv2.
@@ -289,87 +151,12 @@ impl Args {
             Some(config) => std::path::PathBuf::from(config),
             None => {
                 let (repo, filename) = match self.which {
-                    Which::L7b => ("TheBloke/Llama-2-7B-GGML", "llama-2-7b.ggmlv3.q4_0.bin"),
-                    Which::L13b => ("TheBloke/Llama-2-13B-GGML", "llama-2-13b.ggmlv3.q4_0.bin"),
-                    Which::L70b => ("TheBloke/Llama-2-70B-GGML", "llama-2-70b.ggmlv3.q4_0.bin"),
-                    Which::L7bChat => (
-                        "TheBloke/Llama-2-7B-Chat-GGML",
-                        "llama-2-7b-chat.ggmlv3.q4_0.bin",
-                    ),
-                    Which::L13bChat => (
-                        "TheBloke/Llama-2-13B-Chat-GGML",
-                        "llama-2-13b-chat.ggmlv3.q4_0.bin",
-                    ),
-                    Which::L70bChat => (
-                        "TheBloke/Llama-2-70B-Chat-GGML",
-                        "llama-2-70b-chat.ggmlv3.q4_0.bin",
-                    ),
-                    Which::L7bCode => ("TheBloke/CodeLlama-7B-GGUF", "codellama-7b.Q8_0.gguf"),
-                    Which::L13bCode => ("TheBloke/CodeLlama-13B-GGUF", "codellama-13b.Q8_0.gguf"),
-                    Which::L34bCode => ("TheBloke/CodeLlama-34B-GGUF", "codellama-34b.Q8_0.gguf"),
-                    Which::Leo7b => (
-                        "TheBloke/leo-hessianai-7B-GGUF",
-                        "leo-hessianai-7b.Q4_K_M.gguf",
-                    ),
-                    Which::Leo13b => (
-                        "TheBloke/leo-hessianai-13B-GGUF",
-                        "leo-hessianai-13b.Q4_K_M.gguf",
-                    ),
-                    Which::Mixtral => (
-                        "TheBloke/Mixtral-8x7B-v0.1-GGUF",
-                        "mixtral-8x7b-v0.1.Q4_K_M.gguf",
-                    ),
-                    Which::MixtralInstruct => (
-                        "TheBloke/Mixtral-8x7B-Instruct-v0.1-GGUF",
-                        "mixtral-8x7b-instruct-v0.1.Q4_K_M.gguf",
-                    ),
-                    Which::Mistral7b => (
-                        "TheBloke/Mistral-7B-v0.1-GGUF",
-                        "mistral-7b-v0.1.Q4_K_S.gguf",
-                    ),
-                    Which::Mistral7bInstruct => (
-                        "TheBloke/Mistral-7B-Instruct-v0.1-GGUF",
-                        "mistral-7b-instruct-v0.1.Q4_K_S.gguf",
-                    ),
-                    Which::Mistral7bInstructV02 => (
-                        "TheBloke/Mistral-7B-Instruct-v0.2-GGUF",
-                        "mistral-7b-instruct-v0.2.Q4_K_S.gguf",
-                    ),
-                    Which::Zephyr7bAlpha => (
-                        "TheBloke/zephyr-7B-alpha-GGUF",
-                        "zephyr-7b-alpha.Q4_K_M.gguf",
-                    ),
-                    Which::Zephyr7bBeta => {
-                        ("TheBloke/zephyr-7B-beta-GGUF", "zephyr-7b-beta.Q4_K_M.gguf")
-                    }
-                    Which::OpenChat35 => ("TheBloke/openchat_3.5-GGUF", "openchat_3.5.Q4_K_M.gguf"),
-                    Which::Starling7bAlpha => (
-                        "TheBloke/Starling-LM-7B-alpha-GGUF",
-                        "starling-lm-7b-alpha.Q4_K_M.gguf",
-                    ),
-                    // TODO: swap to TheBloke model when available
-                    Which::L8b => (
-                        "QuantFactory/Meta-Llama-3-8B-GGUF",
-                        "Meta-Llama-3-8B.Q4_K_S.gguf",
-                    ),
-                    Which::Phi3 => (
-                        "microsoft/Phi-3-mini-4k-instruct-gguf",
-                        "Phi-3-mini-4k-instruct-q4.gguf",
-                    ),
-                    Which::SmolLM2_360MInstruct => (
-                        "HuggingFaceTB/SmolLM2-360M-Instruct-GGUF",
-                        "smollm2-360m-instruct-q8_0.gguf",
-                    ),
-                    Which::SmolLM2_1BInstruct => (
-                        "HuggingFaceTB/SmolLM2-1.7B-Instruct-GGUF",
-                        "smollm2-1.7b-instruct-q4_k_m.gguf",
+                    Which::Falcon3_1b1_58 => (
+                        "tiiuae/Falcon3-1B-Instruct-1.58bit",
+                        "Falcon3-1B-Instruct-1.58bit.gguf",
                     ),
                 };
-                let revision = if self.which == Which::Phi3 {
-                    "5eef2ce24766d31909c0b269fe90c817a8f263fb"
-                } else {
-                    "main"
-                };
+                let revision = "main";
                 let api = hf_hub::api::sync::Api::new()?;
                 api.repo(hf_hub::Repo::with_revision(
                     repo.to_string(),
@@ -465,32 +252,7 @@ fn main() -> anyhow::Result<()> {
                 start.elapsed().as_secs_f32(),
             );
             println!("params: {:?}", model.hparams);
-            let default_gqa = match args.which {
-                Which::L7b
-                | Which::L13b
-                | Which::L7bChat
-                | Which::L13bChat
-                | Which::L7bCode
-                | Which::L13bCode
-                | Which::L34bCode
-                | Which::Leo7b
-                | Which::Leo13b
-                | Which::L8b
-                | Which::SmolLM2_1BInstruct
-                | Which::SmolLM2_360MInstruct
-                | Which::Phi3 => 1,
-                Which::Mixtral
-                | Which::MixtralInstruct
-                | Which::Mistral7b
-                | Which::Mistral7bInstruct
-                | Which::Mistral7bInstructV02
-                | Which::Zephyr7bAlpha
-                | Which::Zephyr7bBeta
-                | Which::L70b
-                | Which::L70bChat
-                | Which::OpenChat35
-                | Which::Starling7bAlpha => 8,
-            };
+            let default_gqa = 1;
             ModelWeights::from_ggml(model, args.gqa.unwrap_or(default_gqa))?
         }
     };
@@ -596,12 +358,7 @@ fn main() -> anyhow::Result<()> {
         }
 
         let eos_token = match args.which {
-            Which::SmolLM2_360MInstruct | Which::SmolLM2_1BInstruct => "<|endoftext|>",
-            Which::L8b => "<|end_of_text|>",
-            _ => match args.which.is_open_chat() {
-                true => "<|end_of_turn|>",
-                false => "</s>",
-            },
+            Which::Falcon3_1b1_58 => "<|endoftext|>",
         };
 
         let eos_token = *tos.tokenizer().get_vocab(true).get(eos_token).unwrap();

--- a/candle-metal-kernels/src/lib.rs
+++ b/candle-metal-kernels/src/lib.rs
@@ -2164,6 +2164,7 @@ pub enum GgmlDType {
     Q8K,
     F16,
     F32,
+    Q2b0,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2229,7 +2230,7 @@ pub fn call_quantized_matmul_mv_t(
             let align = 4;
             (nth0, nth1, align)
         }
-        GgmlDType::Q3K | GgmlDType::Q5K => {
+        GgmlDType::Q2b0 | GgmlDType::Q3K | GgmlDType::Q5K => {
             let nth0 = 2;
             let nth1 = 32;
             let align = 4;
@@ -2253,7 +2254,7 @@ pub fn call_quantized_matmul_mv_t(
             let nth1 = 1;
             let align = 8;
             (nth0, nth1, align)
-        }
+        },
     };
     let thread_groups_count = MTLSize {
         width: divide(ne01 as usize, align),
@@ -2280,6 +2281,7 @@ pub fn call_quantized_matmul_mv_t(
         GgmlDType::Q8K => "kernel_mul_mv_q8_K_f32",
         GgmlDType::F16 => "kernel_mul_mv_f16_f32",
         GgmlDType::F32 => "kernel_mul_mv_f32_f32",
+        GgmlDType::Q2b0 => todo!(),
     };
 
     let pipeline = kernels.load_pipeline(device, Source::Quantized, name)?;

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -110,3 +110,4 @@ pub mod whisper;
 pub mod with_tracing;
 pub mod wuerstchen;
 pub mod yi;
+pub mod quantized_llama_bitnet;

--- a/candle-transformers/src/models/quantized_llama_bitnet.rs
+++ b/candle-transformers/src/models/quantized_llama_bitnet.rs
@@ -1,0 +1,552 @@
+//! Quantized llama model implementation.
+//!
+//! This provides a quantized implementation of the llama language model architecture.
+//! The model implements parameter efficient quantization for reduced memory usage
+//! while maintaining model quality.
+//!
+//! Key characteristics:
+//! - Transformer decoder architecture
+//! - Support for 2/3/4/8-bit quantization
+//! - Optimized memory usage through quantization
+//! - Configurable model sizes and parameter counts
+//!
+//! - 💻 [GH Link](https://github.com/facebookresearch/llama)
+//! - 📝 [Paper](https://arxiv.org/abs/2302.13971)
+//!
+//! ![](https://raw.githubusercontent.com/huggingface/candle/main/candle-examples/examples/quantized/assets/aoc.gif)
+//!
+
+use std::collections::HashMap;
+
+use crate::quantized_nn::RmsNorm;
+use candle::quantized::QTensor;
+use candle::quantized::{ggml_file, gguf_file};
+use candle::{DType, Device, IndexOp, Result, Tensor, D};
+use candle_nn::{Embedding, Module};
+
+pub const MAX_SEQ_LEN: usize = 4096;
+
+// QMatMul wrapper adding some tracing.
+#[derive(Debug, Clone)]
+struct QMatMul {
+    inner: candle::quantized::QMatMul,
+    span: tracing::Span,
+}
+
+impl QMatMul {
+    fn from_qtensor(qtensor: QTensor) -> Result<Self> {
+        let inner = candle::quantized::QMatMul::from_qtensor(qtensor)?;
+        let span = tracing::span!(tracing::Level::TRACE, "qmatmul");
+        Ok(Self { inner, span })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        self.inner.forward(xs)
+    }
+}
+
+// BitQMatMul wrapper adding some tracing.
+#[derive(Debug, Clone)]
+struct BitQMatMul {
+    inner: candle::quantized::QMatMul,
+    span: tracing::Span,
+}
+
+
+fn activation_quant(x: &Tensor) -> Result<(Tensor, Tensor)> {
+    let scale = (127.0
+        / x.abs()?
+            .max(D::Minus1)?
+            .max(D::Minus1)?
+            .clamp(1e-5, f32::INFINITY)?)?
+    .to_dtype(x.dtype())?;
+
+    let y = x
+        .broadcast_mul(&scale.unsqueeze(D::Minus1)?.unsqueeze(D::Minus1)?)?
+        .round()?
+        .clamp(-128.0, 127.0)?;
+
+    Ok((y, scale))
+}
+
+impl BitQMatMul {
+    fn from_qtensor(qtensor: QTensor) -> Result<Self> {
+        let inner = candle::quantized::QMatMul::from_qtensor(qtensor)?;
+        let span = tracing::span!(tracing::Level::TRACE, "qmatmul");
+        Ok(Self { inner, span })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let (x, x_scale) = activation_quant(x)?;
+
+        let _enter = self.span.enter();
+        self.inner.forward(&x)?.broadcast_div(&x_scale)
+    }
+}
+
+
+#[derive(Debug, Clone)]
+struct Mlp {
+    feed_forward_w1: BitQMatMul,
+    feed_forward_w2: BitQMatMul,
+    feed_forward_w3: BitQMatMul,
+}
+
+impl Module for Mlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let w1 = self.feed_forward_w1.forward(xs)?;
+        let w3 = self.feed_forward_w3.forward(xs)?;
+        self.feed_forward_w2
+            .forward(&(candle_nn::ops::silu(&w1)? * w3)?)
+    }
+}
+
+#[derive(Debug, Clone)]
+enum MlpOrMoe {
+    Mlp(Mlp),
+    MoE {
+        n_expert_used: usize,
+        feed_forward_gate_inp: QMatMul,
+        experts: Vec<Mlp>,
+    },
+}
+
+impl Module for MlpOrMoe {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::MoE {
+                feed_forward_gate_inp,
+                experts,
+                n_expert_used,
+            } => {
+                let (b_size, seq_len, hidden_dim) = xs.dims3()?;
+                let xs = xs.reshape(((), hidden_dim))?;
+                let router_logits = feed_forward_gate_inp.forward(&xs)?;
+                let routing_weights = candle_nn::ops::softmax_last_dim(&router_logits)?;
+
+                // In order to extract topk, we extract the data from the tensor and manipulate it
+                // directly. Maybe we will want to use some custom ops instead at some point.
+                let routing_weights = routing_weights.to_dtype(DType::F32)?.to_vec2::<f32>()?;
+
+                // routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+                // top_x contains the row indexes to evaluate for each expert.
+                let mut top_x = vec![vec![]; experts.len()];
+                let mut selected_rws = vec![vec![]; experts.len()];
+                for (row_idx, rw) in routing_weights.iter().enumerate() {
+                    let mut dst = (0..rw.len() as u32).collect::<Vec<u32>>();
+                    dst.sort_by(|&i, &j| rw[j as usize].total_cmp(&rw[i as usize]));
+                    let mut sum_routing_weights = 0f32;
+                    for &expert_idx in dst.iter().take(*n_expert_used) {
+                        let expert_idx = expert_idx as usize;
+                        let routing_weight = rw[expert_idx];
+                        sum_routing_weights += routing_weight;
+                        top_x[expert_idx].push(row_idx as u32);
+                    }
+                    for &expert_idx in dst.iter().take(*n_expert_used) {
+                        let expert_idx = expert_idx as usize;
+                        let routing_weight = rw[expert_idx];
+                        selected_rws[expert_idx].push(routing_weight / sum_routing_weights)
+                    }
+                }
+
+                // routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+                // expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
+
+                let mut ys = xs.zeros_like()?;
+                for (expert_idx, expert_layer) in experts.iter().enumerate() {
+                    let top_x = &top_x[expert_idx];
+                    if top_x.is_empty() {
+                        continue;
+                    }
+                    let top_x = Tensor::new(top_x.as_slice(), xs.device())?;
+                    let selected_rws =
+                        Tensor::new(selected_rws[expert_idx].as_slice(), xs.device())?
+                            .reshape(((), 1))?;
+                    // Index the correct hidden states and compute the expert hidden state for
+                    // the current expert. We need to make sure to multiply the output hidden
+                    // states by `routing_weights` on the corresponding tokens (top-1 and top-2)
+                    let current_state = xs.index_select(&top_x, 0)?.reshape(((), hidden_dim))?;
+                    // current_hidden_states = expert_layer(current_state, routing_weights[top_x_list, idx_list, None])
+                    let current_hidden_states = expert_layer.forward(&current_state)?;
+                    let current_hidden_states =
+                        current_hidden_states.broadcast_mul(&selected_rws)?;
+                    ys = ys.index_add(&top_x, &current_hidden_states, 0)?;
+                }
+
+                let ys = ys.reshape((b_size, seq_len, hidden_dim))?;
+                Ok(ys)
+            }
+            Self::Mlp(mlp) => mlp.forward(xs),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LayerWeights {
+    attention_wq: BitQMatMul,
+    attention_wk: BitQMatMul,
+    attention_wv: BitQMatMul,
+    attention_wo: BitQMatMul,
+    attention_norm: RmsNorm,
+    mlp_or_moe: MlpOrMoe,
+    ffn_norm: RmsNorm,
+    n_head: usize,
+    n_kv_head: usize,
+    head_dim: usize,
+    cos: Tensor,
+    sin: Tensor,
+    neg_inf: Tensor,
+    kv_cache: Option<(Tensor, Tensor)>,
+    span_attn: tracing::Span,
+    span_rot: tracing::Span,
+    span_mlp: tracing::Span,
+}
+
+fn masked_fill(on_false: &Tensor, mask: &Tensor, on_true: &Tensor) -> Result<Tensor> {
+    let shape = mask.shape();
+    let m = mask.where_cond(&on_true.broadcast_as(shape.dims())?, on_false)?;
+    Ok(m)
+}
+
+impl LayerWeights {
+    fn apply_rotary_emb(&self, x: &Tensor, index_pos: usize) -> Result<Tensor> {
+        let _enter = self.span_rot.enter();
+        let (_b_sz, _n_head, seq_len, _n_embd) = x.dims4()?;
+        let cos = self.cos.narrow(0, index_pos, seq_len)?;
+        let sin = self.sin.narrow(0, index_pos, seq_len)?;
+        // The call to contiguous below is only necessary when processing the prompt.
+        // When the seq_len is 1 in the inference loop, this is a no-op.
+        candle_nn::rotary_emb::rope_i(&x.contiguous()?, &cos, &sin)
+    }
+
+    fn forward_attn(
+        &mut self,
+        x: &Tensor,
+        mask: Option<&Tensor>,
+        index_pos: usize,
+    ) -> Result<Tensor> {
+        let _enter = self.span_attn.enter();
+        let (b_sz, seq_len, n_embd) = x.dims3()?;
+        let q = self.attention_wq.forward(x)?;
+        let k = self.attention_wk.forward(x)?;
+        let v = self.attention_wv.forward(x)?;
+
+        let q = q
+            .reshape((b_sz, seq_len, self.n_head, self.head_dim))?
+            .transpose(1, 2)?;
+        let k = k
+            .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+            .transpose(1, 2)?;
+        let v = v
+            .reshape((b_sz, seq_len, self.n_kv_head, self.head_dim))?
+            .transpose(1, 2)?
+            // This call to contiguous ensures that the fast kernel can be called below. It's
+            // actually a no-op except when processing the initial prompt so has no significant
+            // impact on performance.
+            .contiguous()?;
+
+        let q = self.apply_rotary_emb(&q, index_pos)?;
+        let k = self.apply_rotary_emb(&k, index_pos)?;
+
+        let (k, v) = match &self.kv_cache {
+            None => (k, v),
+            Some((k_cache, v_cache)) => {
+                if index_pos == 0 {
+                    (k, v)
+                } else {
+                    let k = Tensor::cat(&[k_cache, &k], 2)?;
+                    let v = Tensor::cat(&[v_cache, &v], 2)?;
+                    (k, v)
+                }
+            }
+        };
+        self.kv_cache = Some((k.clone(), v.clone()));
+
+        let y = if q.device().is_metal() && seq_len == 1 {
+            // SDPA will do MQA for us
+            candle_nn::ops::sdpa(&q, &k, &v, 1. / (self.head_dim as f32).sqrt(), 1.)?
+        } else {
+            // Support for MQA, useful for 70B models and mistral.
+            let k = crate::utils::repeat_kv(k, self.n_head / self.n_kv_head)?;
+            let v = crate::utils::repeat_kv(v, self.n_head / self.n_kv_head)?;
+
+            let att = (q.matmul(&k.t()?)? / (self.head_dim as f64).sqrt())?;
+            let att = match mask {
+                None => att,
+                Some(mask) => {
+                    let mask = mask.broadcast_as(att.shape())?;
+                    masked_fill(&att, &mask, &self.neg_inf)?
+                }
+            };
+            let att = candle_nn::ops::softmax_last_dim(&att)?;
+            // Convert to contiguous as matmul doesn't support strided vs for now.
+            att.matmul(&v.contiguous()?)?
+        };
+
+        let y = y.transpose(1, 2)?.reshape(&[b_sz, seq_len, n_embd])?;
+        let y = self.attention_wo.forward(&y)?;
+        Ok(y)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ModelWeights {
+    tok_embeddings: Embedding,
+    layers: Vec<LayerWeights>,
+    norm: RmsNorm,
+    output: QMatMul,
+    masks: HashMap<usize, Tensor>,
+    span: tracing::Span,
+    span_output: tracing::Span,
+}
+
+fn precomput_freqs_cis(
+    head_dim: usize,
+    freq_base: f32,
+    device: &Device,
+) -> Result<(Tensor, Tensor)> {
+    let theta: Vec<_> = (0..head_dim)
+        .step_by(2)
+        .map(|i| 1f32 / freq_base.powf(i as f32 / head_dim as f32))
+        .collect();
+    let theta = Tensor::new(theta.as_slice(), device)?;
+    let idx_theta = Tensor::arange(0, MAX_SEQ_LEN as u32, device)?
+        .to_dtype(DType::F32)?
+        .reshape((MAX_SEQ_LEN, 1))?
+        .matmul(&theta.reshape((1, theta.elem_count()))?)?;
+    let cos = idx_theta.cos()?;
+    let sin = idx_theta.sin()?;
+    Ok((cos, sin))
+}
+
+impl ModelWeights {
+    pub fn from_ggml(mut ct: ggml_file::Content, gqa: usize) -> Result<Self> {
+        let head_dim = (ct.hparams.n_embd / ct.hparams.n_head) as usize;
+        let (cos, sin) = precomput_freqs_cis(head_dim, 10000., &ct.device)?;
+        let neg_inf = Tensor::new(f32::NEG_INFINITY, &ct.device)?;
+        let tok_embeddings = ct.remove("tok_embeddings.weight")?;
+        let tok_embeddings = tok_embeddings.dequantize(&ct.device)?;
+        let norm = RmsNorm::from_qtensor(ct.remove("norm.weight")?, 1e-5)?;
+        let output = ct.remove("output.weight")?;
+        let mut layers = Vec::with_capacity(ct.hparams.n_layer as usize);
+        for layer_idx in 0..ct.hparams.n_layer {
+            let prefix = format!("layers.{layer_idx}");
+            let attention_wq = ct.remove(&format!("{prefix}.attention.wq.weight"))?;
+            let attention_wk = ct.remove(&format!("{prefix}.attention.wk.weight"))?;
+            let attention_wv = ct.remove(&format!("{prefix}.attention.wv.weight"))?;
+            let attention_wo = ct.remove(&format!("{prefix}.attention.wo.weight"))?;
+            let mlp_or_moe = {
+                let feed_forward_w1 = ct.remove(&format!("{prefix}.feed_forward.w1.weight"))?;
+                let feed_forward_w2 = ct.remove(&format!("{prefix}.feed_forward.w2.weight"))?;
+                let feed_forward_w3 = ct.remove(&format!("{prefix}.feed_forward.w3.weight"))?;
+                MlpOrMoe::Mlp(Mlp {
+                    feed_forward_w1: BitQMatMul::from_qtensor(feed_forward_w1)?,
+                    feed_forward_w2: BitQMatMul::from_qtensor(feed_forward_w2)?,
+                    feed_forward_w3: BitQMatMul::from_qtensor(feed_forward_w3)?,
+                })
+            };
+            let attention_norm = ct.remove(&format!("{prefix}.attention_norm.weight"))?;
+            let ffn_norm = ct.remove(&format!("{prefix}.ffn_norm.weight"))?;
+            let span_attn = tracing::span!(tracing::Level::TRACE, "attn");
+            let span_rot = tracing::span!(tracing::Level::TRACE, "attn-rot");
+            let span_mlp = tracing::span!(tracing::Level::TRACE, "attn-mlp");
+            layers.push(LayerWeights {
+                attention_wq: BitQMatMul::from_qtensor(attention_wq)?,
+                attention_wk: BitQMatMul::from_qtensor(attention_wk)?,
+                attention_wv: BitQMatMul::from_qtensor(attention_wv)?,
+                attention_wo: BitQMatMul::from_qtensor(attention_wo)?,
+                attention_norm: RmsNorm::from_qtensor(attention_norm, 1e-5)?,
+                mlp_or_moe,
+                ffn_norm: RmsNorm::from_qtensor(ffn_norm, 1e-5)?,
+                n_head: ct.hparams.n_head as usize,
+                n_kv_head: ct.hparams.n_head as usize / gqa,
+                head_dim: (ct.hparams.n_embd / ct.hparams.n_head) as usize,
+                cos: cos.clone(),
+                sin: sin.clone(),
+                neg_inf: neg_inf.clone(),
+                kv_cache: None,
+                span_attn,
+                span_rot,
+                span_mlp,
+            })
+        }
+        let span = tracing::span!(tracing::Level::TRACE, "model");
+        let span_output = tracing::span!(tracing::Level::TRACE, "output");
+        Ok(Self {
+            tok_embeddings: Embedding::new(tok_embeddings, ct.hparams.n_embd as usize),
+            layers,
+            norm,
+            output: QMatMul::from_qtensor(output)?,
+            masks: HashMap::new(),
+            span,
+            span_output,
+        })
+    }
+
+    pub fn from_gguf<R: std::io::Seek + std::io::Read>(
+        ct: gguf_file::Content,
+        reader: &mut R,
+        device: &Device,
+    ) -> Result<Self> {
+        let md_get = |s: &str| match ct.metadata.get(s) {
+            None => candle::bail!("cannot find {s} in metadata"),
+            Some(v) => Ok(v),
+        };
+
+        // Parameter extraction from metadata.
+        let n_expert = md_get("llama.expert_count")
+            .and_then(|v| v.to_u32())
+            .unwrap_or(0) as usize;
+        let n_expert_used = md_get("llama.expert_used_count")
+            .and_then(|v| v.to_u32())
+            .unwrap_or(0) as usize;
+        let head_count = md_get("llama.attention.head_count")?.to_u32()? as usize;
+        let head_count_kv = md_get("llama.attention.head_count_kv")?.to_u32()? as usize;
+        let block_count = md_get("llama.block_count")?.to_u32()? as usize;
+        let embedding_length = md_get("llama.embedding_length")?.to_u32()? as usize;
+        let rope_dim = md_get("llama.rope.dimension_count")?.to_u32()? as usize;
+        // Strangely this value is generally 1e-6 in GGUF file but used to be 1e-5 by default.
+        let rms_norm_eps = md_get("llama.attention.layer_norm_rms_epsilon")?.to_f32()? as f64;
+
+        let rope_freq_base = md_get("llama.rope.freq_base")
+            .and_then(|m| m.to_f32())
+            .unwrap_or(10000f32);
+        let (cos, sin) = precomput_freqs_cis(rope_dim, rope_freq_base, device)?;
+        let neg_inf = Tensor::new(f32::NEG_INFINITY, device)?;
+
+        let tok_embeddings_q = ct.tensor(reader, "token_embd.weight", device)?;
+        let tok_embeddings = tok_embeddings_q.dequantize(device)?;
+        let norm = RmsNorm::from_qtensor(
+            ct.tensor(reader, "output_norm.weight", device)?,
+            rms_norm_eps,
+        )?;
+        let output = match ct.tensor(reader, "output.weight", device) {
+            Ok(tensor) => tensor,
+            Err(_) => tok_embeddings_q,
+        };
+        let mut layers = Vec::with_capacity(block_count);
+        for layer_idx in 0..block_count {
+            let prefix = format!("blk.{layer_idx}");
+            let attention_wq = ct.tensor(reader, &format!("{prefix}.attn_q.weight"), device)?;
+            let attention_wk = ct.tensor(reader, &format!("{prefix}.attn_k.weight"), device)?;
+            let attention_wv = ct.tensor(reader, &format!("{prefix}.attn_v.weight"), device)?;
+            let attention_wo = ct.tensor(reader, &format!("{prefix}.attn_output.weight"), device)?;
+            let mlp_or_moe = if n_expert <= 1 {
+                let feed_forward_w1 =
+                    ct.tensor(reader, &format!("{prefix}.ffn_gate.weight"), device)?;
+                let feed_forward_w2 =
+                    ct.tensor(reader, &format!("{prefix}.ffn_down.weight"), device)?;
+                let feed_forward_w3 =
+                    ct.tensor(reader, &format!("{prefix}.ffn_up.weight"), device)?;
+                MlpOrMoe::Mlp(Mlp {
+                    feed_forward_w1: BitQMatMul::from_qtensor(feed_forward_w1)?,
+                    feed_forward_w2: BitQMatMul::from_qtensor(feed_forward_w2)?,
+                    feed_forward_w3: BitQMatMul::from_qtensor(feed_forward_w3)?,
+                })
+            } else {
+                let feed_forward_gate_inp =
+                    ct.tensor(reader, &format!("{prefix}.ffn_gate_inp.weight"), device)?;
+                let mut experts = Vec::with_capacity(n_expert);
+                for i in 0..n_expert {
+                    let feed_forward_w1 =
+                        ct.tensor(reader, &format!("{prefix}.ffn_gate.{i}.weight"), device)?;
+                    let feed_forward_w2 =
+                        ct.tensor(reader, &format!("{prefix}.ffn_down.{i}.weight"), device)?;
+                    let feed_forward_w3 =
+                        ct.tensor(reader, &format!("{prefix}.ffn_up.{i}.weight"), device)?;
+                    
+                    experts.push(Mlp {
+                        feed_forward_w1: BitQMatMul::from_qtensor(feed_forward_w1)?,
+                        feed_forward_w2: BitQMatMul::from_qtensor(feed_forward_w2)?,
+                        feed_forward_w3: BitQMatMul::from_qtensor(feed_forward_w3)?,
+                    })
+                }
+                MlpOrMoe::MoE {
+                    n_expert_used,
+                    feed_forward_gate_inp: QMatMul::from_qtensor(feed_forward_gate_inp)?,
+                    experts,
+                }
+            };
+            let attention_norm =
+                ct.tensor(reader, &format!("{prefix}.attn_norm.weight"), device)?;
+            let ffn_norm = ct.tensor(reader, &format!("{prefix}.ffn_norm.weight"), device)?;
+            let span_attn = tracing::span!(tracing::Level::TRACE, "attn");
+            let span_rot = tracing::span!(tracing::Level::TRACE, "attn-rot");
+            let span_mlp = tracing::span!(tracing::Level::TRACE, "attn-mlp");
+            layers.push(LayerWeights {
+                attention_wq: BitQMatMul::from_qtensor(attention_wq)?,
+                attention_wk: BitQMatMul::from_qtensor(attention_wk)?,
+                attention_wv: BitQMatMul::from_qtensor(attention_wv)?,
+                attention_wo: BitQMatMul::from_qtensor(attention_wo)?,
+                attention_norm: RmsNorm::from_qtensor(attention_norm, rms_norm_eps)?,
+                mlp_or_moe,
+                ffn_norm: RmsNorm::from_qtensor(ffn_norm, rms_norm_eps)?,
+                n_head: head_count,
+                n_kv_head: head_count_kv,
+                head_dim: embedding_length / head_count,
+                cos: cos.clone(),
+                sin: sin.clone(),
+                neg_inf: neg_inf.clone(),
+                kv_cache: None,
+                span_attn,
+                span_rot,
+                span_mlp,
+            })
+        }
+        let span = tracing::span!(tracing::Level::TRACE, "model");
+        let span_output = tracing::span!(tracing::Level::TRACE, "output");
+        Ok(Self {
+            tok_embeddings: Embedding::new(tok_embeddings, embedding_length),
+            layers,
+            norm,
+            output: QMatMul::from_qtensor(output)?,
+            masks: HashMap::new(),
+            span,
+            span_output,
+        })
+    }
+
+    fn mask(&mut self, t: usize, device: &Device) -> Result<Tensor> {
+        if let Some(mask) = self.masks.get(&t) {
+            Ok(mask.clone())
+        } else {
+            let mask: Vec<_> = (0..t)
+                .flat_map(|i| (0..t).map(move |j| u8::from(j > i)))
+                .collect();
+            let mask = Tensor::from_slice(&mask, (t, t), device)?;
+            self.masks.insert(t, mask.clone());
+            Ok(mask)
+        }
+    }
+
+    pub fn forward(&mut self, x: &Tensor, index_pos: usize) -> Result<Tensor> {
+        let (_b_sz, seq_len) = x.dims2()?;
+        let mask = if seq_len == 1 {
+            None
+        } else {
+            Some(self.mask(seq_len, x.device())?)
+        };
+        let _enter = self.span.enter();
+        let mut layer_in = self.tok_embeddings.forward(x)?;
+        for layer in self.layers.iter_mut() {
+            let x = layer_in;
+            let residual = &x;
+            let x = layer.attention_norm.forward(&x)?;
+            let attn = layer.forward_attn(&x, mask.as_ref(), index_pos)?;
+            let x = (attn + residual)?;
+
+            // MLP
+            let _enter = layer.span_mlp.enter();
+            let residual = &x;
+            let x = layer.ffn_norm.forward(&x)?;
+            let x = layer.mlp_or_moe.forward(&x)?;
+            let x = (x + residual)?;
+            layer_in = x
+        }
+        let x = self.norm.forward(&layer_in)?;
+        let x = x.i((.., seq_len - 1, ..))?;
+        let _enter = self.span_output.enter();
+        self.output.forward(&x)
+    }
+}

--- a/tensor-tools/Cargo.toml
+++ b/tensor-tools/Cargo.toml
@@ -14,3 +14,4 @@ candle = { workspace = true }
 clap = { workspace = true }
 rayon = { workspace = true }
 safetensors = { workspace = true }
+serde_json = { workspace = true }

--- a/tensor-tools/src/main.rs
+++ b/tensor-tools/src/main.rs
@@ -50,6 +50,8 @@ enum Quantization {
     Q8_1,
     #[value(name = "q2b0")]
     Q2b0,
+    #[value(name = "qi8")]
+    QI8,
     Q2k,
     Q3k,
     Q4k,
@@ -78,6 +80,7 @@ impl Quantization {
             Quantization::F16 => GgmlDType::F16,
             Quantization::F32 => GgmlDType::F32,
             Quantization::Q2b0 => GgmlDType::Q2b0,
+            Quantization::QI8 => GgmlDType::QI8,
         }
     }
 }
@@ -470,7 +473,7 @@ fn run_quantize_safetensors(
             .into_par_iter()
             .map(|(mut name, tensor)| {
                 let mut local_dtype = dtype.clone();
-                let should_quantize = tensor.rank() == 2 && tensor.dim(1)? % block_size == 0;
+                let mut should_quantize = tensor.rank() == 2 && tensor.dim(1)? % block_size == 0;
                 let mut tensor = tensor;
 
                 if should_quantize && bitnet_mode {

--- a/tensor-tools/src/main.rs
+++ b/tensor-tools/src/main.rs
@@ -435,137 +435,117 @@ fn unpack_bitnet_weights(tensor: &Tensor) -> Result<Tensor> {
     Ok(unpacked_tensor)
 }
 
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::PathBuf;
+use rayon::prelude::*;
+use serde_json::Value;
+
 fn run_quantize_safetensors(
-    in_files: &[std::path::PathBuf],
-    out_file: std::path::PathBuf,
+    in_files: &[PathBuf],
+    out_file: PathBuf,
     q: Quantization,
     bq: Option<Quantization>,
     bitnet_mode: bool,
 ) -> Result<()> {
-    let mut out_file = std::fs::File::create(out_file)?;
-    let mut tensors = std::collections::HashMap::new();
-    let metadata_file = in_files.iter().find(|f| f.to_string_lossy().ends_with("config.json"));
-    for in_file in in_files.iter() {
-        if metadata_file.is_some() && in_file == metadata_file.unwrap() {
-            continue;
-        }
-        let in_tensors = candle::safetensors::load(in_file, &Device::Cpu)?;
-        tensors.extend(in_tensors)
-    }
-    println!("tensors: {}", tensors.len());
-
+    let mut out_file = File::create(out_file)?;
     let dtype = q.dtype();
     let block_size = dtype.block_size();
 
-    let qtensors = tensors
-        .into_par_iter()
-        .map(|(mut name, tensor)| {
-            let mut local_dtype = dtype.clone();
-            let should_quantize = tensor.rank() == 2 && tensor.dim(1)? % block_size == 0;
-            let mut tensor = tensor;
-            if should_quantize && bitnet_mode {
-                let is_bitnet_weight = 
-                    name.contains("self_attn.v_proj") ||
-                    name.contains("self_attn.q_proj") ||
-                    name.contains("self_attn.o_proj") ||
-                    name.contains("self_attn.k_proj") ||
-                    name.contains("mlp.down_proj") ||
-                    name.contains("mlp.up_proj") ||
-                    name.contains("mlp.gate_proj");
+    let metadata_file = in_files.iter().find(|f| f.to_string_lossy().ends_with("config.json"));
 
-                if is_bitnet_weight {
-                    println!("  unpacking {name} {tensor:?} {should_quantize}");
-                    tensor = unpack_bitnet_weights(&tensor)?;
-                    local_dtype = bq.clone().unwrap().dtype();
+    let mut qtensors = Vec::new();
+
+    for in_file in in_files {
+        if let Some(metadata) = &metadata_file {
+            if Some(in_file) == Some(metadata) {
+                continue;
+            }
+        }
+
+        println!("Loading tensors from file: {:?}", in_file);
+        let in_tensors = candle::safetensors::load(in_file, &Device::Cpu)?;
+
+        let processed_tensors = in_tensors
+            .into_par_iter()
+            .map(|(mut name, tensor)| {
+                let mut local_dtype = dtype.clone();
+                let should_quantize = tensor.rank() == 2 && tensor.dim(1)? % block_size == 0;
+                let mut tensor = tensor;
+
+                if should_quantize && bitnet_mode {
+                    let is_bitnet_weight = 
+                        name.contains("self_attn.v_proj") ||
+                        name.contains("self_attn.q_proj") ||
+                        name.contains("self_attn.o_proj") ||
+                        name.contains("self_attn.k_proj") ||
+                        name.contains("mlp.down_proj") ||
+                        name.contains("mlp.up_proj") ||
+                        name.contains("mlp.gate_proj");
+
+                    if is_bitnet_weight {
+                        println!("  unpacking {name} {tensor:?} {should_quantize}");
+                        tensor = unpack_bitnet_weights(&tensor)?;
+                        local_dtype = bq.clone().unwrap().dtype();
+                    }
                 }
-            }
-            println!("  quantizing {name} {tensor:?} {should_quantize}");
-            let tensor = if should_quantize {
-                QTensor::quantize(&tensor, local_dtype)?
-            } else {
-                QTensor::quantize(&tensor, GgmlDType::F32)?
-            };
-            
-            if name == "model.embed_tokens.weight" {
-                name = "token_embd.weight".to_string();
-            }
+                println!("  quantizing {name} {tensor:?} {should_quantize}");
+                let tensor = if should_quantize {
+                    QTensor::quantize(&tensor, local_dtype)?
+                } else {
+                    QTensor::quantize(&tensor, GgmlDType::F32)?
+                };
 
-            if name == "model.norm.weight" {
-                name = "output_norm.weight".to_string()
-            }
+                if name == "model.embed_tokens.weight" {
+                    name = "token_embd.weight".to_string();
+                } else if name == "model.norm.weight" {
+                    name = "output_norm.weight".to_string();
+                } else if name == "lm_head.weight" {
+                    name = "output.weight".to_string();
+                }
 
-            if name == "lm_head.weight" {
-                name = "output.weight".to_string()
-            }
+                name = name.replace("model.layers.", "blk.");
+                name = name.replace("self_attn.q_proj", "attn_q");
+                name = name.replace("self_attn.k_proj", "attn_k");
+                name = name.replace("self_attn.v_proj", "attn_v");
+                name = name.replace("self_attn.o_proj", "attn_output");
+                name = name.replace("mlp.gate_proj", "ffn_gate");
+                name = name.replace("mlp.down_proj", "ffn_down");
+                name = name.replace("mlp.up_proj", "ffn_up");
+                name = name.replace("input_layernorm", "attn_norm");
+                name = name.replace("post_attention_layernorm", "ffn_norm");
 
-            name = name.replace("model.layers.", "blk.");
-            name = name.replace("self_attn.q_proj", "attn_q");
-            name = name.replace("self_attn.k_proj", "attn_k");
-            name = name.replace("self_attn.v_proj", "attn_v");
-            name = name.replace("self_attn.o_proj", "attn_output");
-            name = name.replace("mlp.gate_proj", "ffn_gate");
-            name = name.replace("mlp.down_proj", "ffn_down");
-            name = name.replace("mlp.up_proj", "ffn_up");
-            name = name.replace("input_layernorm", "attn_norm");
-            name = name.replace("post_attention_layernorm", "ffn_norm");
+                Ok((name, tensor))
+            })
+            .collect::<Result<Vec<_>>>()?;
 
-            Ok((name, tensor))
-        })
-        .collect::<Result<Vec<_>>>()?;
+        qtensors.extend(processed_tensors);
+    }
+
     let qtensors = qtensors
         .iter()
         .map(|(k, v)| (k.as_str(), v))
         .collect::<Vec<_>>();
 
-    // Load metadata
-    let gguf_metadata: Vec<(&str, gguf_file::Value)> = if let Some(metadata_file) = metadata_file {
-        let metadata = std::fs::read_to_string(metadata_file)?;
-        let metadata: serde_json::Value = serde_json::from_str(&metadata).unwrap();
-        
-        let num_attention_heads = gguf_file::Value::from_u32(metadata["num_attention_heads"].as_u64().unwrap() as u32);
-        let num_attention_heads_kv = gguf_file::Value::from_u32(metadata["num_key_value_heads"].as_u64().unwrap() as u32);
+    let gguf_metadata = if let Some(metadata_file) = metadata_file {
+        let metadata_content = std::fs::read_to_string(metadata_file)?;
+        let metadata: serde_json::Value = serde_json::from_str(&metadata_content).unwrap();
 
-        let num_hidden_layers = gguf_file::Value::from_u32(metadata["num_hidden_layers"].as_u64().unwrap() as u32);
-        let embedding_length = gguf_file::Value::from_u32(metadata["hidden_size"].as_u64().unwrap() as u32);
-        let rope_dimension_count = gguf_file::Value::from_u32(
-            (metadata["hidden_size"].as_u64().unwrap() as u32) / (metadata["num_attention_heads"].as_u64().unwrap() as u32)
-        );
-        let layer_norm_eps = gguf_file::Value::from_f32(metadata["rms_norm_eps"].as_f64().unwrap() as f32);
-
-        let mut gguf_metadata: Vec<(&str, gguf_file::Value)> = Vec::new();
-        gguf_metadata.push((
-            "llama.attention.head_count",
-            num_attention_heads.clone(),
-        ));
-        gguf_metadata.push((
-            "llama.attention.head_count_kv",
-            num_attention_heads_kv.clone(),
-        ));
-        gguf_metadata.push((
-            "llama.block_count",
-            num_hidden_layers.clone(),
-        ));
-        gguf_metadata.push((
-            "llama.embedding_length",
-            embedding_length.clone(),
-        ));
-        gguf_metadata.push((
-            "llama.attention.layer_norm_rms_epsilon", layer_norm_eps.clone()
-        ));
-        gguf_metadata.push((
-            "llama.rope.dimension_count",
-            rope_dimension_count.clone(),
-        ));
-
-        // Print metadata
-        for (key, value) in gguf_metadata.iter() {
-            println!("  {key}: {value:?}");
-        }
-        gguf_metadata
+        vec![
+            ("llama.attention.head_count", gguf_file::Value::from_u32(metadata["num_attention_heads"].as_u64().unwrap() as u32)),
+            ("llama.attention.head_count_kv", gguf_file::Value::from_u32(metadata["num_key_value_heads"].as_u64().unwrap() as u32)),
+            ("llama.block_count", gguf_file::Value::from_u32(metadata["num_hidden_layers"].as_u64().unwrap() as u32)),
+            ("llama.embedding_length", gguf_file::Value::from_u32(metadata["hidden_size"].as_u64().unwrap() as u32)),
+            ("llama.attention.layer_norm_rms_epsilon", gguf_file::Value::from_f32(metadata["rms_norm_eps"].as_f64().unwrap() as f32)),
+            ("llama.rope.dimension_count", gguf_file::Value::from_u32(
+                (metadata["hidden_size"].as_u64().unwrap() as u32) / (metadata["num_attention_heads"].as_u64().unwrap() as u32),
+            )),
+        ]
     } else {
-        Vec::new()
+        vec![]
     };
-    gguf_file::write(&mut out_file, gguf_metadata.as_slice(), &qtensors)?;
+
+    gguf_file::write(&mut out_file, &gguf_metadata, &qtensors)?;
     Ok(())
 }
 


### PR DESCRIPTION
## Introduction

Hello again! My name is José Carlos, and I am fully focused on advancing the capabilities of BitNet within the Candle project. BitNet remains a personal passion of mine due to its unique ability to balance performance and efficiency in language models.

This PR builds on my previous work by introducing advanced quantization support tailored specifically for BitNet models. My primary goal is to make BitNet as efficient and accessible as possible for research and real-world applications.

---

## Changes Made

1. **Added Support for New Quantization Method `q2_b0`:**
   - Implemented a double quantization strategy specifically for BitNet models:
     - **BitLinear Layers:** Quantized separately using the `q2_b0` method.
     - **Non-BitLinear Layers:** Quantized independently to maximize overall model efficiency.
   - The `q2_b0` method works by splitting the weight matrix into two smaller matrices containing only binary values (0 and 1), which significantly optimizes storage and computation.

2. **Extended Quantization CLI:**
   - Enhanced the CLI to support BitNet-specific quantization workflows:
   
   `cargo run quantize ~/Downloads/Falcon3-1B-Instruct-1.58bit/model*.safetensors ~/Downloads/Falcon3-1B-Instruct-1.58bit/config.json --out-file ggml-model.gguf --quantization q4_0 -b --bitnet-quantization q2b0`

3. **Support for Quantifying Models Directly in Candle:**
   - Models can now be quantized directly within Candle. This new capability adds metadata during the quantization process, which was not possible before. This makes the workflow more seamless and eliminates the need for external tools to manage metadata.

---

## Known Limitations

- **GPU Support:** The GPU implementation for the `q2_b0` quantization method is currently under development. I welcome collaboration from anyone interested in accelerating this feature.
- **Focus Exclusively on BitNet:** At this time, my contributions are exclusively focused on improving BitNet models. Other architectures are not within the scope of this PR.

---

## Roadmap

1. **Finalize GPU Implementation for BitNet Quantization:**
   - Work is ongoing to enable GPU acceleration for the `q2_b0` quantization method.

2. **Optimize BitNet-Specific Quantization:**
   - Investigate performance improvements to make BitNet quantization more efficient and scalable.

3. **Support Additional BitNet Models:**
   - Expand compatibility to include more variations of BitNet architectures.

---

## Testing

To test the quantized BitNet model, you can use the following command:


`cargo run --example quantized-bitnet --release -- --model tensor-tools/ggml-model.gguf --verbose-prompt --prompt "chat" --temperature 0.01`

---

## Feedback and Collaboration

This PR is currently a **draft**, as I continue to develop and refine GPU support for BitNet. If you are interested in contributing or have feedback on the current implementation, I would love to hear from you.

Thank you for your time and support as I continue to focus solely on advancing BitNet in Candle! 😊