### PR TITLE
Fixed Gemma3 model and example

### DIFF
--- a/candle-transformers/src/models/gemma3.rs
+++ b/candle-transformers/src/models/gemma3.rs
@@ -450,7 +450,7 @@ impl Model {
                 use_flash_attn,
                 cfg,
                 vb_l.pp(layer_idx),
-                sliding_window.then(|| cfg.sliding_window),
+                sliding_window.then_some(cfg.sliding_window),
             )?;
             layers.push(layer)
         }


### PR DESCRIPTION
- In transformers: Made RoPE frequency change based on the layer like the transformers implementation [here](https://github.com/huggingface/transformers/blob/b6d65e40b256d98d9621707762b94bc8ad83b7a7/src/transformers/models/gemma3/modular_gemma3.py#L511) and [here](https://github.com/huggingface/transformers/blob/b6d65e40b256d98d9621707762b94bc8ad83b7a7/src/transformers/models/gemma3/modular_gemma3.py#L375C80-L376C1)
  - Gemma3 uses a 5:1 sliding to non-sliding attention layer ratio ([source](https://arxiv.org/html/2503.19786v1#S2)). 
- In example: Changed prompt format to [Official Recommended Inference Settings](https://docs.unsloth.ai/basics/tutorial-how-to-run-and-fine-tune-gemma-3#official-recommended-inference-settings) for Gemma3 Instruct 
- In example: Changed eos token from `<eos>` to `<end_of_turn>` for Gemma3 Instruct

Fixes issue from [here](https://github.com/huggingface/candle/issues/2891#issuecomment-2819215668)