### PR TITLE
Hotfix: Bump float8 to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ half = { version = "2.5.0", features = [
     "use-intrinsics",
     "rand_distr",
 ] }
-float8 = { version = "0.4.2", features = [
+float8 = { version = "0.5.0", features = [
     "num-traits",
     "rand_distr",
 ] }


### PR DESCRIPTION
Fixes the build on cuda broken by #3219. See: #3222.