### PR TITLE
metal: fix a tiny issue in blit usage

### DIFF
--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -38,7 +38,7 @@ impl QMetalStorage {
 
         let buffer = self.device.allocate_buffer(self.buffer.length())?;
         let blit = self.device.blit_command_encoder()?;
-        blie.set_label("blit_to_cpu")?;
+        blit.set_label("blit_to_cpu");
         blit.copy_from_buffer(&self.buffer, 0, &buffer, 0, self.buffer.length());
         blit.end_encoding();
         self.device.wait_until_completed()?;


### PR DESCRIPTION
# Whats changed

There is a small typo as well as general usage error for `blit`. `blie.set_label("blit_to_cpu")?;` should be `blit.set_label("blit_to_cpu");`.

i was installing candle from git to use `qwen3-vl` and this small mistake is preventing me from using it effectively.