### PR TITLE
Fix docs quantized qwen3

### DIFF
--- a/candle-examples/examples/quantized-qwen2-instruct/README.md
+++ b/candle-examples/examples/quantized-qwen2-instruct/README.md
@@ -8,4 +8,8 @@
 cargo run --example quantized-qwen2-instruct --release -- --prompt "Write a function to count prime numbers up to N."
 ```
 
-0.5b, 1.5b, 7b and 72b models are available via `--model` argument.
+0.5b, 1.5b, 7b and 72b models are available via `--which` argument.
+
+```bash
+ cargo run --release --example quantized-qwen2-instruct --   --which 0.5b   --prompt "Write a function to count prime numbers up to N."
+```

--- a/candle-examples/examples/quantized-qwen3/README.md
+++ b/candle-examples/examples/quantized-qwen3/README.md
@@ -8,4 +8,10 @@
 cargo run --example quantized-qwen3 --release -- --prompt "Write a function to count prime numbers up to N."
 ```
 
-0.6b is used by default, 1.7b, 4b, 8b, 14b, and 32b models are available via `--model` argument.
+
+0.6b is used by default, 1.7b, 4b, 8b, 14b, and 32b models are available via `--which` argument.
+
+```bash
+cargo run --example quantized-qwen3 --release -- --which 4b   --prompt "A train is travelling at 120mph, how far does it travel in 3 minutes 30 seconds?"
+```
+


### PR DESCRIPTION
# What does this PR do?
- Fixed wrong usage in README.md of quantized-qwen3 and quantized-qwen2-instruct

## Part of
Issue #2949 

## Details
Those two models' example works with parameter `which` not `model`.
I added additional example of using different size of model and replaced `model` with `which`

## Who can review?
@LaurentMazare 
Could you review these changes?