### PR TITLE
Upgrade ug dependency for CUDA 13 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,9 +92,9 @@ tokenizers = { version = "0.21.0", default-features = false }
 tracing = "0.1.37"
 tracing-chrome = "0.7.1"
 tracing-subscriber = "0.3.7"
-ug = "0.4.0"
-ug-cuda = "0.4.0"
-ug-metal = "0.4.0"
+ug = "0.5.0"
+ug-cuda = "0.5.0"
+ug-metal = "0.5.0"
 yoke = { version = "0.7.2", features = ["derive"] }
 zip = { version = "1.1.1", default-features = false }
 objc2-metal = { version = "0.3.1" }


### PR DESCRIPTION
ug 0.5.0 pulls in cudarc 0.17.3, which supports CUDA 13

Extension of https://github.com/huggingface/candle/pull/3078
