### PR TITLE
build: Make build.rs candle-kernels compatible with Nix and sandboxed builds

### DIFF
--- a/candle-kernels/build.rs
+++ b/candle-kernels/build.rs
@@ -4,8 +4,10 @@ fn main() {
     println!("cargo:rerun-if-changed=src/cuda_utils.cuh");
     println!("cargo:rerun-if-changed=src/binary_op_macros.cuh");
 
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let ptx_path = out_dir.join("ptx.rs");
     let builder = bindgen_cuda::Builder::default();
     println!("cargo:info={builder:?}");
     let bindings = builder.build_ptx().unwrap();
-    bindings.write("src/ptx.rs").unwrap();
+    bindings.write(ptx_path).unwrap();
 }

--- a/candle-kernels/src/lib.rs
+++ b/candle-kernels/src/lib.rs
@@ -1,4 +1,6 @@
-mod ptx;
+mod ptx {
+    include!(concat!(env!("OUT_DIR"), "/ptx.rs"));
+}
 
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
This PR fixes an issue where the build.rs script writes generated files directly to the src/ directory. This practice violates Cargo's guidelines and causes build failures in sandboxed environments like Nix, where the source directory is read-only.

Changes:

build.rs: The script is updated to write ptx.rs to the Cargo-designated $OUT_DIR instead of src/.

src/lib.rs: The ptx module is now loaded using the include!(concat!(env!("OUT_DIR"), "/ptx.rs")); macro, which is the standard pattern for including code generated by a build script.

This makes the crate compliant with Cargo best practices and significantly improves its compatibility with reproducible build systems.