### PR TITLE
Add link to `llms-from-scratch-rs` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ And then head over to
 - [`gpt-from-scratch-rs`](https://github.com/jeroenvlek/gpt-from-scratch-rs): A port of Andrej Karpathy's _Let's build GPT_ tutorial on YouTube showcasing the Candle API on a toy problem.
 - [`candle-einops`](https://github.com/tomsanbear/candle-einops): A pure rust implementation of the python [einops](https://github.com/arogozhnikov/einops) library.
 - [`atoma-infer`](https://github.com/atoma-network/atoma-infer): A Rust library for fast inference at scale, leveraging FlashAttention2 for efficient attention computation, PagedAttention for efficient KV-cache memory management, and multi-GPU support. It is OpenAI api compatible.
+- [`llms-from-scratch-rs`](https://github.com/nerdai/llms-from-scratch-rs): A comprehensive Rust translation of the code from Sebastian Raschka's Build an LLM from Scratch book.
 
 If you have an addition to this list, please submit a pull request.
 


### PR DESCRIPTION
I was wondering if we could add a link to a project that I've been working on as of late where I translate the PyTorch code in Sebastian Raschka's Build an LLM from Scratch book into Rust/Candle.

I think it could be useful to users who want to learn Candle by following along with Sebastian's really incredible text.