### PR TITLE
Fix candle-core example basics.rs

### DIFF
--- a/candle-core/examples/basics.rs
+++ b/candle-core/examples/basics.rs
@@ -8,10 +8,13 @@ use anyhow::Result;
 use candle_core::{Device, Tensor};
 
 fn main() -> Result<()> {
-    let a = Tensor::new(&[[0.0f32, 1.0, 2.0], [3.0, 4.0, 5.0]], &Device::Cpu)?;
-    let b = Tensor::new(&[[88.0f32, 99.0]], &Device::Cpu)?;
-    let new_a = a.slice_scatter(&b, 1, 2)?;
-    assert_eq!(a.to_vec2::<f32>()?, [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
-    assert_eq!(new_a.to_vec2::<f32>()?, [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]);
+    let a = Tensor::new(&[[0.0f32, 1.0], [2.0, 3.0], [4.0, 5.0]], &Device::Cpu)?;
+    let b = Tensor::new(&[[66.0f32, 77.0], [88.0f32, 99.0]], &Device::Cpu)?;
+    let new_a = a.slice_scatter(&b, 0, 1)?;
+    assert_eq!(a.to_vec2::<f32>()?, [[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]]);
+    assert_eq!(
+        new_a.to_vec2::<f32>()?,
+        [[0.0, 1.0], [66.0, 77.0], [88.0, 99.0]]
+    );
     Ok(())
 }


### PR DESCRIPTION
Fix issue #2782

The original slice_scatter example in basics.rs was failing due to mismatched tensor dimensions. 
This PR:

- Updates the example with correct tensor shapes
- Adds a working demonstration of slice_scatter functionality
- Includes proper assertions to verify the expected behavior
