### PR TITLE
Whisper dynamic time warping

### DIFF
--- a/candle-examples/examples/whisper/main.rs
+++ b/candle-examples/examples/whisper/main.rs
@@ -468,6 +468,10 @@ struct Args {
     #[arg(long)]
     timestamps: bool,
 
+    /// Enable kv-cache on the decoder self attention layers
+    #[arg(long)]
+    cache: bool,
+
     /// Print the full DecodingResult structure rather than just the text.
     #[arg(long)]
     verbose: bool,
@@ -533,8 +537,12 @@ fn main() -> Result<()> {
         };
         (config, tokenizer, model, sample)
     };
-    let config: Config = serde_json::from_str(&std::fs::read_to_string(config_filename)?)?;
+    let mut config: Config = serde_json::from_str(&std::fs::read_to_string(config_filename)?)?;
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
+
+    if args.cache {
+        config.use_self_attention_kv_cache = true;
+    }
 
     let mel_bytes = match config.num_mel_bins {
         80 => include_bytes!("melfilters.bytes").as_slice(),

--- a/candle-examples/examples/whisper/main.rs
+++ b/candle-examples/examples/whisper/main.rs
@@ -528,6 +528,7 @@ impl WhichModel {
             Self::LargeV2 => AlignmentHeads::large_v2(),
             Self::LargeV3 => AlignmentHeads::large_v3(),
             Self::LargeV3Turbo => AlignmentHeads::large_v3_turbo(),
+            Self::DistilLargeV3 => AlignmentHeads::distil_large_v3(),
             _ => Default::default(),
         }
     }

