### PR TITLE
strided_index: inline next + size_hint + exact size iterator

### DIFF
--- a/candle-core/src/strided_index.rs
+++ b/candle-core/src/strided_index.rs
@@ -8,6 +8,7 @@ pub struct StridedIndex<'a> {
     multi_index: Vec<usize>,
     dims: &'a [usize],
     stride: &'a [usize],
+    remaining: usize,
 }
 
 impl<'a> StridedIndex<'a> {
@@ -24,6 +25,7 @@ impl<'a> StridedIndex<'a> {
             multi_index: vec![0; dims.len()],
             dims,
             stride,
+            remaining: elem_count,
         }
     }
 
@@ -35,6 +37,7 @@ impl<'a> StridedIndex<'a> {
 impl Iterator for StridedIndex<'_> {
     type Item = usize;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let storage_index = self.next_storage_index?;
         let mut updated = false;
@@ -57,12 +60,24 @@ impl Iterator for StridedIndex<'_> {
                 *multi_i = 0
             }
         }
+        self.remaining -= 1;
         self.next_storage_index = if updated {
             Some(next_storage_index)
         } else {
             None
         };
         Some(storage_index)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for StridedIndex<'_> {
+    fn len(&self) -> usize {
+        self.remaining
     }
 }
 


### PR DESCRIPTION
This (1) adds `#[inline]` to `next()` of `StridedIndex`, (2) adds `size_hint` impl, (3) adds `ExactSizeIterator` impl.

It does seem to provide boost for broadcast, while not affecting sqrt, but, hey, it's cpu benchmarks...

Results on i7 12700h between main, this (strided-idx-inline) and #3112 (strided-idx-precompute):

```markdown
# main

cpu_broadcast_add_f32/iter
                        time:   [4.4032 ms 4.4126 ms 4.4237 ms]
                        thrpt:  [13.908 MiB/s 13.943 MiB/s 13.973 MiB/s]

cpu_broadcast_add_f16/iter
                        time:   [10.034 ms 10.068 ms 10.104 ms]
                        thrpt:  [3.0446 MiB/s 3.0555 MiB/s 3.0658 MiB/s]

cpu_broadcast_add_bf16/iter
                        time:   [9.3889 ms 9.4151 ms 9.4510 ms]
                        thrpt:  [3.2548 MiB/s 3.2673 MiB/s 3.2764 MiB/s]

cpu_sqrt_F32/iter       time:   [176.05 µs 176.62 µs 177.20 µs]
                        thrpt:  [22.044 GiB/s 22.117 GiB/s 22.188 GiB/s]

cpu_sqrt_BF16/iter      time:   [326.37 µs 330.20 µs 334.43 µs]
                        thrpt:  [5.8401 GiB/s 5.9149 GiB/s 5.9844 GiB/s]

cpu_sqrt_F16/iter       time:   [6.0293 ms 6.0418 ms 6.0563 ms]
                        thrpt:  [330.24 MiB/s 331.02 MiB/s 331.71 MiB/s]

# strided-idx-inline

cpu_broadcast_add_f32/iter
                        time:   [4.5875 ms 4.5969 ms 4.6075 ms]
                        thrpt:  [13.353 MiB/s 13.384 MiB/s 13.411 MiB/s]

cpu_broadcast_add_f16/iter
                        time:   [7.7496 ms 7.7664 ms 7.7855 ms]
                        thrpt:  [3.9511 MiB/s 3.9609 MiB/s 3.9694 MiB/s]

cpu_broadcast_add_bf16/iter
                        time:   [6.8428 ms 6.8558 ms 6.8692 ms]
                        thrpt:  [4.4782 MiB/s 4.4870 MiB/s 4.4955 MiB/s]

cpu_sqrt_F32/iter       time:   [172.09 µs 172.70 µs 173.39 µs]
                        thrpt:  [22.528 GiB/s 22.619 GiB/s 22.699 GiB/s]

cpu_sqrt_BF16/iter      time:   [322.43 µs 323.27 µs 324.29 µs]
                        thrpt:  [6.0227 GiB/s 6.0417 GiB/s 6.0576 GiB/s]

cpu_sqrt_F16/iter       time:   [6.0414 ms 6.0578 ms 6.0773 ms]
                        thrpt:  [329.09 MiB/s 330.15 MiB/s 331.05 MiB/s]

# strided-idx-precompute

cpu_broadcast_add_f32/iter
                        time:   [3.8942 ms 3.9054 ms 3.9169 ms]
                        thrpt:  [15.707 MiB/s 15.754 MiB/s 15.799 MiB/s]

cpu_broadcast_add_f16/iter
                        time:   [8.3133 ms 8.3239 ms 8.3358 ms]
                        thrpt:  [3.6903 MiB/s 3.6956 MiB/s 3.7003 MiB/s]

cpu_broadcast_add_bf16/iter
                        time:   [8.4013 ms 8.4357 ms 8.4711 ms]
                        thrpt:  [3.6314 MiB/s 3.6466 MiB/s 3.6615 MiB/s]

cpu_sqrt_F32/iter       time:   [178.46 µs 179.04 µs 179.72 µs]
                        thrpt:  [21.736 GiB/s 21.818 GiB/s 21.888 GiB/s]

cpu_sqrt_BF16/iter      time:   [325.30 µs 326.27 µs 327.34 µs]
                        thrpt:  [5.9667 GiB/s 5.9861 GiB/s 6.0041 GiB/s]

cpu_sqrt_F16/iter       time:   [6.0381 ms 6.0511 ms 6.0657 ms]
                        thrpt:  [329.72 MiB/s 330.52 MiB/s 331.23 MiB/s]
```

