### PR TITLE
Fix cuda memory error for Qwen3 non-quantized

### DIFF
--- a/candle-transformers/src/models/qwen3.rs
+++ b/candle-transformers/src/models/qwen3.rs
@@ -157,6 +157,8 @@ impl Qwen3Attention {
         // Necessary because the hidden_size in the config isn't always accurate
         let hidden_size = head_dim * cfg.num_attention_heads;
 
+        // Initialize KV cache with 512 tokens capacity to reduce initial memory allocation.
+        // The cache will grow in chunks of 512 tokens when needed.
         let kv_cache = KvCache::new(2, 512);
 
         Ok(Self {

--- a/candle-transformers/src/models/qwen3.rs
+++ b/candle-transformers/src/models/qwen3.rs
@@ -157,7 +157,7 @@ impl Qwen3Attention {
         // Necessary because the hidden_size in the config isn't always accurate
         let hidden_size = head_dim * cfg.num_attention_heads;
 
-        let kv_cache = KvCache::new(2, cfg.max_position_embeddings);
+        let kv_cache = KvCache::new(2, 512);
 
         Ok(Self {
             q_proj,


### PR DESCRIPTION
Instead of initializing the `KvCache` with the full position embedding length, initialize it with 512, similar to what is done in the quantized version [here](https://github.com/huggingface/candle/blob/0224a749f0b2082f19831256ced6afe284c56457/candle-transformers/src/models/quantized_qwen3.rs#L163-L165) This resolves large memory allocation issues. 