### PR TITLE
candle-core: add `broadcast_add` benches

### DIFF
--- a/candle-core/benches/bench_main.rs
+++ b/candle-core/benches/bench_main.rs
@@ -4,6 +4,7 @@ use criterion::criterion_main;
 
 criterion_main!(
     benchmarks::affine::benches,
+    benchmarks::broadcast::benches,
     benchmarks::copy::benches,
     benchmarks::conv_transpose2d::benches,
     benchmarks::matmul::benches,

--- a/candle-core/benches/benchmarks/broadcast.rs
+++ b/candle-core/benches/benchmarks/broadcast.rs
@@ -1,0 +1,47 @@
+use crate::benchmarks::{BenchDevice, BenchDeviceHandler};
+use candle_core::{DType, Device, Tensor};
+use criterion::{criterion_group, Criterion, Throughput};
+use std::hint::black_box;
+use std::time::Instant;
+
+fn run(w: &Tensor, bias: &Tensor) {
+    w.broadcast_add(bias).unwrap();
+}
+
+fn run_benchmark(c: &mut Criterion, device: &Device, dtype: DType, name: &str) {
+    // We simulate a candle-nn style conv2d + bias forward pass.
+    let batch_size = 1;
+    let ch = 1;
+    let m = 126;
+    let bias_size = 128;
+
+    let x = Tensor::ones((batch_size, ch, m, m), dtype, device).unwrap();
+    let bias = Tensor::ones((1, bias_size, 1, 1), dtype, device).unwrap();
+
+    let flops = batch_size * ch * m * bias_size * dtype.size_in_bytes();
+
+    let mut group = c.benchmark_group(device.bench_name(name));
+    group.throughput(Throughput::Bytes(flops as u64));
+    group.bench_function("iter", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            for _i in 0..iters {
+                run(black_box(&x), black_box(&bias));
+            }
+            device.sync().unwrap();
+            start.elapsed()
+        })
+    });
+    group.finish();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let handler = BenchDeviceHandler::new().unwrap();
+    for device in handler.devices {
+        run_benchmark(c, &device, DType::F32, "broadcast_add_f32");
+        run_benchmark(c, &device, DType::F16, "broadcast_add_f16");
+        run_benchmark(c, &device, DType::BF16, "broadcast_add_bf16");
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);

--- a/candle-core/benches/benchmarks/mod.rs
+++ b/candle-core/benches/benchmarks/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod affine;
+pub(crate) mod broadcast;
 pub(crate) mod conv_transpose2d;
 pub(crate) mod copy;
 pub(crate) mod matmul;


### PR DESCRIPTION
`broadcast` ops are very slow on cpu. This PR adds a `broadcast_add` bench, based on shapes used in `conv_2d` bench inside `candle-nn`, so we can track our progress wrt strided and any possible broadcast improvements.

Initial numbers on i7-12700h:
```
cpu_broadcast_add_f32/iter
                        time:   [5.1955 ms 5.2146 ms 5.2373 ms]
                        thrpt:  [11.747 MiB/s 11.798 MiB/s 11.842 MiB/s]

cpu_broadcast_add_f16/iter
                        time:   [12.390 ms 12.434 ms 12.485 ms]
                        thrpt:  [2.4639 MiB/s 2.4741 MiB/s 2.4828 MiB/s]

cpu_broadcast_add_bf16/iter
                        time:   [12.242 ms 12.374 ms 12.503 ms]
                        thrpt:  [2.4603 MiB/s 2.4859 MiB/s 2.5128 MiB/s]
```

On RTX A2000 lappy gpu:
```
cuda_broadcast_add_f32/iter
                        time:   [257.60 µs 258.27 µs 259.00 µs]
                        thrpt:  [237.54 MiB/s 238.21 MiB/s 238.83 MiB/s]

cuda_broadcast_add_f16/iter
                        time:   [250.87 µs 251.42 µs 251.98 µs]
                        thrpt:  [122.08 MiB/s 122.35 MiB/s 122.62 MiB/s]

cuda_broadcast_add_bf16/iter
                        time:   [252.33 µs 252.83 µs 253.34 µs]
                        thrpt:  [121.42 MiB/s 121.67 MiB/s 121.91 MiB/s]
```
