### PR TITLE
Adds onnx ops to support debertav3/piiranha

### DIFF
--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -1021,7 +1021,8 @@ fn simple_eval_(
                 let input = get(&node.input[0])?;
                 // neg() not implemented for i64, work around with multiply by -1
                 let output = if input.dtype() == DType::I64 {
-                    let minus_one = Tensor::new(&[-1i64], input.device())?.broadcast_as(input.shape())?;
+                    let minus_one =
+                        Tensor::new(&[-1i64], input.device())?.broadcast_as(input.shape())?;
                     input.mul(&minus_one)?
                 } else {
                     input.neg()?
@@ -2609,4 +2610,3 @@ fn to_vec0_flexible<T: candle::WithDType>(t: &Tensor) -> Result<T> {
         t.to_vec0::<T>()
     }
 }
-


### PR DESCRIPTION
These are the changes I needed to run the ONNX version of Piiranha, which is debertaV3 based. I've since noticed that the debertaV2 model already in Candle also supports debertaV3, so I'm likely going to switch to using that, but thought the changes may be useful. Let me know if a subset is desired, I can cut it down to a smaller PR.

Adds operations:
- Add
- Or
- Tile
- LessOrEqual
- GreaterOrEqual

Also adds and uses helpers `to_scalar_flexible` and `to_vec0_flexible` that both allow for more broad input definitions that fit what some onnx models export and are still scalar/vec0 but not "true" versions of them because the model didn't squeeze them.