### PR TITLE
candle-datasets: add fashion-mnist

### DIFF
--- a/candle-datasets/src/vision/fashion_mnist.rs
+++ b/candle-datasets/src/vision/fashion_mnist.rs
@@ -1,0 +1,14 @@
+//! Zalando Fashion MNIST dataset.
+//! A slightly more difficult dataset that is drop-in compatible with MNIST.
+//!
+//! Taken from here: https://huggingface.co/datasets/zalando-datasets/fashion_mnist
+use candle::Result;
+
+pub fn load() -> Result<crate::vision::Dataset> {
+    crate::vision::mnist::load_mnist_like(
+        "zalando-datasets/fashion_mnist",
+        "refs/convert/parquet",
+        "fashion_mnist/test/0000.parquet",
+        "fashion_mnist/train/0000.parquet",
+    )
+}

--- a/candle-datasets/src/vision/mod.rs
+++ b/candle-datasets/src/vision/mod.rs
@@ -9,4 +9,5 @@ pub struct Dataset {
 }
 
 pub mod cifar;
+pub mod fashion_mnist;
 pub mod mnist;


### PR DESCRIPTION
This PR adds support for Fashion MNIST dataset for validating (tiny) vision models. It's drop-in compatible with MNIST so reuses existing MNIST dataset code.

Fashion MNIST is a slightly more difficult drop-in replacement for MNIST that can't be solved to 97% with two matchsticks and a napkin blah blah.