### PR TITLE
fix(candle-kernels): conditionally link stdc++ for non-MSVC targets

### DIFF
--- a/candle-kernels/build.rs
+++ b/candle-kernels/build.rs
@@ -46,7 +46,9 @@ fn main() {
     println!("cargo:rustc-link-search={}", out_dir.display());
     println!("cargo:rustc-link-lib=moe");
     println!("cargo:rustc-link-lib=dylib=cudart");
-    println!("cargo:rustc-link-lib=stdc++");
+    if !is_target_msvc {
+        println!("cargo:rustc-link-lib=stdc++");
+    }
 }
 
 fn remove_lines<P: AsRef<std::path::Path>>(file: P, patterns: &[&str]) {


### PR DESCRIPTION
On Windows with MSVC, linking against stdc++ fails because it is a GNU/GCC library that does not exist in the MSVC toolchain. MSVC uses its own C++ runtime which is linked automatically.

This fix wraps the stdc++ link directive in a target check, matching the existing pattern in candle-flash-attn/build.rs.

Fixes https://github.com/huggingface/candle/issues/3277