### PR TITLE
fix: DAC model prefix

### DIFF
--- a/candle-transformers/src/models/dac.rs
+++ b/candle-transformers/src/models/dac.rs
@@ -358,7 +358,6 @@ pub struct Model {
 
 impl Model {
     pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
-        let vb = vb.pp("model");
         let encoder = Encoder::new(64, &[2, 4, 8, 8], cfg.latent_dim, vb.pp("encoder"))?;
         let quantizer = ResidualVectorQuantizer::new(
             cfg.latent_dim,

--- a/candle-transformers/src/models/parler_tts.rs
+++ b/candle-transformers/src/models/parler_tts.rs
@@ -367,7 +367,7 @@ impl Model {
             None
         };
         let audio_encoder =
-            crate::models::dac::Model::new(&cfg.audio_encoder, vb.pp("audio_encoder"))?;
+            crate::models::dac::Model::new(&cfg.audio_encoder, vb.pp("audio_encoder.model"))?;
         Ok(Self {
             decoder,
             text_encoder,


### PR DESCRIPTION
The [descript audio codec](https://github.com/descriptinc/descript-audio-codec) (DAC) model is not prefixed with `model`, so when you try and load it you get the following error:

```
cannot find tensor model.encoder.block.0.weight_g
```
 
This change fixes compatibility with the provided model.

Excerpt from the `state_dict` of the released model https://github.com/descriptinc/descript-audio-codec/releases/tag/1.0.0

```
decoder.model.0.bias
decoder.model.0.weight_g
decoder.model.0.weight_v
decoder.model.1.block.0.alpha
decoder.model.1.block.1.bias
decoder.model.1.block.1.weight_g
decoder.model.1.block.1.weight_v
```