### PR TITLE
Ability to link Candle Flash Attention to prebuilt kernels to save repeated compilation in mixed Candle and PyTorch projects

### DIFF
--- a/candle-flash-attn/build.rs
+++ b/candle-flash-attn/build.rs
@@ -1,95 +1,16 @@
 // Build script to run nvcc and generate the C glue code for launching the flash-attention kernel.
 // The cuda build time is very long so one can set the CANDLE_FLASH_ATTN_BUILD_DIR environment
 // variable in order to cache the compiled artifacts and avoid recompiling too often.
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use std::path::PathBuf;
-
-const KERNEL_FILES: [&str; 33] = [
-    "kernels/flash_api.cu",
-    "kernels/flash_fwd_hdim128_fp16_sm80.cu",
-    "kernels/flash_fwd_hdim160_fp16_sm80.cu",
-    "kernels/flash_fwd_hdim192_fp16_sm80.cu",
-    "kernels/flash_fwd_hdim224_fp16_sm80.cu",
-    "kernels/flash_fwd_hdim256_fp16_sm80.cu",
-    "kernels/flash_fwd_hdim32_fp16_sm80.cu",
-    "kernels/flash_fwd_hdim64_fp16_sm80.cu",
-    "kernels/flash_fwd_hdim96_fp16_sm80.cu",
-    "kernels/flash_fwd_hdim128_bf16_sm80.cu",
-    "kernels/flash_fwd_hdim160_bf16_sm80.cu",
-    "kernels/flash_fwd_hdim192_bf16_sm80.cu",
-    "kernels/flash_fwd_hdim224_bf16_sm80.cu",
-    "kernels/flash_fwd_hdim256_bf16_sm80.cu",
-    "kernels/flash_fwd_hdim32_bf16_sm80.cu",
-    "kernels/flash_fwd_hdim64_bf16_sm80.cu",
-    "kernels/flash_fwd_hdim96_bf16_sm80.cu",
-    "kernels/flash_fwd_hdim128_fp16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim160_fp16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim192_fp16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim224_fp16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim256_fp16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim32_fp16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim64_fp16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim96_fp16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim128_bf16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim160_bf16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim192_bf16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim224_bf16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim256_bf16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim32_bf16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim64_bf16_causal_sm80.cu",
-    "kernels/flash_fwd_hdim96_bf16_causal_sm80.cu",
-];
 
 fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=build.rs");
-    for kernel_file in KERNEL_FILES.iter() {
-        println!("cargo:rerun-if-changed={kernel_file}");
-    }
-    println!("cargo:rerun-if-changed=kernels/flash_fwd_kernel.h");
-    println!("cargo:rerun-if-changed=kernels/flash_fwd_launch_template.h");
-    println!("cargo:rerun-if-changed=kernels/flash.h");
-    println!("cargo:rerun-if-changed=kernels/philox.cuh");
-    println!("cargo:rerun-if-changed=kernels/softmax.h");
-    println!("cargo:rerun-if-changed=kernels/utils.h");
-    println!("cargo:rerun-if-changed=kernels/kernel_traits.h");
-    println!("cargo:rerun-if-changed=kernels/block_info.h");
-    println!("cargo:rerun-if-changed=kernels/static_switch.h");
-    println!("cargo:rerun-if-changed=kernels/hardware_info.h");
-    let out_dir = PathBuf::from(std::env::var("OUT_DIR").context("OUT_DIR not set")?);
+
     let build_dir = match std::env::var("CANDLE_FLASH_ATTN_BUILD_DIR") {
-        Err(_) =>
-        {
-            #[allow(clippy::redundant_clone)]
-            out_dir.clone()
-        }
-        Ok(build_dir) => {
-            let path = PathBuf::from(build_dir);
-            path.canonicalize().expect(&format!(
-                "Directory doesn't exists: {} (the current directory is {})",
-                &path.display(),
-                std::env::current_dir()?.display()
-            ))
-        }
+        Ok(dir) => PathBuf::from(dir),
+        Err(_) => return Err(anyhow!("CANDLE_FLASH_ATTN_BUILD_DIR not set")),
     };
