### PR TITLE
rust-ci: add --benches to clippy, fix warnings

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -90,4 +90,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --tests --examples -- -D warnings
+          args: --workspace --tests --examples --benches -- -D warnings

--- a/candle-core/benches/benchmarks/reduce.rs
+++ b/candle-core/benches/benchmarks/reduce.rs
@@ -45,12 +45,12 @@ fn run_reduce<T: candle_core::FloatDType>(
     let k = 1024;
 
     let a = if strided {
-        Tensor::rand(lo, up, (b, m, k), &device)
+        Tensor::rand(lo, up, (b, m, k), device)
             .unwrap()
             .transpose(0, 2)
             .unwrap()
     } else {
-        Tensor::rand(lo, up, (b, m, k), &device).unwrap()
+        Tensor::rand(lo, up, (b, m, k), device).unwrap()
     };
 
     let flops = b * m * k * T::DTYPE.size_in_bytes();
@@ -106,12 +106,12 @@ fn run_arg_reduce<T: candle_core::FloatDType>(
     let k = 1024;
 
     let a = if strided {
-        Tensor::rand(lo, up, (b, m, k), &device)
+        Tensor::rand(lo, up, (b, m, k), device)
             .unwrap()
             .transpose(0, 2)
             .unwrap()
     } else {
-        Tensor::rand(lo, up, (b, m, k), &device).unwrap()
+        Tensor::rand(lo, up, (b, m, k), device).unwrap()
     };
 
     let flops = b * m * k * T::DTYPE.size_in_bytes();

--- a/candle-core/benches/benchmarks/where_cond.rs
+++ b/candle-core/benches/benchmarks/where_cond.rs
@@ -23,7 +23,7 @@ const M: usize = 1024;
 const K: usize = 1024;
 const SIZE: usize = B * M * K;
 
-const DATA: [u8; SIZE] = create_cond_arr::<SIZE>();
+static DATA: [u8; SIZE] = create_cond_arr::<SIZE>();
 
 fn run_where_cond_benchmark(c: &mut Criterion, device: &Device, dtype: DType, name: &str) {
     let tensor = Tensor::from_slice(DATA.as_slice(), (B, M, K), device).unwrap();

--- a/candle-nn/benches/benchmarks/softmax.rs
+++ b/candle-nn/benches/benchmarks/softmax.rs
@@ -7,7 +7,7 @@ use std::hint::black_box;
 use std::time::Instant;
 
 fn run(input: &Tensor) {
-    let _ = softmax_last_dim(&input).unwrap();
+    let _ = softmax_last_dim(input).unwrap();
 }
 
 const B: usize = 1;
@@ -17,7 +17,7 @@ const K: usize = 1024;
 fn run_softmax_benchmark(c: &mut Criterion, device: &Device, dtype: DType, name: &str) {
     let elements = B * M * K;
 
-    let input = Tensor::rand(-1000.0f32, 1000.0f32, (B, M, K), &device)
+    let input = Tensor::rand(-1000.0f32, 1000.0f32, (B, M, K), device)
         .unwrap()
         .to_dtype(dtype)
         .unwrap();


### PR DESCRIPTION
- adds `--benches` to clippy in `rust-ci` CI step
- fixes the few straggling clippy warnings in benches