### PR TITLE
Add metal_if_available method for API consistency with CUDA

### DIFF
--- a/candle-core/src/device.rs
+++ b/candle-core/src/device.rs
@@ -320,6 +320,14 @@ impl Device {
         }
     }
 
+    pub fn metal_if_available(ordinal: usize) -> Result<Self> {
+        if crate::utils::metal_is_available() {
+            Self::new_metal(ordinal)
+        } else {
+            Ok(Self::Cpu)
+        }
+    }
+
     pub(crate) fn rand_uniform_f64(
         &self,
         lo: f64,


### PR DESCRIPTION
This PR adds the missing `metal_if_available` method to improve API consistency and developer experience with Metal device creation:

### API Consistency:
Adds `Device::metal_if_available(ordinal: usize) -> Result<Self>` method.
Provides feature parity with the existing `cuda_if_available()` functionality.
Ensures consistent, graceful fallback behavior across all GPU backend types.

### Implementation:
Follows the same pattern as `cuda_if_available()` for maintainability.
Automatically falls back to CPU when Metal is unavailable on the system.
Uses existing `crate::utils::metal_is_available()` utility function.

### Benefits:
Improved ergonomics for cross-platform GPU code
Eliminates the need for manual Metal availability checks in user code
Consistent API surface between CUDA and Metal device creation
Better developer experience when writing portable GPU applications