### PR TITLE
bump gemm dependency to 0.18.2 to match ug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ cudarc = { version = "0.17.3", features = [
     "dynamic-linking",
 ], default-features = false }
 fancy-regex = "0.13.0"
-gemm = { version = "0.17.0", features = ["wasm-simd128-enable"] }
+gemm = { version = "0.18.2", features = ["wasm-simd128-enable"] }
 hf-hub = "0.4.1"
 half = { version = "2.5.0", features = [
     "num-traits",


### PR DESCRIPTION
`ug` uses `gemm 0.18`, while `candle-core` and `candle-nn` still depend on `gemm 0.17`.

This causes for 2 `gemm` versions to be compiled currently (visible in `Cargo.lock`).

This PR bumps candle's dependency on `gemm` to `0.18.2`, resulting in just one `gemm` dependency.

I ran the benches on my local machine, the changes are within noise threshold mostly, no big gains or losses.
