### PR TITLE
Optimize Quantized Qwen3 KvCache 

### DIFF
--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -217,6 +217,10 @@ impl AttentionWeights {
         }
         let (k, v) = self.kv_cache.append(&k.contiguous()?, &v.contiguous()?)?;
 
+        // Make tensor contiguous to avoid some strided copies
+        let k = k.contiguous()?;
+        let v = v.contiguous()?;
+
         let k = repeat_kv(k, self.num_kv_groups)?.contiguous()?;
         let v = repeat_kv(v, self.num_kv_groups)?.contiguous()?;
 


### PR DESCRIPTION
Further optimize Qwen3 KvCache as discussed in PR #2951 by making the tensors contiguous before the `repeat_kv` calls. Two times speedup on autoregressive inference in my tests (rtx3090, qwen3:32b). Thanks @LaurentMazare for coming up with the fix.