### PR TITLE
Fix Clippy for CI

### DIFF
--- a/candle-core/src/layout.rs
+++ b/candle-core/src/layout.rs
@@ -187,11 +187,11 @@ impl Layout {
         })
     }
 
-    pub(crate) fn strided_index(&self) -> crate::StridedIndex {
+    pub(crate) fn strided_index(&self) -> crate::StridedIndex<'_> {
         crate::StridedIndex::from_layout(self)
     }
 
-    pub(crate) fn strided_blocks(&self) -> crate::StridedBlocks {
+    pub(crate) fn strided_blocks(&self) -> crate::StridedBlocks<'_> {
         let mut block_len = 1;
         let mut contiguous_dims = 0; // These are counted from the right.
         for (&stride, &dim) in self.stride().iter().zip(self.dims().iter()).rev() {

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -115,7 +115,7 @@ impl QStorage {
         }
     }
 
-    fn data(&self) -> Result<Cow<[u8]>> {
+    fn data(&self) -> Result<Cow<'_, [u8]>> {
         match self {
             QStorage::Cpu(storage) => {
                 let data_ptr = storage.as_ptr();

--- a/candle-core/src/safetensors.rs
+++ b/candle-core/src/safetensors.rs
@@ -57,7 +57,7 @@ impl st::View for Tensor {
         self.shape().dims()
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         // This copies data from GPU to CPU.
         // TODO: Avoid the unwrap here.
         Cow::Owned(convert_back(self).unwrap())
@@ -78,7 +78,7 @@ impl st::View for &Tensor {
         self.dims()
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         // This copies data from GPU to CPU.
         // TODO: Avoid the unwrap here.
         Cow::Owned(convert_back(self).unwrap())

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -1742,7 +1742,7 @@ impl Tensor {
 
     /// Returns an iterator over position of the elements in the storage when ranging over the
     /// index tuples in lexicographic order.
-    pub fn strided_index(&self) -> crate::StridedIndex {
+    pub fn strided_index(&self) -> crate::StridedIndex<'_> {
         self.layout.strided_index()
     }
 
@@ -1750,7 +1750,7 @@ impl Tensor {
     /// as well as the length of the contiguous blocks. For a contiguous tensor, the index iterator
     /// will only return the start offset and the size would be the number of elements in the
     /// tensor.
-    pub fn strided_blocks(&self) -> crate::StridedBlocks {
+    pub fn strided_blocks(&self) -> crate::StridedBlocks<'_> {
         self.layout.strided_blocks()
     }
 

--- a/candle-examples/examples/chinese_clip/main.rs
+++ b/candle-examples/examples/chinese_clip/main.rs
@@ -77,7 +77,7 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn load_weights(model: Option<String>, device: &Device) -> anyhow::Result<nn::VarBuilder> {
+pub fn load_weights(model: Option<String>, device: &Device) -> anyhow::Result<nn::VarBuilder<'_>> {
     let model_file = match model {
         None => {
             let api = hf_hub::api::sync::Api::new()?;

--- a/candle-examples/examples/clip/main.rs
+++ b/candle-examples/examples/clip/main.rs
@@ -88,8 +88,9 @@ pub fn main() -> anyhow::Result<()> {
         ],
     };
     let images = load_images(&vec_imgs, config.image_size)?.to_device(&device)?;
-    let vb =
-        unsafe { VarBuilder::from_mmaped_safetensors(&[model_file.clone()], DType::F32, &device)? };
+    let vb = unsafe {
+        VarBuilder::from_mmaped_safetensors(std::slice::from_ref(&model_file), DType::F32, &device)?
+    };
     let model = clip::ClipModel::new(vb, &config)?;
     let (input_ids, vec_seq) = tokenize_sequences(args.sequences, &tokenizer, &device)?;
     let (_logits_per_text, logits_per_image) = model.forward(&images, &input_ids)?;

--- a/candle-examples/examples/distilbert/main.rs
+++ b/candle-examples/examples/distilbert/main.rs
@@ -134,7 +134,7 @@ impl Args {
         Ok((config, tokenizer, weights))
     }
 
-    fn load_variables(&self, weights_path: &PathBuf, device: &Device) -> Result<VarBuilder> {
+    fn load_variables(&self, weights_path: &PathBuf, device: &Device) -> Result<VarBuilder<'_>> {
         if self.use_pth {
             Ok(VarBuilder::from_pth(weights_path, DTYPE, device)?)
         } else {

--- a/candle-examples/examples/mobileclip/main.rs
+++ b/candle-examples/examples/mobileclip/main.rs
@@ -99,7 +99,13 @@ pub fn main() -> anyhow::Result<()> {
     let vb = if args.use_pth {
         VarBuilder::from_pth(&model_file, DType::F32, &device)?
     } else {
-        unsafe { VarBuilder::from_mmaped_safetensors(&[model_file.clone()], DType::F32, &device)? }
+        unsafe {
+            VarBuilder::from_mmaped_safetensors(
+                std::slice::from_ref(&model_file),
+                DType::F32,
+                &device,
+            )?
+        }
     };
 
     let model = mobileclip::MobileClipModel::new(vb, config)?;

--- a/candle-examples/examples/segformer/main.rs
+++ b/candle-examples/examples/segformer/main.rs
@@ -56,7 +56,10 @@ enum Commands {
     Classify(ClassificationArgs),
 }
 
-fn get_vb_and_config(model_name: String, device: &Device) -> anyhow::Result<(VarBuilder, Config)> {
+fn get_vb_and_config(
+    model_name: String,
+    device: &Device,
+) -> anyhow::Result<(VarBuilder<'_>, Config)> {
     println!("loading model {model_name} via huggingface hub");
     let api = hf_hub::api::sync::Api::new()?;
     let api = api.model(model_name.clone());

--- a/candle-examples/examples/siglip/main.rs
+++ b/candle-examples/examples/siglip/main.rs
@@ -139,8 +139,9 @@ pub fn main() -> anyhow::Result<()> {
         args.image_size.unwrap_or(config.vision_config.image_size),
     )?
     .to_device(&device)?;
-    let vb =
-        unsafe { VarBuilder::from_mmaped_safetensors(&[model_file.clone()], DType::F32, &device)? };
+    let vb = unsafe {
+        VarBuilder::from_mmaped_safetensors(std::slice::from_ref(&model_file), DType::F32, &device)?
+    };
     let model = siglip::Model::new(&config, vb)?;
     let (input_ids, vec_seq) = tokenize_sequences(&config, args.sequences, &tokenizer, &device)?;
     let (_logits_per_text, logits_per_image) = model.forward(&images, &input_ids)?;

--- a/candle-examples/examples/yolo-v3/darknet.rs
+++ b/candle-examples/examples/yolo-v3/darknet.rs
@@ -268,7 +268,7 @@ impl Darknet {
         Ok(image_width)
     }
 
-    pub fn build_model(&self, vb: VarBuilder) -> Result<Func> {
+    pub fn build_model(&self, vb: VarBuilder) -> Result<Func<'_>> {
         let mut blocks: Vec<(usize, Bl)> = vec![];
         let mut prev_channels: usize = 3;
         for (index, block) in self.blocks.iter().enumerate() {

--- a/candle-pyo3/src/lib.rs
+++ b/candle-pyo3/src/lib.rs
@@ -747,7 +747,7 @@ impl PyTensor {
 
             compare(&self.0, &scalar_tensor)
         } else {
-            return Err(PyTypeError::new_err("unsupported rhs for __richcmp__"));
+            Err(PyTypeError::new_err("unsupported rhs for __richcmp__"))
         }
     }
 

--- a/candle-transformers/src/models/encodec.rs
+++ b/candle-transformers/src/models/encodec.rs
@@ -591,7 +591,7 @@ impl<'a> Layer<'a> {
         self.cnt += 1;
     }
 
-    fn next(&mut self) -> VarBuilder {
+    fn next(&mut self) -> VarBuilder<'_> {
         let vb = self.vb.pp(self.cnt.to_string());
         self.cnt += 1;
         vb

--- a/candle-transformers/src/models/xlm_roberta.rs
+++ b/candle-transformers/src/models/xlm_roberta.rs
@@ -128,34 +128,25 @@ impl XLMRobertaSelfAttention {
     ) -> Result<Tensor> {
         let mixed_query_layer = self.query.forward(hidden_states)?;
         let is_cross_attention = encoder_hidden_states.is_some();
-        let (key_layer, value_layer, attention_mask) = if is_cross_attention
-            && past_key_value.is_some()
-        {
-            let key_layer = past_key_value.unwrap().0.clone();
-            let value_layer = past_key_value.unwrap().1.clone();
-            let attention_mask = encoder_attention_mask.unwrap().clone();
-            (key_layer, value_layer, Some(attention_mask))
-        } else if is_cross_attention {
-            let key_layer =
-                self.transpose_for_scores(&self.key.forward(encoder_hidden_states.unwrap())?)?;
-            let value_layer =
-                self.transpose_for_scores(&self.value.forward(encoder_hidden_states.unwrap())?)?;
-            let attention_mask = encoder_attention_mask.unwrap();
-            (key_layer, value_layer, Some(attention_mask.clone()))
-        } else if past_key_value.is_some() {
+        let (key_layer, value_layer, attention_mask) = if is_cross_attention {
+            if let Some((past_key, past_value)) = past_key_value {
+                let key_layer = past_key.clone();
+                let value_layer = past_value.clone();
+                let attention_mask = encoder_attention_mask.unwrap().clone();
+                (key_layer, value_layer, Some(attention_mask))
+            } else {
+                let key_layer =
+                    self.transpose_for_scores(&self.key.forward(encoder_hidden_states.unwrap())?)?;
+                let value_layer = self
+                    .transpose_for_scores(&self.value.forward(encoder_hidden_states.unwrap())?)?;
+                let attention_mask = encoder_attention_mask.unwrap();
+                (key_layer, value_layer, Some(attention_mask.clone()))
+            }
+        } else if let Some((past_key, past_value)) = past_key_value {
             let mut key_layer = self.transpose_for_scores(&self.key.forward(hidden_states)?)?;
             let mut value_layer = self.transpose_for_scores(&self.value.forward(hidden_states)?)?;
-            key_layer = Tensor::cat(
-                &[
-                    past_key_value.clone().as_ref().unwrap().0.clone(),
-                    key_layer,
-                ],
-                2,
-            )?;
-            value_layer = Tensor::cat(
-                &[past_key_value.as_ref().unwrap().1.clone(), value_layer],
-                2,
-            )?;
+            key_layer = Tensor::cat(&[past_key.clone(), key_layer], 2)?;
+            value_layer = Tensor::cat(&[past_value.clone(), value_layer], 2)?;
             (key_layer, value_layer, Some(attention_mask.clone()))
         } else {
             let key_layer = self.transpose_for_scores(&self.key.forward(hidden_states)?)?;

--- a/candle-wasm-examples/llama2-c/src/worker.rs
+++ b/candle-wasm-examples/llama2-c/src/worker.rs
@@ -190,7 +190,7 @@ impl TransformerWeights {
         })
     }
 
-    fn var_builder(&self, cfg: &Config, device: &Device) -> Result<VarBuilder> {
+    fn var_builder(&self, cfg: &Config, device: &Device) -> Result<VarBuilder<'_>> {
         let mut ws = std::collections::HashMap::new();
         let mut insert = |name: &str, t: Tensor| {
             ws.insert(name.to_string(), t);


### PR DESCRIPTION
The new clippy rules are stricter about:

[mismatched-lifetime-syntaxes](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/lifetime_syntax/static.MISMATCHED_LIFETIME_SYNTAXES.html)
[unnecessary_unwrap](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap)
[cloned_ref_to_slice_refs](https://rust-lang.github.io/rust-clippy/master/index.html#cloned_ref_to_slice_refs)