### PR TITLE
[Metal] Skip unsupported quantized matmul tests

### DIFF
--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -20,6 +20,10 @@ fn test_matmul(
     (b, m, n, k): (usize, usize, usize, usize),
     dtype: GgmlDType,
 ) -> Result<()> {
+    if device.is_metal() && (dtype == GgmlDType::Q8_1 || dtype == GgmlDType::Q8K) {
+        return Ok(());
+    }
+
     let lhs = (0..(m * k))
         .map(|v| v as f32 / (m * k) as f32)
         .collect::<Vec<_>>();

--- a/candle-metal-kernels/src/err.rs
+++ b/candle-metal-kernels/src/err.rs
@@ -10,6 +10,8 @@ pub enum MetalKernelError {
     LoadLibraryError(String),
     #[error("Error while loading function: {0}")]
     LoadFunctionError(String),
+    #[error("Unsupported dtype {0} for operation {1}")]
+    UnsupportedDTypeForOp(&'static str, &'static str),
     #[error("Failed to create compute function")]
     FailedToCreateComputeFunction,
     #[error("Failed to create metal resource: {0}")]

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -234,16 +234,16 @@ pub fn call_quantized_matmul_mm_t(
         GgmlDType::Q5_0 => "kernel_mul_mm_q5_0_f32",
         GgmlDType::Q5_1 => "kernel_mul_mm_q5_1_f32",
         GgmlDType::Q8_0 => "kernel_mul_mm_q8_0_f32",
-        GgmlDType::Q8_1 => "kernel_mul_mm_q8_1_f32",
         GgmlDType::Q2K => "kernel_mul_mm_q2_K_f32",
         GgmlDType::Q3K => "kernel_mul_mm_q3_K_f32",
         GgmlDType::Q4K => "kernel_mul_mm_q4_K_f32",
         GgmlDType::Q5K => "kernel_mul_mm_q5_K_f32",
         GgmlDType::Q6K => "kernel_mul_mm_q6_K_f32",
-        GgmlDType::Q8K => "kernel_mul_mm_q8_K_f32",
         GgmlDType::F16 => "kernel_mul_mm_f16_f32",
         GgmlDType::BF16 => "kernel_mul_mm_bf16_f32",
         GgmlDType::F32 => "kernel_mul_mm_f32_f32",
+        GgmlDType::Q8_1 => Err(MetalKernelError::UnsupportedDTypeForOp("Q8_1", "qmatmul"))?,
+        GgmlDType::Q8K => Err(MetalKernelError::UnsupportedDTypeForOp("Q8K", "qmatmul"))?,
     };
 
     let pipeline = kernels.load_pipeline(device, Source::Quantized, name)?;


### PR DESCRIPTION
The kernels `kernel_mul_mm_q8_1_f32` and `kernel_mul_mm_q8_K_f32` do not exist. Not just in candle, but in general.
If someone would like to write them, feel free. For now I am simply removing the references to them skipping the tests that are specific to these kernels.