### PR TITLE
fix kv cache issue with quantized_phi3 implementation

### DIFF
--- a/candle-transformers/src/models/quantized_phi3.rs
+++ b/candle-transformers/src/models/quantized_phi3.rs
@@ -136,7 +136,7 @@ impl LayerWeights {
         let q = self.apply_rotary_emb(&q, index_pos)?.contiguous()?;
         let k = self.apply_rotary_emb(&k, index_pos)?;
 
-	    if index_pos == 0 {
+        if index_pos == 0 {
             self.kv_cache.reset();
         }
         let (k, v) = self.kv_cache.append(&k.contiguous()?, &v.contiguous()?)?;

--- a/candle-transformers/src/models/quantized_phi3.rs
+++ b/candle-transformers/src/models/quantized_phi3.rs
@@ -136,7 +136,7 @@ impl LayerWeights {
         let q = self.apply_rotary_emb(&q, index_pos)?.contiguous()?;
         let k = self.apply_rotary_emb(&k, index_pos)?;
 
-	if index_pos == 0 {
+	    if index_pos == 0 {
             self.kv_cache.reset();
         }
         let (k, v) = self.kv_cache.append(&k.contiguous()?, &v.contiguous()?)?;

--- a/candle-transformers/src/models/quantized_phi3.rs
+++ b/candle-transformers/src/models/quantized_phi3.rs
@@ -136,6 +136,9 @@ impl LayerWeights {
         let q = self.apply_rotary_emb(&q, index_pos)?.contiguous()?;
         let k = self.apply_rotary_emb(&k, index_pos)?;
 
+	if index_pos == 0 {
+            self.kv_cache.reset();
+        }
         let (k, v) = self.kv_cache.append(&k.contiguous()?, &v.contiguous()?)?;
 
         let k = crate::utils::repeat_kv(k, self.n_head / self.n_kv_head)?;


### PR DESCRIPTION
The current implementation of the quantized_phi3 model does not clear its kv cache between distinct prompts. This leads to errors when attempting to generate text sequentially with the same model instance.

If you try to prompt the model more than once you get an shape error like this:

`
cannot broadcast [12, 12] to [1, 40, 12, 124]
`

I double checked quantized gemma3 to make sure that you guys do usually clear the cache and you did, so I went ahead and figured out how to make the fix, it's just a few lines of code to use the .reset method on the KvCache when pos is 0. I already tested it locally and it seems that I have no issues sending multiple prompts sequentially to phi3/phi4 now :)