### PR TITLE
fix: place `ug` dep behind `not wasm32` flag

### DIFF
--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -28,25 +28,26 @@ rand_distr = { workspace = true }
 rayon = { workspace = true }
 safetensors = { workspace = true }
 thiserror = { workspace = true }
-ug = { workspace = true, optional = true }
 ug-cuda = { workspace = true, optional = true }
 ug-metal = { workspace = true, optional = true }
 yoke = { workspace = true }
 zip = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ug = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
 criterion = { workspace = true }
 
-
 [features]
 default = []
-cuda = ["cudarc", "dep:candle-kernels", "dep:ug-cuda", "dep:ug"]
+cuda = ["cudarc", "dep:candle-kernels", "dep:ug-cuda"]
 cudnn = ["cuda", "cudarc/cudnn"]
 mkl = ["dep:libc", "dep:intel-mkl-src"]
 accelerate = ["dep:libc", "dep:accelerate-src"]
-metal = ["dep:metal", "dep:candle-metal-kernels", "dep:ug-metal", "dep:ug"]
+metal = ["dep:metal", "dep:candle-metal-kernels", "dep:ug-metal"]
 
 [[bench]]
 name = "bench_main"

--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -14,7 +14,7 @@ accelerate-src = { workspace = true, optional = true }
 byteorder = { workspace = true }
 candle-kernels = { workspace = true, optional = true }
 candle-metal-kernels = { workspace = true, optional = true }
-metal = { workspace = true, optional = true}
+metal = { workspace = true, optional = true }
 cudarc = { workspace = true, optional = true }
 gemm = { workspace = true }
 half = { workspace = true }
@@ -28,7 +28,7 @@ rand_distr = { workspace = true }
 rayon = { workspace = true }
 safetensors = { workspace = true }
 thiserror = { workspace = true }
-ug = { workspace = true }
+ug = { workspace = true, optional = true }
 ug-cuda = { workspace = true, optional = true }
 ug-metal = { workspace = true, optional = true }
 yoke = { workspace = true }
@@ -42,11 +42,11 @@ criterion = { workspace = true }
 
 [features]
 default = []
-cuda = ["cudarc", "dep:candle-kernels", "dep:ug-cuda"]
+cuda = ["cudarc", "dep:candle-kernels", "dep:ug-cuda", "dep:ug"]
 cudnn = ["cuda", "cudarc/cudnn"]
 mkl = ["dep:libc", "dep:intel-mkl-src"]
 accelerate = ["dep:libc", "dep:accelerate-src"]
-metal = ["dep:metal", "dep:candle-metal-kernels", "dep:ug-metal"]
+metal = ["dep:metal", "dep:candle-metal-kernels", "dep:ug-metal", "dep:ug"]
 
 [[bench]]
 name = "bench_main"

--- a/candle-core/src/cuda_backend/device.rs
+++ b/candle-core/src/cuda_backend/device.rs
@@ -51,6 +51,7 @@ impl CudaDevice {
         self.device.clone()
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn compile(
         &self,
         func_name: &'static str,

--- a/candle-core/src/custom_op.rs
+++ b/candle-core/src/custom_op.rs
@@ -386,6 +386,7 @@ pub struct UgIOp1 {
 
 impl UgIOp1 {
     #[allow(unused)]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn new(
         name: &'static str,
         kernel: ug::lang::ssa::Kernel,

--- a/candle-core/src/error.rs
+++ b/candle-core/src/error.rs
@@ -172,6 +172,7 @@ pub enum Error {
     #[error("Metal error {0}")]
     Metal(#[from] MetalError),
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[error(transparent)]
     Ug(#[from] ug::Error),
 

--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -138,6 +138,7 @@ impl std::ops::Deref for MetalDevice {
 }
 
 impl MetalDevice {
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn compile(
         &self,
         func_name: &'static str,


### PR DESCRIPTION
So that wasm32 can compile

fixes: https://github.com/huggingface/candle/issues/2736