-
-    let kernels = KERNEL_FILES.iter().collect();
-    let builder = bindgen_cuda::Builder::default()
-        .kernel_paths(kernels)
-        .out_dir(build_dir.clone())
-        .arg("-std=c++17")
-        .arg("-O3")
-        .arg("-U__CUDA_NO_HALF_OPERATORS__")
-        .arg("-U__CUDA_NO_HALF_CONVERSIONS__")
-        .arg("-U__CUDA_NO_HALF2_OPERATORS__")
-        .arg("-U__CUDA_NO_BFLOAT16_CONVERSIONS__")
-        .arg("-Icutlass/include")
-        .arg("--expt-relaxed-constexpr")
-        .arg("--expt-extended-lambda")
-        .arg("--use_fast_math")
-        .arg("--verbose");
-
-    let out_file = build_dir.join("libflashattention.a");
-    builder.build_lib(out_file);
 
     println!("cargo:rustc-link-search={}", build_dir.display());
     println!("cargo:rustc-link-lib=flashattention");

--- a/candle-flash-attn/build.rs
+++ b/candle-flash-attn/build.rs
@@ -1,16 +1,118 @@
 // Build script to run nvcc and generate the C glue code for launching the flash-attention kernel.
 // The cuda build time is very long so one can set the CANDLE_FLASH_ATTN_BUILD_DIR environment
 // variable in order to cache the compiled artifacts and avoid recompiling too often.
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use std::path::PathBuf;
+
+const KERNEL_FILES: [&str; 33] = [
+    "kernels/flash_api.cu",
+    "kernels/flash_fwd_hdim128_fp16_sm80.cu",
+    "kernels/flash_fwd_hdim160_fp16_sm80.cu",
+    "kernels/flash_fwd_hdim192_fp16_sm80.cu",
+    "kernels/flash_fwd_hdim224_fp16_sm80.cu",
+    "kernels/flash_fwd_hdim256_fp16_sm80.cu",
+    "kernels/flash_fwd_hdim32_fp16_sm80.cu",
+    "kernels/flash_fwd_hdim64_fp16_sm80.cu",
+    "kernels/flash_fwd_hdim96_fp16_sm80.cu",
+    "kernels/flash_fwd_hdim128_bf16_sm80.cu",
+    "kernels/flash_fwd_hdim160_bf16_sm80.cu",
+    "kernels/flash_fwd_hdim192_bf16_sm80.cu",
+    "kernels/flash_fwd_hdim224_bf16_sm80.cu",
+    "kernels/flash_fwd_hdim256_bf16_sm80.cu",
+    "kernels/flash_fwd_hdim32_bf16_sm80.cu",
+    "kernels/flash_fwd_hdim64_bf16_sm80.cu",
+    "kernels/flash_fwd_hdim96_bf16_sm80.cu",
+    "kernels/flash_fwd_hdim128_fp16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim160_fp16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim192_fp16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim224_fp16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim256_fp16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim32_fp16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim64_fp16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim96_fp16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim128_bf16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim160_bf16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim192_bf16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim224_bf16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim256_bf16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim32_bf16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim64_bf16_causal_sm80.cu",
+    "kernels/flash_fwd_hdim96_bf16_causal_sm80.cu",
+];
 
 fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=build.rs");
