### PR TITLE
Support building on CPUs with AVX but not AVX2

### DIFF
--- a/candle-core/src/cpu/mod.rs
+++ b/candle-core/src/cpu/mod.rs
@@ -60,10 +60,10 @@ trait CpuBF16<const ARR: usize> {
 use half::{bf16, f16};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[cfg(target_feature = "avx")]
+#[cfg(target_feature = "avx2")]
 pub mod avx;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[cfg(target_feature = "avx")]
+#[cfg(target_feature = "avx2")]
 pub use avx::{CurrentCpu, CurrentCpuBF16, CurrentCpuF16};
 
 #[cfg(target_arch = "wasm32")]
@@ -82,7 +82,7 @@ pub use neon::CurrentCpu;
 
 #[cfg(any(
     target_feature = "neon",
-    target_feature = "avx",
+    target_feature = "avx2",
     target_feature = "simd128"
 ))]
 #[inline(always)]
@@ -112,7 +112,7 @@ pub(crate) unsafe fn vec_dot_f32(a_row: *const f32, b_row: *const f32, c: *mut f
 
 #[cfg(not(any(
     target_feature = "neon",
-    target_feature = "avx",
+    target_feature = "avx2",
     target_feature = "simd128"
 )))]
 #[inline(always)]
@@ -125,7 +125,7 @@ pub(crate) unsafe fn vec_dot_f32(a_row: *const f32, b_row: *const f32, c: *mut f
 
 #[cfg(any(
     target_feature = "neon",
-    target_feature = "avx",
+    target_feature = "avx2",
     target_feature = "simd128"
 ))]
 #[inline(always)]
@@ -152,7 +152,7 @@ pub(crate) unsafe fn vec_sum(row: *const f32, b: *mut f32, k: usize) {
 
 #[cfg(not(any(
     target_feature = "neon",
-    target_feature = "avx",
+    target_feature = "avx2",
     target_feature = "simd128"
 )))]
 #[inline(always)]
@@ -163,7 +163,7 @@ pub(crate) unsafe fn vec_sum(row: *const f32, b: *mut f32, k: usize) {
     }
 }
 
