### PR TITLE
Add candle flash attention 3 copyright markers

### DIFF
--- a/candle-flash-attn-v3/build.rs
+++ b/candle-flash-attn-v3/build.rs
@@ -1,4 +1,16 @@
 // build.rs
+
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (c) 2024 Michael Feil
+// adapted from https://github.com/huggingface/candle-flash-attn-v1 , Oliver Dehaene
+// adapted further in 2025 by Eric Buehler for candle repo.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use anyhow::{anyhow, Context, Result};
 use rayon::prelude::*;
 use std::path::PathBuf;

--- a/candle-flash-attn-v3/hkernel/flash_api.cu
+++ b/candle-flash-attn-v3/hkernel/flash_api.cu
@@ -1,3 +1,17 @@
+/* 
+ * Copyright (c) 2024 Michael Feil
+ * originally published at https://github.com/Dao-AILab/flash-attention/tree/main/hopper Tri Dao, BSD-3-Clause License
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+
+ * Authors explaination: Provide a copy of the first two lines in each
+ redistributed version.
+ */
+
 #include "flash_fwd_launch_template.h"
 #include "flash.h"
 #include "static_switch.h"

--- a/candle-flash-attn-v3/src/ffi.rs
+++ b/candle-flash-attn-v3/src/ffi.rs
@@ -1,3 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (c) 2024 Michael Feil
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use core::ffi::{c_int, c_void};
 
 extern "C" {

--- a/candle-flash-attn-v3/src/lib.rs
+++ b/candle-flash-attn-v3/src/lib.rs
@@ -1,3 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (c) 2024 Michael Feil
+//               2025 adjusted by Eric Buehler for candle repo.
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 mod ffi;
 
 use candle::backend::BackendStorage;


### PR DESCRIPTION
Hey, 

I recently tried to publish the my repo `candle-flash-attn-v3` on crates.io. To my surprise, it already existed. 
I am glad that the project at least was published from the huggingface/candle ecosystem, which i appreciate overall. 

Its not super nice that the name got stripped from the repo, so I'd apprechiate adding it back. Thank you! @ivarflakstad