### PR TITLE
Fix sort kernel launch bug when nrows exceed gridDim.y limit

### DIFF
--- a/candle-core/src/sort.rs
+++ b/candle-core/src/sort.rs
@@ -94,7 +94,7 @@ mod cuda {
             let nrows = elem_count / ncols;
             let ncols_pad = next_power_of_2(ncols);
             let cfg = LaunchConfig {
-                grid_dim: (1, nrows as u32, 1),
+                grid_dim: (nrows as u32, 1, 1),
                 block_dim: (ncols_pad as u32, 1, 1),
                 shared_mem_bytes: (ncols_pad * std::mem::size_of::<u32>()) as u32,
             };

--- a/candle-kernels/src/sort.cu
+++ b/candle-kernels/src/sort.cu
@@ -15,7 +15,7 @@ template<int order, typename T>
 static __device__ void k_argsort(const T * x, uint32_t * dst, const int ncols, int ncols_pad) {
     // bitonic sort
     int col = threadIdx.x;
-    int row = blockIdx.y;
+    int row = blockIdx.x;
 
     if (col >= ncols_pad) {
         return;


### PR DESCRIPTION
The sort kernel launch has a bug when the number of rows (`nrows`) to sort exceeds the limit of `gridDim.y` (which is 65,535 according to the CUDA documentation). Issue reported here: https://github.com/EricLBuehler/candle-vllm/issues/237

This causes a `CUDA_ERROR_INVALID_VALUE` launch error. This PR provides a simple fix by changing the indexing from `blockIdx.y` (limited by `gridDim.y`) to `blockIdx.x` (since `gridDim.x` has a much larger limit).

Here is the original kernel launch, which uses `gridDim.y` as `nrows`:

```rust
         let ncols_pad = next_power_of_2(ncols);
            let params = (&slice, &dst, ncols as i32, ncols_pad as i32);
            let cfg = LaunchConfig {
                grid_dim: (1, nrows as u32, 1),
                grid_dim: (nrows as u32, 1, 1),
                block_dim: (ncols_pad as u32, 1, 1),
                shared_mem_bytes: (ncols_pad * std::mem::size_of::<u32>()) as u32,
            };
```