### PR TITLE
Add unsafe from_storage apis

### DIFF
--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -2909,8 +2909,8 @@ impl std::ops::Div<&Tensor> for f64 {
     }
 }
 
-impl From<(Storage, Shape)> for Tensor {
-    fn from((storage, shape): (Storage, Shape)) -> Self {
+impl<S: Into<Shape>> From<(Storage, S)> for Tensor {
+    fn from((storage, shape): (Storage, S)) -> Self {
         from_storage(storage, shape, BackpropOp::none(), false)
     }
 }


### PR DESCRIPTION
These APIs are useful for low-level creation of tensors.