### PR TITLE
Fix iOS app store validation issues

### DIFF
--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -37,15 +37,6 @@ ug = { workspace = true }
 ug-cuda = { workspace = true, optional = true }
 ug-metal = { workspace = true, optional = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-ug-cuda = { workspace = true, optional = true }
-ug-metal = { workspace = true, optional = true }
-
-[target.'cfg(target_os = "ios")'.dependencies]
-ug = "0.0.2"
-ug-cuda = "0.0.2"
-ug-metal = "0.0.2"
-
 [dev-dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }

--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -29,13 +29,22 @@ rand_distr = { workspace = true }
 rayon = { workspace = true }
 safetensors = { workspace = true }
 thiserror = { workspace = true }
-ug-cuda = { workspace = true, optional = true }
-ug-metal = { workspace = true, optional = true }
 yoke = { workspace = true }
 zip = { workspace = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "ios")))'.dependencies]
 ug = { workspace = true }
+ug-cuda = { workspace = true, optional = true }
+ug-metal = { workspace = true, optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+ug-cuda = { workspace = true, optional = true }
+ug-metal = { workspace = true, optional = true }
+
+[target.'cfg(target_os = "ios")'.dependencies]
+ug = "0.0.2"
+ug-cuda = "0.0.2"
+ug-metal = "0.0.2"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/candle-core/src/cuda_backend/device.rs
+++ b/candle-core/src/cuda_backend/device.rs
@@ -163,7 +163,7 @@ impl CudaDevice {
         self.context.is_event_tracking()
     }
 
-    #[cfg(target_arch = "cuda")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn compile(
         &self,
         func_name: &'static str,

--- a/candle-core/src/cuda_backend/device.rs
+++ b/candle-core/src/cuda_backend/device.rs
@@ -163,7 +163,7 @@ impl CudaDevice {
         self.context.is_event_tracking()
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(target_arch = "cuda")]
     pub fn compile(
         &self,
         func_name: &'static str,

--- a/candle-core/src/custom_op.rs
+++ b/candle-core/src/custom_op.rs
@@ -386,7 +386,7 @@ pub struct UgIOp1 {
 
 impl UgIOp1 {
     #[allow(unused)]
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "ios")))]
     pub fn new(
         name: &'static str,
         kernel: ug::lang::ssa::Kernel,

--- a/candle-core/src/error.rs
+++ b/candle-core/src/error.rs
@@ -172,7 +172,7 @@ pub enum Error {
     #[error("Metal error {0}")]
     Metal(#[from] MetalError),
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "ios")))]
     #[error(transparent)]
     Ug(#[from] ug::Error),
 

--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -137,7 +137,7 @@ impl std::ops::Deref for MetalDevice {
 }
 
 impl MetalDevice {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "ios")))]
     pub fn compile(
         &self,
         func_name: &'static str,


### PR DESCRIPTION
From #2749, when uploading to app store some users get an error:
> ITMS-90755: Invalid Binary - The following binaries in your app contains prohibited instructions: (my binary with candle in it). Remove the instructions from the binaries, rebuild and resubmit.

This seems to be because the `ug` crate uses `gemm` ops that are unsupported on iOS. This PR hides any `ug` functionality behind a cfg flag similar to `wasm`.