### PR TITLE
Optimize Tensor::new when called on nested Vec<..>.

### DIFF
--- a/candle-core/benches/bench_main.rs
+++ b/candle-core/benches/bench_main.rs
@@ -4,11 +4,12 @@ use criterion::criterion_main;
 
 criterion_main!(
     benchmarks::affine::benches,
+    benchmarks::copy::benches,
+    benchmarks::conv_transpose2d::benches,
     benchmarks::matmul::benches,
+    benchmarks::qmatmul::benches,
     benchmarks::random::benches,
     benchmarks::reduce::benches,
+    benchmarks::unary::benches,
     benchmarks::where_cond::benches,
-    benchmarks::conv_transpose2d::benches,
-    benchmarks::qmatmul::benches,
-    benchmarks::unary::benches
 );

--- a/candle-core/benches/benchmarks/copy.rs
+++ b/candle-core/benches/benchmarks/copy.rs
@@ -1,0 +1,38 @@
+use crate::benchmarks::{BenchDevice, BenchDeviceHandler};
+use candle_core::{Device, Tensor, WithDType};
+use criterion::{black_box, criterion_group, Criterion, Throughput};
+use std::time::Instant;
+
+fn run_copy_mask_benchmark<D: WithDType>(c: &mut Criterion, device: &Device, name: &str) {
+    let batch_size = 128;
+    let in_seq_len = 1;
+    let kv_seq_len = 1024;
+
+    let attn_mask = vec![vec![vec![D::zero(); kv_seq_len]; in_seq_len]; batch_size];
+    let size_in_bytes = batch_size * in_seq_len * kv_seq_len * D::DTYPE.size_in_bytes();
+
+    let mut group = c.benchmark_group(device.bench_name(name));
+    group.throughput(Throughput::Bytes(size_in_bytes as u64));
+    group.bench_function("iter", move |b| {
+        b.iter_custom(|iters| {
+            let attn_masks = vec![attn_mask.clone(); iters as usize];
+            let start = Instant::now();
+            for attn_mask in attn_masks.into_iter() {
+                let tensor = Tensor::new(black_box(attn_mask), device).unwrap();
+                black_box(tensor);
+            }
+            device.sync().unwrap();
+            start.elapsed()
+        })
+    });
+    group.finish();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let handler = BenchDeviceHandler::new().unwrap();
+    for device in handler.devices {
+        run_copy_mask_benchmark::<f32>(c, &device, "copy_mask");
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);

--- a/candle-core/benches/benchmarks/mod.rs
+++ b/candle-core/benches/benchmarks/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod affine;
 pub(crate) mod conv_transpose2d;
+pub(crate) mod copy;
 pub(crate) mod matmul;
 pub(crate) mod qmatmul;
 pub(crate) mod random;

--- a/candle-core/src/device.rs
+++ b/candle-core/src/device.rs
@@ -203,14 +203,19 @@ impl<S: WithDType> NdArray for Vec<Vec<Vec<Vec<S>>>> {
     }
 
     fn to_cpu_storage(&self) -> CpuStorage {
-        let data = self
+        let len: usize = self
             .iter()
-            .flatten()
-            .flatten()
-            .flatten()
-            .copied()
-            .collect::<Vec<_>>();
-        S::to_cpu_storage_owned(data)
+            .map(|v| v.iter().map(|v| v.len()).sum::<usize>())
+            .sum();
+        let mut dst = Vec::with_capacity(len);
+        for v1 in self.iter() {
+            for v2 in v1.iter() {
+                for v3 in v2.iter() {
+                    dst.extend(v3.iter().copied());
+                }
+            }
+        }
+        S::to_cpu_storage_owned(dst)
     }
 }
 

--- a/candle-core/src/device.rs
+++ b/candle-core/src/device.rs
@@ -150,8 +150,12 @@ impl<S: WithDType> NdArray for Vec<Vec<S>> {
     }
 
     fn to_cpu_storage(&self) -> CpuStorage {
-        let data = self.iter().flatten().copied().collect::<Vec<_>>();
-        S::to_cpu_storage_owned(data)
+        let len: usize = self.iter().map(|v| v.len()).sum();
+        let mut dst = Vec::with_capacity(len);
+        for v in self.iter() {
+            dst.extend(v.iter().copied());
+        }
+        S::to_cpu_storage_owned(dst)
     }
 }
 
