### PR TITLE
[Metal] Add macos clippy runner with metal feature flag

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -56,10 +56,20 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy --workspace --tests --examples --benches -- -D warnings
+
+      - name: clippy metal
+        if: runner.os == 'macOS'
+        run: cargo clippy --features=metal --workspace --tests --examples --benches -- -D warnings
+
+      - name: clippy
+        if: runner.os != 'macOS'
+        run: cargo clippy --workspace --tests --examples --benches -- -D warnings


### PR DESCRIPTION
Having CI running with `--features=metal` would be a real QOL improvement for the project.
This PR attempts to enable `cargo clippy --features=metal ...` so that we at least have CI linting on the metal specific code.