### PR TITLE
[Metal] fix random kernel

### DIFF
--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -2046,8 +2046,8 @@ impl BackendDevice for MetalDevice {
         let command_queue = device.new_command_queue();
         let kernels = Arc::new(Kernels::new());
         let seed = Arc::new(Mutex::new(device.new_buffer_with_data(
-            [299792458].as_ptr() as *const c_void,
-            4,
+            [299792458u64].as_ptr() as *const c_void,
+            8,
             MTLResourceOptions::StorageModeManaged,
         )));
         let commands = device::Commands::new(command_queue)?;


### PR DESCRIPTION
In my previous [PR](https://github.com/huggingface/candle/pull/3067) I used 2 `atomic_uint` to emulate the lack of support for `atomic_ulong` in Metal with the `atomic_uintx2` struct.
I then referenced it as `device atomic_uintx2 * seed` in the metal function. I think the double `*` led to passing an incorrect ptr into the atomic load and store functions.

In any case the core idea works correctly with this new approach.
