### PR TITLE
Add GradStore::insert_id for inserting gradients by tensor ID

### DIFF
--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -754,6 +754,11 @@ impl GradStore {
         self.0.insert(tensor.id(), grad)
     }
 
+    /// Insert a gradient tensor associated with the given tensor id, returning the previous gradient tensor if it existed
+    pub fn insert_id(&mut self, id: TensorId, grad: Tensor) -> Option<Tensor> {
+        self.0.insert(id, grad)
+    }
+
     /// Get the gradient tensor associated with the given tensor, or, if it does not exist,
     /// insert a tensor of zeroes, with the same shape and type as the given tensors and return it
     fn or_insert(&mut self, tensor: &Tensor) -> Result<&mut Tensor> {


### PR DESCRIPTION
This PR adds a simple insert_id method to GradStore, allowing insertion of gradients directly by TensorId. This is motivated by #2962 on supporting gradient clipping. Without this function, it is impossible to clip gradients without access to the original Tensor instances.