### PR TITLE
Fix getrandom build error for wasm examples

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 rustflags = ["-C", "target-cpu=native"]
 
 [target.wasm32-unknown-unknown]
-rustflags = ["-C", "target-feature=+simd128"]
+rustflags = ["-C", "target-feature=+simd128", "--cfg", 'getrandom_backend="wasm_js"']
 
 [target.x86_64-apple-darwin]
 rustflags = ["-C", "target-feature=-avx,-avx2"]


### PR DESCRIPTION
Fixes error when building the `candle-wasm-examples/whisper` example (and possibly other WASM examples) with `sh build-lib.sh`. Currently the build fails with error:

```
bai@Bais-MacBook-Pro whisper % sh build-lib.sh
   Compiling getrandom v0.3.3
error: The wasm32-unknown-unknown targets are not supported by default; you may need to enable the "wasm_js" configuration flag. Note that enabling the `wasm_js` feature flag alone is insufficient. For more information see: https://docs.rs/getrandom/0.3.3/#webassembly-support
```

The root cause is that getrandom requires explicit configuration to select the backend when targeting wasm32-unknown-unknown.