### PR TITLE
pick seed <= u32::MAX when using metal

### DIFF
--- a/candle-examples/examples/stable-diffusion/main.rs
+++ b/candle-examples/examples/stable-diffusion/main.rs
@@ -617,7 +617,18 @@ fn run(args: Args) -> Result<()> {
     let mut scheduler = sd_config.build_scheduler(n_steps)?;
     let device = candle_examples::device(cpu)?;
     // If a seed is not given, generate a random seed and print it
-    let seed = seed.unwrap_or(rand::rng().random_range(0u64..u64::MAX));
+    let seed = seed.unwrap_or_else(|| {
+        #[cfg(feature = "metal")]
+        {
+            // Metal backend requires seed to be within u32 range
+            rand::rng().random_range(0u64..u32::MAX as u64)
+        }
+        #[cfg(not(feature = "metal"))]
+        {
+            rand::rng().random_range(0u64..u64::MAX)
+        }
+    });
+
     println!("Using seed {seed}");
     device.set_seed(seed)?;
     let use_guide_scale = guidance_scale > 1.0;


### PR DESCRIPTION
## Problem

Running the stable diffusion example with Metal results in an error with the seed (possibly) being out of range.

```
$ cargo run --example stable-diffusion --release --features=metal -- --prompt "a cosmonaut on a horse (hd, realistic, high-def)" --sd-version turbo
   Compiling candle-transformers v0.9.1 (/Users/kylekelley/code/src/github.com/huggingface/candle/candle-transformers)
   Compiling candle-examples v0.9.1 (/Users/kylekelley/code/src/github.com/huggingface/candle/candle-examples)
    Finished `release` profile [optimized] target(s) in 13.34s
     Running `target/release/examples/stable-diffusion --prompt 'a cosmonaut on a horse (hd, realistic, high-def)' --sd-version turbo`
Using seed 14094623835642992148
Error: Metal error Metal seed must be less than or equal to u32::MAX

Caused by:
    Metal seed must be less than or equal to u32::MAX
```

The user can manually set `--seed` but we can make this easier.

## Solution

Generate the seed up to `u32::MAX` when metal is enabled.