### PR TITLE
In the BERT example: apply the attention mask from tokenization during pooling

### DIFF
--- a/candle-examples/examples/bert/main.rs
+++ b/candle-examples/examples/bert/main.rs
@@ -186,9 +186,7 @@ fn main() -> Result<()> {
             // tokens, including padding. This was the original behavior of this
             // example, and we'd like to preserve it for posterity.
             let (_n_sentence, n_tokens, _hidden_size) = embeddings.dims3()?;
-            let embeddings = (embeddings.sum(1)? / (n_tokens as f64))?;
-
-            embeddings
+            (embeddings.sum(1)? / (n_tokens as f64))?
         } else {
             // Apply avg-pooling by taking the mean embedding value for all
             // tokens (after applying the attention mask from tokenization).
@@ -197,9 +195,7 @@ fn main() -> Result<()> {
             let attention_mask_for_pooling = attention_mask.to_dtype(DTYPE)?.unsqueeze(2)?;
             let sum_mask = attention_mask_for_pooling.sum(1)?;
             let embeddings = (embeddings.broadcast_mul(&attention_mask_for_pooling)?).sum(1)?;
-            let embeddings = embeddings.broadcast_div(&sum_mask)?;
-
-            embeddings
+            embeddings.broadcast_div(&sum_mask)?
         };
         let embeddings = if args.normalize_embeddings {
             normalize_l2(&embeddings)?


### PR DESCRIPTION
So the results match those from Python examples on HuggingFace.

This will help people who want to migrate from Python `sentence_transformers` or `transformers` to candle. I think it's also more correct, in that it is more consistent with how the models are trained and evaluated: no padding or other masked token outputs (but I'm less confident about that).

It certainly helped me when I was comparing a reference Python implementation to my new rust implementation.