### PR TITLE
chore(dep): bump cudarc to 0.18.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ candle-transformers = { path = "./candle-transformers", version = "0.9.2-alpha.2
 candle-ug = { path = "./candle-ug", version = "0.9.2-alpha.2" }
 clap = { version = "4.2.4", features = ["derive"] }
 criterion = { version = "0.7.0", default-features = false }
-cudarc = { version = "0.18.1", features = [
+cudarc = { version = "0.18.2", features = [
     "std",
     "cublas",
     "cublaslt",


### PR DESCRIPTION
This is required to support cuda toolkit version 13.1.