-#[cfg(target_feature = "avx")]
+#[cfg(target_feature = "avx2")]
 #[inline(always)]
 pub(crate) unsafe fn vec_dot_f16(a_row: *const f16, b_row: *const f16, c: *mut f32, k: usize) {
     let mut sumf = 0.0f32;
@@ -191,7 +191,7 @@ pub(crate) unsafe fn vec_dot_f16(a_row: *const f16, b_row: *const f16, c: *mut f
     *c = sumf;
 }
 
-#[cfg(target_feature = "avx")]
+#[cfg(target_feature = "avx2")]
 #[inline(always)]
 pub(crate) unsafe fn vec_dot_bf16(a_row: *const bf16, b_row: *const bf16, c: *mut f32, k: usize) {
     let mut sumf = 0.0f32;
@@ -219,7 +219,7 @@ pub(crate) unsafe fn vec_dot_bf16(a_row: *const bf16, b_row: *const bf16, c: *mu
     *c = sumf;
 }
 
-#[cfg(not(target_feature = "avx"))]
+#[cfg(not(target_feature = "avx2"))]
 #[inline(always)]
 pub(crate) unsafe fn vec_dot_f16(a_row: *const f16, b_row: *const f16, c: *mut f32, k: usize) {
     // leftovers
@@ -230,7 +230,7 @@ pub(crate) unsafe fn vec_dot_f16(a_row: *const f16, b_row: *const f16, c: *mut f
     *c = sum;
 }
 
-#[cfg(not(target_feature = "avx"))]
+#[cfg(not(target_feature = "avx2"))]
 #[inline(always)]
 pub(crate) unsafe fn vec_dot_bf16(a_row: *const bf16, b_row: *const bf16, c: *mut f32, k: usize) {
     // leftovers

--- a/candle-core/src/quantized/k_quants.rs
+++ b/candle-core/src/quantized/k_quants.rs
@@ -222,7 +222,7 @@ impl GgmlType for BlockQ4_0 {
     // https://github.com/ggerganov/llama.cpp/blob/b5ffb2849d23afe73647f68eec7b68187af09be6/ggml.c#L2361C10-L2361C122
     #[allow(unreachable_code)]
     fn vec_dot(n: usize, xs: &[Self], ys: &[Self::VecDotType]) -> Result<f32> {
-        #[cfg(target_feature = "avx")]
+        #[cfg(target_feature = "avx2")]
         return super::avx::vec_dot_q4_0_q8_0(n, xs, ys);
 
         #[cfg(target_feature = "neon")]
@@ -616,7 +616,7 @@ impl GgmlType for BlockQ8_0 {
 
     #[allow(unreachable_code)]
     fn vec_dot(n: usize, xs: &[Self], ys: &[Self::VecDotType]) -> Result<f32> {
-        #[cfg(target_feature = "avx")]
+        #[cfg(target_feature = "avx2")]
         return super::avx::vec_dot_q8_0_q8_0(n, xs, ys);
 
         #[cfg(target_feature = "neon")]
@@ -702,7 +702,7 @@ impl GgmlType for BlockQ2K {
 
     #[allow(unreachable_code)]
     fn vec_dot(n: usize, xs: &[Self], ys: &[Self::VecDotType]) -> Result<f32> {
-        #[cfg(target_feature = "avx")]
+        #[cfg(target_feature = "avx2")]
         return super::avx::vec_dot_q2k_q8k(n, xs, ys);
 
         #[cfg(target_feature = "neon")]
@@ -878,7 +878,7 @@ impl GgmlType for BlockQ3K {
 
     #[allow(unreachable_code)]
     fn vec_dot(n: usize, xs: &[Self], ys: &[Self::VecDotType]) -> Result<f32> {
-        #[cfg(target_feature = "avx")]
+        #[cfg(target_feature = "avx2")]
         return super::avx::vec_dot_q3k_q8k(n, xs, ys);
 
         #[cfg(target_feature = "neon")]
@@ -1156,7 +1156,7 @@ impl GgmlType for BlockQ4K {
 
     #[allow(unreachable_code)]
     fn vec_dot(n: usize, xs: &[Self], ys: &[Self::VecDotType]) -> Result<f32> {
-        #[cfg(target_feature = "avx")]
+        #[cfg(target_feature = "avx2")]
         return super::avx::vec_dot_q4k_q8k(n, xs, ys);
 
         #[cfg(target_feature = "neon")]
@@ -1349,7 +1349,7 @@ impl GgmlType for BlockQ5K {
 
     #[allow(unreachable_code)]
     fn vec_dot(n: usize, xs: &[Self], ys: &[Self::VecDotType]) -> Result<f32> {
-        #[cfg(target_feature = "avx")]
+        #[cfg(target_feature = "avx2")]
         return super::avx::vec_dot_q5k_q8k(n, xs, ys);
 
         #[cfg(target_feature = "neon")]
@@ -1570,7 +1570,7 @@ impl GgmlType for BlockQ6K {
 
     #[allow(unreachable_code)]
     fn vec_dot(n: usize, xs: &[Self], ys: &[Self::VecDotType]) -> Result<f32> {
-        #[cfg(target_feature = "avx")]
+        #[cfg(target_feature = "avx2")]
         return super::avx::vec_dot_q6k_q8k(n, xs, ys);
 
         #[cfg(target_feature = "neon")]
@@ -1753,7 +1753,7 @@ impl GgmlType for BlockQ8K {
 
     #[allow(unreachable_code)]
     fn vec_dot(n: usize, xs: &[Self], ys: &[Self::VecDotType]) -> Result<f32> {
-        #[cfg(target_feature = "avx")]
+        #[cfg(target_feature = "avx2")]
         return super::avx::vec_dot_q8k_q8k(n, xs, ys);
 
         #[cfg(target_feature = "neon")]

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -3,7 +3,7 @@ use crate::{Context, CpuStorage, DType, Device, Result, Shape, Storage, Tensor};
 use k_quants::*;
 use std::borrow::Cow;
 
-#[cfg(target_feature = "avx")]
+#[cfg(target_feature = "avx2")]
 pub mod avx;
 mod dummy_cuda;
 mod dummy_metal;

--- a/candle-core/src/utils.rs
+++ b/candle-core/src/utils.rs
@@ -29,7 +29,7 @@ pub fn metal_is_available() -> bool {
 }
 
 pub fn with_avx() -> bool {
-    cfg!(target_feature = "avx")
+    cfg!(target_feature = "avx2")
 }
 
 pub fn with_neon() -> bool {


### PR DESCRIPTION
This change corrects an issue causing AVX2 intrinsics to be called on CPUs that do not support them. These intrinsics were conditionally compiled in behind an `avx` feature gate. This change correctly uses them only if `avx2` is available. This change should have no impact on modern CPUs, but it allows older CPUs to work properly using the unoptimized code path.

An alternative to this change would be to rework the AVX code paths to avoid AVX2 intrinsics, but that would be a larger change and likely less desirable as AVX2 seems like a very reasonable baseline these days. Dropping AVX2 intrinsics would likely be a performance regression on modern CPUs.

This change corrects an issue that I was facing related to an `Illegal Instruction` after building the crate, and should also address similar issues that have been encountered by others such as #1327 and #2140.