### PR TITLE
feat(stable-diffusion): add build_unet_sharded method 

### DIFF
--- a/candle-transformers/src/models/stable_diffusion/mod.rs
+++ b/candle-transformers/src/models/stable_diffusion/mod.rs
@@ -491,6 +491,26 @@ impl StableDiffusionConfig {
         Ok(unet)
     }
 
+    pub fn build_unet_sharded<P: AsRef<std::path::Path>>(
+        &self,
+        unet_weight_files: &[P],
+        device: &Device,
+        in_channels: usize,
+        use_flash_attn: bool,
+        dtype: DType,
+    ) -> Result<unet_2d::UNet2DConditionModel> {
+        let vs_unet =
+            unsafe { nn::VarBuilder::from_mmaped_safetensors(unet_weight_files, dtype, device)? };
+        let unet = unet_2d::UNet2DConditionModel::new(
+            vs_unet,
+            in_channels,
+            4,
+            use_flash_attn,
+            self.unet.clone(),
+        )?;
+        Ok(unet)
+    }
+
     pub fn build_scheduler(&self, n_steps: usize) -> Result<Box<dyn Scheduler>> {
         self.scheduler.build(n_steps)
     }

--- a/candle-transformers/src/models/stable_diffusion/mod.rs
+++ b/candle-transformers/src/models/stable_diffusion/mod.rs
@@ -501,14 +501,13 @@ impl StableDiffusionConfig {
     ) -> Result<unet_2d::UNet2DConditionModel> {
         let vs_unet =
             unsafe { nn::VarBuilder::from_mmaped_safetensors(unet_weight_files, dtype, device)? };
-        let unet = unet_2d::UNet2DConditionModel::new(
+        unet_2d::UNet2DConditionModel::new(
             vs_unet,
             in_channels,
             4,
             use_flash_attn,
             self.unet.clone(),
-        )?;
-        Ok(unet)
+        )
     }
 
     pub fn build_scheduler(&self, n_steps: usize) -> Result<Box<dyn Scheduler>> {


### PR DESCRIPTION
Add build_unet_sharded method to StableDiffusionConfig to support loading UNet models from multiple sharded safetensors files. This is necessary for large models that are distributed across multiple files to avoid memory constraints during model storage and distribution.

The new method accepts a slice of file paths instead of a single directory, allowing direct specification of shard files. It uses mmaped_safetensors for efficient memory usage when loading from multiple weight files.

Key differences from build_unet:
- Accepts &[P] where P: AsRef<Path> for multiple file paths
- Uses from_mmaped_safetensors with file list instead of directory
- Maintains same signature for in_channels, use_flash_attn, and dtype

Use case: Loading models like FLUX or large SD3.5 variants that are distributed as model-00001-of-00003.safetensors, model-00002-of-00003.safetensors, etc.

Example usage:
```rust
let unet_files = [
    "model-00001-of-00002.safetensors",
    "model-00002-of-00002.safetensors",
];
let unet = config.build_unet_sharded(&unet_files, &device, 4, false, DType::F32)?;
```