+    for kernel_file in KERNEL_FILES.iter() {
+        println!("cargo:rerun-if-changed={kernel_file}");
+    }
+    println!("cargo:rerun-if-changed=kernels/flash_fwd_kernel.h");
+    println!("cargo:rerun-if-changed=kernels/flash_fwd_launch_template.h");
+    println!("cargo:rerun-if-changed=kernels/flash.h");
+    println!("cargo:rerun-if-changed=kernels/philox.cuh");
+    println!("cargo:rerun-if-changed=kernels/softmax.h");
+    println!("cargo:rerun-if-changed=kernels/utils.h");
+    println!("cargo:rerun-if-changed=kernels/kernel_traits.h");
+    println!("cargo:rerun-if-changed=kernels/block_info.h");
+    println!("cargo:rerun-if-changed=kernels/static_switch.h");
+    println!("cargo:rerun-if-changed=kernels/hardware_info.h");
 
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").context("OUT_DIR not set")?);
     let build_dir = match std::env::var("CANDLE_FLASH_ATTN_BUILD_DIR") {
-        Ok(dir) => PathBuf::from(dir),
-        Err(_) => return Err(anyhow!("CANDLE_FLASH_ATTN_BUILD_DIR not set")),
+        Err(_) =>
+        {
+            #[allow(clippy::redundant_clone)]
+            out_dir.clone()
+        }
+        Ok(build_dir) => {
+            let path = PathBuf::from(build_dir);
+            path.canonicalize().expect(&format!(
+                "Directory doesn't exists: {} (the current directory is {})",
+                &path.display(),
+                std::env::current_dir()?.display()
+            ))
+        }
     };
+
+    let kernels = if std::env::var("CANDLE_FLASH_ATTN_USE_PREBUILT_KERNELS").is_ok() {
+        // Link rustc to the prebuilt kernels
+        let prebuilt_kernels_dir =
+            PathBuf::from(std::env::var("CANDLE_FLASH_ATTN_PREBUILT_KERNELS_DIR").map_err(|_| {
+                anyhow::anyhow!("If CANDLE_FLASH_ATTN_USE_PREBUILT_KERNELS CANDLE_FLASH_ATTN_PREBUILT_KERNELS_DIR must be set")
+            })?);
+        let prebuilt_kernels_lib_name =
+            PathBuf::from(std::env::var("CANDLE_FLASH_ATTN_PREBUILT_KERNELS_LIB_NAME").map_err(|_| {
+                anyhow::anyhow!("If CANDLE_FLASH_ATTN_USE_PREBUILT_KERNELS CANDLE_FLASH_ATTN_PREBUILT_KERNELS_LIB_NAME must be set")
+            })?);
+        println!(
+            "cargo:rustc-link-search=native={}",
+            prebuilt_kernels_dir.display()
+        );
+        println!(
+            "cargo:rustc-link-lib=dylib={}",
+            prebuilt_kernels_lib_name.display()
+        );
+        // If using pre-built kernels, we only need to compile the rust specific flash api code used in this crate.
+        ["kernels/flash_api.cu"].iter().collect()
+    } else {
+        KERNEL_FILES.iter().collect()
+    };
+    let builder = bindgen_cuda::Builder::default()
+        .kernel_paths(kernels)
+        .out_dir(build_dir.clone())
+        .arg("-std=c++17")
+        .arg("-O3")
+        .arg("-U__CUDA_NO_HALF_OPERATORS__")
+        .arg("-U__CUDA_NO_HALF_CONVERSIONS__")
+        .arg("-U__CUDA_NO_HALF2_OPERATORS__")
+        .arg("-U__CUDA_NO_BFLOAT16_CONVERSIONS__")
+        .arg("-Icutlass/include")
+        .arg("--expt-relaxed-constexpr")
+        .arg("--expt-extended-lambda")
+        .arg("--use_fast_math")
+        .arg("--verbose");
+
+    let out_file = build_dir.join("libflashattention.a");
+    builder.build_lib(out_file);
 
     println!("cargo:rustc-link-search={}", build_dir.display());
     println!("cargo:rustc-link-lib=flashattention");


### PR DESCRIPTION
Hello, I didn't see a guide on how to contribute so I'd just thought I'd create a PR.

Essentially, I am using candle to run transformers in a project that also uses PyTorch. This project already has a [flash attention python package](https://github.com/Dao-AILab/flash-attention/tree/main) installed so wanted a way to save having to compile twice (which takes ages).

Please let me know if you think this is a worthwhile addition and if so what else you need from me to get it merged. Thanks :)