### PR TITLE
Bench using chosen device only

### DIFF
--- a/candle-core/benches/benchmarks/mod.rs
+++ b/candle-core/benches/benchmarks/mod.rs
@@ -67,8 +67,9 @@ impl BenchDeviceHandler {
             devices.push(Device::new_metal(0)?);
         } else if cfg!(feature = "cuda") {
             devices.push(Device::new_cuda(0)?);
+        } else {
+            devices.push(Device::Cpu);
         }
-        devices.push(Device::Cpu);
         Ok(Self { devices })
     }
 }


### PR DESCRIPTION
I only care about cpu benchmarks if I'm making cpu changes.

The original reasoning behind always running cpu benchmarks as well as your chosen device was that we wanted to catch regressions. The code for cpu and cuda/metal impls are not connected in a way where such regressions are likely to happen, and it has not happened so far. Additionally cpu should not be the primary focus of candle. It would make more sense to reverse the relationship so that if you are benchmarking your cpu changes you have run cuda/metal benchmarks as well - but not enough sense that I am suggesting we do that either.

Instead I propose that we save a bit of time by in our iteration cycle by only benchmarking what we are currently working on.
If you are working on something that affects both cpu and cuda/metal, then you benchmark both/all.