### PR TITLE
[Metal] Add conv ops for more dtypes

### DIFF
--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -960,6 +960,10 @@ impl BackendStorage for MetalStorage {
         let command_buffer = self.device.command_buffer()?;
         let name = match self.dtype {
             DType::F32 => "im2col1d_f32",
+            DType::F16 => "im2col1d_f16",
+            DType::BF16 => "im2col1d_bf16",
+            DType::U8 => "im2col1d_u8",
+            DType::U32 => "im2col1d_u32",
             dtype => crate::bail!("Metal conv1d {dtype:?} not implemented"),
         };
         let src = buffer_o(&self.buffer, layout, self.dtype);
@@ -1039,6 +1043,8 @@ impl BackendStorage for MetalStorage {
 
             let name = match self.dtype {
                 DType::F32 => "col2im1d_f32",
+                DType::F16 => "col2im1d_f16",
+                DType::BF16 => "col2im1d_bf16",
                 DType::U32 => "col2im1d_u32",
                 DType::U8 => "col2im1d_u8",
                 dtype => crate::bail!("metal col2im1d {dtype:?} not implemented"),

--- a/candle-examples/examples/based/main.rs
+++ b/candle-examples/examples/based/main.rs
@@ -245,7 +245,7 @@ fn main() -> Result<()> {
     let start = std::time::Instant::now();
     let config = serde_json::from_reader(std::fs::File::open(config_file)?)?;
     let device = candle_examples::device(args.cpu)?;
-    let dtype = if device.is_cuda() {
+    let dtype = if device.is_cuda() || device.is_metal() {
         DType::BF16
     } else {
         DType::F32

--- a/candle-metal-kernels/src/kernels/mlx_gemm.rs
+++ b/candle-metal-kernels/src/kernels/mlx_gemm.rs
@@ -61,7 +61,8 @@ pub fn call_mlx_gemm(
             lhs_stride: lhs_stride.to_vec(),
             rhs_stride: rhs_stride.to_vec(),
             mnk: (m, n, k),
-        })?;
+        }
+        .bt())?;
     };
     // rhs has shape b, k, n
     let (ldb, b_trans) = if (rhs_m1 == 1 || n == 1) && (rhs_m2 == n || k == 1) {
@@ -73,7 +74,8 @@ pub fn call_mlx_gemm(
             lhs_stride: lhs_stride.to_vec(),
             rhs_stride: rhs_stride.to_vec(),
             mnk: (m, n, k),
-        })?;
+        }
+        .bt())?;
     };
     let (bm, bn, bk, wn, wm) = (32, 32, 16, 2, 2);
     // https://github.com/ml-explore/mlx/blob/02efb310cac667bc547d1b96f21596c221f84fe7/mlx/backend/metal/matmul.cpp#L422

--- a/candle-metal-kernels/src/metal_src/conv.metal
+++ b/candle-metal-kernels/src/metal_src/conv.metal
@@ -249,7 +249,7 @@ kernel void FN_NAME(  \
 ) {  \
   col2im1d<T>(dst_el, l_out, l_in, c_out, k_size, stride, src, dst, tid); \
 } \
- 
+
 #define UPSAMPLE_NEAREST2D_OP(TYPENAME, FN_NAME) \
 kernel void FN_NAME(  \
     constant size_t &w_out, \
@@ -487,7 +487,7 @@ METAL_FUNC void conv_transpose2d(
   const size_t c_in = input_dims[1];
   const size_t h_in = input_dims[2];
   const size_t w_in = input_dims[3];
-  
+
   if (tid >= input_dims[0] * c_out * w_out * h_out) {
     return;
   }
@@ -553,12 +553,20 @@ IM2COL_OP(bfloat, im2col_bf16)
 #endif
 
 COL2IM1D_OP(float, col2im1d_f32)
+COL2IM1D_OP(half, col2im1d_f16)
 COL2IM1D_OP(uint8_t, col2im1d_u8)
 COL2IM1D_OP(uint32_t, col2im1d_u32)
+#if defined(__HAVE_BFLOAT__)
+COL2IM1D_OP(bfloat, col2im1d_bf16)
+#endif
 
 IM2COL1D_OP(float, im2col1d_f32)
+IM2COL1D_OP(half, im2col1d_f16)
 IM2COL1D_OP(uint8_t, im2col1d_u8)
 IM2COL1D_OP(uint32_t, im2col1d_u32)
+#if defined(__HAVE_BFLOAT__)
+IM2COL1D_OP(bfloat, im2col1d_bf16)
+#endif
 
 UPSAMPLE_NEAREST2D_OP(float, upsample_nearest2d_f32)
 UPSAMPLE_NEAREST2D_OP(half, upsample_nearest2d_f16)


### PR DESCRIPTION
Now we can run models that use convolutions on metal with bf16. Need to update our metal gemm though as the current version does not handle all the odd strides / dims that for example `based` creates.

Also added backtracing to metal kernel errors for easier debugging