### PR TITLE
Fix MoE WMMA kernel on V100

### DIFF
--- a/candle-kernels/src/moe/moe_wmma.cu
+++ b/candle-kernels/src/moe/moe_wmma.cu
@@ -181,6 +181,7 @@ __global__ void moe_gemm_grouped_kernel(
 
             // Accumulate into c_frag (which persists across k_base iterations)
             mma_sync(c_frag, a_frag, b_frag, c_frag);
+            __syncthreads(); // Fix shared memory mismatch on V100
         } // end k_base loop (we have a fully-accumulated c_frag for this m_base tile)
 
         // Store the accumulated c_frag to C_sh (shared) once per warp


### PR DESCRIPTION
This PR fixes potential issue of MoE WMMA kernel on certain hardware (e.g., V100).