### PR TITLE
Add ZeroShotClassification examples (WASM and Native)

### DIFF
--- a/candle-examples/examples/zeroshotclassification/README.md
+++ b/candle-examples/examples/zeroshotclassification/README.md
@@ -1,0 +1,9 @@
+# candle-zeroshotclassification
+
+To run this ZeroShotClassification, run:
+
+```bash
+cargo run --example zeroshotclassification
+```
+
+

--- a/candle-examples/examples/zeroshotclassification/main.rs
+++ b/candle-examples/examples/zeroshotclassification/main.rs
@@ -1,0 +1,634 @@
+mod utils;
+
+const MODEL_ID: &str = "MoritzLaurer/ModernBERT-base-zeroshot-v2.0";
+const REVISION_ID: &str = "main";
+
+use candle::{self as candle_core, IndexOp, D};
+use candle_core::{Device, Error as CandleError, Result as CandleResult, Tensor};
+use candle_nn::{ops::softmax, VarBuilder};
+use candle_transformers::models::modernbert::{
+    Config as ModernBertConfig, ModernBertForSequenceClassification,
+};
+use hf_hub::api::sync::ApiError;
+use serde::Deserialize;
+use std::error::Error;
+use std::fs::File;
+use std::path::PathBuf;
+use std::{fmt, fs};
+use tokenizers::{Encoding, PaddingParams, Tokenizer, TruncationParams};
+use utils::{
+    download_config, download_safetensors, download_special_map_config, download_tokenizer,
+    download_tokenizer_config,
+};
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+struct ModernBertTokenizerConfig {
+    max_len: Option<usize>,
+}
+
+impl ModernBertTokenizerConfig {
+    fn from_file(path: &str) -> Result<Self, DeserializationError> {
+        let reader = File::open(path)?;
+        let tokenizer_config: ModernBertTokenizerConfig = serde_json::from_reader(reader)?;
+        Ok(tokenizer_config)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+struct ModernBertSpecialToken {
+    content: String,
+    lstrip: bool,
+    normalized: bool,
+    rstrip: bool,
+    single_word: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+struct ModernBertSpecialTokens {
+    pad_token: ModernBertSpecialToken,
+    sep_token: ModernBertSpecialToken,
+    unk_token: ModernBertSpecialToken,
+    mask_token: ModernBertSpecialToken,
+    cls_token: ModernBertSpecialToken,
+}
+
+#[derive(Debug)]
+pub enum DeserializationError {
+    IOError(std::io::Error),
+    SerdeError(serde_json::Error),
+}
+
+impl fmt::Display for DeserializationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DeserializationError::IOError(err) => write!(f, "{}", err),
+            DeserializationError::SerdeError(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+impl From<std::io::Error> for DeserializationError {
+    fn from(err: std::io::Error) -> Self {
+        DeserializationError::IOError(err)
+    }
+}
+impl From<serde_json::Error> for DeserializationError {
+    fn from(err: serde_json::Error) -> Self {
+        DeserializationError::SerdeError(err)
+    }
+}
+
+impl ModernBertSpecialTokens {
+    fn from_file(path: &str) -> Result<Self, DeserializationError> {
+        let reader = File::open(path)?;
+        let special_tokens_map: ModernBertSpecialTokens = serde_json::from_reader(reader)?;
+        Ok(special_tokens_map)
+    }
+}
+
+pub struct ModernBertTokenizer {
+    tokenizer: Tokenizer,
+    special_tokens_map: ModernBertSpecialTokens,
+}
+type EncodingError = Box<dyn Error + Send + Sync>;
+#[derive(Debug)]
+pub enum ModernBertError {
+    EncodingError(EncodingError),
+    CandleError(CandleError),
+    OtherError(String),
+    DeserializationError(DeserializationError),
+    PathBufToStrError(PathBufToStrError),
+}
+
+impl fmt::Display for ModernBertError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ModernBertError::EncodingError(err) => write!(f, "IO error: {}", err),
+            ModernBertError::CandleError(err) => write!(f, "Candle error: {}", err),
+            ModernBertError::OtherError(err) => write!(f, "Other error {}", err),
+            ModernBertError::DeserializationError(err) => {
+                write!(f, "DeserializationError error {}", err)
+            }
+            ModernBertError::PathBufToStrError(err) => {
+                write!(f, "{}", err)
+            }
+        }
+    }
+}
+
+impl From<EncodingError> for ModernBertError {
+    fn from(err: EncodingError) -> Self {
+        ModernBertError::EncodingError(err)
+    }
+}
+impl From<CandleError> for ModernBertError {
+    fn from(err: CandleError) -> Self {
+        ModernBertError::CandleError(err)
+    }
+}
+impl From<String> for ModernBertError {
+    fn from(err: String) -> Self {
+        ModernBertError::OtherError(err)
+    }
+}
+impl From<DeserializationError> for ModernBertError {
+    fn from(err: DeserializationError) -> Self {
+        ModernBertError::DeserializationError(err)
+    }
+}
+impl From<PathBufToStrError> for ModernBertError {
+    fn from(err: PathBufToStrError) -> Self {
+        ModernBertError::PathBufToStrError(err)
+    }
+}
+
+#[derive(Debug)]
+pub struct PathBufToStrError();
+
+impl fmt::Display for PathBufToStrError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Failed converting PathBuf to str")
+    }
+}
+
+impl ModernBertTokenizer {
+    pub fn from_file(
+        tokenizer: PathBuf,
+        tokenizer_config: PathBuf,
+        special_tokens_map: PathBuf,
+    ) -> Result<Self, ModernBertError> {
+        let special_tokens = ModernBertSpecialTokens::from_file(
+            special_tokens_map.to_str().ok_or(PathBufToStrError())?,
+        )?;
+        let mut tokenizer = Tokenizer::from_file(tokenizer.to_str().ok_or(PathBufToStrError())?)?;
+        let tokenizer_config = ModernBertTokenizerConfig::from_file(
+            tokenizer_config.to_str().ok_or(PathBufToStrError())?,
+        )?;
+
+        let pad_token = special_tokens.pad_token.content.clone();
+        let pad_id = tokenizer
+            .token_to_id(pad_token.clone().as_str())
+            .ok_or(String::from("Failed to retrieve pad token id"))?;
+
+        tokenizer
+            .with_padding(Some(PaddingParams {
+                pad_token,
+                pad_id,
+                ..Default::default()
+            }))
+            .with_truncation(Some(TruncationParams {
+                max_length: tokenizer_config.max_len.unwrap_or(8192),
+                strategy: tokenizers::TruncationStrategy::LongestFirst,
+                ..Default::default()
+            }))?;
+
+        Ok(Self {
+            tokenizer,
+            special_tokens_map: special_tokens,
+        })
+    }
+    fn tokenize_hypothesis(&self, x: String, sep_token: &str) -> Vec<String> {
+        vec![sep_token.into(), x]
+    }
+    /// Encode a text with hypothesis
+    ///
+    /// ```rust
+    /// tokenizer.encode(
+    ///     "Financial markets gained 5 %.".to_string(),
+    ///     "The sentence is positive".to_string(),
+    /// )
+    /// ```
+    pub fn encode(
+        &self,
+        text: String,
+        hypothesis: String,
+        sep_token: &str,
+    ) -> Result<Encoding, Box<dyn Error + Send + Sync>> {
+        let encoded_hypothesis = self.tokenize_hypothesis(hypothesis, sep_token);
+        let mut input = vec![text];
+        input.extend(encoded_hypothesis);
+        self.tokenizer.encode(input, true)
+    }
+
+    pub fn encode_batch(
+        &self,
+        texts: Vec<String>,
+        hypothesis: String,
+        sep_token: &str,
+    ) -> Result<Vec<Encoding>, Box<dyn Error + Send + Sync>> {
+        let encoded_hypothesis = self.tokenize_hypothesis(hypothesis, sep_token);
+        let mut inputs: Vec<Vec<String>> = Vec::with_capacity(texts.len());
+        for (i, text) in texts.iter().enumerate() {
+            inputs.push(vec![text.to_string()]);
+            inputs[i].extend(encoded_hypothesis.clone());
+        }
+        self.tokenizer.encode_batch(inputs, true)
+    }
+}
+
+#[derive(Debug)]
+pub struct ClassificationOutput {
+    labels: Vec<String>,
+    probs: Tensor,
+}
+
+pub struct ModernBertPredictor {
+    model: ModernBertForSequenceClassification,
+    tokenizer: ModernBertTokenizer,
+    device: Device,
+    config: ModernBertConfig,
+}
+
+impl ModernBertPredictor {
+    pub fn from_file(
+        config: PathBuf,
+        model: PathBuf,
+        tokenizer: PathBuf,
+        tokenizer_config: PathBuf,
+        special_tokens_map: PathBuf,
+    ) -> Result<Self, ModernBertError> {
+        let device = Device::Cpu;
+        let reader = File::open(config).map_err(DeserializationError::IOError)?;
+        let config: ModernBertConfig =
+            serde_json::from_reader(reader).map_err(DeserializationError::SerdeError)?;
+
+        let buffer = fs::read(model).map_err(DeserializationError::IOError)?;
+        let vb = VarBuilder::from_buffered_safetensors(buffer, candle_core::DType::F32, &device)?;
+        let model = ModernBertForSequenceClassification::load(vb, &config)?;
+
+        let tokenizer =
+            ModernBertTokenizer::from_file(tokenizer, tokenizer_config, special_tokens_map)?;
+
+        Ok(ModernBertPredictor {
+            model,
+            tokenizer,
+            device,
+            config,
+        })
+    }
+
+    fn get_entail_contradict_id(&self) -> Result<(u32, u32), String> {
+        let label2id = self
+            .config
+            .classifier_config
+            .clone()
+            .ok_or("Classifier configuration is missing")?
+            .label2id;
+
+        let mut entail_id: Option<u32> = None;
+        let mut contradict_id: Option<u32> = None;
+
+        match label2id.len() {
+            2..=3 => (),
+            n => return Err(format!("Invalid number of labels ({}): must be 2 or 3", n)),
+        }
+
+        for (label, id) in &label2id {
+            match label.as_str() {
+                l if l.starts_with("entail") => {
+                    entail_id = Some(*id);
+                    if label2id.len() == 2 {
+                        for (other_label, other_id) in &label2id {
+                            if other_label != label {
+                                contradict_id = Some(*other_id);
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                }
+                l if l.starts_with("contradict") || l.starts_with("not_entail") => {
+                    contradict_id = Some(*id)
+                }
+                _ => continue,
+            }
+        }
+
+        let entail_id = entail_id.ok_or("No 'entail' label found in label2id")?;
+        let contradict_id = contradict_id.ok_or("No 'contradict' label found in label2id")?;
+
+        Ok((entail_id, contradict_id))
+    }
+
+    fn forward(
+        &self,
+        input_ids: &Tensor,
+        attention_mask: &Tensor,
+    ) -> Result<Tensor, ModernBertError> {
+        let logits = self.model.forward(input_ids, attention_mask)?;
+        let (entail_id, _) = self.get_entail_contradict_id()?;
+        let column_indices = Tensor::new(&[entail_id], &self.device)?;
+        let selected_logits = logits.index_select(&column_indices, D::Minus1)?;
+        Ok(selected_logits)
+    }
+
+    fn forward_multilabel(
+        &self,
+        input_ids: &Tensor,
+        attention_mask: &Tensor,
+    ) -> Result<Tensor, ModernBertError> {
+        let logits = self.model.forward(input_ids, attention_mask)?;
+
+        let (entail_id, contradict_id) = self.get_entail_contradict_id()?;
+
+        let mut col_indices = vec![contradict_id, entail_id];
+        col_indices.sort();
+        let column_indices = Tensor::from_vec(col_indices.clone(), (2,), &self.device)?;
+        let selected_logits = logits.index_select(&column_indices, D::Minus1)?;
+        let probs = softmax(&selected_logits, 1)?;
+
+        let entailment_id = Tensor::from_vec(vec![entail_id], (1,), &self.device)?;
+        let entailment = probs.index_select(&entailment_id, D::Minus1)?;
+        Ok(entailment)
+    }
+
+    pub fn predict(
+        &self,
+        text: String,
+        hypotheses: Vec<String>,
+        multi_label: bool,
+    ) -> Result<ClassificationOutput, ModernBertError> {
+        let outputs = self.process_batch(vec![text], hypotheses.clone(), multi_label)?;
+        Ok(ClassificationOutput {
+            labels: hypotheses,
+            probs: outputs,
+        })
+    }
+
+    pub fn predict_batch(
+        &self,
+        texts: Vec<String>,
+        hypotheses: Vec<String>,
+        multi_label: bool,
+    ) -> Result<ClassificationOutput, ModernBertError> {
+        let outputs = self.process_batch(texts, hypotheses.clone(), multi_label)?;
+        Ok(ClassificationOutput {
+            labels: hypotheses,
+            probs: outputs,
+        })
+    }
+
+    fn process_batch(
+        &self,
+        texts: Vec<String>,
+        hypotheses: Vec<String>,
+        multi_label: bool,
+    ) -> Result<Tensor, ModernBertError> {
+        let mut outputs = Vec::with_capacity(hypotheses.len());
+        let sep_token = &self.tokenizer.special_tokens_map.sep_token;
+
+        for hypothesis in hypotheses {
+            let encodings = self.tokenizer.encode_batch(
+                texts.clone(),
+                hypothesis,
+                sep_token.content.as_str(),
+            )?;
+            let (input_ids, attention_mask) = self.prepare_tensors(&encodings)?;
+
+            let logits = if multi_label {
+                self.forward_multilabel(&input_ids, &attention_mask)?
+            } else {
+                self.forward(&input_ids, &attention_mask)?
+            };
+            outputs.push(logits);
+        }
+
+        let outputs = Tensor::cat(&outputs, 1)?;
+        let probs = if multi_label {
+            outputs
+        } else {
+            softmax(&outputs, 1)?
+        };
+
+        Ok(probs)
+    }
+
+    fn prepare_tensors(&self, encodings: &[Encoding]) -> Result<(Tensor, Tensor), ModernBertError> {
+        let input_ids = Tensor::stack(
+            &encodings
+                .iter()
+                .map(|enc| Tensor::new(enc.get_ids(), &self.device))
+                .collect::<CandleResult<Vec<_>>>()?,
+            0,
+        )?;
+        let attention_mask = Tensor::stack(
+            &encodings
+                .iter()
+                .map(|enc| Tensor::new(enc.get_attention_mask(), &self.device))
+                .collect::<CandleResult<Vec<_>>>()?,
+            0,
+        )?;
+        Ok((input_ids, attention_mask))
+    }
+}
+
+#[derive(Debug)]
+pub enum ZeroShotError {
+    ModernBertError(ModernBertError),
+    ApiError(ApiError),
+}
+
+impl From<ModernBertError> for ZeroShotError {
+    fn from(err: ModernBertError) -> Self {
+        ZeroShotError::ModernBertError(err)
+    }
+}
+
+impl From<ApiError> for ZeroShotError {
+    fn from(err: ApiError) -> Self {
+        ZeroShotError::ApiError(err)
+    }
+}
+
+impl fmt::Display for ZeroShotError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ZeroShotError::ApiError(err) => write!(f, "{}", err),
+            ZeroShotError::ModernBertError(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+fn main() -> Result<(), ZeroShotError> {
+    let examples = vec![
+        "Financial markets gained 5 %.".to_string(),
+        "Financial markets went down by 5%.".to_string(),
+    ];
+
+    let hypotheses = vec![
+        "This sentence is positive.".to_string(),
+        "This sentence is negative.".to_string(),
+    ];
+    let model = ModernBertPredictor::from_file(
+        download_config(MODEL_ID, REVISION_ID)?,
+        download_safetensors(MODEL_ID, REVISION_ID)?,
+        download_tokenizer(MODEL_ID, REVISION_ID)?,
+        download_tokenizer_config(MODEL_ID, REVISION_ID)?,
+        download_special_map_config(MODEL_ID, REVISION_ID)?,
+    )?;
+    let output = model.predict_batch(examples.clone(), hypotheses, true)?;
+    for (i, text) in examples.iter().enumerate().take(2) {
+        let hyp1 = &output.labels[0];
+        let hyp2 = &output.labels[1];
+        let prob_hypothesis_1 = output
+            .probs
+            .i((i, 0))
+            .map_err(ModernBertError::CandleError)?;
+        let prob_hypothesis_2 = output
+            .probs
+            .i((i, 1))
+            .map_err(ModernBertError::CandleError)?;
+        println!("Text: {}", text);
+        println!(
+            "\tProbability of entailment of hypothesis 1: `{}` = {:?}",
+            hyp1, prob_hypothesis_1
+        );
+        println!(
+            "\tProbability of entailment of hypothesis 2: `{}` = {:?}\n",
+            hyp2, prob_hypothesis_2
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DEVICE: Device = Device::Cpu;
+
+    fn setup_model_and_data(
+    ) -> Result<(ModernBertPredictor, Vec<String>, Vec<String>), ZeroShotError> {
+        let examples = vec![
+            "Financial markets gained 5 %.".to_string(),
+            "Financial markets went down by 5%.".to_string(),
+        ];
+        let hypotheses = vec![
+            "This sentence is positive.".to_string(),
+            "This sentence is negative.".to_string(),
+        ];
+        let model = ModernBertPredictor::from_file(
+            download_config(MODEL_ID, REVISION_ID)?,
+            download_safetensors(MODEL_ID, REVISION_ID)?,
+            download_tokenizer(MODEL_ID, REVISION_ID)?,
+            download_tokenizer_config(MODEL_ID, REVISION_ID)?,
+            download_special_map_config(MODEL_ID, REVISION_ID)?,
+        )?;
+        Ok((model, examples, hypotheses))
+    }
+
+    // Helper function to compare tensors
+    fn assert_tensor_eq(
+        actual: &Tensor,
+        expected: &Tensor,
+        tolerance: f32,
+    ) -> Result<(), ZeroShotError> {
+        let diff = (actual - expected)
+            .map_err(ModernBertError::CandleError)?
+            .abs()
+            .map_err(ModernBertError::CandleError)?;
+        let max_diff = diff
+            .max_all()
+            .map_err(ModernBertError::CandleError)?
+            .to_scalar::<f32>()
+            .map_err(ModernBertError::CandleError)?;
+        assert!(
+            max_diff < tolerance,
+            "Logits differ too much from expected values. Max difference: {}. Expected: {:?}, Got: {:?}",
+            max_diff,
+            expected.to_vec2::<f32>().map_err(ModernBertError::CandleError)?,
+            actual.to_vec2::<f32>().map_err(ModernBertError::CandleError)?
+        );
+        Ok(())
+    }
+
+    /// Testing that the behaviour is equivalent to Python
+    ///
+    /// ```python
+    /// from transformers import pipeline
+    ///
+    /// model_id = "MoritzLaurer/ModernBERT-base-zeroshot-v2.0"
+    ///
+    /// examples = ["Financial markets gained 5 %.", "Financial markets went down by 5%."]
+    /// hypotheses = ["This sentence is positive.", "This sentence is negative."]
+    /// print("Inference with multi_label = True")
+    /// pipe = pipeline("zero-shot-classification", model=model_id)
+    /// output = pipe(
+    ///     examples,
+    ///     candidate_labels=hypotheses,
+    ///     hypothesis_template="{}",
+    ///     multi_label=True,
+    /// )
+    /// print(output)
+    /// # [
+    /// #     {
+    /// #         "sequence": "Financial markets gained 5 %.",
+    /// #         "labels": ["This sentence is positive.", "This sentence is negative."],
+    /// #         "scores": [0.9642423391342163, 0.0035960127133876085],
+    /// #     },
+    /// #     {
+    /// #         "sequence": "Financial markets went down by 5%.",
+    /// #         "labels": ["This sentence is negative.", "This sentence is positive."],
+    /// #         "scores": [0.995209813117981, 0.00039684693911112845],
+    /// #     },
+    /// # ]
+    ///
+    /// print("Inference with multi_label=False")
+    /// output = pipe(
+    ///     examples,
+    ///     candidate_labels=hypotheses,
+    ///     hypothesis_template="{}",
+    ///     multi_label=False,
+    /// )
+    /// print(output)
+    /// # [
+    /// #     {
+    /// #         "sequence": "Financial markets gained 5 %.",
+    /// #         "labels": ["This sentence is positive.", "This sentence is negative."],
+    /// #         "scores": [0.9893742203712463, 0.010625768452882767],
+    /// #     },
+    /// #     {
+    /// #         "sequence": "Financial markets went down by 5%.",
+    /// #         "labels": ["This sentence is negative.", "This sentence is positive."],
+    /// #         "scores": [0.9986220002174377, 0.001377981505356729],
+    /// #     },
+    /// # ]
+    /// ```
+
+    #[test]
+    fn test_inference() -> Result<(), ZeroShotError> {
+        let (model, examples, hypotheses) = setup_model_and_data()?;
+
+        // Test multi_label = true
+        {
+            let output = model.predict_batch(examples.clone(), hypotheses.clone(), true)?;
+            let probs = output.probs;
+            let expected_probs = Tensor::new(
+                vec![
+                    vec![0.9642423391342163f32, 0.0035960127133876085f32],
+                    vec![0.00039684693911112845f32, 0.995209813117981f32],
+                ],
+                &DEVICE,
+            )
+            .map_err(ModernBertError::CandleError)?;
+            assert_tensor_eq(&probs, &expected_probs, 1e-4)?;
+        }
+
+        // Test multi_label = false
+        {
+            let output = model.predict_batch(examples.clone(), hypotheses.clone(), false)?;
+            let probs = output.probs;
+            let expected_probs = Tensor::new(
+                vec![
+                    vec![0.9893742203712463f32, 0.010625768452882767f32],
+                    vec![0.001377981505356729f32, 0.9986220002174377f32],
+                ],
+                &DEVICE,
+            )
+            .map_err(ModernBertError::CandleError)?;
+            assert_tensor_eq(&probs, &expected_probs, 1e-4)?;
+        }
+
+        Ok(())
+    }
+}

--- a/candle-examples/examples/zeroshotclassification/utils.rs
+++ b/candle-examples/examples/zeroshotclassification/utils.rs
@@ -1,0 +1,61 @@
+use hf_hub::{
+    api::sync::{Api, ApiError},
+    Repo,
+};
+use std::path::PathBuf;
+
+pub fn download_safetensors(model_id: &str, revision_id: &str) -> Result<PathBuf, ApiError> {
+    let api = Api::new()?;
+    let repo = api.repo(Repo::with_revision(
+        model_id.into(),
+        hf_hub::RepoType::Model,
+        revision_id.into(),
+    ));
+    let weights = repo.get("model.safetensors")?;
+    Ok(weights)
+}
+
+pub fn download_tokenizer_config(model_id: &str, revision_id: &str) -> Result<PathBuf, ApiError> {
+    let api = Api::new()?;
+    let repo = api.repo(Repo::with_revision(
+        model_id.into(),
+        hf_hub::RepoType::Model,
+        revision_id.into(),
+    ));
+    let weights = repo.get("tokenizer_config.json")?;
+    Ok(weights)
+}
+
+pub fn download_special_map_config(model_id: &str, revision_id: &str) -> Result<PathBuf, ApiError> {
+    let api = Api::new()?;
+    let repo = api.repo(Repo::with_revision(
+        model_id.into(),
+        hf_hub::RepoType::Model,
+        revision_id.into(),
+    ));
+    let weights = repo.get("special_tokens_map.json")?;
+    Ok(weights)
+}
+
+pub fn download_tokenizer(model_id: &str, revision_id: &str) -> Result<PathBuf, ApiError> {
+    let api = Api::new()?;
+    let repo = api.repo(Repo::with_revision(
+        model_id.into(),
+        hf_hub::RepoType::Model,
+        revision_id.into(),
+    ));
+    let weights = repo.get("tokenizer.json")?;
+    Ok(weights)
+}
+
+pub fn download_config(model_id: &str, revision_id: &str) -> Result<PathBuf, ApiError> {
+    let api = Api::new()?;
+    let repo = api.repo(Repo::with_revision(
+        model_id.into(),
+        hf_hub::RepoType::Model,
+        revision_id.into(),
+    ));
+
+    let config = repo.get("config.json")?;
+    Ok(config)
+}

--- a/candle-transformers/src/models/modernbert.rs
+++ b/candle-transformers/src/models/modernbert.rs
@@ -47,7 +47,7 @@ pub enum ClassifierPooling {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct ClassifierConfig {
     pub id2label: HashMap<String, String>,
-    pub label2id: HashMap<String, String>,
+    pub label2id: HashMap<String, u32>,
     pub classifier_pooling: ClassifierPooling,
 }
 
@@ -455,8 +455,7 @@ impl ModernBertClassifier {
 
 impl Module for ModernBertClassifier {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let xs = xs.apply(&self.classifier)?;
-        softmax(&xs, D::Minus1)
+        xs.apply(&self.classifier)
     }
 }
 

--- a/candle-wasm-examples/zeroshotclassification/Cargo.toml
+++ b/candle-wasm-examples/zeroshotclassification/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "zeroshotclassification"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+
+[dependencies]
+candle = { workspace = true }
+candle-nn = { workspace = true }
+candle-transformers = { workspace = true}
+tokenizers = { workspace = true, features = ["unstable_wasm"] }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+js-sys = "0.3.77"
+
+getrandom = { version = "0.3.2", features = ["wasm_js"] }
+wasm-bindgen = "0.2.100"
+serde-wasm-bindgen = "0.6.5"
+console_error_panic_hook = "0.1.7"

--- a/candle-wasm-examples/zeroshotclassification/README.md
+++ b/candle-wasm-examples/zeroshotclassification/README.md
@@ -1,0 +1,20 @@
+# ZeroShotClassification WASM app
+
+A WebAssembly application for zero-shot classification tasks.
+
+## Building the WASM Target
+
+To compile the app to WebAssembly, run:
+
+```bash
+./build.sh
+```
+
+## Running
+
+Serve the built application using a local web server. For example:
+
+```bash
+python -m http.server
+```
+

--- a/candle-wasm-examples/zeroshotclassification/build.sh
+++ b/candle-wasm-examples/zeroshotclassification/build.sh
@@ -1,0 +1,2 @@
+RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo build --target wasm32-unknown-unknown --release
+wasm-bindgen ../../target/wasm32-unknown-unknown/release/m.wasm --out-dir build --target web

--- a/candle-wasm-examples/zeroshotclassification/index.html
+++ b/candle-wasm-examples/zeroshotclassification/index.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>ZeroShot Classification</title>
+        <script src="https://cdn.tailwindcss.com"></script>
+        <script src="script.js"></script>
+    </head>
+
+    <body class="bg-gray-50 min-h-screen flex items-center justify-center p-4">
+        <div
+            class="rounded-lg border bg-white text-gray-900 shadow-sm w-full max-w-md mx-auto"
+        >
+            <div class="flex flex-col space-y-1.5 p-6">
+                <h3 class="font-semibold tracking-tight text-2xl">
+                    ZeroShot Classification
+                </h3>
+            </div>
+            <div class="p-6">
+                <select
+                    id="select-example"
+                    class="flex h-9 items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&amp;>span]:line-clamp-1 w-[180px]"
+                >
+                    <option value="">--Choose Example--</option>
+                    <option value="1">Example1</option>
+                    <option value="2">Example2</option>
+                </select>
+            </div>
+            <form id="form" autocomplete="false">
+                <div class="p-6 pt-0 space-y-4">
+                    <div class="space-y-2">
+                        <label
+                            class="text-sm font-medium leading-none"
+                            for="text"
+                            >Text</label
+                        >
+                        <textarea
+                            id="text"
+                            rows="4"
+                            class="mt-1 p-2 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                            placeholder="Enter your text"
+                        ></textarea>
+                    </div>
+                    <div class="space-y-2">
+                        <label
+                            class="text-sm font-medium leading-none"
+                            for="labels"
+                            >Labels (comma-separated)</label
+                        >
+                        <input
+                            class="flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                            id="labels"
+                            placeholder="Enter labels separated by commas"
+                            autocomplete="false"
+                            value=""
+                            type="text"
+                        />
+                    </div>
+                    <div>
+                        <input
+                            type="checkbox"
+                            id="multilabel"
+                            name="multilabel"
+                            checked="true"
+                        />
+                        <label for="multilabel"
+                            >Allow multiple true classes</label
+                        >
+                    </div>
+                </div>
+                <div class="flex items-center p-6 pt-0">
+                    <button
+                        class="inline-flex items-center justify-center w-full h-10 px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none"
+                        type="submit"
+                    >
+                        Compute
+                    </button>
+                </div>
+                <div class="p-6 pt-0">
+                    <div id="status" class="text-sm text-gray-600"></div>
+                    <div id="progressContainer" class="mt-4 hidden">
+                        <label
+                            for="progressBar"
+                            class="block text-sm font-medium text-gray-700"
+                            >Download Progress</label
+                        >
+                        <div
+                            class="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700"
+                        >
+                            <div
+                                id="progressBar"
+                                class="bg-indigo-600 h-2.5 rounded-full"
+                                style="width: 0%"
+                            ></div>
+                        </div>
+                    </div>
+                    <div id="spinner" class="mt-4 hidden">
+                        <svg
+                            class="animate-spin h-5 w-5 text-gray-600"
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                        >
+                            <circle
+                                class="opacity-25"
+                                cx="12"
+                                cy="12"
+                                r="10"
+                                stroke="currentColor"
+                                stroke-width="4"
+                            ></circle>
+                            <path
+                                class="opacity-75"
+                                fill="currentColor"
+                                d="M4 12a8 8 0 018-8v8a8 8 0 01-8 8z"
+                            ></path>
+                        </svg>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </body>
+</html>

--- a/candle-wasm-examples/zeroshotclassification/script.js
+++ b/candle-wasm-examples/zeroshotclassification/script.js
@@ -1,0 +1,206 @@
+/** @type {boolean}*/
+let loaded = false;
+let isLoading = false;
+const worker = new Worker("./worker.js", { type: "module" });
+const modelName = "MoritzLaurer_ModernBERT_base_zeroshot_v2_0";
+
+/**
+ * @param {string} id HTMLElement's id
+ */
+function elementNotFound(id) {
+    return new Error(`Element with id=${id} not found.`);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    const form = document.getElementById("form");
+    const statusDiv = document.getElementById("status");
+    const progressContainer = document.getElementById("progressContainer");
+    const progressBar = document.getElementById("progressBar");
+    const spinner = document.getElementById("spinner");
+
+    const selectExample = document.getElementById("select-example");
+
+    if (
+        !form ||
+        !statusDiv ||
+        !progressContainer ||
+        !progressBar ||
+        !spinner ||
+        !selectExample
+    ) {
+        console.error("Required elements not found");
+        return;
+    }
+
+    statusDiv.textContent = "Ready to load model";
+    selectExample.addEventListener("change", (event) => {
+        const textInput = /** @type {HTMLInputElement | null} */ (
+            document.getElementById("text")
+        );
+        const labelsInput = /** @type {HTMLInputElement | null} */ (
+            document.getElementById("labels")
+        );
+        if (!textInput || !labelsInput) {
+            console.error("Form inputs not found");
+            return;
+        }
+
+        const value = /** @type {HTMLSelectElement} */ (event.target).value;
+        let example = "";
+        let hypothesis = "";
+        switch (value) {
+            case "1":
+                example = "Financial markets gained 5 %.";
+                hypothesis = "This sentence is positive.";
+                break;
+            case "2":
+                example = "Financial markets went down by 5%.";
+                hypothesis = "This sentence is negative.";
+                break;
+            case "":
+                return;
+            default:
+                console.warn("Unexpected select value:", value);
+                return;
+        }
+        textInput.value = example;
+        labelsInput.value = hypothesis;
+    });
+
+    form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+
+        const textInput = /** @type {HTMLInputElement | null} */ (
+            document.getElementById("text")
+        );
+        const labelsInput = /** @type {HTMLInputElement | null} */ (
+            document.getElementById("labels")
+        );
+        const multiLabelInput = /** @type {HTMLInputElement | null} */ (
+            document.getElementById("multilabel")
+        );
+
+        if (!textInput || !labelsInput || !multiLabelInput) {
+            console.error("Form inputs not found");
+            return;
+        }
+
+        const text = textInput.value.trim();
+        if (!text) {
+            statusDiv.textContent = "Please enter some text";
+            return;
+        }
+
+        const labels = labelsInput.value.trim()
+            ? labelsInput.value.split(",").map((label) => label.trim())
+            : [];
+
+        if (labels.length === 0) {
+            statusDiv.textContent = "Please enter at least one label";
+            return;
+        }
+
+        const multiLabel = multiLabelInput.checked;
+
+        if (!loaded && !isLoading) {
+            isLoading = true;
+            statusDiv.textContent = "Loading model...";
+            spinner.classList.remove("hidden");
+            progressContainer.classList.remove("hidden");
+
+            worker.postMessage({
+                type: "load",
+                data: {
+                    modelName: modelName,
+                },
+            });
+            return;
+        }
+
+        if (isLoading) {
+            statusDiv.textContent = "Please wait while the model loads...";
+            return;
+        }
+
+        spinner.classList.remove("hidden");
+        statusDiv.textContent = "Processing...";
+        console.log("Labels sent");
+        console.log(labels);
+        worker.postMessage({
+            type: "infer",
+            data: {
+                text: [text],
+                hypothesis: labels,
+                multiLabel: multiLabel,
+            },
+        });
+    });
+});
+
+worker.onmessage = (event) => {
+    const { type, message } = event.data;
+    const progressContainer = document.getElementById("progressContainer");
+    const statusDiv = document.getElementById("status");
+    const progressBar = document.getElementById("progressBar");
+    const spinner = document.getElementById("spinner");
+
+    if (!progressContainer || !statusDiv || !progressBar || !spinner) {
+        throw elementNotFound("Required elements");
+    }
+
+    switch (type) {
+        case "initialized":
+            statusDiv.textContent = "Ready to start";
+            break;
+
+        case "loading":
+            progressContainer.classList.remove("hidden");
+            spinner.classList.remove("hidden");
+            break;
+
+        case "download":
+            const { file, bytes, total } = message;
+            statusDiv.textContent = `Downloading: ${file}`;
+            const progress = (bytes / total) * 100;
+            progressBar.style.width = `${progress}%`;
+            break;
+
+        case "ready":
+            progressContainer.classList.add("hidden");
+            loaded = true;
+            isLoading = false;
+            statusDiv.textContent = "Model loaded - Ready to process";
+            spinner.classList.add("hidden");
+            progressBar.style.width = "0%";
+            /** @type {HTMLFormElement}*/ (
+                document.getElementById("form")
+            )?.requestSubmit();
+            break;
+
+        case "result":
+            spinner.classList.add("hidden");
+            if (message.error) {
+                statusDiv.textContent = `Error: ${message.error}`;
+            } else {
+                const { probs, labels } = message;
+                const results = labels.map(
+                    (label, i) =>
+                        `${label}: ${(probs[0][i] * 100).toFixed(2)}%`,
+                );
+                statusDiv.innerHTML = "Results:<br>" + results.join("<br>");
+            }
+            break;
+
+        case "error":
+            isLoading = false;
+            spinner.classList.add("hidden");
+            statusDiv.textContent = `Error: ${message || "Unknown error occurred"}`;
+            break;
+
+        case "disposed":
+            loaded = false;
+            isLoading = false;
+            statusDiv.textContent = "Model disposed";
+            break;
+    }
+};

--- a/candle-wasm-examples/zeroshotclassification/src/bin/m.rs
+++ b/candle-wasm-examples/zeroshotclassification/src/bin/m.rs
@@ -1,0 +1,415 @@
+use candle::{self as candle_core, D};
+use candle_core::{Device, Error as CandleError, Result as CandleResult, Tensor};
+use candle_nn::{ops::softmax, VarBuilder};
+use candle_transformers::models::modernbert::{
+    Config as ModernBertConfig, ModernBertForSequenceClassification,
+};
+use serde::Deserialize;
+use std::error::Error;
+use tokenizers::{Encoding, PaddingParams, Tokenizer, TruncationParams};
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    pub fn log(s: &str);
+}
+
+macro_rules! console_log {
+    ($($t:tt)*) => ($crate::log(&format_args!($($t)*).to_string()))
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+struct ModernBertTokenizerConfig {
+    max_len: Option<usize>,
+}
+
+impl ModernBertTokenizerConfig {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, serde_json::error::Error> {
+        let tokenizer_config: ModernBertTokenizerConfig = serde_json::from_slice(bytes)?;
+        Ok(tokenizer_config)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+struct ModernBertSpecialToken {
+    content: String,
+    lstrip: bool,
+    normalized: bool,
+    rstrip: bool,
+    single_word: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+struct ModernBertSpecialTokens {
+    pad_token: ModernBertSpecialToken,
+    sep_token: ModernBertSpecialToken,
+    unk_token: ModernBertSpecialToken,
+    mask_token: ModernBertSpecialToken,
+    cls_token: ModernBertSpecialToken,
+}
+impl ModernBertSpecialTokens {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, serde_json::error::Error> {
+        let special_tokens_map: ModernBertSpecialTokens = serde_json::from_slice(bytes)?;
+        Ok(special_tokens_map)
+    }
+}
+
+#[wasm_bindgen]
+pub struct ModernBertTokenizer {
+    tokenizer: Tokenizer,
+    special_tokens_map: ModernBertSpecialTokens,
+}
+type EncodingError = Box<dyn Error + Send + Sync>;
+#[derive(Debug)]
+pub enum ModernBertError {
+    EncodingError(EncodingError),
+    CandleError(CandleError),
+    OtherError(String),
+    DeserializationError(serde_json::Error),
+}
+use std::fmt;
+
+impl fmt::Display for ModernBertError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ModernBertError::EncodingError(err) => write!(f, "IO error: {}", err),
+            ModernBertError::CandleError(err) => write!(f, "Candle error: {}", err),
+            ModernBertError::OtherError(err) => write!(f, "Other error {}", err),
+            ModernBertError::DeserializationError(err) => {
+                write!(f, "DeserializationError error {}", err)
+            }
+        }
+    }
+}
+
+impl From<EncodingError> for ModernBertError {
+    fn from(err: EncodingError) -> Self {
+        ModernBertError::EncodingError(err)
+    }
+}
+impl From<CandleError> for ModernBertError {
+    fn from(err: CandleError) -> Self {
+        ModernBertError::CandleError(err)
+    }
+}
+impl From<String> for ModernBertError {
+    fn from(err: String) -> Self {
+        ModernBertError::OtherError(err)
+    }
+}
+impl From<serde_json::Error> for ModernBertError {
+    fn from(err: serde_json::Error) -> Self {
+        ModernBertError::DeserializationError(err)
+    }
+}
+
+impl ModernBertTokenizer {
+    pub fn from_bytes(
+        tokenizer: &[u8],
+        tokenizer_config: &[u8],
+        special_tokens_map: &[u8],
+    ) -> Result<Self, ModernBertError> {
+        let mut tokenizer = Tokenizer::from_bytes(tokenizer)?;
+        let special_tokens = ModernBertSpecialTokens::from_bytes(special_tokens_map)?;
+        let tokenizer_config = ModernBertTokenizerConfig::from_bytes(tokenizer_config)?;
+        console_log!("Success");
+
+        let pad_token = special_tokens.pad_token.content.clone();
+        let pad_id = tokenizer
+            .token_to_id(pad_token.clone().as_str())
+            .ok_or(String::from("Failed to retrieve pad token id"))?;
+
+        tokenizer
+            .with_padding(Some(PaddingParams {
+                pad_token,
+                pad_id,
+                ..Default::default()
+            }))
+            .with_truncation(Some(TruncationParams {
+                max_length: tokenizer_config.max_len.unwrap_or(8192),
+                strategy: tokenizers::TruncationStrategy::LongestFirst,
+                ..Default::default()
+            }))?;
+
+        Ok(Self {
+            tokenizer,
+            special_tokens_map: special_tokens,
+        })
+    }
+    fn tokenize_hypothesis(&self, x: String, sep_token: &str) -> Vec<String> {
+        vec![sep_token.into(), x]
+    }
+    /// Encode a text with hypothesis
+    ///
+    /// ```rust
+    /// tokenizer.encode(
+    ///     "Financial markets gained 5 %.".to_string(),
+    ///     "The sentence is positive.".to_string(),
+    /// )
+    /// ```
+    pub fn encode(
+        &self,
+        text: String,
+        hypothesis: String,
+        sep_token: &str,
+    ) -> Result<Encoding, Box<dyn Error + Send + Sync>> {
+        let encoded_hypothesis = self.tokenize_hypothesis(hypothesis, sep_token);
+        let mut input = vec![text];
+        input.extend(encoded_hypothesis);
+        self.tokenizer.encode(input, true)
+    }
+
+    pub fn encode_batch(
+        &self,
+        texts: Vec<String>,
+        hypothesis: String,
+        sep_token: &str,
+    ) -> Result<Vec<Encoding>, Box<dyn Error + Send + Sync>> {
+        // TODO: avoid unnecessary copies
+        let encoded_hypothesis = self.tokenize_hypothesis(hypothesis, sep_token);
+        let mut inputs: Vec<Vec<String>> = Vec::with_capacity(texts.len());
+        for (i, text) in texts.iter().enumerate() {
+            inputs.push(vec![text.to_string()]);
+            inputs[i].extend(encoded_hypothesis.clone());
+        }
+        self.tokenizer.encode_batch(inputs, true)
+    }
+}
+
+#[wasm_bindgen]
+pub struct ClassificationOutput {
+    labels: Vec<String>,
+    probs: Vec<Vec<f32>>,
+}
+
+#[wasm_bindgen]
+impl ClassificationOutput {
+    /// Returns the labels for each prediction
+    #[wasm_bindgen]
+    pub fn get_labels(&self) -> JsValue {
+        serde_wasm_bindgen::to_value(&self.labels).unwrap_or(JsValue::NULL)
+    }
+
+    /// Returns the probabilities for each prediction
+    #[wasm_bindgen]
+    pub fn get_probs(&self) -> JsValue {
+        serde_wasm_bindgen::to_value(&self.probs).unwrap_or(JsValue::NULL)
+    }
+
+    /// Returns the probability for a specific class index in a specific prediction, or `None` if out of bounds.
+    #[wasm_bindgen]
+    pub fn get_prob(&self, prediction_idx: usize, class_idx: u32) -> Option<f32> {
+        self.probs.get(prediction_idx).and_then(|probs| {
+            let class_idx = class_idx as usize;
+            if class_idx < probs.len() {
+                probs.get(class_idx).copied()
+            } else {
+                None
+            }
+        })
+    }
+
+    #[wasm_bindgen]
+    pub fn to_json(&self) -> JsValue {
+        let json_struct = serde_json::json!({
+            "probs": self.probs,
+            "labels": self.labels
+        });
+
+        serde_wasm_bindgen::to_value(&json_struct).unwrap_or(JsValue::NULL)
+    }
+}
+
+#[wasm_bindgen]
+pub struct ModernBertPredictor {
+    model: ModernBertForSequenceClassification,
+    tokenizer: ModernBertTokenizer,
+    device: Device,
+    #[allow(dead_code)]
+    config: ModernBertConfig,
+}
+
+#[wasm_bindgen]
+impl ModernBertPredictor {
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        config: Vec<u8>,
+        model: Vec<u8>,
+        tokenizer: Vec<u8>,
+        tokenizer_config: Vec<u8>,
+        special_tokens_map: Vec<u8>,
+    ) -> Result<Self, JsError> {
+        let device = Device::Cpu;
+
+        let config: ModernBertConfig = serde_json::from_reader(config.as_slice())?;
+        let vb = VarBuilder::from_buffered_safetensors(model, candle_core::DType::F32, &device)?;
+        console_log!("Loading safe tensors");
+        let model = ModernBertForSequenceClassification::load(vb, &config)?;
+
+        console_log!("Loading Tokenizer");
+        let tokenizer = ModernBertTokenizer::from_bytes(
+            tokenizer.as_slice(),
+            tokenizer_config.as_slice(),
+            special_tokens_map.as_slice(),
+        )
+        .map_err(|m| JsError::new(&m.to_string()))?;
+
+        Ok(ModernBertPredictor {
+            model,
+            tokenizer,
+            device,
+            config,
+        })
+    }
+
+    fn get_entail_contradict_id(&self) -> Result<(u32, u32), String> {
+        let label2id = self
+            .config
+            .classifier_config
+            .clone()
+            .ok_or("Classifier configuration is missing")?
+            .label2id;
+
+        let mut entail_id: Option<u32> = None;
+        let mut contradict_id: Option<u32> = None;
+
+        match label2id.len() {
+            2..=3 => (),
+            n => return Err(format!("Invalid number of labels ({}): must be 2 or 3", n)),
+        }
+
+        for (label, id) in &label2id {
+            match label.as_str() {
+                l if l.starts_with("entail") => {
+                    entail_id = Some(*id);
+                    if label2id.len() == 2 {
+                        for (other_label, other_id) in &label2id {
+                            if other_label != label {
+                                contradict_id = Some(*other_id);
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                }
+                l if l.starts_with("contradict") || l.starts_with("not_entail") => {
+                    contradict_id = Some(*id)
+                }
+                _ => continue,
+            }
+        }
+
+        let entail_id = entail_id.ok_or("No 'entail' label found in label2id")?;
+        let contradict_id = contradict_id.ok_or("No 'contradict' label found in label2id")?;
+
+        Ok((entail_id, contradict_id))
+    }
+
+    fn forward(
+        &self,
+        input_ids: &Tensor,
+        attention_mask: &Tensor,
+    ) -> Result<Tensor, ModernBertError> {
+        let logits = self.model.forward(input_ids, attention_mask)?;
+        let (entail_id, _) = self.get_entail_contradict_id()?;
+        let column_indices = Tensor::new(&[entail_id], &self.device)?;
+        let selected_logits = logits.index_select(&column_indices, D::Minus1)?;
+        Ok(selected_logits)
+    }
+
+    fn forward_multilabel(
+        &self,
+        input_ids: &Tensor,
+        attention_mask: &Tensor,
+    ) -> Result<Tensor, ModernBertError> {
+        console_log!("Inferring");
+        let logits = self.model.forward(input_ids, attention_mask)?;
+        console_log!("Inference finished");
+
+        let (entail_id, contradict_id) = self.get_entail_contradict_id()?;
+
+        let mut col_indices = vec![contradict_id, entail_id];
+        col_indices.sort();
+        let column_indices = Tensor::from_vec(col_indices.clone(), (2,), &self.device)?;
+        let selected_logits = logits.index_select(&column_indices, D::Minus1)?;
+        let probs = softmax(&selected_logits, 1)?;
+
+        let entailment_id = Tensor::from_vec(vec![entail_id], (1,), &self.device)?;
+        let entailment = probs.index_select(&entailment_id, D::Minus1)?;
+        Ok(entailment)
+    }
+
+    pub fn predict(
+        &self,
+        text: String,
+        hypotheses: Vec<String>,
+        multi_label: bool,
+    ) -> Result<ClassificationOutput, JsError> {
+        let outputs = self
+            .process_batch(vec![text], hypotheses.clone(), multi_label)
+            .map_err(|m| JsError::new(&m.to_string()))?;
+        Ok(ClassificationOutput {
+            labels: hypotheses,
+            probs: outputs,
+        })
+    }
+
+    fn process_batch(
+        &self,
+        texts: Vec<String>,
+        hypotheses: Vec<String>,
+        multi_label: bool,
+    ) -> Result<Vec<Vec<f32>>, ModernBertError> {
+        let mut outputs = Vec::with_capacity(hypotheses.len());
+        let sep_token = &self.tokenizer.special_tokens_map.sep_token;
+
+        for hypothesis in hypotheses {
+            let encodings = self.tokenizer.encode_batch(
+                texts.clone(),
+                hypothesis,
+                sep_token.content.as_str(),
+            )?;
+            let (input_ids, attention_mask) = self.prepare_tensors(&encodings)?;
+
+            let logits = if multi_label {
+                self.forward_multilabel(&input_ids, &attention_mask)?
+            } else {
+                self.forward(&input_ids, &attention_mask)?
+            };
+            outputs.push(logits);
+        }
+
+        let outputs = Tensor::cat(&outputs, 1)?;
+        let probs = if multi_label {
+            outputs.to_vec2::<f32>()?
+        } else {
+            softmax(&outputs, 1)?.to_vec2::<f32>()?
+        };
+
+        Ok(probs)
+    }
+
+    fn prepare_tensors(&self, encodings: &[Encoding]) -> Result<(Tensor, Tensor), ModernBertError> {
+        let input_ids = Tensor::stack(
+            &encodings
+                .iter()
+                .map(|enc| Tensor::new(enc.get_ids(), &self.device))
+                .collect::<CandleResult<Vec<_>>>()?,
+            0,
+        )?;
+        let attention_mask = Tensor::stack(
+            &encodings
+                .iter()
+                .map(|enc| Tensor::new(enc.get_attention_mask(), &self.device))
+                .collect::<CandleResult<Vec<_>>>()?,
+            0,
+        )?;
+        Ok((input_ids, attention_mask))
+    }
+}
+
+fn main() {
+    console_error_panic_hook::set_once();
+}

--- a/candle-wasm-examples/zeroshotclassification/worker.js
+++ b/candle-wasm-examples/zeroshotclassification/worker.js
@@ -1,0 +1,326 @@
+/**
+ * @typedef {Uint8Array} U8Array
+ * @description An array of unsigned 8-bit integers (0-255).
+ */
+import init, { ModernBertPredictor } from "./build/m.js";
+
+/**
+ * Fetches an array buffer from a URL, with caching support and progress callback.
+ * @param {string} url - The URL to fetch the data from.
+ * @param {function} onProgress - A callback function to track progress.
+ * @returns {Promise<U8Array>} - A Uint8Array containing the fetched data.
+ */
+async function fetchArrayBuffer(url, onProgress) {
+    try {
+        const res = await fetch(url, { cache: "force-cache" });
+        if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
+
+        const contentLength = res.headers.get("Content-Length");
+        if (!contentLength) {
+            throw new Error("Content-Length response header missing");
+        }
+
+        const total = parseInt(contentLength, 10);
+        let loaded = 0;
+
+        const reader = res.body?.getReader();
+        const chunks = [];
+
+        while (true) {
+            const { done, value } = (await reader?.read()) ?? {
+                done: true,
+                value: undefined,
+            };
+            if (done) break;
+
+            chunks.push(value);
+            loaded += value.length;
+            onProgress(loaded, total);
+        }
+
+        // Concatenate chunks into a single Uint8Array
+        const totalLength = chunks.reduce(
+            (sum, chunk) => sum + chunk.length,
+            0,
+        );
+        const result = new Uint8Array(totalLength);
+        let position = 0;
+        for (const chunk of chunks) {
+            result.set(chunk, position);
+            position += chunk.length;
+        }
+
+        return result;
+    } catch (error) {
+        self.postMessage({
+            type: "error",
+            message: `Fetch failed: ${error.message}`,
+        });
+        throw error;
+    }
+}
+
+/**
+ * @class Model
+ * @description A class representing a model instance with configuration, model, and vocabulary.
+ */
+class Model {
+    /** @type {ModernBertPredictor | undefined} */
+    static loadedModel = undefined;
+    constructor() {
+        /** @type {string | undefined} */
+        this.configURL = undefined;
+        /** @type {string | undefined} */
+        this.modelURL = undefined;
+        /** @type {string | undefined} */
+        this.vocabURL = undefined;
+        /** @type {string | undefined} */
+        this.tokenizerConfigURL = undefined;
+        /** @type {string | undefined} */
+        this.specialTokensMapURL = undefined;
+
+        /** @type {U8Array | undefined} vocab - The vocabulary data for the tokenizer.*/
+        this.vocab = undefined;
+        /**@type {U8Array | undefined} model - The safetensor model data.*/
+        this.model = undefined;
+        /** @type {U8Array | undefined} config - The model configuration data.*/
+        this.config = undefined;
+        /** @type {U8Array | undefined} config - The model configuration data.*/
+        this.tokenizerConfig = undefined;
+        /** @type {U8Array | undefined} config - The model configuration data.*/
+        this.specialTokensMap = undefined;
+    }
+    /**
+       * Creates a new Model instance.
+       
+       * 
+       *      */
+    async loadFiles(modelFiles) {
+        /**
+         * @param {string} file
+         */
+        const createDownloadHandler = (file) => {
+            /**
+             * @param {number} bytesLoaded
+             * @param {number} totalBytes
+             **/
+            const handler = (bytesLoaded, totalBytes) => {
+                self.postMessage({
+                    type: "download",
+                    message: {
+                        file: file,
+                        bytes: bytesLoaded,
+                        total: totalBytes,
+                    },
+                });
+            };
+            return handler;
+        };
+        const {
+            configURL,
+            modelURL,
+            vocabURL,
+            specialTokensMapURL,
+            tokenizerConfigURL,
+        } = modelFiles;
+        this.configURL = configURL;
+        this.vocabURL = vocabURL;
+        this.modelURL = modelURL;
+        this.specialTokensMapURL = specialTokensMapURL;
+        this.tokenizerConfigURL = tokenizerConfigURL;
+
+        try {
+            self.postMessage({
+                type: "loading",
+                message: "Starting file downloads",
+            });
+            this.config = await fetchArrayBuffer(
+                configURL,
+                createDownloadHandler(configURL.split("/").pop()),
+            );
+
+            this.model = await fetchArrayBuffer(
+                modelURL,
+                createDownloadHandler(modelURL.split("/").pop()),
+            );
+
+            this.vocab = await fetchArrayBuffer(
+                vocabURL,
+                createDownloadHandler(vocabURL.split("/").pop()),
+            );
+            this.tokenizerConfig = await fetchArrayBuffer(
+                tokenizerConfigURL,
+                createDownloadHandler(tokenizerConfigURL.split("/").pop()),
+            );
+            this.specialTokensMap = await fetchArrayBuffer(
+                specialTokensMapURL,
+                createDownloadHandler(specialTokensMapURL.split("/").pop()),
+            );
+
+            self.postMessage({
+                type: "loading",
+                message: "All files downloaded successfully",
+            });
+        } catch (error) {
+            self.postMessage({
+                type: "error",
+                message: `Failed to load files: ${error.message}`,
+            });
+            throw error;
+        }
+    }
+
+    /**
+       * Initializes and loads the BERT/ModernBert model.
+          * @param {string} modelName
+       * @returns {Promise<ModernBertPredictor>} - The loaded model instance.
+      
+       */
+    async initializeModel(modelName) {
+        if (!Model.loadedModel) {
+            await init();
+            self.postMessage({ type: "loading", message: "Loading Model" });
+            const files = getModel(modelName);
+            await this.loadFiles(files);
+            Model.loadedModel = new ModernBertPredictor(
+                // @ts-ignore
+                this.config,
+                this.model,
+                this.vocab,
+                this.tokenizerConfig,
+                this.specialTokensMap,
+            );
+
+            self.postMessage({
+                type: "ready",
+                message: "Model Loaded",
+                modelName: modelName,
+            });
+        } else {
+            self.postMessage({
+                type: "ready",
+                message: "Model Already Loaded",
+            });
+        }
+        return Model.loadedModel;
+    }
+
+    /**
+     * Disposes of the loaded model to free memory.
+     */
+    dispose() {
+        if (Model.loadedModel) {
+            Model.loadedModel = undefined;
+            self.postMessage({ type: "disposed", message: "Model unloaded" });
+        }
+    }
+
+    /**
+     * @param {object} event - The message event
+     * @param {object} event.data
+     * @param {'load' | 'infer' | 'dispose'} event.data.type
+     * @param {LoadData | InferData} event.data.data The data attached to the type of message
+     *
+     * @typedef {Object} LoadData
+     * @property {string} modelName - The name of the model being loaded.
+     * @typedef {Object} InferData
+     *
+     * @property {Array<string>} text - An array of text
+     * @property {Array<string>} hypothesis - An array of labels/hypothesis/classes
+     * @property {boolean} multiLabel - Whether to use multiLabel prediction
+     *
+     */
+    async handleMessage(event) {
+        const { type, data } = event.data;
+        switch (type) {
+            case "load":
+                const loadData = /** @type {LoadData} */ (data);
+                await this.initializeModel(loadData.modelName);
+                break;
+
+            case "infer":
+                if (!Model.loadedModel) {
+                    self.postMessage({
+                        type: "error",
+                        message: "Model not loaded",
+                    });
+                    return;
+                }
+                try {
+                    const inferData = /** @type {InferData} */ (data);
+                    const result = Model.loadedModel.predict(
+                        inferData.text[0],
+                        inferData.hypothesis,
+                        inferData.multiLabel,
+                    );
+                    let rawMap = result.to_json();
+                    self.postMessage({
+                        type: "result",
+                        message: {
+                            probs: rawMap.get("probs"),
+                            labels: rawMap.get("labels"),
+                        },
+                    });
+                } catch (error) {
+                    self.postMessage({
+                        type: "error",
+                        message: `Inference failed: ${error.message}`,
+                    });
+                }
+                break;
+
+            case "dispose":
+                this.dispose();
+                break;
+
+            default:
+                self.postMessage({
+                    type: "error",
+                    message: `Unknown message type: ${type}`,
+                });
+        }
+    }
+}
+
+/**
+ * @param {string} modelName
+ * @typedef {{configURL: string, modelURL: string, vocabURL: string, tokenizerConfigURL: string, specialTokensMapURL: string}} modelFiles
+ * @returns {modelFiles}
+ */
+function getModel(modelName) {
+    const models = {
+        MoritzLaurer_ModernBERT_base_zeroshot_v2_0: {
+            configURL:
+                "https://huggingface.co/MoritzLaurer/ModernBERT-base-zeroshot-v2.0/resolve/main/config.json",
+            modelURL:
+                "https://huggingface.co/MoritzLaurer/ModernBERT-base-zeroshot-v2.0/resolve/main/model.safetensors",
+            vocabURL:
+                "https://huggingface.co/MoritzLaurer/ModernBERT-base-zeroshot-v2.0/resolve/main/tokenizer.json",
+            tokenizerConfigURL:
+                "https://huggingface.co/MoritzLaurer/ModernBERT-base-zeroshot-v2.0/resolve/main/tokenizer_config.json",
+            specialTokensMapURL:
+                "https://huggingface.co/MoritzLaurer/ModernBERT-base-zeroshot-v2.0/resolve/main/special_tokens_map.json",
+        },
+    };
+    return models[modelName];
+}
+
+(async () => {
+    try {
+        const modelInstance = new Model();
+        /**
+         * @param {MessageEvent} event - The message event
+         */
+        self.onmessage = (event) => modelInstance.handleMessage(event);
+
+        self.postMessage({
+            type: "initialized",
+            message: "Worker initialized",
+        });
+    } catch (error) {
+        self.postMessage({
+            type: "error",
+            message: `Initialization failed: ${error.message}`,
+        });
+    }
+})();


### PR DESCRIPTION
This pull request implements two zero-shot classification examples:

- A native implementation
- A WebAssembly implementation

Additionally, this PR modifies the `ModernBertClassifier`, removing the softmax function call in its forward method and returning logits instead. This change ensures compatibility with more downstream tasks.

To align with common conventions in Hugging Face models, the following type adjustment was made:

- `label2id`: Updated to use a string key with an unsigned integer value.