### PR TITLE
[Metal] Improve command buffer map

### DIFF
--- a/candle-metal-kernels/src/metal/command_buffer.rs
+++ b/candle-metal-kernels/src/metal/command_buffer.rs
@@ -2,6 +2,7 @@ use crate::{BlitCommandEncoder, ComputeCommandEncoder};
 use objc2::{rc::Retained, runtime::ProtocolObject};
 use objc2_foundation::NSString;
 use objc2_metal::{MTLCommandBuffer, MTLCommandBufferStatus};
+use std::{collections::HashMap, thread};
 
 #[derive(Clone, Debug)]
 pub struct CommandBuffer {
@@ -49,5 +50,29 @@ impl CommandBuffer {
 
     pub fn wait_until_completed(&self) {
         unsafe { self.raw.waitUntilCompleted() }
+    }
+}
+
+pub struct CommandBufferThreadMap {
+    inner: HashMap<thread::ThreadId, CommandBuffer>,
+}
+
+impl CommandBufferThreadMap {
+    pub fn new() -> Self {
+        Self {
+            inner: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self) -> Option<&CommandBuffer> {
+        self.inner.get(&thread::current().id())
+    }
+
+    pub fn get_mut(&mut self) -> Option<&mut CommandBuffer> {
+        self.inner.get_mut(&thread::current().id())
+    }
+
+    pub fn insert(&mut self, command_buffer: CommandBuffer) -> Option<CommandBuffer> {
+        self.inner.insert(thread::current().id(), command_buffer)
     }
 }

--- a/candle-metal-kernels/src/metal/commands.rs
+++ b/candle-metal-kernels/src/metal/commands.rs
@@ -94,10 +94,10 @@ impl Commands {
                     command_buffer.commit();
                     command_buffer.wait_until_completed();
                 }
-                MTLCommandBufferStatus::Committed => {
+                MTLCommandBufferStatus::Committed | MTLCommandBufferStatus::Scheduled => {
                     command_buffer.wait_until_completed();
                 }
-                MTLCommandBufferStatus::Scheduled | MTLCommandBufferStatus::Completed => {}
+                MTLCommandBufferStatus::Completed => {}
                 _ => {}
             }
             *command_buffer = create_command_buffer(&self.command_queue)?;

--- a/candle-metal-kernels/src/metal/commands.rs
+++ b/candle-metal-kernels/src/metal/commands.rs
@@ -1,19 +1,13 @@
-use crate::metal::CommandBuffer;
+use crate::metal::{CommandBuffer, CommandBufferThreadMap};
 use crate::MetalKernelError;
 use objc2::{rc::Retained, runtime::ProtocolObject};
 use objc2_metal::{MTLCommandBufferStatus, MTLCommandQueue, MTLCounterSet};
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-    thread,
-};
+use std::sync::{Arc, Mutex};
 
 // Use Retained when appropriate. Gives us a more elegant way of handling memory (peaks) than autoreleasepool.
 // https://docs.rs/objc2/latest/objc2/rc/struct.Retained.html
 pub type CommandQueue = Retained<ProtocolObject<dyn MTLCommandQueue>>;
 pub type CounterSet = Retained<ProtocolObject<dyn MTLCounterSet>>;
-
-type CommandBufferMap = HashMap<thread::ThreadId, CommandBuffer>;
 
 pub struct Commands {
     /// Single command queue for the entire device.
@@ -27,7 +21,7 @@ pub struct Commands {
     /// Despite what the documentation says, command buffers are NOT ordered. They are ordered
     /// for their START time, but there's no guarantee that command buffer1 will finish before
     /// command buffer2 starts (or there are metal bugs there)
-    command_buffers: Arc<Mutex<CommandBufferMap>>,
+    command_buffers: Arc<Mutex<CommandBufferThreadMap>>,
     /// Keeps track of the current amount of compute command encoders on the current
     /// command buffer
     /// Arc, RwLock because of the interior mutability.
@@ -52,7 +46,8 @@ impl Commands {
     pub fn new(command_queue: CommandQueue) -> Result<Self, MetalKernelError> {
         let command_buffer = create_command_buffer(&command_queue)?;
         command_buffer.enqueue();
-        let command_buffers = HashMap::from([(thread::current().id(), command_buffer)]);
+        let mut command_buffers = CommandBufferThreadMap::new();
+        command_buffers.insert(command_buffer);
         let command_buffers = Arc::new(Mutex::new(command_buffers));
 
         let compute_per_buffer = match std::env::var("CANDLE_METAL_COMPUTE_PER_BUFFER") {
@@ -69,12 +64,14 @@ impl Commands {
 
     pub fn command_buffer(&mut self) -> Result<(bool, CommandBuffer), MetalKernelError> {
         let mut command_buffers = self.command_buffers.lock()?;
-        let command_buffer =
-            command_buffers
-                .get_mut(&thread::current().id())
-                .ok_or(MetalKernelError::LockError(
-                    "Command buffer map".to_string(),
-                ))?;
+        let command_buffer = match command_buffers.get_mut() {
+            Some(command_buffer) => command_buffer,
+            None => {
+                let command_buffer = create_command_buffer(&self.command_queue)?;
+                command_buffers.insert(command_buffer);
+                command_buffers.get_mut().unwrap()
+            }
+        };
 
         let mut flushed = false;
         if self.command_buffer_index > self.compute_per_buffer {
@@ -89,23 +86,25 @@ impl Commands {
 
     pub fn wait_until_completed(&mut self) -> Result<(), MetalKernelError> {
         let mut command_buffers = self.command_buffers.lock()?;
-        let command_buffer =
-            command_buffers
-                .get_mut(&thread::current().id())
-                .ok_or(MetalKernelError::LockError(
-                    "Command buffer map".to_string(),
-                ))?;
-        match command_buffer.status() {
-            MTLCommandBufferStatus::Committed
-            | MTLCommandBufferStatus::Scheduled
-            | MTLCommandBufferStatus::Completed => {
-                panic!("Already committed");
+        // Only wait for the current command buffer if it exists
+        if let Some(command_buffer) = command_buffers.get_mut() {
+            // Only commit and wait if it needed
+            match command_buffer.status() {
+                MTLCommandBufferStatus::NotEnqueued | MTLCommandBufferStatus::Enqueued => {
+                    command_buffer.commit();
+                    command_buffer.wait_until_completed();
+                }
+                MTLCommandBufferStatus::Committed => {
+                    command_buffer.wait_until_completed();
+                }
+                MTLCommandBufferStatus::Scheduled | MTLCommandBufferStatus::Completed => {}
+                _ => {}
             }
-            _ => {}
+            *command_buffer = create_command_buffer(&self.command_queue)?;
+        } else {
+            let command_buffer = create_command_buffer(&self.command_queue)?;
+            command_buffers.insert(command_buffer);
         }
-        command_buffer.commit();
-        command_buffer.wait_until_completed();
-        *command_buffer = create_command_buffer(&self.command_queue)?;
 
         Ok(())
     }


### PR DESCRIPTION
Hide the `ThreadId` usage inside `CommandBufferThreadMap`.

Remove some failure points from `wait_until_completed`.