### PR TITLE
use moondream1 model/revision for moondream example

### DIFF
--- a/candle-examples/examples/moondream/main.rs
+++ b/candle-examples/examples/moondream/main.rs
@@ -259,8 +259,8 @@ async fn main() -> anyhow::Result<()> {
                 ("santiagomed/candle-moondream".to_string(), None)
             } else {
                 (
-                    "vikhyatk/moondream2".to_string(),
-                    Some("30c7cdf3fa6914f50bee3956694374143f5cc884"),
+                    "vikhyatk/moondream1".to_string(),
+                    Some("f6e9da68e8f1b78b8f3ee10905d56826db7a5802"),
                 )
             }
         }


### PR DESCRIPTION
`moondream` example seems to be broken now.

The revision in repo fails to load.
```
Error: path: "../models--vikhyatk--moondream2/snapshots/30c7cdf3fa6914f50bee3956694374143f5cc884/model.safetensors" MetadataIncompleteBuffer
```

I think upstream may have broken it.

Changing it to the latest revision of  `vikhyatk/moondream1` fixes the example.

Quantized version works just fine.