### PR TITLE
Enabling different linking options for MKL downstream.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ half = { version = "2.5.0", features = ["num-traits", "use-intrinsics", "rand_di
 hound = "3.5.1"
 image = { version = "0.25.2", default-features = false, features = ["jpeg", "png"] }
 imageproc = { version = "0.24.0", default-features = false }
-intel-mkl-src = { version = "0.8.1", features = ["mkl-static-lp64-iomp"] }
+intel-mkl-src = { version = "0.8.1" }
 libc = { version = "0.2.147" }
 log = "0.4"
 memmap2 = { version = "0.9.3", features = ["stable_deref_trait"] }

--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -45,7 +45,8 @@ criterion = { workspace = true }
 default = []
 cuda = ["cudarc", "dep:candle-kernels", "dep:ug-cuda"]
 cudnn = ["cuda", "cudarc/cudnn"]
-mkl = ["dep:libc", "dep:intel-mkl-src"]
+_mkl = ["dep:libc", "dep:intel-mkl-src"]
+mkl = ["_mkl", "intel-mkl-src?/mkl-static-lp64-iomp"] 
 accelerate = ["dep:libc", "dep:accelerate-src"]
 metal = ["dep:metal", "dep:candle-metal-kernels", "dep:ug-metal"]
 

--- a/candle-core/benches/benchmarks/mod.rs
+++ b/candle-core/benches/benchmarks/mod.rs
@@ -39,7 +39,7 @@ impl BenchDevice for Device {
             Device::Cpu => {
                 let cpu_type = if cfg!(feature = "accelerate") {
                     "accelerate"
-                } else if cfg!(feature = "mkl") {
+                } else if cfg!(feature = "_mkl") {
                     "mkl"
                 } else {
                     "cpu"

--- a/candle-core/examples/basics.rs
+++ b/candle-core/examples/basics.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 #[cfg(feature = "accelerate")]

--- a/candle-core/examples/cuda_basics.rs
+++ b/candle-core/examples/cuda_basics.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "accelerate")]
 extern crate accelerate_src;
 
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 use anyhow::Result;

--- a/candle-core/examples/cuda_sum_benchmark.rs
+++ b/candle-core/examples/cuda_sum_benchmark.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 #[cfg(feature = "accelerate")]

--- a/candle-core/examples/metal_basics.rs
+++ b/candle-core/examples/metal_basics.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "accelerate")]
 extern crate accelerate_src;
 
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 use anyhow::Result;

--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -1246,7 +1246,7 @@ impl MatMul {
 impl Map2 for MatMul {
     const OP: &'static str = "mat_mul";
 
-    #[cfg(all(not(feature = "mkl"), not(feature = "accelerate")))]
+    #[cfg(all(not(feature = "_mkl"), not(feature = "accelerate")))]
     fn f<T: 'static + WithDType + num_traits::Num + Copy>(
         &self,
         lhs: &[T],
@@ -1411,7 +1411,7 @@ impl Map2 for MatMul {
         Ok(dst)
     }
 
-    #[cfg(feature = "mkl")]
+    #[cfg(feature = "_mkl")]
     fn f<T: 'static + WithDType + num_traits::Num + Copy>(
         &self,
         lhs: &[T],

--- a/candle-core/src/lib.rs
+++ b/candle-core/src/lib.rs
@@ -68,7 +68,7 @@ mod indexer;
 pub mod layout;
 #[cfg(feature = "metal")]
 pub mod metal_backend;
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 mod mkl;
 pub mod npy;
 pub mod op;
@@ -118,7 +118,7 @@ pub use metal_backend::{MetalDevice, MetalError, MetalStorage};
 #[cfg(not(feature = "metal"))]
 pub use dummy_metal_backend::{MetalDevice, MetalError, MetalStorage};
 
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 #[cfg(feature = "accelerate")]

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -294,16 +294,16 @@ macro_rules! bin_op {
                 $e(v1, v2)
             }
 
-            #[cfg(feature = "mkl")]
+            #[cfg(feature = "_mkl")]
             const F32_VEC: bool = true;
-            #[cfg(feature = "mkl")]
+            #[cfg(feature = "_mkl")]
             const F64_VEC: bool = true;
-            #[cfg(feature = "mkl")]
+            #[cfg(feature = "_mkl")]
             #[inline(always)]
             fn f32_vec(xs1: &[f32], xs2: &[f32], ys: &mut [f32]) {
                 crate::mkl::$f32_vec(xs1, xs2, ys)
             }
-            #[cfg(feature = "mkl")]
+            #[cfg(feature = "_mkl")]
             #[inline(always)]
             fn f64_vec(xs1: &[f64], xs2: &[f64], ys: &mut [f64]) {
                 crate::mkl::$f64_vec(xs1, xs2, ys)
@@ -418,16 +418,16 @@ macro_rules! unary_op {
                 todo!("no unary function for i64")
             }
 
-            #[cfg(feature = "mkl")]
+            #[cfg(feature = "_mkl")]
             const F32_VEC: bool = true;
-            #[cfg(feature = "mkl")]
+            #[cfg(feature = "_mkl")]
             const F64_VEC: bool = true;
-            #[cfg(feature = "mkl")]
+            #[cfg(feature = "_mkl")]
             #[inline(always)]
             fn f32_vec(xs: &[f32], ys: &mut [f32]) {
                 crate::mkl::$f32_vec(xs, ys)
             }
-            #[cfg(feature = "mkl")]
+            #[cfg(feature = "_mkl")]
             #[inline(always)]
             fn f64_vec(xs: &[f64], ys: &mut [f64]) {
                 crate::mkl::$f64_vec(xs, ys)
@@ -518,19 +518,19 @@ impl UnaryOpT for Gelu {
     }
     const KERNEL: &'static str = "ugelu";
 
-    #[cfg(feature = "mkl")]
+    #[cfg(feature = "_mkl")]
     const F32_VEC: bool = true;
 
-    #[cfg(feature = "mkl")]
+    #[cfg(feature = "_mkl")]
     #[inline(always)]
     fn f32_vec(xs: &[f32], ys: &mut [f32]) {
         crate::mkl::vs_gelu(xs, ys)
     }
 
-    #[cfg(feature = "mkl")]
+    #[cfg(feature = "_mkl")]
     const F64_VEC: bool = true;
 
-    #[cfg(feature = "mkl")]
+    #[cfg(feature = "_mkl")]
     #[inline(always)]
     fn f64_vec(xs: &[f64], ys: &mut [f64]) {
         crate::mkl::vd_gelu(xs, ys)
@@ -625,19 +625,19 @@ impl UnaryOpT for Silu {
     }
     const KERNEL: &'static str = "usilu";
 
-    #[cfg(feature = "mkl")]
+    #[cfg(feature = "_mkl")]
     const F32_VEC: bool = true;
 
-    #[cfg(feature = "mkl")]
+    #[cfg(feature = "_mkl")]
     #[inline(always)]
     fn f32_vec(xs: &[f32], ys: &mut [f32]) {
         crate::mkl::vs_silu(xs, ys)
     }
 
-    #[cfg(feature = "mkl")]
+    #[cfg(feature = "_mkl")]
     const F64_VEC: bool = true;
 
-    #[cfg(feature = "mkl")]
+    #[cfg(feature = "_mkl")]
     #[inline(always)]
     fn f64_vec(xs: &[f64], ys: &mut [f64]) {
         crate::mkl::vd_silu(xs, ys)

--- a/candle-core/src/utils.rs
+++ b/candle-core/src/utils.rs
@@ -17,7 +17,7 @@ pub fn has_accelerate() -> bool {
 }
 
 pub fn has_mkl() -> bool {
-    cfg!(feature = "mkl")
+    cfg!(feature = "_mkl")
 }
 
 pub fn cuda_is_available() -> bool {

--- a/candle-nn/Cargo.toml
+++ b/candle-nn/Cargo.toml
@@ -33,7 +33,8 @@ criterion = { workspace = true }
 default = []
 accelerate = ["dep:accelerate-src", "candle/accelerate"]
 cuda = ["candle/cuda"]
-mkl = ["dep:intel-mkl-src", "candle/mkl"]
+mkl = ["candle/mkl"]
+_mkl = ["dep:intel-mkl-src", "candle/_mkl"]
 metal = ["candle/metal", "dep:candle-metal-kernels", "dep:metal"]
 
 [[bench]]

--- a/candle-nn/Cargo.toml
+++ b/candle-nn/Cargo.toml
@@ -33,8 +33,8 @@ criterion = { workspace = true }
 default = []
 accelerate = ["dep:accelerate-src", "candle/accelerate"]
 cuda = ["candle/cuda"]
-mkl = ["candle/mkl"]
 _mkl = ["dep:intel-mkl-src", "candle/_mkl"]
+mkl = ["candle/mkl"]
 metal = ["candle/metal", "dep:candle-metal-kernels", "dep:metal"]
 
 [[bench]]

--- a/candle-nn/benches/benchmarks/mod.rs
+++ b/candle-nn/benches/benchmarks/mod.rs
@@ -34,7 +34,7 @@ impl BenchDevice for Device {
             Device::Cpu => {
                 let cpu_type = if cfg!(feature = "accelerate") {
                     "accelerate"
-                } else if cfg!(feature = "mkl") {
+                } else if cfg!(feature = "_mkl") {
                     "mkl"
                 } else {
                     "cpu"

--- a/candle-nn/examples/basic_optimizer.rs
+++ b/candle-nn/examples/basic_optimizer.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 #[cfg(feature = "accelerate")]

--- a/candle-nn/examples/cpu_benchmarks.rs
+++ b/candle-nn/examples/cpu_benchmarks.rs
@@ -1,5 +1,5 @@
 /// This example contains some simple benchmarks so that it's easy to run them in perf etc.
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 #[cfg(feature = "accelerate")]

--- a/candle-nn/tests/batch_norm.rs
+++ b/candle-nn/tests/batch_norm.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 #[cfg(feature = "accelerate")]

--- a/candle-nn/tests/group_norm.rs
+++ b/candle-nn/tests/group_norm.rs
@@ -18,7 +18,7 @@ t = torch.tensor(
 print(group_norm(t, num_groups=2))
 print(group_norm(t, num_groups=3))
 */
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 #[cfg(feature = "accelerate")]

--- a/candle-nn/tests/kv_cache.rs
+++ b/candle-nn/tests/kv_cache.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 #[cfg(feature = "accelerate")]

--- a/candle-nn/tests/layer_norm.rs
+++ b/candle-nn/tests/layer_norm.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 #[cfg(feature = "accelerate")]

--- a/candle-nn/tests/loss.rs
+++ b/candle-nn/tests/loss.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 #[cfg(feature = "accelerate")]

--- a/candle-nn/tests/ops.rs
+++ b/candle-nn/tests/ops.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 #[cfg(feature = "accelerate")]

--- a/candle-nn/tests/optim.rs
+++ b/candle-nn/tests/optim.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 #[cfg(feature = "accelerate")]

--- a/candle-nn/tests/rnn.rs
+++ b/candle-nn/tests/rnn.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "mkl")]
+#[cfg(feature = "_mkl")]
 extern crate intel_mkl_src;
 
 #[cfg(feature = "accelerate")]


### PR DESCRIPTION
When using `candle/mkl` right now, it forces the use of static linking.

However, this is not optimal in some circumstances, for instance we need to hotpatch the library to enable faster runtime on non-Intel CPU: https://github.com/huggingface/text-embeddings-inference/blob/main/Dockerfile#L39-L40

In order for the thing to be practical it's easier to use dynamic linking and use clever ordering to force patch the library at runtime.

I made the change non breaking.

- feature `mkl` becomes `_mkl` and doesn't include the actual `intel-mkl-src/mkl-static-lp64-iomp` feature, so it's agnostic the linking procedure.
- Adding a new `mkl` feature which solely adds `mkl-static-lp64-iomp` to keep backward compatibility in examples and downstream crates
- Propagate to `candle-nn`
- Didn't propagate to `candle-transformers` (user can simply opt-out of `mkl` altogether since no code actually uses it)

So now for power-users than want to custom link `mkl` all they need to do is enable the `_mkl` feature, and manually enable the `intel-mkl-src/mkl-dynamic-lp64-iomp` in their own crate/binary.

I haven't modified the documentation since it's a power user feature anyway, but I can do it if deemed necessary.

