### PR TITLE
Add mimi encoder-only variant

### DIFF
--- a/candle-transformers/src/models/mimi/mod.rs
+++ b/candle-transformers/src/models/mimi/mod.rs
@@ -42,4 +42,4 @@ pub enum NormType {
     LayerNorm,
 }
 
-pub use encodec::{load, Config, Encodec as Model};
+pub use encodec::{load, load_encoder_only, Config, Encodec as Model, EncoderOnly};


### PR DESCRIPTION
# Add mimi encoder-only variant

- Add `EncoderOnly` struct to the mimi module that contains only encoder components (SeaNet encoder, transformer, downsampler, quantizer)
- Add `load_encoder_only()` convenience function for loading encoder-only weights
- Export new types from `mod.rs`

This enables loading Mimi encoder weights without requiring decoder weights, which is necessary for models like Qwen3-TTS that only distribute encoder weights for their speech tokenizer.

### Use Cases

- Qwen3-TTS speech tokenizer (encodes reference audio for voice cloning)
- Any audio model that needs encoding without decoding
- Reduced memory footprint when only encoding is needed