### PR TITLE
fix(onnx): Make Transpose output contiguous to prevent MatMul errors

### DIFF
--- a/candle-examples/examples/bert/main.rs
+++ b/candle-examples/examples/bert/main.rs
@@ -177,9 +177,14 @@ fn main() -> Result<()> {
         println!("running inference on batch {:?}", token_ids.shape());
         let embeddings = model.forward(&token_ids, &token_type_ids, Some(&attention_mask))?;
         println!("generated embeddings {:?}", embeddings.shape());
-        // Apply some avg-pooling by taking the mean embedding value for all tokens (including padding)
-        let (_n_sentence, n_tokens, _hidden_size) = embeddings.dims3()?;
-        let embeddings = (embeddings.sum(1)? / (n_tokens as f64))?;
+        // Apply avg-pooling by taking the mean embedding value for all tokens
+        // (after applying the attention mask from tokenization). This should
+        // produce the same numeric result as the `sentence_transformers` Python
+        // library.
+        let attention_mask_for_pooling = attention_mask.to_dtype(DTYPE)?.unsqueeze(2)?;
+        let sum_mask = attention_mask_for_pooling.sum(1)?;
+        let embeddings = (embeddings.broadcast_mul(&attention_mask_for_pooling)?).sum(1)?;
+        let embeddings = embeddings.broadcast_div(&sum_mask)?;
         let embeddings = if args.normalize_embeddings {
             normalize_l2(&embeddings)?
         } else {

--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -443,7 +443,7 @@ fn simple_eval_(
                     None => input.t()?,
                     Some(perm) => {
                         let perm = perm.iter().map(|&v| v as usize).collect::<Vec<_>>();
-                        input.permute(perm)?
+                        input.permute(perm)?.contiguous()?
                     }
                 };
                 values.insert(node.output[0].clone(), output);


### PR DESCRIPTION
### Problem:

Running `sentence-transformers/all-MiniLM-L6-v2` fails with a MatMulUnexpectedStriding error because the MatMul operation receives a non-contiguous tensor.

I used both the official `model.onnx` file from HuggingFace, as well as generating one locally using `optimum-cli`. I can run the ONNX model using ONNX Runtime in Python, so I suspected that the model file itself is fine, and the problem is with candle's evaluator.

### Error Message:

```
    Error: MatMulUnexpectedStriding { ..., msg: "non-contiguous rhs" }
```
(and sometimes lhs)

### Root Cause:

I added print statements in `eval.rs` to figure out which operator in the computation graph produced non-contiguous outputs, and it was Transpose. 

I found that this only happens when a permutation has been applied.

### Solution:

This PR fixes the issue at the source by applying .contiguous() to the output of Transpose when a permutation has been applied in eval.rs. Otherwise, do nothing. I think this is the most efficient way to to avoid downstream errors without doing something fancy like analyzing the computation graph to avoid getting non-contiguous tensors in the first place. 

Since `.contiguous` does a cheap `.clone()` of the underlying `Arc` when the tensor is actually contiguous, this should probably not be very expensive. I didn't do any benchmarking though.