### PR TITLE
re-export prost::Message

### DIFF
--- a/candle-onnx/src/lib.rs
+++ b/candle-onnx/src/lib.rs
@@ -1,4 +1,5 @@
 use candle::Result;
+pub use prost;
 use prost::Message;
 
 pub mod onnx {


### PR DESCRIPTION
To decode a model into ModelProto you need to have the prost::Message trait in scope. If you depend on a different version of prost then candle decoding will fail. By re-exporting prost users can depend directly on our version.