### PR TITLE
make cuda benches run again

### DIFF
--- a/candle-core/benches/benchmarks/mod.rs
+++ b/candle-core/benches/benchmarks/mod.rs
@@ -23,8 +23,8 @@ impl BenchDevice for Device {
             Device::Cuda(device) => {
                 #[cfg(feature = "cuda")]
                 {
-                    use cuda::WrapErr;
-                    return Ok(device.synchronize().w()?);
+                    use candle_core::backend::BackendDevice;
+                    return Ok(device.synchronize()?);
                 }
                 #[cfg(not(feature = "cuda"))]
                 panic!("Cuda device without cuda feature enabled: {:?}", device)

--- a/candle-nn/benches/benchmarks/mod.rs
+++ b/candle-nn/benches/benchmarks/mod.rs
@@ -16,7 +16,10 @@ impl BenchDevice for Device {
             Device::Cpu => Ok(()),
             Device::Cuda(device) => {
                 #[cfg(feature = "cuda")]
-                return Ok(device.synchronize()?);
+                {
+                    use candle::backend::BackendDevice;
+                    return Ok(device.synchronize()?);
+                }
                 #[cfg(not(feature = "cuda"))]
                 panic!("Cuda device without cuda feature enabled: {:?}", device)
             }


### PR DESCRIPTION
Looks like `cargo bench` with `--features cuda,cudnn` has not been touched for a while, and fails to compile these days.

Fortunately, this is easily fixed by adding a missing trait import and removing some error wrapping.

Leaving the wrap `w()` produced more compile errors, but removing it compiles and works just fine, so idk? `candle-nn` benches already skipped the `w()`, so I skipped it as well.