### PR TITLE
Fixed Quantized Qwen3 Model

### DIFF
--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -10,7 +10,7 @@ use super::with_tracing::QMatMul;
 use crate::{quantized_nn::RmsNorm, utils::repeat_kv};
 use candle::quantized::{gguf_file, QTensor};
 use candle::{DType, Device, Result, Tensor};
-use candle_nn::{kv_cache::KvCache, Activation, Embedding, Module};
+use candle_nn::{Activation, Embedding, Module};
 use std::io::{Read, Seek};
 use std::sync::Arc;
 
@@ -136,7 +136,7 @@ struct AttentionWeights {
     num_kv_groups: usize,
     head_dim: usize,
     rotary_emb: Arc<RotaryEmbedding>,
-    kv_cache: KvCache,
+    kv_cache: Option<(Tensor, Tensor)>,
     span_attn: tracing::Span,
 }
 
@@ -160,13 +160,6 @@ impl AttentionWeights {
         let q_norm = gg.rms_norm(&format!("{prefix}.attn_q_norm.weight"), rms_norm_eps)?;
         let k_norm = gg.rms_norm(&format!("{prefix}.attn_k_norm.weight"), rms_norm_eps)?;
 
-        let max_position_embeddings = gg
-            .metadata()
-            .get("qwen3.context_length")
-            .and_then(|v| v.to_u32().ok())
-            .unwrap_or(4096) as usize;
-        let kv_cache = KvCache::new(2, max_position_embeddings);
-
         let span_attn = tracing::span!(tracing::Level::TRACE, "attn");
 
         Ok(Self {
@@ -181,7 +174,7 @@ impl AttentionWeights {
             num_kv_groups,
             head_dim,
             rotary_emb,
-            kv_cache,
+            kv_cache: None,
             span_attn,
         })
     }
@@ -214,11 +207,20 @@ impl AttentionWeights {
 
         let (q, k) = self.rotary_emb.apply(&q, &k, offset)?;
 
-        // Reset KV cache if we're at the first position
-        if offset == 0 {
-            self.kv_cache.reset();
-        }
-        let (k, v) = self.kv_cache.append(&k.contiguous()?, &v.contiguous()?)?;
+        // Refer to the `kv_cache` logic of quantized Qwen2.
+        let (k, v) = match self.kv_cache {
+            None => (k.contiguous()?, v.contiguous()?),
+            Some((ref k_cache, ref v_cache)) => {
+                if offset == 0 {
+                    (k.contiguous()?, v.contiguous()?)
+                } else {
+                    let k = Tensor::cat(&[k_cache, &k.contiguous()?], 2)?;
+                    let v = Tensor::cat(&[v_cache, &v.contiguous()?], 2)?;
+                    (k, v)
+                }
+            }
+        };
+        self.kv_cache = Some((k.clone(), v.clone()));
 
         let k = repeat_kv(k, self.num_kv_groups)?.contiguous()?;
         let v = repeat_kv(v, self.num_kv_groups)?.contiguous()?;


### PR DESCRIPTION
## Description
This PR optimizes the KV cache implementation in the quantized Qwen3 model by adopting the same approach used in Qwen2. The changes address the OOM issue reported in #2950.

## Changes
- Replaced the `KvCache` type with `Option<(Tensor, Tensor)>` for more efficient memory management
- Removed dependency on `candle_nn::kv_cache::KvCache`
- Simplified cache initialization and reset logic
- Implemented direct tensor concatenation for cache updates

## References
Implementation based on the KV cache approach in quantized Qwen2 model
        