### PR TITLE
Add `ReduceLROnPlateau` learning rate scheduler

### DIFF
--- a/candle-nn/src/optim.rs
+++ b/candle-nn/src/optim.rs
@@ -199,3 +199,334 @@ impl AdamW {
         self.params = params;
     }
 }
+
+/// Specifies whether the metric should be minimized or maximized. Used for [`ReduceLROnPlateau`]
+// Named with a prefix to avoid naming conflicts with similar types in future. Modules are an alternative,
+// but this did not feel more ergonomic than a name prefix.
+#[derive(Clone, Copy, Debug)]
+pub enum LRPlateauMode {
+    Min,
+    Max,
+}
+
+/// Specifies how the threshold is applied: relative or absolute. Used for [`ReduceLROnPlateau`]
+// Named with a prefix to avoid naming conflicts with similar types in future.
+#[derive(Clone, Copy, Debug)]
+pub enum LRPlateauThresholdMode {
+    Rel,
+    Abs,
+}
+
+/// A learning rate scheduler which reduces the learning rate when a quantity has stopped improving.
+/// Analogous to the PyTorch `ReduceLROnPlateau`.
+///
+/// Models typically benefit from reducing the learning rate by a few orders of magnitude when learning stalls.
+/// This scheduler observes some quantity/metric and will reduce the learning rate when no improvement has been seen
+/// for a "patience" number of epochs.
+///
+/// # Example
+///
+/// ```
+/// use candle_nn::{AdamW, ParamsAdamW, Optimizer};
+/// use candle_nn::optim::{ReduceLROnPlateauBuilder, LRPlateauMode};
+///
+/// // Create an optimizer
+/// let opt = AdamW::new(vec![], ParamsAdamW::default()).unwrap();
+/// let initial_lr = opt.learning_rate();
+///
+/// // Create scheduler
+/// let mut scheduler = ReduceLROnPlateauBuilder::new(opt)
+///     .patience(0)  // Wait 5 epochs before reducing LR
+///     .factor(0.5)  // Reduce LR by half
+///     .build();
+///
+/// // Example losses
+/// let losses = vec![1., 1., 0.75, 0.5, 0.5];
+/// let expected_lrs = vec![
+///     initial_lr,           // Epoch 1: First value, sets baseline
+///     initial_lr * 0.5,     // Epoch 2: Loss didn't improve (1.0 == 1.0)
+///     initial_lr * 0.5,     // Epoch 3: Loss improved (0.75 < 1.0)
+///     initial_lr * 0.5,     // Epoch 4: Loss improved (0.5 < 0.75)
+///     initial_lr * 0.25,    // Epoch 5: Loss didn't improve (0.5 == 0.5)
+/// ];
+/// // In your training loop:
+/// for epoch in 1..=5 {
+///     // ... training code ...
+///     
+///     // Get validation loss
+///     let val_loss = losses[epoch - 1];
+///     
+///     // Update scheduler
+///     scheduler.step(val_loss).unwrap();
+///     
+///     // Current learning rate after potential adjustment
+///     let current_lr = scheduler.opt().learning_rate();
+/// }
+/// ```
+#[derive(Debug)]
+pub struct ReduceLROnPlateau<O> {
+    /// The optimizer to schedule
+    optimizer: O,
+    /// One of min or max. In min mode, the lr will be reduced with the quantity has stopped decreasing.
+    /// In max mode, the quantity will reduce when the quantity has stopped increasing.
+    mode: LRPlateauMode,
+    /// Factor the lr will be reduced by (new_lr = lr * factor)
+    factor: f64,
+    /// The number of epochs with no improvement in quantity (crossing a threshold) before reducing the lr
+    patience: usize,
+    /// The threshold for the quantity to stop reducing
+    threshold: f64,
+    /// The mode for the threshold. Determines how the threshold will calculate the quantity
+    threshold_mode: LRPlateauThresholdMode,
+    /// The number of epochs to wait before resuming normal operation after a lr reduction
+    cooldown: usize,
+    /// The minimum lr value
+    min_lr: f64,
+    /// Minimal decay applied to the lr. If the difference between the previous and the current lr is less than eps, the update is ignored.
+    eps: f64,
+    /// The best metric value seen so far
+    best: Option<f64>,
+    /// The number of epochs with no improvement in quantity (crossing a threshold) before reducing the lr
+    num_bad_epochs: usize,
+    /// The number of epochs to wait before resuming normal operation after a lr reduction
+    cooldown_counter: usize,
+}
+
+impl<O: Optimizer> std::fmt::Display for ReduceLROnPlateau<O> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ReduceLROnPlateau {{")?;
+        write!(f, "mode: {:?}, ", self.mode)?;
+        write!(f, "factor: {}, ", self.factor)?;
+        write!(f, "patience: {}, ", self.patience)?;
+        write!(f, "threshold: {}, ", self.threshold)?;
+        write!(f, "threshold_mode: {:?}, ", self.threshold_mode)?;
+        write!(f, "cooldown: {}, ", self.cooldown)?;
+        write!(f, "min_lr: {}, ", self.min_lr)?;
+        write!(f, "eps: {}, ", self.eps)?;
+        write!(f, "best: {:?}, ", self.best)?;
+        write!(f, "num_bad_epochs: {}, ", self.num_bad_epochs)?;
+        write!(f, "cooldown_counter: {}, ", self.cooldown_counter)?;
+        // Instead of printing the entire optimizer, print the most relevant field
+        // which is the current learning rate
+        write!(f, "current_lr: {}", self.optimizer.learning_rate())?;
+        write!(f, "}}")
+    }
+}
+
+impl<O: Optimizer> ReduceLROnPlateau<O> {
+    /// Perform a learning rate step given the currrent metric level. This learning rate scheduler will adjust the
+    /// learning rate based on how this metric value compares to the previously best seen metric.
+    pub fn step(&mut self, metric: f64) -> Result<()> {
+        let improvement = match self.mode {
+            LRPlateauMode::Min => match self.threshold_mode {
+                LRPlateauThresholdMode::Rel => self
+                    .best
+                    .map_or(true, |best| metric < best * (1.0 - self.threshold)),
+                LRPlateauThresholdMode::Abs => self
+                    .best
+                    .map_or(true, |best| metric < best - self.threshold),
+            },
+            LRPlateauMode::Max => match self.threshold_mode {
+                LRPlateauThresholdMode::Rel => self
+                    .best
+                    .map_or(true, |best| metric > best * (1.0 + self.threshold)),
+                LRPlateauThresholdMode::Abs => self
+                    .best
+                    .map_or(true, |best| metric > best + self.threshold),
+            },
+        };
+
+        if improvement {
+            self.best = Some(metric);
+            self.num_bad_epochs = 0;
+        } else {
+            self.num_bad_epochs += 1;
+        }
+
+        if self.cooldown_counter > 0 {
+            self.cooldown_counter -= 1;
+            self.num_bad_epochs = 0;
+        }
+
+        if self.num_bad_epochs > self.patience {
+            let current_lr = self.optimizer.learning_rate();
+            let new_lr = current_lr * self.factor;
+            if (current_lr - new_lr) > self.eps && new_lr >= self.min_lr {
+                self.optimizer.set_learning_rate(new_lr);
+                self.cooldown_counter = self.cooldown;
+                self.num_bad_epochs = 0;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get the inner optimizer mutably
+    pub fn opt_mut(&mut self) -> &mut O {
+        &mut self.optimizer
+    }
+
+    /// Get the inner optimizer immutably
+    pub fn opt(&self) -> &O {
+        &self.optimizer
+    }
+
+    /// Get the number of consecutive epochs for which the best metric has not decreased below the threshold
+    pub fn num_bad_epochs(&self) -> usize {
+        self.num_bad_epochs
+    }
+
+    /// Get the mode (Min or Max)
+    pub fn mode(&self) -> LRPlateauMode {
+        self.mode
+    }
+
+    /// Get the factor by which the learning rate is reduced
+    pub fn factor(&self) -> f64 {
+        self.factor
+    }
+
+    /// Get the number of epochs with no improvement before reducing the learning rate
+    pub fn patience(&self) -> usize {
+        self.patience
+    }
+
+    /// Get the threshold for determining improvement
+    pub fn threshold(&self) -> f64 {
+        self.threshold
+    }
+
+    /// Get the threshold mode (Rel or Abs)
+    pub fn threshold_mode(&self) -> LRPlateauThresholdMode {
+        self.threshold_mode
+    }
+
+    /// Get the cooldown period after a learning rate reduction
+    pub fn cooldown(&self) -> usize {
+        self.cooldown
+    }
+
+    /// Get the minimum learning rate
+    pub fn min_lr(&self) -> f64 {
+        self.min_lr
+    }
+
+    /// Get the epsilon value for minimal learning rate changes
+    pub fn eps(&self) -> f64 {
+        self.eps
+    }
+
+    /// Get the best metric value seen so far
+    pub fn best(&self) -> Option<f64> {
+        self.best
+    }
+
+    /// Get the current cooldown counter
+    pub fn cooldown_counter(&self) -> usize {
+        self.cooldown_counter
+    }
+}
+
+/// Builder for the [`ReduceLROnPlateau`] scheduler
+// Uses a builder to provide sensible, overridable defaults and to allow extensible fields.
+pub struct ReduceLROnPlateauBuilder<O> {
+    /// The optimizer to schedule
+    optimizer: O,
+    /// One of min or max. In min mode, the lr will be reduced with the quantity has stopped decreasing.
+    /// In max mode, the quantity will reduce when the quantity has stopped increasing.
+    mode: LRPlateauMode,
+    /// Factor the lr will be reduced by (new_lr = lr * factor)
+    factor: f64,
+    /// The number of epochs with no improvement in quantity (crossing a threshold) before reducing the lr
+    patience: usize,
+    /// The threshold for the quantity to stop reducing
+    threshold: f64,
+    /// The mode for the threshold. Determines how the threshold will calculate the quantity
+    threshold_mode: LRPlateauThresholdMode,
+    /// The number of epochs to wait before resuming normal operation after a lr reduction
+    cooldown: usize,
+    /// The minimum lr value
+    min_lr: f64,
+    /// Minimal decay applied to the lr. If the difference between the previous and the current lr is less than eps, the update is ignored.
+    eps: f64,
+}
+
+impl<O: Optimizer> ReduceLROnPlateauBuilder<O> {
+    /// Initializes a new builder for the ReduceLROnPlateau scheduler with sensible, overridable defaults.
+    pub fn new(optimizer: O) -> Self {
+        // Default values mirror PyTorch
+        Self {
+            optimizer,
+            mode: LRPlateauMode::Min,
+            factor: 0.1,
+            patience: 10,
+            threshold: 1e-4,
+            threshold_mode: LRPlateauThresholdMode::Rel,
+            cooldown: 0,
+            min_lr: 0.0,
+            eps: 1e-8,
+        }
+    }
+
+    pub fn optimizer(mut self, optimizer: O) -> Self {
+        self.optimizer = optimizer;
+        self
+    }
+
+    pub fn mode(mut self, mode: LRPlateauMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    pub fn factor(mut self, factor: f64) -> Self {
+        self.factor = factor;
+        self
+    }
+
+    pub fn patience(mut self, patience: usize) -> Self {
+        self.patience = patience;
+        self
+    }
+
+    pub fn threshold(mut self, threshold: f64) -> Self {
+        self.threshold = threshold;
+        self
+    }
+
+    pub fn threshold_mode(mut self, threshold_mode: LRPlateauThresholdMode) -> Self {
+        self.threshold_mode = threshold_mode;
+        self
+    }
+
+    pub fn cooldown(mut self, cooldown: usize) -> Self {
+        self.cooldown = cooldown;
+        self
+    }
+
+    pub fn min_lr(mut self, min_lr: f64) -> Self {
+        self.min_lr = min_lr;
+        self
+    }
+
+    pub fn eps(mut self, eps: f64) -> Self {
+        self.eps = eps;
+        self
+    }
+
+    pub fn build(self) -> ReduceLROnPlateau<O> {
+        ReduceLROnPlateau {
+            optimizer: self.optimizer,
+            mode: self.mode,
+            factor: self.factor,
+            patience: self.patience,
+            threshold: self.threshold,
+            threshold_mode: self.threshold_mode,
+            cooldown: self.cooldown,
+            min_lr: self.min_lr,
+            eps: self.eps,
+            best: None,
+            num_bad_epochs: 0,
+            cooldown_counter: 0,
+        }
+    }
+}

--- a/candle-nn/tests/optim.rs
+++ b/candle-nn/tests/optim.rs
@@ -158,3 +158,395 @@ fn adamw_linear_regression_varmap() -> Result<()> {
     assert_eq!(to_vec0_round(lin.bias().unwrap(), 4)?, 1.);
     Ok(())
 }
+
+// Tests for `ReduceLROnPlateau`
+mod reduce_lr_on_plateau_tests {
+    use candle::backprop;
+    use candle_nn::optim::{LRPlateauMode, LRPlateauThresholdMode, ReduceLROnPlateauBuilder};
+
+    use super::*;
+
+    /// Assert that two floating point numbers are approximately equal
+    macro_rules! assert_approx_eq {
+        ($a:expr, $b:expr) => {
+            assert!(
+                ($a - $b).abs() < 1e-8,
+                "{} is not approximately equal to {}",
+                $a,
+                $b
+            );
+        };
+    }
+
+    // A mock optimizer for testing the scheduler
+    pub struct MockOptimizer {
+        learning_rate: f64,
+    }
+
+    impl Default for MockOptimizer {
+        fn default() -> Self {
+            Self::new(vec![], MockOptimizerConfig::default()).unwrap()
+        }
+    }
+
+    pub struct MockOptimizerConfig {
+        learning_rate: f64,
+    }
+
+    impl Default for MockOptimizerConfig {
+        fn default() -> Self {
+            Self { learning_rate: 0.1 }
+        }
+    }
+
+    impl Optimizer for MockOptimizer {
+        type Config = MockOptimizerConfig;
+        fn new(_vars: Vec<Var>, config: Self::Config) -> candle::Result<Self> {
+            Ok(Self {
+                learning_rate: config.learning_rate,
+            })
+        }
+
+        fn learning_rate(&self) -> f64 {
+            self.learning_rate
+        }
+
+        fn set_learning_rate(&mut self, lr: f64) {
+            self.learning_rate = lr;
+        }
+
+        fn step(&mut self, _grads: &backprop::GradStore) -> candle::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_reduce_lr_on_plateau_min_mode() -> Result<()> {
+        // Initialize with a mock optimizer and min mode (default)
+        let optimizer = MockOptimizer::default();
+        let mut scheduler = ReduceLROnPlateauBuilder::new(optimizer)
+            .mode(LRPlateauMode::Min)
+            .patience(2)
+            .factor(0.5)
+            .build();
+
+        // First metric sets the best value
+        scheduler.step(10.0)?;
+        assert_eq!(scheduler.opt().learning_rate(), 0.1);
+        assert_eq!(scheduler.best(), Some(10.0));
+        assert_eq!(scheduler.num_bad_epochs(), 0);
+
+        // Improvement
+        scheduler.step(9.0)?;
+        assert_eq!(scheduler.opt().learning_rate(), 0.1);
+        assert_eq!(scheduler.best(), Some(9.0));
+        assert_eq!(scheduler.num_bad_epochs(), 0);
+
+        // No improvement (first bad epoch)
+        scheduler.step(9.0)?;
+        assert_eq!(scheduler.opt().learning_rate(), 0.1);
+        assert_eq!(scheduler.num_bad_epochs(), 1);
+
+        // No improvement (second bad epoch)
+        scheduler.step(9.1)?;
+        assert_eq!(scheduler.opt().learning_rate(), 0.1);
+        assert_eq!(scheduler.num_bad_epochs(), 2);
+
+        // No improvement (third bad epoch - should reduce LR)
+        scheduler.step(9.2)?;
+        assert_approx_eq!(scheduler.opt().learning_rate(), 0.05); // 0.1 * 0.5
+        assert_eq!(scheduler.num_bad_epochs(), 0); // Reset after LR reduction
+        assert_eq!(scheduler.cooldown_counter(), 0); // No cooldown set
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reduce_lr_on_plateau_max_mode() -> Result<()> {
+        // Initialize with max mode
+        let optimizer = MockOptimizer::default();
+        let starting_lr = optimizer.learning_rate();
+        let decay_factor = 0.5;
+        let mut scheduler = ReduceLROnPlateauBuilder::new(optimizer)
+            .mode(LRPlateauMode::Max)
+            .patience(2)
+            .factor(decay_factor)
+            .build();
+
+        // First metric sets the best value
+        scheduler.step(10.0)?;
+        assert_eq!(scheduler.best(), Some(10.0));
+
+        // No improvement
+        scheduler.step(9.0)?;
+        assert_eq!(scheduler.num_bad_epochs(), 1);
+
+        // Improvement
+        scheduler.step(11.0)?;
+        assert_eq!(scheduler.best(), Some(11.0));
+        assert_eq!(scheduler.num_bad_epochs(), 0);
+
+        // No improvement (first bad epoch)
+        scheduler.step(10.9)?;
+        assert_eq!(scheduler.num_bad_epochs(), 1);
+
+        // No improvement (second bad epoch)
+        scheduler.step(10.8)?;
+        assert_eq!(scheduler.num_bad_epochs(), 2);
+
+        // No improvement (third bad epoch - should reduce LR)
+        scheduler.step(10.7)?;
+        assert_approx_eq!(scheduler.opt().learning_rate(), starting_lr * decay_factor);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reduce_lr_on_plateau_threshold_rel() -> Result<()> {
+        let optimizer = MockOptimizer::default();
+        let mut scheduler = ReduceLROnPlateauBuilder::new(optimizer)
+            .mode(LRPlateauMode::Min)
+            .threshold(0.1) // 10% threshold
+            .threshold_mode(LRPlateauThresholdMode::Rel)
+            .patience(1)
+            .build();
+
+        // First step establishes baseline
+        scheduler.step(10.0)?;
+        assert_eq!(scheduler.best(), Some(10.0));
+
+        // Improvement but within threshold (10.0 * (1 - 0.1) = 9.0)
+        // 9.5 > 9.0, so this isn't enough improvement to count
+        scheduler.step(9.5)?;
+        assert_eq!(scheduler.num_bad_epochs(), 1);
+        assert_eq!(scheduler.best(), Some(10.0)); // Best value doesn't change
+
+        // Real improvement beyond threshold
+        scheduler.step(8.9)?;
+        assert_eq!(scheduler.best(), Some(8.9));
+        assert_eq!(scheduler.num_bad_epochs(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reduce_lr_on_plateau_threshold_abs() -> Result<()> {
+        let optimizer = MockOptimizer::default();
+        let mut scheduler = ReduceLROnPlateauBuilder::new(optimizer)
+            .mode(LRPlateauMode::Min)
+            .threshold(1.0) // Absolute threshold of 1.0
+            .threshold_mode(LRPlateauThresholdMode::Abs)
+            .patience(1)
+            .build();
+
+        // First step establishes baseline
+        scheduler.step(10.0)?;
+        assert_eq!(scheduler.best(), Some(10.0));
+
+        // Improvement but within threshold (10.0 - 1.0 = 9.0)
+        // 9.5 > 9.0, so this isn't enough improvement to count
+        scheduler.step(9.5)?;
+        assert_eq!(scheduler.num_bad_epochs(), 1);
+        assert_eq!(scheduler.best(), Some(10.0)); // Best value doesn't change
+
+        // Real improvement beyond threshold
+        scheduler.step(8.9)?;
+        assert_eq!(scheduler.best(), Some(8.9));
+        assert_eq!(scheduler.num_bad_epochs(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reduce_lr_on_plateau_cooldown() -> Result<()> {
+        let optimizer = MockOptimizer::default();
+        let starting_lr = optimizer.learning_rate();
+        let decay_factor = 0.5;
+        let mut scheduler = ReduceLROnPlateauBuilder::new(optimizer)
+            .mode(LRPlateauMode::Min)
+            .patience(1)
+            .cooldown(2) // 2 epochs cooldown
+            .factor(decay_factor)
+            .build();
+
+        // First metric sets the best value
+        scheduler.step(10.0)?;
+        assert_eq!(scheduler.best(), Some(10.0));
+
+        // No improvement (first bad epoch)
+        scheduler.step(10.1)?;
+        assert_eq!(scheduler.num_bad_epochs(), 1);
+
+        // No improvement (second bad epoch - should reduce LR)
+        scheduler.step(10.2)?;
+        assert_approx_eq!(scheduler.opt().learning_rate(), starting_lr * decay_factor);
+        assert_eq!(scheduler.cooldown_counter(), 2); // Cooldown starts
+
+        // Even though this is worse, we're in cooldown so no reduction
+        scheduler.step(10.3)?;
+        assert_approx_eq!(scheduler.opt().learning_rate(), starting_lr * decay_factor);
+        assert_eq!(scheduler.cooldown_counter(), 1); // Cooldown decreases
+        assert_eq!(scheduler.num_bad_epochs(), 0); // Bad epochs reset during cooldown
+
+        // Still in cooldown
+        scheduler.step(10.4)?;
+        assert_approx_eq!(scheduler.opt().learning_rate(), starting_lr * decay_factor);
+        assert_eq!(scheduler.cooldown_counter(), 0); // Cooldown over after this step
+
+        // Cooldown over, this will count as a bad epoch
+        scheduler.step(10.5)?;
+        assert_approx_eq!(scheduler.opt().learning_rate(), starting_lr * decay_factor);
+        assert_eq!(scheduler.num_bad_epochs(), 1); // Bad epochs increment again
+
+        // Another bad epoch, should reduce LR again
+        scheduler.step(10.6)?;
+        assert_approx_eq!(
+            scheduler.opt().learning_rate(),
+            starting_lr * decay_factor * decay_factor
+        );
+        assert_eq!(scheduler.cooldown_counter(), 2); // Cooldown starts again
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reduce_lr_on_plateau_min_lr() -> Result<()> {
+        let optimizer = MockOptimizer::default();
+        let starting_lr = optimizer.learning_rate();
+        let mut scheduler = ReduceLROnPlateauBuilder::new(optimizer)
+            .patience(0) // No patience, so we should reduce LR immediately
+            .min_lr(0.01) // Set minimum learning rate
+            .build();
+
+        // First step sets best
+        scheduler.step(10.0)?;
+        assert_approx_eq!(scheduler.opt().learning_rate(), starting_lr);
+
+        // Reduce LR from 0.1 to 0.01
+        scheduler.step(10.1)?;
+        assert_approx_eq!(scheduler.opt().learning_rate(), 0.01);
+
+        // No improvement, reached min_lr
+        scheduler.step(10.2)?;
+        assert_approx_eq!(scheduler.opt().learning_rate(), 0.01);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reduce_lr_on_plateau_epsilon() -> Result<()> {
+        let optimizer = MockOptimizer::default();
+        let starting_lr = optimizer.learning_rate();
+        let mut scheduler = ReduceLROnPlateauBuilder::new(optimizer)
+            .mode(LRPlateauMode::Min)
+            .patience(1)
+            .factor(0.999) // Very small reduction factor
+            .eps(1e-5) // Minimum meaningful change
+            .build();
+
+        // First step sets best
+        let mut data = 10.0;
+        scheduler.step(10.0)?;
+
+        // Add an eps that is very small
+        data += 1e-9;
+        scheduler.step(data)?;
+        // No change
+        assert_approx_eq!(scheduler.opt().learning_rate(), starting_lr);
+
+        // Try with a bigger factor that exceeds eps
+        data += 1e-2;
+        scheduler.step(data)?;
+        assert_approx_eq!(scheduler.opt().learning_rate(), 0.0999); // Change applied
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reduce_lr_on_plateau_builder() {
+        let optimizer = MockOptimizer::default();
+
+        // Test that all builder methods work
+        let scheduler = ReduceLROnPlateauBuilder::new(optimizer)
+            .mode(LRPlateauMode::Max)
+            .factor(0.2)
+            .patience(5)
+            .threshold(0.05)
+            .threshold_mode(LRPlateauThresholdMode::Abs)
+            .cooldown(3)
+            .min_lr(0.001)
+            .eps(0.00001)
+            .build();
+
+        // Verify all properties were set correctly
+        assert!(matches!(scheduler.mode(), LRPlateauMode::Max));
+        assert_eq!(scheduler.factor(), 0.2);
+        assert_eq!(scheduler.patience(), 5);
+        assert_eq!(scheduler.threshold(), 0.05);
+        assert!(matches!(
+            scheduler.threshold_mode(),
+            LRPlateauThresholdMode::Abs
+        ));
+        assert_eq!(scheduler.cooldown(), 3);
+        assert_eq!(scheduler.min_lr(), 0.001);
+        assert_eq!(scheduler.eps(), 0.00001);
+    }
+
+    #[test]
+    fn test_with_real_optimizer() -> Result<()> {
+        // Create a tensor to optimize
+        let device = Device::Cpu;
+        let tensor = Tensor::new(&[0.0f32, 0.0], &device)?;
+        let tensor = Var::from_tensor(&tensor)?;
+
+        // Set up a real AdamW optimizer
+        let optimizer = AdamW::new(vec![tensor], ParamsAdamW::default())?;
+        let initial_lr = optimizer.learning_rate();
+
+        let mut scheduler = ReduceLROnPlateauBuilder::new(optimizer)
+            .patience(1)
+            .factor(0.1)
+            .build();
+
+        // First step to establish baseline
+        scheduler.step(1.0)?;
+
+        // Two consecutive non-improvements should trigger LR reduction
+        scheduler.step(1.1)?;
+        scheduler.step(1.2)?;
+
+        assert_approx_eq!(scheduler.opt().learning_rate(), initial_lr * 0.1);
+
+        Ok(())
+    }
+
+    /// Test the struct prints as expected
+    #[test]
+    fn test_display() {
+        let optimizer = MockOptimizer::default();
+        let scheduler = ReduceLROnPlateauBuilder::new(optimizer)
+            .factor(0.5)
+            .patience(5)
+            .threshold(1e-3)
+            .threshold_mode(LRPlateauThresholdMode::Abs)
+            .cooldown(2)
+            .min_lr(1e-6)
+            .eps(1e-9)
+            .build();
+
+        let display_output = format!("{}", scheduler);
+
+        // Verify that all fields are included in the display output
+        assert!(display_output.contains("mode: Min"));
+        assert!(display_output.contains("factor: 0.5"));
+        assert!(display_output.contains("patience: 5"));
+        assert!(display_output.contains("threshold: 0.001"));
+        assert!(display_output.contains("threshold_mode: Abs"));
+        assert!(display_output.contains("cooldown: 2"));
+        assert!(display_output.contains("min_lr: 0.000001"));
+        assert!(display_output.contains("eps: 0.000000001"));
+        assert!(display_output.contains("best: None"));
+        assert!(display_output.contains("num_bad_epochs: 0"));
+        assert!(display_output.contains("current_lr: 0.1"));
+    }
+}


### PR DESCRIPTION
I encountered a need for a learning rate scheduler analogous to the PyTorch `ReduceLROnPlateau` so I rolled my own. I figured others may find it useful as well so made a PR with it here. 

There is an open thread about adding this feature from last year (https://github.com/huggingface/candle/discussions/2224). It looks like there was code written to add a core `Scheduler` trait to set up for learning rate schedulers which was written but never merged (https://github.com/huggingface/candle/pull/2225).  

I think a core trait like that makes sense and I think adding this feature first is still compatible with that design, if it is eventually merged. One note is that `Scheduler` trait from the PR does not take additional arguments in the `step()` function, but `ReduceLROnPlateau` is an exception to the [other PyTorch LR schedulers ](https://github.com/pytorch/pytorch/blob/v2.6.0/torch/optim/lr_scheduler.py#L1363) since it takes a metric as argument. 

For now, `ReduceLROnPlateau` is standalone, but I think the `Scheduler` trait proposed can be generalized to support this, or the API of `ReduceLROnPlateau` could be modified to be consistent: 
```rust
scheduler.set_metric(loss);
scheduler.step();
```