### PR TITLE
fix: disable rayon gemm

### DIFF
--- a/candle-core/src/utils.rs
+++ b/candle-core/src/utils.rs
@@ -7,8 +7,8 @@ pub fn get_num_threads() -> usize {
         .ok()
         .and_then(|s| usize::from_str(&s).ok())
     {
-        Some(x) if x > 0 => x,
-        Some(_) | None => num_cpus::get(),
+        Some(x) => x,
+        None => num_cpus::get(),
     }
 }
 


### PR DESCRIPTION
closes #3134. 

when running inference on small models or in constrained environments (e.g. single-core CPU setups). Even with RAYON_NUM_THREADS=1, there remains non-trivial thread management and cache-affinity overhead.

Currently, the `gemm` crate does not allow fully disabling parallelism by passing [`Parallelism::None`](https://docs.rs/gemm/0.18.2/gemm/enum.Parallelism.html) 
Change Summary

This PR introduces a small change to get_num_threads() so setting RAYON_NUM_THREADS=0 now explicitly disables Rayon (single-threaded mode).

Default behavior (using all cores) remains unchanged when the variable is not set.
