### PR TITLE
Fix: main failing Rust 1.93 clippy CI

### DIFF
--- a/candle-transformers/src/models/glm4_new.rs
+++ b/candle-transformers/src/models/glm4_new.rs
@@ -39,8 +39,8 @@ impl RotaryEmbedding {
         let dim = cfg
             .head_dim
             .unwrap_or(cfg.hidden_size / cfg.num_attention_heads);
-        let rotary_dim = if cfg.partial_rotary_factor.is_some() {
-            (cfg.partial_rotary_factor.unwrap() * dim as f32) as usize
+        let rotary_dim = if let Some(factor) = cfg.partial_rotary_factor {
+            (factor * dim as f32) as usize
         } else {
             dim
         };

--- a/candle-transformers/src/models/quantized_glm4.rs
+++ b/candle-transformers/src/models/quantized_glm4.rs
@@ -215,20 +215,21 @@ impl AttentionWeights {
         let q = self.q_proj.forward(x)?;
         let k = self.k_proj.forward(x)?;
         let v = self.v_proj.forward(x)?;
-        let q = if self.attention_bq.is_some() {
-            q.broadcast_add(self.attention_bq.as_ref().unwrap())?
+
+        let q = if let Some(bq) = &self.attention_bq {
+            q.broadcast_add(bq)?
         } else {
             q
         };
 
-        let k = if self.attention_bk.is_some() {
-            k.broadcast_add(self.attention_bk.as_ref().unwrap())?
+        let k = if let Some(bk) = &self.attention_bk {
+            k.broadcast_add(bk)?
         } else {
             k
         };
 
-        let v = if self.attention_bv.is_some() {
-            v.broadcast_add(self.attention_bv.as_ref().unwrap())?
+        let v = if let Some(bv) = &self.attention_bv {
+            v.broadcast_add(bv)?
         } else {
             v
         };

--- a/candle-transformers/src/models/quantized_qwen3_moe.rs
+++ b/candle-transformers/src/models/quantized_qwen3_moe.rs
@@ -134,20 +134,20 @@ impl QuantizedAttention {
         let k = self.attention_wk.forward(x)?;
         let v = self.attention_wv.forward(x)?;
 
-        let q = if self.attention_bq.is_some() {
-            q.broadcast_add(self.attention_bq.as_ref().unwrap())?
+        let q = if let Some(bq) = &self.attention_bq {
+            q.broadcast_add(bq)?
         } else {
             q
         };
 
-        let k = if self.attention_bk.is_some() {
-            k.broadcast_add(self.attention_bk.as_ref().unwrap())?
+        let k = if let Some(bk) = &self.attention_bk {
+            k.broadcast_add(bk)?
         } else {
             k
         };
 
-        let v = if self.attention_bv.is_some() {
-            v.broadcast_add(self.attention_bv.as_ref().unwrap())?
+        let v = if let Some(bv) = &self.attention_bv {
+            v.broadcast_add(bv)?
         } else {
             v
         };


### PR DESCRIPTION
Rust 1.93 added `clippy::unnecessary_unwrap` which flags `is_some()` followed by `unwrap()`. 

Replaced with `if let Some(...)` patterns in:
- deepseek2.rs
- glm4_new.rs
- quantized_glm4.rs
- quantized_qwen3_moe.rs