### PR TITLE
Fix DINOv2 no-interpolation shortcut

### DIFF
--- a/candle-transformers/src/models/dinov2.rs
+++ b/candle-transformers/src/models/dinov2.rs
@@ -270,7 +270,7 @@ impl DinoVisionTransformer {
         let n = self.pos_embed.dim(1)? - 1;
         let sqrt_n = (n as f64).sqrt();
         if npatch == n && w == h {
-            return Ok(xs.clone());
+            return Ok(self.pos_embed.clone());
         }
         let class_pos_embed = self.pos_embed.i((.., ..1))?;
         let patch_pos_embed = self.pos_embed.i((.., 1..))?;


### PR DESCRIPTION
As described in #2286 by @v-espitalier and confirmed by @zlogic.

Example test:

```bash
cargo run --features metal,depth_anything_v2 --release --package candle-examples --example depth_anything_v2 -- --color-map --image candle-examples/examples/yolo-v8/assets/bike.jpg
```

Before:

![depth_bike_colormap_before](https://github.com/user-attachments/assets/d0c961dd-4593-4153-b36d-7303ca34c901)

After:

![depth_bike_colormap](https://github.com/user-attachments/assets/93d3b2d5-4adc-40ca-84e2-ebffe473d858)
