### PR TITLE
Fix GLM4 alignment issue

### DIFF
--- a/candle-book/Cargo.toml
+++ b/candle-book/Cargo.toml
@@ -25,7 +25,7 @@ cudarc = { workspace = true, optional = true }
 half = { workspace = true, optional = true }
 image = { workspace = true, optional = true }
 anyhow = { workspace = true }
-tokio = "1.29.1"
+tokio = "1.43.0"
 
 [dev-dependencies]
 byteorder = { workspace = true }

--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -50,7 +50,7 @@ tracing = { workspace = true }
 tracing-chrome = { workspace = true }
 tracing-subscriber = { workspace = true }
 # Necessary to disambiguate with tokio in wasm examples which are 1.28.1
-tokio = "1.29.1"
+tokio = "1.43.0"
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/candle-examples/src/lib.rs
+++ b/candle-examples/src/lib.rs
@@ -4,9 +4,9 @@ pub mod coco_classes;
 pub mod imagenet;
 pub mod token_output_stream;
 pub mod wav;
-
 use candle::utils::{cuda_is_available, metal_is_available};
 use candle::{Device, Result, Tensor};
+use std::path::Path;
 
 pub fn device(cpu: bool) -> Result<Device> {
     if cpu {
@@ -145,5 +145,25 @@ pub fn hub_load_safetensors(
         .iter()
         .map(|v| repo.get(v).map_err(candle::Error::wrap))
         .collect::<Result<Vec<_>>>()?;
+    Ok(safetensors_files)
+}
+
+pub fn hub_load_local_safetensors(
+    path: &String,
+    json_file: &str,
+) -> Result<Vec<std::path::PathBuf>> {
+    let jsfile = std::fs::File::open(Path::new(&path).join(json_file))?;
+    let json: serde_json::Value = serde_json::from_reader(&jsfile).map_err(candle::Error::wrap)?;
+    let weight_map = match json.get("weight_map") {
+        None => candle::bail!("no weight map in {json_file:?}"),
+        Some(serde_json::Value::Object(map)) => map,
+        Some(_) => candle::bail!("weight map in {json_file:?} is not a map"),
+    };
+    let mut safetensors_files = Vec::<std::path::PathBuf>::new();
+    for value in weight_map.values() {
+        if let Some(file) = value.as_str() {
+            safetensors_files.insert(0, Path::new(&path).join(file));
+        }
+    }
     Ok(safetensors_files)
 }

--- a/candle-transformers/src/models/glm4.rs
+++ b/candle-transformers/src/models/glm4.rs
@@ -8,7 +8,7 @@ use crate::models::with_tracing::{linear_b as linear, Linear};
 use candle::{DType, Device, IndexOp, Module, Result, Tensor, D};
 use candle_nn::VarBuilder;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Deserialize, Default)]
 pub struct Config {
     pub num_layers: usize,
     pub padded_vocab_size: usize,
@@ -29,6 +29,7 @@ pub struct Config {
     pub apply_query_key_layer_scaling: bool,
     pub attention_softmax_in_fp32: bool,
     pub fp32_residual_connection: bool,
+    pub rope_ratio: usize,
 }
 
 impl Config {
@@ -53,6 +54,7 @@ impl Config {
             apply_query_key_layer_scaling: true,
             attention_softmax_in_fp32: true,
             fp32_residual_connection: false,
+            rope_ratio: 500,
         }
     }
 }
@@ -66,9 +68,10 @@ impl RotaryEmbedding {
     fn new(cfg: &Config, dtype: DType, dev: &Device) -> Result<Self> {
         let rotary_dim = cfg.kv_channels;
         let n_elem = rotary_dim / 2;
+        let base = 10_000f64 * cfg.rope_ratio as f64;
         let inv_freq: Vec<_> = (0..n_elem)
             .step_by(2)
-            .map(|i| 1f32 / 10_000f64.powf(i as f64 / n_elem as f64) as f32)
+            .map(|i| 1f32 / base.powf(i as f64 / n_elem as f64) as f32)
             .collect();
         let inv_freq_len = inv_freq.len();
         let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?.to_dtype(dtype)?;


### PR DESCRIPTION
This PR primarily addresses the generation issue in GLM4, specifically the missing `rope_ratio` in the construction of the cosine-sine cache. Additionally, it enables the configuration to be loaded from a JSON file and allows weights to be loaded from a local path, facilitated by a new utility function named `hub_load_local_safetensors`. Furthermore, it resolves a compilation issue caused by the updated `hf-hub` crate in the previous #2691, which now depends on a newer version of the `tokio` package.

Tested case: 

```shell
cargo run --release --example glm4 --features cuda -- --weight-path /home/weights/glm-4-9b-chat/ --prompt "Please talk about deep learning."
```

It now generates better answers (align with the official results).