### PR TITLE
Load safetensors with i8

### DIFF
--- a/candle-core/src/safetensors.rs
+++ b/candle-core/src/safetensors.rs
@@ -209,6 +209,10 @@ impl Tensor {
 
 fn convert(view: &st::TensorView<'_>, device: &Device) -> Result<Tensor> {
     match view.dtype() {
+        st::Dtype::I8 => {
+            let conv = |x| Ok(i64::from(x));
+            convert_with_cast_::<i8, i64, _>(view, device, conv)
+        }
         st::Dtype::U8 => convert_::<u8>(view, device),
         st::Dtype::U16 => {
             let conv = |x| Ok(u32::from(x));
@@ -472,5 +476,18 @@ mod tests {
         let bytes = std::fs::read("multi.safetensors").unwrap();
         assert_eq!(bytes, b"x\0\0\0\0\0\0\0{\"t\":{\"dtype\":\"F32\",\"shape\":[2,2],\"data_offsets\":[0,16]},\"u\":{\"dtype\":\"F32\",\"shape\":[1,2],\"data_offsets\":[16,24]}}      \0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
         std::fs::remove_file("multi.safetensors").unwrap();
+    }
+
+    #[test]
+    fn load_i8() {
+        let bytes = b"8\0\0\0\0\0\0\0{\"x\":{\"dtype\":\"I8\",\"shape\":[2],\"data_offsets\":[0,2]}}   \x01\x03";
+        std::fs::write("test_i8.safetensors", bytes).unwrap();
+        let weights = load("test_i8.safetensors", &Device::Cpu).unwrap();
+        let tensor = weights.get("x").unwrap();
+        assert_eq!(tensor.dims(), &[2]);
+        assert_eq!(tensor.dtype(), DType::I64);
+        let data: Vec<i64> = tensor.to_vec1().unwrap();
+        assert_eq!(data, vec![1, 3]);
+        std::fs::remove_file("test_i8.safetensors").unwrap();
     }
 }


### PR DESCRIPTION
Hi,

I have a small ML-enabled [app](https://www.voegele.me/posts/suppalist/) that uses candle with wasm under the hood. Downloading the model takes a long time so I quantized it to 8-bit integers. Candle doesn't have an I8 `DType` and the safetensors load doesn't support I8.

This PR adds the ability to load a safetensors file with I8 by upcasting it to I64, similar to the existing I32 to I64 conversion.

Based on this [PR](https://github.com/huggingface/candle/pull/2432) for adding a `DType::I32`, I skipped adding a `DType::I8` for now, but would consider that if requested.

Thanks!