--- a/candle-examples/examples/whisper/main.rs
+++ b/candle-examples/examples/whisper/main.rs
@@ -429,7 +429,7 @@ impl Decoder {
                 )
             }
             if self.dtw_timestamps {
-                let timestamps = self
+                if let Some(timestamps) = self
                     .model
                     .dtw_timestamps(
                         self.which_model.alignment_heads(),
@@ -439,19 +439,21 @@ impl Decoder {
                     )?
                     .into_iter()
                     .next()
-                    .ok_or_else(|| candle::Error::msg("missing dtw timestamps"))?;
+                {
+                    let words = <Self as timestamps::PostProcessor>::label(
+                        self,
+                        &timestamps,
+                        &segment.dr.tokens,
+                    )?
+                    .into_iter()
+                    .map(|word| {
+                        word.offset_start(std::time::Duration::from_secs_f64(segment.start))
+                    });
 
-                let words = <Self as timestamps::PostProcessor>::label(
-                    self,
-                    &timestamps,
-                    &segment.dr.tokens,
-                )?
-                .into_iter()
-                .map(|word| word.offset_start(std::time::Duration::from_secs_f64(segment.start)));
-
-                println!("dtw timestamps: {:?}", timestamps);
-                for word in words {
-                    println!("{word:?}");
+                    println!("dtw timestamps: {:?}", timestamps);
+                    for word in words {
+                        println!("{word:?}");
+                    }
                 }
             }
             if self.verbose {

--- a/candle-examples/examples/whisper/multilingual.rs
+++ b/candle-examples/examples/whisper/multilingual.rs
@@ -135,5 +135,7 @@ pub fn detect_language(
         println!("{language}: {p}")
     }
     let language = crate::token_id(tokenizer, &format!("<|{}|>", probs[0].0 .0))?;
+    model.clear_attention_outputs();
+
     Ok(language)
 }

--- a/candle-transformers/src/models/whisper/mod.rs
+++ b/candle-transformers/src/models/whisper/mod.rs
@@ -13,6 +13,7 @@
 pub mod audio;
 pub mod model;
 pub mod quantized_model;
+pub mod timestamps;
 
 use serde::Deserialize;
 
@@ -34,6 +35,14 @@ pub struct Config {
     pub suppress_tokens: Vec<u32>,
     #[serde(default)]
     pub use_self_attention_kv_cache: bool,
+    #[serde(default)]
+    pub dtw_timestamps: bool,
+}
+
+#[derive(Debug, Clone)]
+enum AttentionOutput {
+    Disabled,
+    Enabled(Vec<candle::Tensor>),
 }
 
 pub const DTYPE: candle::DType = candle::DType::F32;

--- a/candle-transformers/src/models/whisper/mod.rs
+++ b/candle-transformers/src/models/whisper/mod.rs
@@ -42,7 +42,7 @@ pub struct Config {
 #[derive(Debug, Clone)]
 enum AttentionOutput {
     Disabled,
-    Enabled(Vec<candle::Tensor>),
+    Enabled(Option<candle::Tensor>),
 }
 
 pub const DTYPE: candle::DType = candle::DType::F32;

--- a/candle-transformers/src/models/whisper/mod.rs
+++ b/candle-transformers/src/models/whisper/mod.rs
@@ -32,6 +32,8 @@ pub struct Config {
     pub decoder_layers: usize,          // n_text_layer
     #[serde(default)]
     pub suppress_tokens: Vec<u32>,
+    #[serde(default)]
+    pub use_self_attention_kv_cache: bool,
 }
 
 pub const DTYPE: candle::DType = candle::DType::F32;

--- a/candle-transformers/src/models/whisper/quantized_model.rs
+++ b/candle-transformers/src/models/whisper/quantized_model.rs
@@ -145,15 +145,13 @@ impl MultiHeadAttention {
             let mask = mask.i((0..n_ctx, 0..n_ctx))?;
             qk = qk.broadcast_add(&mask)?
         }
+        if let AttentionOutput::Enabled(attentions) = &mut self.output_attentions {
+            attentions.push(qk.clone());
+        }
         let w = {
             let _enter = self.softmax_span.enter();
             candle_nn::ops::softmax_last_dim(&qk)?
         };
-
-        if let AttentionOutput::Enabled(attentions) = &mut self.output_attentions {
-            attentions.push(w.clone());
-        }
-
         let wv = {
             let _enter = self.matmul_span.enter();
             w.matmul(&v)?
@@ -487,7 +485,7 @@ impl Whisper {
         &mut self,
         alignment_heads: timestamps::AlignmentHeads,
         filter_width: NonZeroUsize,
-        n_samples: usize,
+        n_frames: usize,
         n_start_tokens: usize,
     ) -> Result<Vec<timestamps::Raw>> {
         if !self.config.dtw_timestamps {
@@ -500,7 +498,7 @@ impl Whisper {
         alignment_heads.extract_timestamps(
             &self.take_attention_outputs(),
             filter_width,
-            n_samples,
+            n_frames,
             n_start_tokens,
         )
     }
@@ -516,8 +514,7 @@ impl Whisper {
             .flat_map(|layer| layer.cross_attn.as_mut())
             .filter_map(|(attn, _)| match &mut attn.output_attentions {
                 AttentionOutput::Enabled(attns) if !attns.is_empty() => {
-                    let attns = std::mem::take(attns);
-                    Tensor::cat(&attns, 2).ok()
+                    Tensor::cat(&std::mem::take(attns), 2).ok()
                 }
                 _ => None,
             })

--- a/candle-transformers/src/models/whisper/quantized_model.rs
+++ b/candle-transformers/src/models/whisper/quantized_model.rs
@@ -30,10 +30,16 @@ struct MultiHeadAttention {
     softmax_span: tracing::Span,
     matmul_span: tracing::Span,
     kv_cache: Option<(Tensor, Tensor)>,
+    use_self_attention_kv_cache: bool,
 }
 
 impl MultiHeadAttention {
-    fn load(n_state: usize, n_head: usize, vb: VarBuilder) -> Result<Self> {
+    fn load(
+        n_state: usize,
+        n_head: usize,
+        use_self_attention_kv_cache: bool,
+        vb: VarBuilder,
+    ) -> Result<Self> {
         let span = tracing::span!(tracing::Level::TRACE, "multi-head-attn");
         let softmax_span = tracing::span!(tracing::Level::TRACE, "multi-head-attn-softmax");
         let matmul_span = tracing::span!(tracing::Level::TRACE, "multi-head-attn-matmul");
@@ -51,6 +57,7 @@ impl MultiHeadAttention {
             softmax_span,
             matmul_span,
             kv_cache: None,
+            use_self_attention_kv_cache,
         })
     }
 
@@ -64,6 +71,21 @@ impl MultiHeadAttention {
         let _enter = self.span.enter();
         let q = self.query.forward(x)?;
         let (k, v) = match xa {
+            None if self.use_self_attention_kv_cache => {
+                if flush_cache {
+                    self.kv_cache = None;
+                }
+
+                let mut k = self.key.forward(x)?;
+                let mut v = self.value.forward(x)?;
+                if let Some((ks, vs)) = self.kv_cache.take() {
+                    k = Tensor::cat(&[k, ks], 1)?;
+                    v = Tensor::cat(&[v, vs], 1)?;
+                }
+                self.kv_cache = Some((k.clone(), v.clone()));
+
+                (k, v)
+            }
             None => {
                 let k = self.key.forward(x)?;
                 let v = self.value.forward(x)?;
@@ -145,12 +167,24 @@ struct ResidualAttentionBlock {
 }
 
 impl ResidualAttentionBlock {
-    fn load(n_state: usize, n_head: usize, ca: bool, vb: VarBuilder) -> Result<Self> {
+    fn load(
+        n_state: usize,
+        n_head: usize,
+        ca: bool,
+        use_self_attention_kv_cache: bool,
+        vb: VarBuilder,
+    ) -> Result<Self> {
         let span = tracing::span!(tracing::Level::TRACE, "residual-attn");
-        let attn = MultiHeadAttention::load(n_state, n_head, vb.pp("self_attn"))?;
+        let attn = MultiHeadAttention::load(
+            n_state,
+            n_head,
+            use_self_attention_kv_cache,
+            vb.pp("self_attn"),
+        )?;
         let attn_ln = layer_norm(n_state, 1e-5, vb.pp("self_attn_layer_norm"))?;
         let cross_attn = if ca {
-            let cross_attn = MultiHeadAttention::load(n_state, n_head, vb.pp("encoder_attn"))?;
+            let cross_attn =
+                MultiHeadAttention::load(n_state, n_head, false, vb.pp("encoder_attn"))?;
             let cross_attn_ln = layer_norm(n_state, 1e-5, vb.pp("encoder_attn_layer_norm"))?;
             Some((cross_attn, cross_attn_ln))
         } else {
@@ -256,7 +290,13 @@ impl AudioEncoder {
         let positional_embedding = sinusoids(n_ctx, n_state, vb.device())?;
         let blocks = (0..cfg.encoder_layers)
             .map(|i| {
-                ResidualAttentionBlock::load(n_state, n_head, false, vb.pp(format!("layers.{i}")))
+                ResidualAttentionBlock::load(
+                    n_state,
+                    n_head,
+                    false,
+                    false,
+                    vb.pp(format!("layers.{i}")),
+                )
             })
             .collect::<Result<Vec<_>>>()?;
         let ln_post = layer_norm(n_state, 1e-5, vb.pp("layer_norm"))?;
@@ -325,7 +365,13 @@ impl TextDecoder {
             .dequantize(vb.device())?;
         let blocks = (0..cfg.decoder_layers)
             .map(|i| {
-                ResidualAttentionBlock::load(n_state, n_head, true, vb.pp(format!("layers.{i}")))
+                ResidualAttentionBlock::load(
+                    n_state,
+                    n_head,
+                    true,
+                    cfg.use_self_attention_kv_cache,
+                    vb.pp(format!("layers.{i}")),
+                )
             })
             .collect::<Result<Vec<_>>>()?;
         let ln = layer_norm(n_state, 1e-5, vb.pp("layer_norm"))?;
@@ -346,9 +392,22 @@ impl TextDecoder {
 
     pub fn forward(&mut self, x: &Tensor, xa: &Tensor, flush_kv_cache: bool) -> Result<Tensor> {
         let _enter = self.span.enter();
+        let offset = self
+            .blocks
+            .first()
+            .and_then(|b| b.attn.kv_cache.as_ref())
+            .and_then(|(k, _)| k.dim(1).ok())
+            .unwrap_or_default();
+
+        let x = if offset > 0 {
+            &x.narrow(1, offset, 1)?
+        } else {
+            x
+        };
+
         let last = x.dim(D::Minus1)?;
         let token_embedding = self.token_embedding.forward(x)?;
-        let positional_embedding = self.positional_embedding.narrow(0, 0, last)?;
+        let positional_embedding = self.positional_embedding.narrow(0, offset, last)?;
         let mut x = token_embedding.broadcast_add(&positional_embedding)?;
         for block in self.blocks.iter_mut() {
             x = block.forward(&x, Some(xa), Some(&self.mask), flush_kv_cache)?;

--- a/candle-transformers/src/models/whisper/timestamps.rs
+++ b/candle-transformers/src/models/whisper/timestamps.rs
@@ -112,6 +112,11 @@ impl AlignmentHeads {
             weights.dim(D::Minus2)? - n_start_tokens - 1,
         )?;
 
+        if cost.dim(D::Minus2)? == 0 {
+            // No tokens to be aligned
+            return Ok(Default::default());
+        }
+
         // Do the timewarp
         let timestamps = Tensor::stack(
             &((0..weights.dim(0)?).map(|batch_idx| {

--- a/candle-transformers/src/models/whisper/timestamps.rs
+++ b/candle-transformers/src/models/whisper/timestamps.rs
@@ -1,0 +1,415 @@
+use std::num::NonZeroUsize;
+
+use candle::{IndexOp, Tensor, D};
+use candle_nn::ops::softmax_last_dim;
+
+/// Raw dtw timestamps
+#[derive(Debug)]
+pub struct Raw(pub Vec<f32>);
+
+/// Word-level timestamp
+#[derive(Debug)]
+pub struct Word {
+    pub text: String,
+    pub start: f32,
+    pub end: f32,
+}
+
+/// Helper trait for processing timestamps.
+pub trait PostProcessor {
+    type Error: std::error::Error;
+
+    fn decode(&self, tokens: &[u32]) -> Result<String, Self::Error>;
+    fn segment(&self, s: String) -> Vec<String> {
+        s.split(" ")
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+    }
+    fn label(&self, Raw(timestamps): &Raw, tokens: &[u32]) -> Result<Vec<Word>, Self::Error> {
+        let text = self.decode(tokens)?;
+        let words = self.segment(text);
+        Ok(words
+            .into_iter()
+            .zip(timestamps.iter().copied())
+            .zip(timestamps.iter().copied().skip(1))
+            .map(|((text, start), end)| Word { text, start, end })
+            .collect())
+    }
+}
+
+/// A specific cross-attention head to use for timestamp determination
+#[derive(Debug, Clone, Copy)]
+pub struct AlignmentHead {
+    pub layer: usize,
+    pub head: usize,
+}
+
+/// The collection of cross-attention heads to use for timestamp determination
+#[derive(Debug)]
+pub enum AlignmentHeads {
+    /// Uses all heads from the top layers up to the specified maximum
+    TopLayerHeads { max_layers: usize },
+    /// Uses only the specified alignment heads
+    PreDetermined(Vec<AlignmentHead>),
+}
+
+impl AlignmentHeads {
+    /// Returns the token-level timestamps as a tensor of shape batch x timestamps
+    pub(super) fn extract_timestamps(
+        &self,
+        cross_attentions: &[Tensor],
+        filter_width: NonZeroUsize,
+        n_samples: usize,
+        n_start_tokens: usize,
+    ) -> candle::Result<Vec<Raw>> {
+        // Select relevant cross-attention heads
+        let weights = match self {
+            Self::TopLayerHeads { max_layers } => {
+                let layers = (cross_attentions.len() / 2).min(*max_layers);
+                Tensor::cat(
+                    &cross_attentions[cross_attentions.len().saturating_sub(layers)..],
+                    1,
+                )?
+            }
+
+            Self::PreDetermined(heads) => Tensor::stack(
+                &heads
+                    .iter()
+                    .copied()
+                    .filter_map(|AlignmentHead { layer, head }| {
+                        cross_attentions.get(layer)?.i((.., head)).ok()
+                    })
+                    .collect::<Vec<_>>(),
+                0,
+            )?
+            .permute((1, 0, 2, 3))?,
+        }
+        .narrow(
+            3,
+            0,
+            (n_samples / super::HOP_LENGTH).min(super::N_FRAMES) / 2,
+        )?;
+
+        // Smooth and normalize
+        let weights = softmax_last_dim(
+            &median_filter(
+                filter_width,
+                weights
+                    .broadcast_sub(&weights.mean_keepdim(D::Minus2)?)?
+                    .broadcast_div(&weights.var_keepdim(D::Minus2)?.sqr()?)?,
+            )?
+            .contiguous()?,
+        )?
+        .mean(1)?;
+
+        // Exclude start tokens
+        let cost = weights.narrow(
+            D::Minus2,
+            n_start_tokens,
+            weights.dim(D::Minus2)? - n_start_tokens,
+        )?;
+
+        // Do the timewarp for each batch
+        let timestamps = Tensor::stack(
+            &((0..weights.dim(0)?).map(|batch_idx| {
+                let (text_indices, time_indices) = dynamic_time_warp(
+                    cost.neg()?
+                        .i(batch_idx)?
+                        .to_dtype(candle::DType::F64)?
+                        .to_vec2::<f64>()?,
+                )?;
+
+                let jumps = text_indices
+                    .iter()
+                    .copied()
+                    .zip(std::iter::once(0.).chain(text_indices.iter().copied()))
+                    .map(|(a, b)| (a - b) as usize)
+                    .collect::<Vec<_>>();
+                let times = jumps
+                    .into_iter()
+                    .enumerate()
+                    .filter(|(_, n)| *n == 1)
+                    .map(|(i, _)| {
+                        time_indices[i] / (super::SAMPLE_RATE / (super::HOP_LENGTH * 2)) as f64
+                    })
+                    .collect::<Vec<_>>();
+
+                Tensor::new(times, weights.device())?.to_dtype(weights.dtype())
+            }))
+            .collect::<candle::Result<Vec<_>>>()?,
+            0,
+        )?;
+
+        // batch * timestamps
+        Ok(timestamps.to_vec2::<f32>()?.into_iter().map(Raw).collect())
+    }
+}
+
+/// Computes the lowest cost warping path through the provided cost matrix
+fn dynamic_time_warp(matrix: Vec<Vec<f64>>) -> candle::Result<(Vec<f64>, Vec<f64>)> {
+    let [n, m] = [matrix.len(), matrix[0].len()];
+    let (mut cost, mut trace) = (vec![vec![1.; m + 1]; n + 1], vec![vec![1.; m + 1]; n + 1]);
+
+    cost[0][0] = 0.;
+    for j in 1..m + 1 {
+        for i in 1..n + 1 {
+            let (c0, c1, c2) = (cost[i - 1][j - 1], cost[i - 1][j], cost[i][j - 1]);
+            let (c, t) = match (c0.lt(&c1), c0.lt(&c2), c1.lt(&c2)) {
+                (true, true, _) => (c0, 0.),  // match
+                (false, _, true) => (c1, 1.), // insertion
+                _ => (c2, 2.),                // deletion
+            };
+
+            cost[i][j] = matrix[i - 1][j - 1] + c;
+            trace[i][j] = t;
+        }
+    }
+
+    let (mut i, mut j) = (trace.len() as u32 - 1, trace[0].len() as u32 - 1);
+    trace[0] = vec![2.; trace[0].len()];
+    for t in &mut trace {
+        t[0] = 1.;
+    }
+
+    let (mut xs, mut ys) = (vec![], vec![]);
+    while i > 0 || j > 0 {
+        xs.push(i.saturating_sub(1) as f64);
+        ys.push(j.saturating_sub(1) as f64);
+        match trace[i as usize][j as usize] as i32 {
+            0 => {
+                i = i.saturating_sub(1);
+                j = j.saturating_sub(1);
+            }
+
+            1 => {
+                i = i.saturating_sub(1);
+            }
+
+            _ => {
+                j = j.saturating_sub(1);
+            }
+        }
+    }
+    xs.reverse();
+    ys.reverse();
+
+    Ok((xs, ys))
+}
+
+fn median_filter(filter_width: NonZeroUsize, weights: Tensor) -> candle::Result<Tensor> {
+    let filter_width = filter_width.get();
+    let pad_width = filter_width / 2;
+    let (_, _c, _, w) = weights.dims4()?;
+    if w <= pad_width {
+        return Ok(weights);
+    }
+
+    let weights = weights.pad_with_same(3, pad_width, pad_width)?;
+    let mut medians = vec![];
+    for i in 0..w {
+        let weights = weights.narrow(3, i, filter_width)?;
+        medians.push(weights.unsqueeze(D::Minus2)?);
+    }
+
+    let medians = Tensor::cat(&medians, 3)?
+        .contiguous()?
+        .to_device(&candle::Device::Cpu)? // TODO: investigate why CUDA fails here
+        .sort_last_dim(true)?
+        .0
+        .narrow(4, pad_width, 1)?
+        .squeeze(4)?;
+    Ok(medians)
+}
+
+impl From<[usize; 2]> for AlignmentHead {
+    fn from([layer, head]: [usize; 2]) -> Self {
+        Self { layer, head }
+    }
+}
+
+impl<T> FromIterator<T> for AlignmentHeads
+where
+    T: Into<AlignmentHead>,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut heads = vec![];
+
+        for head in iter {
+            heads.push(head.into());
+        }
+
+        Self::PreDetermined(heads)
+    }
+}
+
+impl Default for AlignmentHeads {
+    fn default() -> Self {
+        Self::TopLayerHeads { max_layers: 3 }
+    }
+}
+
+/// Creation methods for pre-determined heads
+impl AlignmentHeads {
+    pub fn tiny() -> Self {
+        TINY.iter().copied().collect()
+    }
+
+    pub fn tiny_en() -> Self {
+        TINY_EN.iter().copied().collect()
+    }
+
+    pub fn base() -> Self {
+        BASE.iter().copied().collect()
+    }
+
+    pub fn base_en() -> Self {
+        BASE_EN.iter().copied().collect()
+    }
+
+    pub fn small() -> Self {
+        SMALL.iter().copied().collect()
+    }
+
+    pub fn small_en() -> Self {
+        SMALL_EN.iter().copied().collect()
+    }
+
+    pub fn medium() -> Self {
+        MEDIUM.iter().copied().collect()
+    }
+
+    pub fn medium_en() -> Self {
+        MEDIUM_EN.iter().copied().collect()
+    }
+
+    pub fn large_v1() -> Self {
+        LARGE_V1.iter().copied().collect()
+    }
+
+    pub fn large_v2() -> Self {
+        LARGE_V2_V3.iter().copied().collect()
+    }
+
+    pub fn large_v3() -> Self {
+        LARGE_V2_V3.iter().copied().collect()
+    }
+
+    pub fn large_v3_turbo() -> Self {
+        TURBO.iter().copied().collect()
+    }
+}
+
+const TINY: &[[usize; 2]] = &[[2, 2], [3, 0], [3, 2], [3, 3], [3, 4], [3, 5]];
+const TINY_EN: &[[usize; 2]] = &[
+    [1, 0],
+    [2, 0],
+    [2, 5],
+    [3, 0],
+    [3, 1],
+    [3, 2],
+    [3, 3],
+    [3, 4],
+];
+const BASE: &[[usize; 2]] = &[
+    [3, 1],
+    [4, 2],
+    [4, 3],
+    [4, 7],
+    [5, 1],
+    [5, 2],
+    [5, 4],
+    [5, 6],
+];
+const BASE_EN: &[[usize; 2]] = &[[3, 3], [4, 7], [5, 1], [5, 5], [5, 7]];
+const SMALL: &[[usize; 2]] = &[
+    [5, 3],
+    [5, 9],
+    [8, 0],
+    [8, 4],
+    [8, 7],
+    [8, 8],
+    [9, 0],
+    [9, 7],
+    [9, 9],
+    [10, 5],
+];
+const SMALL_EN: &[[usize; 2]] = &[
+    [6, 6],
+    [7, 0],
+    [7, 3],
+    [7, 8],
+    [8, 2],
+    [8, 5],
+    [8, 7],
+    [9, 0],
+    [9, 4],
+    [9, 8],
+    [9, 10],
+    [10, 0],
+    [10, 1],
+    [10, 2],
+    [10, 3],
+    [10, 6],
+    [10, 11],
+    [11, 2],
+    [11, 4],
+];
+const MEDIUM: &[[usize; 2]] = &[[13, 15], [15, 4], [15, 15], [16, 1], [20, 0], [23, 4]];
+const MEDIUM_EN: &[[usize; 2]] = &[
+    [11, 4],
+    [14, 1],
+    [14, 12],
+    [14, 14],
+    [15, 4],
+    [16, 0],
+    [16, 4],
+    [16, 9],
+    [17, 12],
+    [17, 14],
+    [18, 7],
+    [18, 10],
+    [18, 15],
+    [20, 0],
+    [20, 3],
+    [20, 9],
+    [20, 14],
+    [21, 12],
+];
+const LARGE_V1: &[[usize; 2]] = &[
+    [9, 19],
+    [11, 2],
+    [11, 4],
+    [11, 17],
+    [22, 7],
+    [22, 11],
+    [22, 17],
+    [23, 2],
+    [23, 15],
+];
+const LARGE_V2_V3: &[[usize; 2]] = &[
+    [10, 12],
+    [13, 17],
+    [16, 11],
+    [16, 12],
+    [16, 13],
+    [17, 15],
+    [17, 16],
+    [18, 4],
+    [18, 11],
+    [18, 19],
+    [19, 11],
+    [21, 2],
+    [21, 3],
+    [22, 3],
+    [22, 9],
+    [22, 12],
+    [23, 5],
+    [23, 7],
+    [23, 13],
+    [25, 5],
+    [26, 1],
+    [26, 12],
+    [27, 15],
+];
+const TURBO: &[[usize; 2]] = &[[2, 4], [2, 11], [3, 3], [3, 6], [3, 11], [3, 14]];

--- a/candle-transformers/src/models/whisper/timestamps.rs
+++ b/candle-transformers/src/models/whisper/timestamps.rs
@@ -110,7 +110,7 @@ impl AlignmentHeads {
             weights.dim(D::Minus2)? - n_start_tokens,
         )?;
 
-        // Do the timewarp for each batch
+        // Do the timewarp
         let timestamps = Tensor::stack(
             &((0..weights.dim(0)?).map(|batch_idx| {
                 let (text_indices, time_indices) = dynamic_time_warp(
@@ -141,7 +141,6 @@ impl AlignmentHeads {
             0,
         )?;
 
-        // batch * timestamps
         Ok(timestamps.to_vec2::<f32>()?.into_iter().map(Raw).collect())
     }
 }
@@ -298,6 +297,14 @@ impl AlignmentHeads {
     pub fn large_v3_turbo() -> Self {
         TURBO.iter().copied().collect()
     }
+
+    pub fn distil_small_en() -> Self {
+        DISTIL_SMALL_EN.iter().copied().collect()
+    }
+
+    pub fn distil_large_v3() -> Self {
+        DISTIL_LARGE_V3.iter().copied().collect()
+    }
 }
 
 const TINY: &[[usize; 2]] = &[[2, 2], [3, 0], [3, 2], [3, 3], [3, 4], [3, 5]];
@@ -413,3 +420,46 @@ const LARGE_V2_V3: &[[usize; 2]] = &[
     [27, 15],
 ];
 const TURBO: &[[usize; 2]] = &[[2, 4], [2, 11], [3, 3], [3, 6], [3, 11], [3, 14]];
+const DISTIL_SMALL_EN: &[[usize; 2]] = &[
+    [6, 6],
+    [7, 0],
+    [7, 3],
+    [7, 8],
+    [8, 2],
+    [8, 5],
+    [8, 7],
+    [9, 0],
+    [9, 4],
+    [9, 8],
+    [9, 10],
+    [10, 0],
+    [10, 1],
+    [10, 2],
+    [10, 3],
+    [10, 6],
+    [10, 11],
+    [11, 2],
+    [11, 4],
+];
+const DISTIL_LARGE_V3: &[[usize; 2]] = &[
+    [1, 0],
+    [1, 1],
+    [1, 2],
+    [1, 3],
+    [1, 4],
+    [1, 5],
+    [1, 6],
+    [1, 7],
+    [1, 8],
+    [1, 9],
+    [1, 10],
+    [1, 11],
+    [1, 12],
+    [1, 13],
+    [1, 14],
+    [1, 15],
+    [1, 16],
+    [1, 17],
+    [1, 18],
+    [1, 19],
+];


### PR DESCRIPTION
Hi again, I thought it'd be useful to have these token/word-level timestamps available from the whisper implementation here.

The first commit adds an option (`--cache`) to use the kv cache on the decoder self attention, in which case after the initial pass, only the final token is needed. My main goal isn't really to improve performance, but I couldn't get the timestamps working without this change. The speed gains on the CPU appear significant (about 4x in my case), though I haven't done any true benchmarking and any gains on the GPU or with the quantized models are less noticeable.

For the timestamps I mainly followed [OpenAI's python implementation](https://github.com/openai/whisper/blob/main/whisper/timing.py#L163), and given the same inputs the timestamps should match closely.

With these changes, passing the `--dtw-timestamps` flag prints the word-level timestamps:

> Word { text: "and", start: 0.0, end: 0.7 }
> Word { text: "so", start: 0.7, end: 1.06 }
> Word { text: "my", start: 1.06, end: 1.44 }
> Word { text: "fellow", start: 1.44, end: 1.74 }
> Word { text: "americans", start: 1.74, end: 2.34 }
> Word { text: "ask", start: 2.34, end: 3.86 }
> Word { text: "not", start: 3.86, end: 4.54 }
> Word { text: "what", start: 4.54, end: 5.68 }
> Word { text: "your", start: 5.68, end: 6.02 }
> Word { text: "country", start: 6.02, end: 6.34 }
> Word { text: "can", start: 6.34, end: 6.76 }
> Word { text: "do", start: 6.76, end: 7.0 }
> Word { text: "for", start: 7.0, end: 7.24 }
> Word { text: "you", start: 7.24, end: 8.06 }
> Word { text: "ask", start: 8.06, end: 8.64 }
> Word { text: "what", start: 8.64, end: 8.94 }
> Word { text: "you", start: 8.94, end: 9.26 }
> Word { text: "can", start: 9.26, end: 9.48 }
> Word { text: "do", start: 9.48, end: 9.72 }
> Word { text: "for", start: 9.72, end: 9.9 }
> Word { text: "your", start: 9.9, end: 10.22 }
> Word { text: "country", start: 10.22, end: 10.54 }

Time permitting, here are some things I'd still like to do here in no particular order:
- [x] Verify that this doesn't break any existing whisper functionality
- [x] Verify that this produces output consistent with the referenced implementation (9109c02e1affe4b858cd89909bb90a4a375676c1 gets raw output for the JFK sample to sub-millisecond consistency)
- [x] Add alignment heads for the distilled models: (57346e19d240796492730f534b0d639c8d9b877c adds small en and large v3)
- [x] Improve the post-processing logic (15e0b1d054be756b9991555a47b6a5f893f3e4e4 adds some merging and part-of-speech handling, still pretty basic)

Any feedback is appreciated 👍 