### PR TITLE
Replace unmaintained gemm with qlora-gemm fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ cudarc = { version = "0.19.0", features = [
     "dynamic-linking",
 ], default-features = false }
 fancy-regex = "0.17.0"
-gemm = { version = "0.19.0", features = ["wasm-simd128-enable"] }
+qlora-gemm = { version = "0.20.0", features = ["wasm-simd128-enable"] }
 hf-hub = "0.4.1"
 half = { version = "2.5.0", features = [
     "num-traits",

--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -17,7 +17,7 @@ candle-metal-kernels = { workspace = true, optional = true }
 objc2-metal = { workspace = true, optional = true }
 objc2-foundation = { workspace = true, optional = true }
 cudarc = { workspace = true, optional = true }
-gemm = { workspace = true }
+qlora-gemm = { workspace = true }
 half = { workspace = true }
 float8 = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }

--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -1362,7 +1362,7 @@ impl Map2 for MatMul {
         rhs: &[T],
         rhs_l: &Layout,
     ) -> Result<Vec<T>> {
-        use gemm::{gemm, Parallelism};
+        use qlora_gemm::{gemm, Parallelism};
 
         match T::DTYPE {
             DType::F16 | DType::F32 | DType::F64 => {}


### PR DESCRIPTION
## Summary

This PR replaces the `gemm` crate dependency with `qlora-gemm`, a maintained fork.

### Problem

The `gemm` crate depends on the `paste` crate, which is unmaintained:
- No releases since 2023
- No active maintainer responding to issues
- Compatibility issues with newer Rust versions

### Solution

Switch to `qlora-gemm` v0.20.0, a maintained fork that:
- Uses `qlora-paste` (maintained `paste` fork) instead of unmaintained `paste`
- Maintains full API compatibility with `gemm` v0.19.x
- Published to crates.io: https://crates.io/crates/qlora-gemm

### Changes

- `Cargo.toml`: `gemm = "0.19.0"` -> `qlora-gemm = "0.20.0"`
- `candle-core/Cargo.toml`: `gemm` -> `qlora-gemm`
- `candle-core/src/cpu_backend/mod.rs`: `use gemm` -> `use qlora_gemm`

### Testing

- All existing tests pass
- API is 1:1 compatible, no functional changes