### PR TITLE
Fix for whisper example. rand::distribution is now rand::distr

### DIFF
--- a/candle-examples/examples/whisper/main.rs
+++ b/candle-examples/examples/whisper/main.rs
@@ -14,7 +14,9 @@ use candle::{Device, IndexOp, Tensor};
 use candle_nn::{ops::softmax, VarBuilder};
 use clap::{Parser, ValueEnum};
 use hf_hub::{api::sync::Api, Repo, RepoType};
-use rand::{distributions::Distribution, SeedableRng};
+use rand::distr::weighted::WeightedIndex;
+use rand::distr::Distribution;
+use rand::SeedableRng;
 use tokenizers::Tokenizer;
 
 mod multilingual;
@@ -208,7 +210,7 @@ impl Decoder {
             let next_token = if t > 0f64 {
                 let prs = softmax(&(&logits / t)?, 0)?;
                 let logits_v: Vec<f32> = prs.to_vec1()?;
-                let distr = rand::distributions::WeightedIndex::new(&logits_v)?;
+                let distr = WeightedIndex::new(&logits_v)?;
                 distr.sample(&mut self.rng) as u32
             } else {
                 let logits_v: Vec<f32> = logits.to_vec1()?;


### PR DESCRIPTION
```
error[E0432]: unresolved import `rand::distributions`
  --> candle-examples/examples/whisper/main.rs:17:12
   |
17 | use rand::{distributions::Distribution, SeedableRng};
   |            ^^^^^^^^^^^^^ could not find `distributions` in `rand`

error[E0433]: failed to resolve: could not find `distributions` in `rand`
   --> candle-examples/examples/whisper/main.rs:211:35
    |
211 |                 let distr = rand::distributions::WeightedIndex::new(&logits_v)?;
    |                                   ^^^^^^^^^^^^^ could not find `distributions` in `rand`
    |
help: consider importing this struct
    |
12  + use rand::distr::weighted::WeightedIndex;
    |
help: if you import `WeightedIndex`, refer to it directly
    |
211 -                 let distr = rand::distributions::WeightedIndex::new(&logits_v)?;
211 +                 let distr = WeightedIndex::new(&logits_v)?;
    |

Some errors have detailed explanations: E0432, E0433.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `candle-examples` (example "whisper") due to 2 previous errors
```