### PR TITLE
fix: wrong mask for distilbert::MultiHeadSelfAttention

### DIFF
--- a/candle-examples/examples/distilbert/main.rs
+++ b/candle-examples/examples/distilbert/main.rs
@@ -312,7 +312,7 @@ fn attention_mask_maskedlm(tokenizer: &Tokenizer, input: &str, device: &Device) 
     let ids = tokens.get_ids();
     for _ in 0..seq_len {
         for id in ids.iter() {
-            let mask_value = if id == &mask_token_id { 1u8 } else { 0u8 };
+            let mask_value = if id == &mask_token_id { 0u8 } else { 1u8 };
             attention_mask_vec.push(mask_value);
         }
     }

--- a/candle-transformers/src/models/distilbert.rs
+++ b/candle-transformers/src/models/distilbert.rs
@@ -183,7 +183,7 @@ impl MultiHeadSelfAttention {
 
         let q: Tensor = (q / (dim_per_head as f64).sqrt())?;
         let scores = q.matmul(&k.transpose(2, 3)?.contiguous()?)?;
-        let mask = attention_mask.broadcast_as(scores.shape())?;
+        let mask = attention_mask.eq(0u8)?.broadcast_as(scores.shape())?;
 
         let scores = masked_fill(&scores.to_dtype(DType::F32)?, &mask, f32::NEG_INFINITY)?;
         let weights = candle_nn::ops::softmax(&scores, candle::D::Minus1)?;


### PR DESCRIPTION
It seems that attention mask should be reversed first in `distilbert::MultiHeadSelfAttention`

https://github.com/huggingface/transformers/blob/main/src/transformers/models/distilbert/modeling_distilbert.py#L218