### PR TITLE
Fix dtype mismatch in BERT attention mask handling

### DIFF
--- a/candle-transformers/src/models/bert.rs
+++ b/candle-transformers/src/models/bert.rs
@@ -504,8 +504,9 @@ impl BertModel {
             Some(attention_mask) => attention_mask.clone(),
             None => input_ids.ones_like()?,
         };
+        let dtype = embedding_output.dtype();
         // https://github.com/huggingface/transformers/blob/6eedfa6dd15dc1e22a55ae036f681914e5a0d9a1/src/transformers/models/bert/modeling_bert.py#L995
-        let attention_mask = get_extended_attention_mask(&attention_mask, DType::F32)?;
+        let attention_mask = get_extended_attention_mask(&attention_mask, dtype)?;
         let sequence_output = self.encoder.forward(&embedding_output, &attention_mask)?;
         Ok(sequence_output)
     }
@@ -519,8 +520,11 @@ fn get_extended_attention_mask(attention_mask: &Tensor, dtype: DType) -> Result<
     };
     let attention_mask = attention_mask.to_dtype(dtype)?;
     // torch.finfo(dtype).min
-    (attention_mask.ones_like()? - &attention_mask)?
-        .broadcast_mul(&Tensor::try_from(f32::MIN)?.to_device(attention_mask.device())?)
+    (attention_mask.ones_like()? - &attention_mask)?.broadcast_mul(
+        &Tensor::try_from(f32::MIN)?
+            .to_device(attention_mask.device())?
+            .to_dtype(dtype)?,
+    )
 }
 
 //https://github.com/huggingface/transformers/blob/1bd604d11c405dfb8b78bda4062d88fc75c17de0/src/transformers/models/bert/modeling_bert.py#L752-L766


### PR DESCRIPTION
This PR addresses a critical issue with dtype compatibility in the BERT implementation. Previously, the attention mask was hardcoded to use DType::F32, which caused dtype mismatch errors when using models with different precision types (such as BF16 causing Error: dtype mismatch in mul, lhs: BF16, rhs: F32)

Changes:
Modified the get_extended_attention_mask function to convert the f32::MIN tensor to the same dtype as the attention mask

Updated BertModel::forward to use the model's dtype (obtained from embedding_output) instead of hardcoding DType::F32

This change ensures that the attention mask uses the same dtype as the model weights, preventing errors when using non-F32 precision types like BF16.


