### PR TITLE
Fix last_hidden_state slicing position in ModernBertForSequenceClassification

### DIFF
--- a/candle-transformers/src/models/modernbert.rs
+++ b/candle-transformers/src/models/modernbert.rs
@@ -488,7 +488,7 @@ impl ModernBertForSequenceClassification {
     pub fn forward(&self, xs: &Tensor, mask: &Tensor) -> Result<Tensor> {
         let output = self.model.forward(xs, mask)?;
         let last_hidden_state = match self.classifier_pooling {
-            ClassifierPooling::CLS => output.i((.., .., 0))?,
+            ClassifierPooling::CLS => output.i((.., 0, ..))?,
             ClassifierPooling::MEAN => {
                 let unsqueezed_mask = &mask.unsqueeze(D::Minus1)?.to_dtype(DType::F32)?;
                 let sum_output = output.broadcast_mul(unsqueezed_mask)?.sum(1)?;


### PR DESCRIPTION
# Problem
The shape of the tensor passed to the classifier is different.
Transformers: correctly uses the [CLS] token → shape (batch_size, hidden_size)
slices across the feature dimension → shape (batch_size, seq_len)

# Suggestion
I would like to propose the following change.
before

let last_hidden_state = output.i((.., .., 0))?;

after

let last_hidden_state = output.i((.., 0, ..))?;

This selects the first token (i.e., [CLS]) across all samples , resulting in a shape of (batch_size, hidden_size) 
# issue
https://github.com/huggingface/candle/issues/3000