@@ -175,7 +179,10 @@ impl<S: WithDType> NdArray for Vec<Vec<Vec<S>>> {
         if self.is_empty() {
             return S::to_cpu_storage_owned(vec![]);
         }
-        let len: usize = self.iter().map(|v| v.len()).sum();
+        let len: usize = self
+            .iter()
+            .map(|v| v.iter().map(|v| v.len()).sum::<usize>())
+            .sum();
         let mut dst = Vec::with_capacity(len);
         for v1 in self.iter() {
             for v2 in v1.iter() {
@@ -205,7 +212,11 @@ impl<S: WithDType> NdArray for Vec<Vec<Vec<Vec<S>>>> {
     fn to_cpu_storage(&self) -> CpuStorage {
         let len: usize = self
             .iter()
-            .map(|v| v.iter().map(|v| v.len()).sum::<usize>())
+            .map(|v| {
+                v.iter()
+                    .map(|v| v.iter().map(|v| v.len()).sum::<usize>())
+                    .sum::<usize>()
+            })
             .sum();
         let mut dst = Vec::with_capacity(len);
         for v1 in self.iter() {

--- a/candle-core/src/device.rs
+++ b/candle-core/src/device.rs
@@ -172,8 +172,17 @@ impl<S: WithDType> NdArray for Vec<Vec<Vec<S>>> {
     }
 
     fn to_cpu_storage(&self) -> CpuStorage {
-        let data = self.iter().flatten().flatten().copied().collect::<Vec<_>>();
-        S::to_cpu_storage_owned(data)
+        if self.is_empty() {
+            return S::to_cpu_storage_owned(vec![]);
+        }
+        let len: usize = self.iter().map(|v| v.len()).sum();
+        let mut dst = Vec::with_capacity(len);
+        for v1 in self.iter() {
+            for v2 in v1.iter() {
+                dst.extend(v2.iter().copied());
+            }
+        }
+        S::to_cpu_storage_owned(dst)
     }
 }
 

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -1811,3 +1811,26 @@ fn test_flip_3d_channels() -> Result<()> {
     candle_core::test_utils::assert_tensor_eq(&flipped, &expected)?;
     Ok(())
 }
+
+#[test]
+fn tensor_new() -> Result<()> {
+    let t1 = Tensor::new(vec![1f32, 2.0, 3.0], &Device::Cpu)?;
+    assert_eq!(t1.to_vec1::<f32>()?, [1.0, 2.0, 3.0]);
+    let t2 = Tensor::new(vec![vec![1f32, 2., 3.], vec![4., 5., 6.]], &Device::Cpu)?;
+    assert_eq!(t2.to_vec2::<f32>()?, [[1., 2., 3.], [4., 5., 6.]]);
+    let t3 = Tensor::new(
+        vec![
+            vec![vec![1f32, 2., 3.], vec![4., 5., 6.]],
+            vec![vec![3f32, 1., 4.], vec![1., 5., 9.]],
+        ],
+        &Device::Cpu,
+    )?;
+    assert_eq!(
+        t3.to_vec3::<f32>()?,
+        [
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            [[3.0, 1.0, 4.0], [1.0, 5.0, 9.0]]
+        ]
+    );
+    Ok(())
+}


### PR DESCRIPTION
This reduces the set of types on which `Tensor::new` can be called, e.g. `Vec<Vec<&[T]>>` is not supported anymore.

The main upside is that it improves performance a lot. I've added a benchmark that is similar to the copy of an attention mask that we ran in our model inference setup. On a ryzen 7950x with a single core I go from ~150MB/s to ~2.1GB/s (which is still quite far from the specs bandwidth).

_edit_: With further changes the benchmark now runs at 13GB/s, still a bit low compared to the specs.