### PR TITLE
Fix mistral attention on Metal

### DIFF
--- a/candle-transformers/src/models/mistral.rs
+++ b/candle-transformers/src/models/mistral.rs
@@ -262,7 +262,8 @@ impl Attention {
             .contiguous()?;
         let value_states = value_states
             .reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?
-            .transpose(1, 2)?;
+            .transpose(1, 2)?
+            .contiguous()?;
 
         let (query_states, key_states) =
             self.rotary_emb


### PR DESCRIPTION
This PR fixes Mistral attention on Metal device.

Before fix:

```
Metal(KernelError(MatMulNonContiguous { lhs_stride: [64, 4, 2, 1], rhs_stride: [2048, 64, 1024, 1], mnk: (2, 64, 2) }))
```