### PR TITLE
Remove `test.onnx` from root directory

### DIFF
--- a/test.onnx
+++ b/test.onnx
@@ -1,12 +1,0 @@
-backend-test:J
-
-xytest"Relu
-SingleReluZ
-x
-
-
-b
-y
-
-
-B


### PR DESCRIPTION
## Description

This PR removes the `test.onnx` file from the root directory of this repository, given that it's apparently not used anywhere and most likely uploaded by mistake as per https://github.com/huggingface/candle/pull/1260 (?)

cc @ivarflakstad to confirm