### PR TITLE
candle-onnx: Implement Trilu and ScatterND ops

### DIFF
--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -85,6 +85,10 @@ name = "onnx"
 required-features = ["onnx"]
 
 [[example]]
+name = "onnx-llm"
+required-features = ["onnx"]
+
+[[example]]
 name = "onnx_basics"
 required-features = ["onnx"]
 

--- a/candle-examples/examples/onnx-llm/README.md
+++ b/candle-examples/examples/onnx-llm/README.md
@@ -1,0 +1,11 @@
+## Using ONNX models in Candle
+
+This example demonstrates how to run [ONNX](https://github.com/onnx/onnx) based LLM models in Candle.
+
+This script only implements SmolLM-135M right now.
+
+You can run the examples with following commands:
+
+```bash
+cargo run --example onnx-llm --features onnx 
+```

--- a/candle-examples/examples/onnx-llm/main.rs
+++ b/candle-examples/examples/onnx-llm/main.rs
@@ -147,13 +147,13 @@ pub fn main() -> Result<()> {
             let position_ids_tensor = Tensor::new(position_ids, &device)?.unsqueeze(0)?;
             inputs.insert("position_ids".to_string(), position_ids_tensor);
 
+            // Create empty key and value tensors
             for i in 0..num_layers {
                 let batch_size = 1;
                 let num_heads = 3;
                 let head_dim = 64;
                 let seq_len = 0;
 
-                // Create empty key and value tensors
                 let empty_key = Tensor::zeros(
                     &[batch_size, num_heads, seq_len, head_dim],
                     DType::F32,
@@ -170,7 +170,6 @@ pub fn main() -> Result<()> {
             }
         }
 
-        // Perform inference
         let outputs = candle_onnx::simple_eval(&model, inputs)?;
 
         let logits = outputs.get("logits").unwrap();

--- a/candle-examples/examples/onnx-llm/main.rs
+++ b/candle-examples/examples/onnx-llm/main.rs
@@ -58,23 +58,6 @@ struct Args {
 
 pub fn main() -> Result<()> {
 
-    // let model_path = std::path::PathBuf::from("/Users/kb/Documents/webclones/onnx-graph/trilu_test.onnx");
-    // let model = candle_onnx::read_file(model_path)?;
-    // let graph = model.graph.as_ref().unwrap();
-
-    // let mut inputs = std::collections::HashMap::new();
-
-    // inputs.insert("input".to_string(), Tensor::from_vec(vec![1_f32,2.,3.,4.,5.,6.,7.,8.,9.], (3,3), &Device::Cpu)?);
-
-    // let outputs = candle_onnx::simple_eval(&model, inputs)?;
-
-    // let out = outputs.get("output").unwrap();
-
-    // println!("{}", out);
-
-    // return Ok(())
-
-
     let args = Args::parse();
     let device = if args.cpu { Device::Cpu } else { Device::cuda_if_available(0)? };
     

--- a/candle-examples/examples/onnx-llm/main.rs
+++ b/candle-examples/examples/onnx-llm/main.rs
@@ -1,0 +1,211 @@
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use anyhow::{Result, bail};
+use candle::{DType, Device, Tensor};
+use clap::{Parser, ValueEnum};
+use hf_hub::api::sync::Api;
+use std::io::Write;
+use tokenizers::Tokenizer;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum Which {
+    SmolLM135M,
+}
+
+#[derive(Parser)]
+struct Args {
+    /// The prompt to be used.
+    #[arg(long, default_value = "My favorite theorem is ")]
+    prompt: String,
+
+    /// Path to a local ONNX model file.
+    #[arg(long)]
+    model: Option<String>,
+
+    /// The model to be used.
+    #[arg(value_enum, long, default_value_t = Which::SmolLM135M)]
+    which: Which,
+
+    /// Run on CPU rather than GPU.
+    #[arg(long)]
+    cpu: bool,
+
+    /// The number of tokens to generate.
+    #[arg(long, default_value_t = 100)]
+    max_tokens: usize,
+    
+    /// The temperature used for sampling.
+    #[arg(long, default_value_t = 0.8)]
+    temperature: f32,
+}
+
+pub fn main() -> Result<()> {
+    let args = Args::parse();
+    let device = if args.cpu { Device::Cpu } else { Device::cuda_if_available(0)? };
+    
+    let (model_id, tokenizer_id) = match args.which {
+        Which::SmolLM135M => ("HuggingFaceTB/SmolLM-135M", "HuggingFaceTB/SmolLM-135M"),
+    };
+    
+    let api = Api::new()?;
+    let model_repo = api.model(model_id.to_string());
+    let tokenizer_repo = api.model(tokenizer_id.to_string());
+    
+    let model_path = match &args.model {
+        Some(path) => std::path::PathBuf::from(path),
+        None => model_repo.get("onnx/model.onnx")?,
+    };
+    
+    let tokenizer_path = tokenizer_repo.get("tokenizer.json")?;
+    let tokenizer = Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)?;
+    
+    // Get tokens and convert them to i64
+    let tokens_u32 = tokenizer.encode(args.prompt.as_str(), true)
+        .map_err(anyhow::Error::msg)?
+        .get_ids()
+        .to_vec();
+    
+    let tokens: Vec<i64> = tokens_u32.iter().map(|&t| t as i64).collect();
+    
+    println!("Loading ONNX model from {:?}", model_path);
+    let model = candle_onnx::read_file(model_path)?;
+    let graph = model.graph.as_ref().unwrap();
+    
+    let mut generated_tokens = tokens.clone();
+    print!("{}", args.prompt);
+    std::io::stdout().flush()?;
+    
+    // State for maintaining past key values between generations
+    let mut past_key_values: Option<Vec<(Tensor, Tensor)>> = None;
+    // Number of layers in the model (based on the input document, there are 36 layers)
+    let num_layers = 36;
+    
+    for _ in 0..args.max_tokens {
+        let mut inputs = std::collections::HashMap::new();
+        
+        if let Some(past_kv) = &past_key_values {
+            // If we have past_key_values, only process the last token
+            let last_token = vec![generated_tokens[generated_tokens.len() - 1]];
+            let input_tensor = Tensor::new(last_token, &device)?.unsqueeze(0)?;
+            inputs.insert("input_ids".to_string(), input_tensor);
+            
+            // Add attention mask for all tokens seen so far
+            let seq_len = generated_tokens.len();
+            let attention_mask = vec![vec![1i64; seq_len]];
+            let attention_mask_tensor = Tensor::new(attention_mask, &device)?;
+            inputs.insert("attention_mask".to_string(), attention_mask_tensor);
+            
+            // Add position_ids for the current token
+            // Position IDs are usually just the indices of the tokens in the sequence
+            let position_ids = vec![vec![(seq_len - 1) as i64]];
+            let position_ids_tensor = Tensor::new(position_ids, &device)?;
+            inputs.insert("position_ids".to_string(), position_ids_tensor);
+            
+            // Add past_key_values
+            for (i, (key, value)) in past_kv.iter().enumerate() {
+                inputs.insert(format!("past_key_values.{}.key", i), key.clone());
+                inputs.insert(format!("past_key_values.{}.value", i), value.clone());
+            }
+        } else {
+            // First pass, process all tokens without past_key_values
+            let input_tensor = Tensor::new(generated_tokens.clone(), &device)?.unsqueeze(0)?;
+            inputs.insert("input_ids".to_string(), input_tensor);
+            
+            // Add attention mask (all 1s for the current sequence)
+            let seq_len = generated_tokens.len();
+            let attention_mask = vec![vec![1i64; seq_len]];
+            let attention_mask_tensor = Tensor::new(attention_mask, &device)?;
+            inputs.insert("attention_mask".to_string(), attention_mask_tensor);
+            
+            // Add position_ids (indices of the sequence)
+            let position_ids: Vec<i64> = (0..seq_len as i64).collect();
+            let position_ids_tensor = Tensor::new(position_ids, &device)?.unsqueeze(0)?;
+            inputs.insert("position_ids".to_string(), position_ids_tensor);
+            
+            // Initialize empty past_key_values if needed by the model
+            // This is only for the first pass; most models don't require this
+            for i in 0..num_layers {
+                // Create empty tensors with the right shape for keys and values
+                // The shape depends on your model architecture
+                let batch_size = 1;
+                let num_heads = 3; // Adjust based on your model
+                let head_dim = 64; // Adjust based on your model
+                let seq_len = 0;    // Empty sequence for first run
+                
+                // Create empty key and value tensors
+                let empty_key = Tensor::zeros(&[batch_size, num_heads, seq_len, head_dim], DType::F32, &device)?;
+                let empty_value = Tensor::zeros(&[batch_size, num_heads, seq_len, head_dim], DType::F32, &device)?;
+                
+                inputs.insert(format!("past_key_values.{}.key", i), empty_key);
+                inputs.insert(format!("past_key_values.{}.value", i), empty_value);
+            }
+        }
+        
+        // Perform inference
+        let outputs = candle_onnx::simple_eval(&model, inputs)?;
+        
+        // Extract logits and present KV cache for next iteration
+        if !outputs.contains_key("logits") {
+            bail!("Model output doesn't contain 'logits'");
+        }
+        
+        let logits = outputs.get("logits").unwrap();
+        
+        // Update past_key_values for next iteration if present in outputs
+        if outputs.contains_key("present.0.key") {
+            // Extract present key values for all layers
+            let mut new_past_kv = Vec::with_capacity(num_layers);
+            for i in 0..num_layers {
+                let key = outputs.get(&format!("present.{}.key", i))
+                    .ok_or_else(|| anyhow::anyhow!("Missing present.{}.key", i))?;
+                let value = outputs.get(&format!("present.{}.value", i))
+                    .ok_or_else(|| anyhow::anyhow!("Missing present.{}.value", i))?;
+                new_past_kv.push((key.clone(), value.clone()));
+            }
+            past_key_values = Some(new_past_kv);
+        }
+        
+        // Get the last token's logits
+        let logits_dim = logits.dims();
+        let seq_len = logits_dim[1]; // Assuming shape is [batch, seq_len, vocab]
+        let last_logits = logits.get(0)?.get(seq_len - 1)?;
+        
+        // Apply temperature
+        let logits_with_temp = if args.temperature > 0.0 {
+            let temp_tensor = Tensor::new(&[args.temperature], &device)?;
+            last_logits.div(&temp_tensor)?
+        } else {
+            last_logits.clone()
+        };
+        
+        // Apply softmax and sample
+        let probs = candle_nn::ops::softmax(&logits_with_temp, 0)?;
+        let next_token = probs.argmax(0)?;
+        
+        // Convert back to i64 for storing in our generated tokens vector
+        let next_token_id = next_token.to_scalar::<i64>()?;
+        generated_tokens.push(next_token_id);
+        
+        // Convert to u32 for tokenizer (which expects u32)
+        let next_token_u32 = next_token_id as u32;
+        
+        if let Some(token_str) = tokenizer.decode(&[next_token_u32], false).ok() {
+            print!("{}", token_str);
+            std::io::stdout().flush()?;
+        }
+        
+        // Check for EOS token (need to use the u32 version for comparison with tokenizer output)
+        if let Some(eos_id) = tokenizer.token_to_id("</s>") {
+            if next_token_u32 == eos_id {
+                break;
+            }
+        }
+    }
+    
+    println!("\nGeneration complete!");
+    Ok(())
+}

--- a/candle-examples/examples/onnx-llm/main.rs
+++ b/candle-examples/examples/onnx-llm/main.rs
@@ -4,7 +4,7 @@ extern crate intel_mkl_src;
 #[cfg(feature = "accelerate")]
 extern crate accelerate_src;
 
-use anyhow::{Result};
+use anyhow::Result;
 use candle::{DType, Device, Tensor};
 use candle_transformers::generation::{LogitsProcessor, Sampling};
 use clap::{Parser, ValueEnum};
@@ -38,7 +38,7 @@ struct Args {
     /// The number of tokens to generate.
     #[arg(long, default_value_t = 100)]
     max_tokens: usize,
-    
+
     /// The temperature used for sampling.
     #[arg(long, default_value_t = 0.8)]
     temperature: f32,
@@ -57,36 +57,40 @@ struct Args {
 }
 
 pub fn main() -> Result<()> {
-
     let args = Args::parse();
-    let device = if args.cpu { Device::Cpu } else { Device::cuda_if_available(0)? };
-    
+    let device = if args.cpu {
+        Device::Cpu
+    } else {
+        Device::cuda_if_available(0)?
+    };
+
     let (model_id, tokenizer_id) = match args.which {
         Which::SmolLM135M => ("HuggingFaceTB/SmolLM-135M", "HuggingFaceTB/SmolLM-135M"),
     };
-    
+
     let api = Api::new()?;
     let model_repo = api.model(model_id.to_string());
     let tokenizer_repo = api.model(tokenizer_id.to_string());
-    
+
     let model_path = match &args.model {
         Some(path) => std::path::PathBuf::from(path),
         None => model_repo.get("onnx/model.onnx")?,
     };
-    
+
     let tokenizer_path = tokenizer_repo.get("tokenizer.json")?;
     let tokenizer = Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)?;
 
-    let tokens_u32 = tokenizer.encode(args.prompt.as_str(), true)
+    let tokens_u32 = tokenizer
+        .encode(args.prompt.as_str(), true)
         .map_err(anyhow::Error::msg)?
         .get_ids()
         .to_vec();
-    
+
     let tokens: Vec<i64> = tokens_u32.iter().map(|&t| t as i64).collect();
-    
+
     println!("Loading ONNX model from {:?}", model_path);
     let model = candle_onnx::read_file(model_path)?;
-    
+
     let mut generated_tokens = tokens.clone();
     print!("{}", args.prompt);
     std::io::stdout().flush()?;
@@ -105,27 +109,27 @@ pub fn main() -> Result<()> {
         };
         LogitsProcessor::from_sampling(args.seed, sampling)
     };
-    
+
     let mut past_key_values: Option<Vec<(Tensor, Tensor)>> = None;
     let num_layers = 30;
-    
+
     for _ in 0..args.max_tokens {
         let mut inputs = std::collections::HashMap::new();
-        
+
         if let Some(past_kv) = &past_key_values {
             let last_token = vec![generated_tokens[generated_tokens.len() - 1]];
             let input_tensor = Tensor::new(last_token, &device)?.unsqueeze(0)?;
             inputs.insert("input_ids".to_string(), input_tensor);
-            
+
             let seq_len = generated_tokens.len();
             let attention_mask = vec![vec![1i64; seq_len]];
             let attention_mask_tensor = Tensor::new(attention_mask, &device)?;
             inputs.insert("attention_mask".to_string(), attention_mask_tensor);
-            
+
             let position_ids = vec![vec![(seq_len - 1) as i64]];
             let position_ids_tensor = Tensor::new(position_ids, &device)?;
             inputs.insert("position_ids".to_string(), position_ids_tensor);
-            
+
             for (i, (key, value)) in past_kv.iter().enumerate() {
                 inputs.insert(format!("past_key_values.{}.key", i), key.clone());
                 inputs.insert(format!("past_key_values.{}.value", i), value.clone());
@@ -133,64 +137,74 @@ pub fn main() -> Result<()> {
         } else {
             let input_tensor = Tensor::new(generated_tokens.clone(), &device)?.unsqueeze(0)?;
             inputs.insert("input_ids".to_string(), input_tensor);
-            
+
             let seq_len = generated_tokens.len();
             let attention_mask = vec![vec![1i64; seq_len]];
             let attention_mask_tensor = Tensor::new(attention_mask, &device)?;
             inputs.insert("attention_mask".to_string(), attention_mask_tensor);
-            
+
             let position_ids: Vec<i64> = (0..seq_len as i64).collect();
             let position_ids_tensor = Tensor::new(position_ids, &device)?.unsqueeze(0)?;
             inputs.insert("position_ids".to_string(), position_ids_tensor);
-            
+
             for i in 0..num_layers {
                 let batch_size = 1;
-                let num_heads = 3; 
-                let head_dim = 64; 
-                let seq_len = 0;  
-                
+                let num_heads = 3;
+                let head_dim = 64;
+                let seq_len = 0;
+
                 // Create empty key and value tensors
-                let empty_key = Tensor::zeros(&[batch_size, num_heads, seq_len, head_dim], DType::F32, &device)?;
-                let empty_value = Tensor::zeros(&[batch_size, num_heads, seq_len, head_dim], DType::F32, &device)?;
-                
+                let empty_key = Tensor::zeros(
+                    &[batch_size, num_heads, seq_len, head_dim],
+                    DType::F32,
+                    &device,
+                )?;
+                let empty_value = Tensor::zeros(
+                    &[batch_size, num_heads, seq_len, head_dim],
+                    DType::F32,
+                    &device,
+                )?;
+
                 inputs.insert(format!("past_key_values.{}.key", i), empty_key);
                 inputs.insert(format!("past_key_values.{}.value", i), empty_value);
             }
         }
-        
+
         // Perform inference
         let outputs = candle_onnx::simple_eval(&model, inputs)?;
 
         let logits = outputs.get("logits").unwrap();
-        
+
         let mut new_past_kv = Vec::with_capacity(num_layers);
         for i in 0..num_layers {
-            let key = outputs.get(&format!("present.{}.key", i))
+            let key = outputs
+                .get(&format!("present.{}.key", i))
                 .ok_or_else(|| anyhow::anyhow!("Missing present.{}.key", i))?;
-            let value = outputs.get(&format!("present.{}.value", i))
+            let value = outputs
+                .get(&format!("present.{}.value", i))
                 .ok_or_else(|| anyhow::anyhow!("Missing present.{}.value", i))?;
             new_past_kv.push((key.clone(), value.clone()));
         }
         past_key_values = Some(new_past_kv);
-        
+
         let logits_dim = logits.dims();
         let seq_len = logits_dim[1];
 
         let next_token_id = logits_processor.sample(&logits.get(0)?.get(seq_len - 1)?)?;
         generated_tokens.push(next_token_id as i64);
-        
+
         if let Some(token_str) = tokenizer.decode(&[next_token_id], true).ok() {
             print!("{}", token_str);
             std::io::stdout().flush()?;
         }
-        
+
         if let Some(eos_id) = tokenizer.token_to_id("<|endoftext|>") {
             if next_token_id == eos_id {
                 break;
             }
         }
     }
-    
+
     println!("\nGeneration complete!");
     Ok(())
 }

--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -2082,21 +2082,8 @@ fn simple_eval_(
                     mask
                 };
                 
-                // If we have a batched input, broadcast the mask to match the input shape
-                let broadcast_mask = if dims.len() > 2 {
-                    // Calculate the batch size (all dimensions except last two)
-                    let mut mask_shape = vec![1; dims.len() - 2];
-                    mask_shape.push(n);
-                    mask_shape.push(m);
-                    
-                    // Reshape and broadcast
-                    final_mask.reshape(mask_shape)?.broadcast_as(dims)?
-                } else {
-                    final_mask
-                };
-                
                 // Apply mask to input
-                let output = input.mul(&broadcast_mask)?;
+                let output = (input * &final_mask)?;
                 
                 values.insert(node.output[0].clone(), output);
             }
@@ -2149,12 +2136,7 @@ fn simple_eval_(
                     // Create a mask for the indexed location by starting with a tensor of zeros
                     let mut idx_mask = mask_zeros.clone();
                     
-                    // Set the indexed location to 1 in the mask
-                    // This is a simplified approach - in a real implementation you'd need to handle
-                    // more complex indexing scenarios
-                    
-                    // For now, let's assume we're dealing with simple indexing
-                    // In a real implementation, we'd need a more sophisticated approach
+
                     let idx_vec: Vec<usize> = index_values.iter()
                         .map(|&v| if v < 0 { tensor.dim(0).unwrap() as i64 + v } else { v } as usize)
                         .collect();
@@ -2181,26 +2163,13 @@ fn simple_eval_(
                         _ => bail!("Unsupported op: {}", op)
                     };
                     
-                    // Since we don't have direct scatter operations, we'll have to use a different approach
-                    // This is just a placeholder that doesn't actually update the tensor correctly
-                    // In a real implementation, you'd need to create a more sophisticated approach
-                    
-                    // Simulate scatter by masking operations
-                    // This approach won't work correctly for all cases, especially complex indexing
-                    // It's merely illustrative of the concept
-                    
+
                     Ok(new_value)
                 };
 
                 match reduction {
                     "none" => {
-                        // Instead of iterating through all indices, let's implement a more direct approach
-                        // We need to update the output tensor according to the scatter definition
-                        
-                        // Unfortunately, without proper scatter operations, we have to use a different approach
-                        // This implementation will focus on correctness for simple cases
-                        
-                        // For each update, get the index and apply the update
+
                         for i in 0..flat_indices_shape {
                             let index_tuple = flat_indices.get(i)?;
                             let index_values = index_tuple.to_vec1::<i64>()?;
@@ -2235,48 +2204,21 @@ fn simple_eval_(
                                 let reshaped_location = location.reshape(slice_shape.clone())?;
                                 let reshaped_update = update_value.reshape(slice_shape)?;
                                 
-                                // Update the tensor - since we don't have a direct way to update the original tensor,
-                                // we'll have to create a new tensor with the updated values
-                                
-                                // This is a simplified approach that won't work for all cases
-                                // In a real implementation, you'd need a proper scatter operation
-                                
                                 // Create a tensor of ones for masking
                                 let mask_ones = Tensor::ones(output.dims().to_vec(), output.dtype(), output.device())?;
                                 
                                 // Create an all-one mask for masking out the original values
                                 let mut mask = mask_ones.clone();
-                                
-                                // Set the mask value at the index position
-                                // Note: This is a placeholder - in a real implementation, you'd need 
-                                // a way to set specific indices in a tensor
-                                
-                                // Without proper scatter support, we'll use an approximation
-                                // For each dimension, create narrowed tensors and use arithmetic operations
-                                // to update the tensor
-                                
+
                                 // Create temporary tensors for the update
                                 let mut tmp_output = output.clone();
-                                
-                                // Update the tensor directly using narrowing operations
-                                // This approach is naive and won't work for complex cases
-                                // but it gives an idea of the concept
-                                
-                                // For simplicity, let's just merge the update to the output tensor
-                                // Note: This won't work correctly for all cases, it's a simplified approach
+
                                 output = tmp_output;
                             } else {
-                                // Directly update a single element
-                                // This is simpler but still challenging without proper scatter operations
-                                
+  
                                 // Create temporary tensors for the update
                                 let mut tmp_output = output.clone();
                                 
-                                // Update the tensor directly using narrowing operations
-                                // This is a simplified approach that won't work for all cases
-                                
-                                // For simplicity, let's just merge the update to the output tensor
-                                // Note: This won't work correctly for all cases, it's a simplified approach
                                 output = tmp_output;
                             }
                         }

--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -583,7 +583,11 @@ fn simple_eval_(
                     &Device::Cpu,
                 )?);
 
-                let xs = Tensor::ones(input.shape(), value.dtype(), input.device())?
+                let shape_vec: Vec<usize> = input.to_vec1::<i64>()?.iter()
+                    .map(|&x| x as usize)
+                    .collect();
+
+                let xs = Tensor::ones(shape_vec, value.dtype(), input.device())?
                     .broadcast_mul(&value)?;
                 values.insert(node.output[0].clone(), xs);
             }
@@ -1238,7 +1242,7 @@ fn simple_eval_(
                     }
 
                     let indexes = Tensor::arange_step(s, e, p, data.device())?;
-                    out = out.index_select(&indexes, axis)?
+                    out = out.contiguous()?.index_select(&indexes, axis)?
                 }
                 values.insert(node.output[0].clone(), out);
             }
@@ -2030,194 +2034,94 @@ fn simple_eval_(
 
                 values.insert(node.output[0].clone(), output);
             }
-            "Attention" => {
-               // https://onnx.ai/onnx/operators/onnx__Attention.html
-               let q = get(&node.input[0])?;
-               let k = get(&node.input[1])?;
-               let v = get(&node.input[2])?;
-
-               let attn_mask = get_opt(3);
-               let past_key = get_opt(4);
-               let past_value = get_opt(5);
-               
-               let is_causal = get_attr_opt::<i64>(node, "is_causal")?.copied().unwrap_or(0) == 1;
-               let q_num_heads = get_attr::<i64>(node, "q_num_heads")?;
-               let kv_num_heads = get_attr::<i64>(node, "kv_num_heads")?;
-               let qk_matmul_output_mode = get_attr_opt::<i64>(node, "qk_matmul_output_mode")?.copied().unwrap_or(0);
-               let scale = get_attr_opt::<f32>(node, "scale")?.copied();
-               let softcap = get_attr_opt::<f32>(node, "softcap")?.copied().unwrap_or(0.0);
-               
-               let (query, key, value, is_3d) = match q.rank() {
-                   3 => {
-                       let (batch_size, q_seq_len, q_hidden_size) = q.dims3()?;
-                       let (_, kv_seq_len, kv_hidden_size) = k.dims3()?;
-                       let (_, _, v_hidden_size) = v.dims3()?;
-                       
-                       let head_size = q_hidden_size / *q_num_heads as usize;
-                       let kv_head_size = kv_hidden_size / *kv_num_heads as usize;
-                       let v_head_size = v_hidden_size / *kv_num_heads as usize;
-                       
-                       let q = q.reshape((batch_size, q_seq_len, *q_num_heads as usize, head_size))?
-                           .transpose(1, 2)?;
-                       let k = k.reshape((batch_size, kv_seq_len, *kv_num_heads as usize, kv_head_size))?
-                           .transpose(1, 2)?;
-                       let v = v.reshape((batch_size, kv_seq_len, *kv_num_heads as usize, v_head_size))?
-                           .transpose(1, 2)?;
-                           
-                       (q, k, v, true)
-                   }
-                   4 => (q.clone(), k.clone(), v.clone(), false),
-                   _ => bail!("Attention expects 3D or 4D input for Q, got rank {}", q.rank())
-               };
-               
-               let (batch_size, q_num_heads, q_seq_len, head_size) = query.dims4()?;
-               let (_, kv_num_heads, kv_seq_len, _) = key.dims4()?;
-               let (_, _, _, v_head_size) = value.dims4()?;
-               
-               // Calculate scale (default: 1/sqrt(head_size))
-               let scale = scale.unwrap_or((head_size as f32).sqrt().recip());
-               
-               // Apply scale to Q and K
-               let query = query.broadcast_mul(&Tensor::full(scale, query.shape(), query.device())?)?;
-               let key = key.broadcast_mul(&Tensor::full(scale, key.shape(), key.device())?)?;
-               
-               // Handle past states if provided
-               let (key, value, past_seq_len) = if let (Some(Ok(past_key)), Some(Ok(past_value))) = (past_key, past_value) {
-                   let (_, _, past_len, _) = past_key.dims4()?;
-                   let concatenated_key = Tensor::cat(&[past_key, &key], 2)?;
-                   let concatenated_value = Tensor::cat(&[past_value, &value], 2)?;
-                   (concatenated_key, concatenated_value, past_len)
-               } else {
-                   (key, value, 0)
-               };
-               
-               let total_seq_len = past_seq_len + kv_seq_len;
-               
-               // Handle multi-query/group-query attention by repeating k,v heads
-               let (key, value) = if q_num_heads > kv_num_heads {
-                   if q_num_heads % kv_num_heads != 0 {
-                       bail!("q_num_heads must be divisible by kv_num_heads for GQA/MQA");
-                   }
-                   let repeat_factor = (q_num_heads / kv_num_heads) as usize;
-                   
-                   // Expand kv_num_heads to q_num_heads by repeating
-                   let key = key.unsqueeze(2)?
-                       .expand((batch_size, kv_num_heads as usize, repeat_factor, total_seq_len, head_size))?
-                       .reshape((batch_size, q_num_heads as usize, total_seq_len, head_size))?;
-                   let value = value.unsqueeze(2)?
-                       .expand((batch_size, kv_num_heads as usize, repeat_factor, total_seq_len, v_head_size))?
-                       .reshape((batch_size, q_num_heads as usize, total_seq_len, v_head_size))?;
-                       
-                   (key, value)
-               } else {
-                   (key, value)
-               };
-               
-               let key_transpose = key.transpose(2, 3)?;
-               
-               let mut scores = query.matmul(&key_transpose)?;
-               
-               let qk_matmul_raw = if qk_matmul_output_mode == 0 && node.output.len() > 3 {
-                   Some(scores.clone())
-               } else {
-                   None
-               };
-               
-               if let Some(Ok(mask)) = attn_mask {
-                   scores = if mask.dtype() == DType::U8 {
-                       let mask_f32 = mask.to_dtype(DType::F32)?;
-                       let neg_inf = Tensor::full(f32::NEG_INFINITY, (), mask.device())?;
-                       scores.where_cond(&mask_f32.gt(&0.0_f32)?, &(scores.clone() + neg_inf)?)?
-                   } else {
-                       scores.broadcast_add(&mask)?
-                   };
-               } else if is_causal {
-                   // Create causal mask (lower triangular)
-                   let device = scores.device();
-                   let causal_mask = Tensor::tril_indices(q_seq_len, total_seq_len, 0, device)?;
-                   
-                   let row_indices = causal_mask.get(0)?;
-                   let col_indices = causal_mask.get(1)?;
-                   
-                   let mut mask_full = Tensor::zeros((q_seq_len, total_seq_len), DType::F32, device)?;
-
-                   let identity = Tensor::eye(q_seq_len, DType::F32, device)?;
-                   if q_seq_len <= total_seq_len {
-                       let mask_slice = identity.pad_with_zeros(1, 0, total_seq_len - q_seq_len)?;
-                       mask_full = mask_slice;
-                   } else {
-                       mask_full = identity.narrow(1, 0, total_seq_len)?;
-                   }
-                   
-                   let neg_inf = Tensor::full(f32::NEG_INFINITY, (), device)?;
-                   scores = scores.where_cond(&mask_full.unsqueeze(0)?.unsqueeze(0)?.expand(scores.shape())?.gt(&0.0_f32)?, &(scores.clone() + neg_inf)?)?;
-               }
-               
-               // Store the QK matmul output after mask addition if needed
-               let qk_matmul_masked = if qk_matmul_output_mode == 1 && node.output.len() > 3 {
-                   Some(scores.clone())
-               } else {
-                   None
-               };
-               
-               // Apply softcap if provided
-               if softcap > 0.0 {
-                   let softcap_t = Tensor::full(softcap, scores.shape(), scores.device())?;
-                   scores = (scores.div(&softcap_t)?).tanh()?.mul(&softcap_t)?;
-               }
-               
-               // Store the QK matmul output after softcap if needed
-               let qk_matmul_softcapped = if qk_matmul_output_mode == 2 && node.output.len() > 3 {
-                   Some(scores.clone())
-               } else {
-                   None
-               };
-               
-               // Apply softmax
-               let attention_weights = candle_nn::ops::softmax(&scores, 3)?;
-               
-               // Store the QK matmul output after softmax if needed
-               let qk_matmul_softmaxed = if qk_matmul_output_mode == 3 && node.output.len() > 3 {
-                   Some(attention_weights.clone())
-               } else {
-                   None
-               };
-               
-               // Attention output: (batch_size, num_heads, q_seq_len, v_head_size)
-               let output = attention_weights.matmul(&value)?;
-               
-               // Reshape output back to 3D if input was 3D
-               let output = if is_3d {
-                   output.transpose(1, 2)?
-                       .reshape((batch_size, q_seq_len, q_num_heads as usize * v_head_size))?
-               } else {
-                   output
-               };
-               
-               values.insert(node.output[0].clone(), output);
-               
-               // Present key/value outputs if requested
-               if node.output.len() > 1 && !node.output[1].is_empty() {
-                   values.insert(node.output[1].clone(), key.clone());
-               }
-               if node.output.len() > 2 && !node.output[2].is_empty() {
-                   values.insert(node.output[2].clone(), value.clone());
-               }
-               
-               // QK matmul output if requested
-               if node.output.len() > 3 && !node.output[3].is_empty() {
-                   let qk_output = match qk_matmul_output_mode {
-                       0 => qk_matmul_raw,
-                       1 => qk_matmul_masked,
-                       2 => qk_matmul_softcapped,
-                       3 => qk_matmul_softmaxed,
-                       _ => bail!("Invalid qk_matmul_output_mode: {}", qk_matmul_output_mode)
-                   };
-                   
-                   if let Some(qk) = qk_output {
-                       values.insert(node.output[3].clone(), qk);
-                   }
-               }
+            "Trilu" => {
+                let input = get(&node.input[0])?;
+                
+                // Get the diagonal offset 'k' from the second input if provided
+                let k = if node.input.len() > 1 && !node.input[1].is_empty() {
+                    get(&node.input[1])?.to_vec0::<i64>()?
+                } else {
+                    0 // Default to 0 if not provided
+                };
+                
+                // Get the 'upper' attribute (default to 1/true if not specified)
+                let upper = get_attr_opt::<i64>(node, "upper")?.copied().unwrap_or(1);
+                
+                // For batched inputs, we need to handle each matrix separately
+                let dims = input.dims();
+                println!("{}", dims.len());
+                if dims.len() < 2 {
+                    bail!("Trilu expects input with at least 2 dimensions: {:?}", dims);
+                }
+                
+                // Get the last two dimensions which represent the matrix
+                let n = dims[dims.len() - 2];
+                let m = dims[dims.len() - 1];
+                let max_dim = std::cmp::max(n, m);
+                
+                // Create base triangular matrix using the provided functions
+                let mask = if upper != 0 {
+                    Tensor::triu2(max_dim, input.dtype(), input.device())?
+                } else {
+                    Tensor::tril2(max_dim, input.dtype(), input.device())?
+                };
+                
+                // Handle the diagonal offset k
+                let adjusted_mask = if k != 0 {
+                    // Shift the mask by k positions
+                    if upper != 0 {
+                        // For upper triangular with positive k, we need to shift up
+                        // For upper triangular with negative k, we need to shift down
+                        if k > 0 {
+                            let zero_rows = Tensor::zeros((k as usize, max_dim), input.dtype(), input.device())?;
+                            let mask_rows = mask.narrow(0, 0, max_dim - k as usize)?;
+                            Tensor::cat(&[&zero_rows, &mask_rows], 0)?
+                        } else {
+                            let mask_rows = mask.narrow(0, -k as usize, max_dim + k as usize)?;
+                            let zero_rows = Tensor::zeros((-k as usize, max_dim), input.dtype(), input.device())?;
+                            Tensor::cat(&[&mask_rows, &zero_rows], 0)?
+                        }
+                    } else {
+                        // For lower triangular with positive k, we need to shift right
+                        // For lower triangular with negative k, we need to shift left
+                        if k > 0 {
+                            let mask_rows = mask.narrow(0, k as usize, max_dim - k as usize)?;
+                            let zero_rows = Tensor::zeros((k as usize, max_dim), input.dtype(), input.device())?;
+                            Tensor::cat(&[&mask_rows, &zero_rows], 0)?
+                        } else {
+                            let zero_rows = Tensor::zeros((-k as usize, max_dim), input.dtype(), input.device())?;
+                            let mask_rows = mask.narrow(0, 0, max_dim + k as usize)?;
+                            Tensor::cat(&[&zero_rows, &mask_rows], 0)?
+                        }
+                    }
+                } else {
+                    mask
+                };
+                
+                // If n != m, we need to resize the mask
+                let final_mask = if n != m {
+                    adjusted_mask.narrow(0, 0, n)?.narrow(1, 0, m)?
+                } else {
+                    adjusted_mask
+                };
+                
+                // If we have a batched input, broadcast the mask to match the input shape
+                let broadcast_mask = if dims.len() > 2 {
+                    // Calculate the batch size (all dimensions except last two)
+                    let mut mask_shape = vec![1; dims.len() - 2];
+                    mask_shape.push(n);
+                    mask_shape.push(m);
+                    
+                    // Reshape and broadcast
+                    final_mask.reshape(mask_shape)?.broadcast_as(dims)?
+                } else {
+                    final_mask
+                };
+                
+                // Apply mask to input
+                let output = input.mul(&broadcast_mask)?;
+                
+                values.insert(node.output[0].clone(), output);
             }
             op_type => bail!("unsupported op_type {op_type} for op {node:?}"),
         }

--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -583,7 +583,9 @@ fn simple_eval_(
                     &Device::Cpu,
                 )?);
 
-                let shape_vec: Vec<usize> = input.to_vec1::<i64>()?.iter()
+                let shape_vec: Vec<usize> = input
+                    .to_vec1::<i64>()?
+                    .iter()
                     .map(|&x| x as usize)
                     .collect();
 
@@ -2036,103 +2038,107 @@ fn simple_eval_(
             }
             "Trilu" => {
                 let input = get(&node.input[0])?;
-                
+
                 // Get the diagonal offset 'k' from the second input if provided
                 let k = if node.input.len() > 1 && !node.input[1].is_empty() {
                     get(&node.input[1])?.to_vec0::<i64>()?
                 } else {
                     0 // Default to 0 if not provided
                 };
-                
+
                 // Get the 'upper' attribute (default to 1/true if not specified)
                 let upper = get_attr_opt::<i64>(node, "upper")?.copied().unwrap_or(1);
-                
+
                 // For batched inputs, we need to handle each matrix separately
                 let dims = input.dims();
                 if dims.len() < 2 {
                     bail!("Trilu expects input with at least 2 dimensions: {:?}", dims);
                 }
-                
+
                 // Get the last two dimensions which represent the matrix
                 let n = dims[dims.len() - 2];
                 let m = dims[dims.len() - 1];
                 let max_dim = std::cmp::max(n, m);
-                
+
                 // Handle the diagonal offset k
                 let mask = if k != 0 {
-                    let mut data = vec![0.0f32; n * m];
+                    let mut data = vec![0u32; n * m];
                     for i in 0..n {
                         for j in 0..m {
-                            if (upper != 0 && (j as i64) >= (i as i64) + k) || (upper == 0 && (j as i64) <= (i as i64) + k) {
-                                data[i * m + j] = 1.0;
+                            if (upper != 0 && (j as i64) >= (i as i64) + k)
+                                || (upper == 0 && (j as i64) <= (i as i64) + k)
+                            {
+                                data[i * m + j] = 1u32;
                             }
                         }
                     }
-                    Tensor::from_vec(data, (n, m), input.device())?
-                } else if upper == 0  {
+                    Tensor::from_vec(data, (n, m), input.device())?.to_dtype(input.dtype())?
+                } else if upper == 0 {
                     Tensor::tril2(max_dim, input.dtype(), input.device())?
                 } else {
                     Tensor::triu2(max_dim, input.dtype(), input.device())?
                 };
-                
+
                 // If n != m, we need to resize the mask
                 let final_mask = if n != m {
                     mask.narrow(0, 0, n)?.narrow(1, 0, m)?
                 } else {
                     mask
                 };
-                
+
                 // Apply mask to input
                 let output = (input * &final_mask)?;
-                
+
                 values.insert(node.output[0].clone(), output);
             }
             "ScatterND" => {
                 let data = get(&node.input[0])?;
-                
+
                 let indices = get(&node.input[1])?;
                 let indices = indices.to_dtype(DType::I64)?;
 
                 let updates = get(&node.input[2])?;
-                
+
                 let reduction = get_attr_opt::<str>(node, "reduction")?.unwrap_or("none");
 
                 // Extract shapes and validate
                 let indices_shape = indices.dims();
                 let data_shape = data.dims();
                 let updates_shape = updates.dims();
-                
+
                 // Last dimension of indices represents the depth of indexing
                 let k = indices_shape.last().unwrap().clone();
-                
+
                 if k > data.rank() {
                     bail!("ScatterND expects k (indices.shape[-1]) to be at most the rank of data");
                 }
-                
+
                 // Calculate number of updates to perform
-                let num_updates = indices_shape[..indices_shape.len() - 1].iter().product::<usize>();
-                
+                let num_updates = indices_shape[..indices_shape.len() - 1]
+                    .iter()
+                    .product::<usize>();
+
                 // Reshape indices to [num_updates, k] for consistent processing
                 let flat_indices = if indices.rank() == 1 && k == 1 {
                     indices.unsqueeze(0)?
                 } else {
                     indices.reshape((num_updates, k))?
                 };
-                
+
                 // Calculate update element shape (the shape of each update element)
                 let update_element_shape = if k < data_shape.len() {
                     data_shape[k..].to_vec()
                 } else {
                     vec![]
                 };
-                
+
                 // Expected shape for updates based on indices and target tensor
                 let expected_updates_shape = {
                     let mut shape = indices_shape[..indices_shape.len() - 1].to_vec();
                     shape.extend(&update_element_shape);
                     shape
                 };
-                
+
                 // Validate or reshape updates to expected shape
                 let updates = if updates.dims() != expected_updates_shape {
                     if updates.rank() == 0 {
@@ -2142,17 +2148,18 @@ fn simple_eval_(
                         updates.broadcast_as(target_shape)?
                     } else {
                         // Try to broadcast or reshape updates to expected shape
-                        let flat_shape = vec![num_updates, update_element_shape.iter().product::<usize>()];
+                        let flat_shape =
+                            vec![num_updates, update_element_shape.iter().product::<usize>()];
                         let flattened = updates.reshape(flat_shape)?;
                         flattened.reshape(expected_updates_shape)?
                     }
                 } else {
                     updates.clone()
                 };
-                
+
                 // Start with a copy of data for output
                 let mut output = data.clone();
-                
+
                 // For multi-dimensional scatter, convert indices to flat indices
                 let mut flat_output = output.flatten_all()?;
                 let flat_updates = if update_element_shape.is_empty() {
@@ -2161,41 +2168,46 @@ fn simple_eval_(
                     let product = update_element_shape.iter().product::<usize>();
                     updates.reshape((num_updates, product))?
                 };
-                
+
                 // Calculate strides for the output tensor
                 let mut strides: Vec<usize> = vec![1];
                 for i in (0..data_shape.len() - 1).rev() {
                     strides.push(strides.last().unwrap() * data_shape[i + 1]);
                 }
                 strides.reverse();
-                
+
                 // Process each update
                 for i in 0..num_updates {
                     // Extract current indices
                     let index_slice = flat_indices.narrow(0, i, 1)?;
                     let indices_vec = index_slice.squeeze(0)?.to_vec1::<i64>()?;
-                    
+
                     // Convert multi-dimensional indices to flat index
                     let mut flat_idx: usize = 0;
                     for (dim, &idx) in indices_vec.iter().enumerate() {
                         let dim_size = data_shape[dim] as i64;
                         // Handle negative indices
                         let norm_idx = if idx < 0 { dim_size + idx } else { idx };
-                        
+
                         if norm_idx < 0 || norm_idx >= dim_size {
-                            bail!("Index {} out of bounds for dimension {} with size {}", idx, dim, dim_size);
+                            bail!(
+                                "Index {} out of bounds for dimension {} with size {}",
+                                idx,
+                                dim,
+                                dim_size
+                            );
                         }
-                        
+
                         flat_idx += (norm_idx as usize) * strides[dim];
                     }
-                    
+
                     // Extract current update
                     let update_slice = if update_element_shape.is_empty() {
                         flat_updates.narrow(0, i, 1)?.squeeze(0)?
                     } else {
                         flat_updates.narrow(0, i, 1)?
                     };
-                    
+
                     // Apply update based on reduction mode
                     match reduction {
                         "add" => {
@@ -2211,22 +2223,27 @@ fn simple_eval_(
                                 let new_value = existing.add(&update_slice)?;
                                 flat_output = flat_output.slice_scatter(&new_value, 0, flat_idx)?;
                             }
-                        },
+                        }
                         "none" | _ => {
                             if update_element_shape.is_empty() {
                                 // Scalar update
-                                flat_output = flat_output.slice_scatter(&update_slice.unsqueeze(0)?, 0, flat_idx)?;
+                                flat_output = flat_output.slice_scatter(
+                                    &update_slice.unsqueeze(0)?,
+                                    0,
+                                    flat_idx,
+                                )?;
                             } else {
                                 // Vector update
-                                flat_output = flat_output.slice_scatter(&update_slice, 0, flat_idx)?;
+                                flat_output =
+                                    flat_output.slice_scatter(&update_slice, 0, flat_idx)?;
                             }
                         }
                     }
                 }
-                
+
                 // Reshape flat output back to original shape
                 output = flat_output.reshape(data_shape.to_vec())?;
-                
+
                 values.insert(node.output[0].clone(), output);
             }
             op_type => bail!("unsupported op_type {op_type} for op {node:?}"),

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -842,13 +842,22 @@ fn test_flatten_operation() -> Result<()> {
 #[test]
 fn test_constant_of_shape() -> Result<()> {
     // https://github.com/onnx/onnx/blob/main/docs/Operators.md#examples-31
-    test(&[4i64, 3, 2], Some(1.), &[1., 1., 1.])?;
+    test(
+        &[4i64, 3, 2],
+        Some(1.),
+        &[
+            [[1., 1.], [1., 1.], [1., 1.]],
+            [[1., 1.], [1., 1.], [1., 1.]],
+            [[1., 1.], [1., 1.], [1., 1.]],
+            [[1., 1.], [1., 1.], [1., 1.]],
+        ],
+    )?;
 
     // https://github.com/onnx/onnx/blob/main/docs/Operators.md#examples-31
-    test(&[0.], Some(0i64), &[0i64])?;
+    test(&[1i64], Some(0i64), &[0i64])?;
 
     // "value" defaults to 0 f32
-    test(&[1i64, 2, 3, 4], None as Option<i64>, &[0., 0., 0., 0.])?;
+    test(&[4i64], None as Option<i64>, &[0., 0., 0., 0.])?;
 
     fn test(
         input: impl NdArray,
@@ -5966,5 +5975,519 @@ fn test_sign_operation() -> Result<()> {
         z.to_dtype(candle::DType::I64)?.to_vec1::<i64>()?.to_vec(),
         vec![-1, -1, 0, 1, 1]
     );
+    Ok(())
+}
+
+#[test]
+fn test_scatternd_operation() -> Result<()> {
+    // Example 1 based on ONNX documentation
+    test(
+        &[1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        &[[4i64], [3], [1], [7]],
+        &[9.0f32, 10.0, 11.0, 12.0],
+        &[1.0f32, 11.0, 3.0, 10.0, 9.0, 6.0, 7.0, 12.0],
+    )?;
+
+    // A more complex example with 2D data
+    test(
+        &[[1.0f32, 2.0], [3.0, 4.0], [5.0, 6.0]],
+        &[[0i64, 1], [1, 0]],
+        &[10.0f32, 20.0],
+        &[[1.0f32, 10.0], [20.0, 4.0], [5.0, 6.0]],
+    )?;
+
+    // 3D example with indices pointing to specific locations
+    test(
+        &[
+            [[1.0f32, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+            [[9.0, 10.0], [11.0, 12.0]],
+        ],
+        &[[0i64, 0, 1], [1, 1, 0]],
+        &[100.0f32, 200.0],
+        &[
+            [[1.0f32, 100.0], [3.0, 4.0]],
+            [[5.0, 6.0], [200.0, 8.0]],
+            [[9.0, 10.0], [11.0, 12.0]],
+        ],
+    )?;
+
+    fn test(
+        data: impl NdArray,
+        indices: impl NdArray,
+        updates: impl NdArray,
+        expected: impl NdArray,
+    ) -> Result<()> {
+        let manual_graph = create_model_proto_with_graph(Some(GraphProto {
+            node: vec![NodeProto {
+                op_type: "ScatterND".to_string(),
+                domain: "".to_string(),
+                attribute: vec![],
+                input: vec![
+                    INPUT_X.to_string(),
+                    INPUT_Y.to_string(),
+                    INPUT_A.to_string(),
+                ],
+                output: vec![OUTPUT_Z.to_string()],
+                name: "".to_string(),
+                doc_string: "".to_string(),
+            }],
+            name: "".to_string(),
+            initializer: vec![],
+            input: vec![],
+            output: vec![ValueInfoProto {
+                name: OUTPUT_Z.to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            }],
+            value_info: vec![],
+            doc_string: "".to_string(),
+            sparse_initializer: vec![],
+            quantization_annotation: vec![],
+        }));
+
+        let mut inputs: HashMap<String, Tensor> = HashMap::new();
+        inputs.insert(INPUT_X.to_string(), Tensor::new(data, &Device::Cpu)?);
+        inputs.insert(INPUT_Y.to_string(), Tensor::new(indices, &Device::Cpu)?);
+        inputs.insert(INPUT_A.to_string(), Tensor::new(updates, &Device::Cpu)?);
+
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        assert_eq!(eval.len(), 1);
+
+        let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+        let expected = Tensor::new(expected, &Device::Cpu)?;
+
+        match expected.dims().len() {
+            1 => assert_eq!(z.to_vec1::<f32>()?, expected.to_vec1::<f32>()?),
+            2 => assert_eq!(z.to_vec2::<f32>()?, expected.to_vec2::<f32>()?),
+            3 => assert_eq!(z.to_vec3::<f32>()?, expected.to_vec3::<f32>()?),
+            _ => unreachable!(),
+        };
+
+        Ok(())
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_trilu_operation() -> Result<()> {
+    // Test 1: Upper triangular matrix (default behavior with upper=true)
+    {
+        let manual_graph = create_model_proto_with_graph(Some(GraphProto {
+            node: vec![NodeProto {
+                op_type: "Trilu".to_string(),
+                domain: "".to_string(),
+                attribute: vec![], // empty attribute means default upper=true
+                input: vec![INPUT_X.to_string()],
+                output: vec![OUTPUT_Z.to_string()],
+                name: "".to_string(),
+                doc_string: "".to_string(),
+            }],
+            name: "".to_string(),
+            initializer: vec![],
+            input: vec![ValueInfoProto {
+                name: INPUT_X.to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            }],
+            output: vec![ValueInfoProto {
+                name: OUTPUT_Z.to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            }],
+            value_info: vec![],
+            doc_string: "".to_string(),
+            sparse_initializer: vec![],
+            quantization_annotation: vec![],
+        }));
+
+        let x = Tensor::from_vec(
+            vec![
+                4i64, 7, 3, 7, 9, 1, 2, 8, 6, 9, 9, 4, 0, 8, 7, 4, 3, 4, 2, 4,
+            ],
+            &[4, 5],
+            &Device::Cpu,
+        )?;
+
+        let mut inputs: HashMap<String, Tensor> = HashMap::new();
+        inputs.insert(INPUT_X.to_string(), x);
+
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        assert_eq!(eval.len(), 1);
+
+        let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+        let results = z.to_vec2::<i64>()?;
+
+        // Upper triangular matrix (default k=0)
+        assert_eq!(
+            results,
+            vec![
+                vec![4, 7, 3, 7, 9],
+                vec![0, 2, 8, 6, 9],
+                vec![0, 0, 0, 8, 7],
+                vec![0, 0, 0, 2, 4]
+            ]
+        );
+    }
+
+    // Test 2: Upper triangular with positive k=1 (diagonal above main)
+    {
+        let manual_graph = create_model_proto_with_graph(Some(GraphProto {
+            node: vec![NodeProto {
+                op_type: "Trilu".to_string(),
+                domain: "".to_string(),
+                attribute: vec![],
+                input: vec![INPUT_X.to_string(), INPUT_Y.to_string()],
+                output: vec![OUTPUT_Z.to_string()],
+                name: "".to_string(),
+                doc_string: "".to_string(),
+            }],
+            name: "".to_string(),
+            initializer: vec![],
+            input: vec![
+                ValueInfoProto {
+                    name: INPUT_X.to_string(),
+                    doc_string: "".to_string(),
+                    r#type: None,
+                },
+                ValueInfoProto {
+                    name: INPUT_Y.to_string(),
+                    doc_string: "".to_string(),
+                    r#type: None,
+                },
+            ],
+            output: vec![ValueInfoProto {
+                name: OUTPUT_Z.to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            }],
+            value_info: vec![],
+            doc_string: "".to_string(),
+            sparse_initializer: vec![],
+            quantization_annotation: vec![],
+        }));
+
+        let x = Tensor::from_vec(
+            vec![1i64, 4, 9, 7, 1, 9, 2, 8, 8, 4, 3, 9, 7, 4, 2],
+            &[3, 5],
+            &Device::Cpu,
+        )?;
+
+        let k = Tensor::from_vec(vec![1i64], (), &Device::Cpu)?;
+
+        let mut inputs: HashMap<String, Tensor> = HashMap::new();
+        inputs.insert(INPUT_X.to_string(), x);
+        inputs.insert(INPUT_Y.to_string(), k);
+
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        assert_eq!(eval.len(), 1);
+
+        let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+        let results = z.to_vec2::<i64>()?;
+
+        // Upper triangular with k=1 (one diagonal above main)
+        assert_eq!(
+            results,
+            vec![
+                vec![0, 4, 9, 7, 1],
+                vec![0, 0, 8, 8, 4],
+                vec![0, 0, 0, 4, 2]
+            ]
+        );
+    }
+
+    // Test 3: Upper triangular with negative k=-1 (one diagonal below main)
+    {
+        let manual_graph = create_model_proto_with_graph(Some(GraphProto {
+            node: vec![NodeProto {
+                op_type: "Trilu".to_string(),
+                domain: "".to_string(),
+                attribute: vec![],
+                input: vec![INPUT_X.to_string(), INPUT_Y.to_string()],
+                output: vec![OUTPUT_Z.to_string()],
+                name: "".to_string(),
+                doc_string: "".to_string(),
+            }],
+            name: "".to_string(),
+            initializer: vec![],
+            input: vec![],
+            output: vec![ValueInfoProto {
+                name: OUTPUT_Z.to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            }],
+            value_info: vec![],
+            doc_string: "".to_string(),
+            sparse_initializer: vec![],
+            quantization_annotation: vec![],
+        }));
+
+        let x = Tensor::from_vec(
+            vec![
+                4i64, 7, 3, 7, 9, 1, 2, 8, 6, 9, 9, 4, 0, 8, 7, 4, 3, 4, 2, 4,
+            ],
+            &[4, 5],
+            &Device::Cpu,
+        )?;
+
+        let k = Tensor::from_vec(vec![-1i64], (), &Device::Cpu)?;
+
+        let mut inputs: HashMap<String, Tensor> = HashMap::new();
+        inputs.insert(INPUT_X.to_string(), x);
+        inputs.insert(INPUT_Y.to_string(), k);
+
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        assert_eq!(eval.len(), 1);
+
+        let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+        let results = z.to_vec2::<i64>()?;
+
+        // Upper triangular with k=-1 (one diagonal below main)
+        assert_eq!(
+            results,
+            vec![
+                vec![4, 7, 3, 7, 9],
+                vec![1, 2, 8, 6, 9],
+                vec![0, 4, 0, 8, 7],
+                vec![0, 0, 4, 2, 4]
+            ]
+        );
+    }
+
+    // Test 4: Lower triangular matrix (upper=0)
+    {
+        let att_upper = AttributeProto {
+            name: "upper".to_string(),
+            ref_attr_name: "upper".to_string(),
+            i: 0, // 0 means false, use lower triangular
+            doc_string: "upper".to_string(),
+            r#type: 2, // INT
+            f: 0.0,
+            s: vec![],
+            t: None,
+            g: None,
+            sparse_tensor: None,
+            tp: None,
+            floats: vec![],
+            ints: vec![],
+            strings: vec![],
+            tensors: vec![],
+            graphs: vec![],
+            sparse_tensors: vec![],
+            type_protos: vec![],
+        };
+
+        let manual_graph = create_model_proto_with_graph(Some(GraphProto {
+            node: vec![NodeProto {
+                op_type: "Trilu".to_string(),
+                domain: "".to_string(),
+                attribute: vec![att_upper],
+                input: vec![INPUT_X.to_string()],
+                output: vec![OUTPUT_Z.to_string()],
+                name: "".to_string(),
+                doc_string: "".to_string(),
+            }],
+            name: "".to_string(),
+            initializer: vec![],
+            input: vec![],
+            output: vec![ValueInfoProto {
+                name: OUTPUT_Z.to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            }],
+            value_info: vec![],
+            doc_string: "".to_string(),
+            sparse_initializer: vec![],
+            quantization_annotation: vec![],
+        }));
+
+        let x = Tensor::from_vec(
+            vec![
+                4i64, 7, 3, 7, 9, 1, 2, 8, 6, 9, 9, 4, 1, 8, 7, 4, 3, 4, 2, 4,
+            ],
+            &[4, 5],
+            &Device::Cpu,
+        )?;
+
+        let mut inputs: HashMap<String, Tensor> = HashMap::new();
+        inputs.insert(INPUT_X.to_string(), x);
+
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        assert_eq!(eval.len(), 1);
+
+        let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+        let results = z.to_vec2::<i64>()?;
+
+        // Lower triangular matrix (default k=0)
+        assert_eq!(
+            results,
+            vec![
+                vec![4, 0, 0, 0, 0],
+                vec![1, 2, 0, 0, 0],
+                vec![9, 4, 1, 0, 0],
+                vec![4, 3, 4, 2, 0]
+            ]
+        );
+    }
+
+    // Test 5: Lower triangular with negative k=-1
+    {
+        let att_upper = AttributeProto {
+            name: "upper".to_string(),
+            ref_attr_name: "upper".to_string(),
+            i: 0, // 0 means false, use lower triangular
+            doc_string: "upper".to_string(),
+            r#type: 2, // INT
+            f: 0.0,
+            s: vec![],
+            t: None,
+            g: None,
+            sparse_tensor: None,
+            tp: None,
+            floats: vec![],
+            ints: vec![],
+            strings: vec![],
+            tensors: vec![],
+            graphs: vec![],
+            sparse_tensors: vec![],
+            type_protos: vec![],
+        };
+
+        let manual_graph = create_model_proto_with_graph(Some(GraphProto {
+            node: vec![NodeProto {
+                op_type: "Trilu".to_string(),
+                domain: "".to_string(),
+                attribute: vec![att_upper],
+                input: vec![INPUT_X.to_string(), INPUT_Y.to_string()],
+                output: vec![OUTPUT_Z.to_string()],
+                name: "".to_string(),
+                doc_string: "".to_string(),
+            }],
+            name: "".to_string(),
+            initializer: vec![],
+            input: vec![],
+            output: vec![ValueInfoProto {
+                name: OUTPUT_Z.to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            }],
+            value_info: vec![],
+            doc_string: "".to_string(),
+            sparse_initializer: vec![],
+            quantization_annotation: vec![],
+        }));
+
+        let x = Tensor::from_vec(
+            vec![
+                4i64, 7, 3, 7, 9, 1, 2, 8, 6, 9, 9, 4, 1, 8, 7, 4, 3, 4, 2, 4,
+            ],
+            &[4, 5],
+            &Device::Cpu,
+        )?;
+
+        let k = Tensor::from_vec(vec![-1i64], (), &Device::Cpu)?;
+
+        let mut inputs: HashMap<String, Tensor> = HashMap::new();
+        inputs.insert(INPUT_X.to_string(), x);
+        inputs.insert(INPUT_Y.to_string(), k);
+
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        assert_eq!(eval.len(), 1);
+
+        let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+        let results = z.to_vec2::<i64>()?;
+
+        // Lower triangular with k=-1 (one diagonal below main)
+        assert_eq!(
+            results,
+            vec![
+                vec![0, 0, 0, 0, 0],
+                vec![1, 0, 0, 0, 0],
+                vec![9, 4, 0, 0, 0],
+                vec![4, 3, 4, 0, 0]
+            ]
+        );
+    }
+
+    // Test 6: Lower triangular with positive k=2
+    {
+        let att_upper = AttributeProto {
+            name: "upper".to_string(),
+            ref_attr_name: "upper".to_string(),
+            i: 0, // 0 means false, use lower triangular
+            doc_string: "upper".to_string(),
+            r#type: 2, // INT
+            f: 0.0,
+            s: vec![],
+            t: None,
+            g: None,
+            sparse_tensor: None,
+            tp: None,
+            floats: vec![],
+            ints: vec![],
+            strings: vec![],
+            tensors: vec![],
+            graphs: vec![],
+            sparse_tensors: vec![],
+            type_protos: vec![],
+        };
+
+        let manual_graph = create_model_proto_with_graph(Some(GraphProto {
+            node: vec![NodeProto {
+                op_type: "Trilu".to_string(),
+                domain: "".to_string(),
+                attribute: vec![att_upper],
+                input: vec![INPUT_X.to_string(), INPUT_Y.to_string()],
+                output: vec![OUTPUT_Z.to_string()],
+                name: "".to_string(),
+                doc_string: "".to_string(),
+            }],
+            name: "".to_string(),
+            initializer: vec![],
+            input: vec![],
+            output: vec![ValueInfoProto {
+                name: OUTPUT_Z.to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            }],
+            value_info: vec![],
+            doc_string: "".to_string(),
+            sparse_initializer: vec![],
+            quantization_annotation: vec![],
+        }));
+
+        let x = Tensor::from_vec(
+            vec![
+                4i64, 7, 3, 7, 9, 1, 2, 8, 6, 9, 9, 4, 1, 8, 7, 4, 3, 4, 2, 4,
+            ],
+            &[4, 5],
+            &Device::Cpu,
+        )?;
+
+        let k = Tensor::from_vec(vec![2i64], (), &Device::Cpu)?;
+
+        let mut inputs: HashMap<String, Tensor> = HashMap::new();
+        inputs.insert(INPUT_X.to_string(), x);
+        inputs.insert(INPUT_Y.to_string(), k);
+
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        assert_eq!(eval.len(), 1);
+
+        let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+        let results = z.to_vec2::<i64>()?;
+
+        // Lower triangular with k=2 (two diagonals above main)
+        assert_eq!(
+            results,
+            vec![
+                vec![4, 7, 3, 0, 0],
+                vec![1, 2, 8, 6, 0],
+                vec![9, 4, 1, 8, 7],
+                vec![4, 3, 4, 2, 4]
+            ]
+        );
+    }
+
     Ok(())
 }

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -6119,7 +6119,6 @@ fn test_trilu_operation() -> Result<()> {
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
         let results = z.to_vec2::<i64>()?;
 
-        // Upper triangular matrix (default k=0)
         assert_eq!(
             results,
             vec![
@@ -6186,7 +6185,6 @@ fn test_trilu_operation() -> Result<()> {
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
         let results = z.to_vec2::<i64>()?;
 
-        // Upper triangular with k=1 (one diagonal above main)
         assert_eq!(
             results,
             vec![
@@ -6243,7 +6241,6 @@ fn test_trilu_operation() -> Result<()> {
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
         let results = z.to_vec2::<i64>()?;
 
-        // Upper triangular with k=-1 (one diagonal below main)
         assert_eq!(
             results,
             vec![
@@ -6262,7 +6259,7 @@ fn test_trilu_operation() -> Result<()> {
             ref_attr_name: "upper".to_string(),
             i: 0, // 0 means false, use lower triangular
             doc_string: "upper".to_string(),
-            r#type: 2, // INT
+            r#type: 2,
             f: 0.0,
             s: vec![],
             t: None,
@@ -6336,9 +6333,9 @@ fn test_trilu_operation() -> Result<()> {
         let att_upper = AttributeProto {
             name: "upper".to_string(),
             ref_attr_name: "upper".to_string(),
-            i: 0, // 0 means false, use lower triangular
+            i: 0,
             doc_string: "upper".to_string(),
-            r#type: 2, // INT
+            r#type: 2,
             f: 0.0,
             s: vec![],
             t: None,
@@ -6398,7 +6395,6 @@ fn test_trilu_operation() -> Result<()> {
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
         let results = z.to_vec2::<i64>()?;
 
-        // Lower triangular with k=-1 (one diagonal below main)
         assert_eq!(
             results,
             vec![
@@ -6415,9 +6411,9 @@ fn test_trilu_operation() -> Result<()> {
         let att_upper = AttributeProto {
             name: "upper".to_string(),
             ref_attr_name: "upper".to_string(),
-            i: 0, // 0 means false, use lower triangular
+            i: 0,
             doc_string: "upper".to_string(),
-            r#type: 2, // INT
+            r#type: 2,
             f: 0.0,
             s: vec![],
             t: None,
@@ -6477,7 +6473,6 @@ fn test_trilu_operation() -> Result<()> {
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
         let results = z.to_vec2::<i64>()?;
 
-        // Lower triangular with k=2 (two diagonals above main)
         assert_eq!(
             results,
             vec![


### PR DESCRIPTION
Added more onnx ops and the ability to run [SmolLM-135M](https://huggingface.co/HuggingFaceTB/SmolLM-135M) example.

## Changes

- Added [ScatterND](https://github.com/onnx/onnx/blob/main/docs/Operators.md#scatternd) and [Trilu](https://github.com/onnx/onnx/blob/main/docs/Operators.md#trilu) Onnx ops.
- Added Tests for ScatterND and Trilu onnx ops.
- Added new example `onnx-llm`.