### PR TITLE
feat: add inverse trigonometric functions (asin, acos, atan)

### DIFF
--- a/candle-core/src/accelerate.rs
+++ b/candle-core/src/accelerate.rs
@@ -52,6 +52,12 @@ mod ffi {
         pub fn vvlog(dst: *mut c_double, src: *const c_double, len: *const c_int);
         pub fn vvtanhf(dst: *mut c_float, src: *const c_float, len: *const c_int);
         pub fn vvtanh(dst: *mut c_double, src: *const c_double, len: *const c_int);
+        pub fn vvasinf(dst: *mut c_float, src: *const c_float, len: *const c_int);
+        pub fn vvasin(dst: *mut c_double, src: *const c_double, len: *const c_int);
+        pub fn vvacosf(dst: *mut c_float, src: *const c_float, len: *const c_int);
+        pub fn vvacos(dst: *mut c_double, src: *const c_double, len: *const c_int);
+        pub fn vvatanf(dst: *mut c_float, src: *const c_float, len: *const c_int);
+        pub fn vvatan(dst: *mut c_double, src: *const c_double, len: *const c_int);
 
         pub fn vDSP_vaddD(
             _: *const c_double,
@@ -462,6 +468,66 @@ macro_rules! binary_op {
         }
     };
 }
+#[inline]
+pub fn vs_asin(a: &[f32], y: &mut [f32]) {
+    let a_len = a.len();
+    let y_len = y.len();
+    if a_len != y_len {
+        panic!("a and y have different lengths {a_len} <> {y_len}")
+    }
+    unsafe { ffi::vvasinf(y.as_mut_ptr(), a.as_ptr(), &(a_len as i32)) }
+}
+
+#[inline]
+pub fn vd_asin(a: &[f64], y: &mut [f64]) {
+    let a_len = a.len();
+    let y_len = y.len();
+    if a_len != y_len {
+        panic!("a and y have different lengths {a_len} <> {y_len}")
+    }
+    unsafe { ffi::vvasin(y.as_mut_ptr(), a.as_ptr(), &(a_len as i32)) }
+}
+
+#[inline]
+pub fn vs_acos(a: &[f32], y: &mut [f32]) {
+    let a_len = a.len();
+    let y_len = y.len();
+    if a_len != y_len {
+        panic!("a and y have different lengths {a_len} <> {y_len}")
+    }
+    unsafe { ffi::vvacosf(y.as_mut_ptr(), a.as_ptr(), &(a_len as i32)) }
+}
+
+#[inline]
+pub fn vd_acos(a: &[f64], y: &mut [f64]) {
+    let a_len = a.len();
+    let y_len = y.len();
+    if a_len != y_len {
+        panic!("a and y have different lengths {a_len} <> {y_len}")
+    }
+    unsafe { ffi::vvacos(y.as_mut_ptr(), a.as_ptr(), &(a_len as i32)) }
+}
+
+#[inline]
+pub fn vs_atan(a: &[f32], y: &mut [f32]) {
+    let a_len = a.len();
+    let y_len = y.len();
+    if a_len != y_len {
+        panic!("a and y have different lengths {a_len} <> {y_len}")
+    }
+    unsafe { ffi::vvatanf(y.as_mut_ptr(), a.as_ptr(), &(a_len as i32)) }
+}
+
+#[inline]
+pub fn vd_atan(a: &[f64], y: &mut [f64]) {
+    let a_len = a.len();
+    let y_len = y.len();
+    if a_len != y_len {
+        panic!("a and y have different lengths {a_len} <> {y_len}")
+    }
+    unsafe { ffi::vvatan(y.as_mut_ptr(), a.as_ptr(), &(a_len as i32)) }
+}
+
 binary_op!(vs_add, f32, vDSP_vadd);
 binary_op!(vd_add, f64, vDSP_vaddD);
 binary_op!(vs_sub, f32, vDSP_vsub);

--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -543,6 +543,24 @@ impl Tensor {
                         let sum_grad = grads.or_insert(arg)?;
                         *sum_grad = sum_grad.sub(&(&grad * arg.sin())?)?
                     }
+                    Op::Unary(arg, UnaryOp::Asin) => {
+                        // d/dx asin(x) = 1/sqrt(1-x^2)
+                        let sum_grad = grads.or_insert(arg)?;
+                        let asin_grad = (arg.sqr()?.neg()? + 1.)?.sqrt()?.recip()?;
+                        *sum_grad = sum_grad.add(&(&grad * asin_grad)?)?
+                    }
+                    Op::Unary(arg, UnaryOp::Acos) => {
+                        // d/dx acos(x) = -1/sqrt(1-x^2)
+                        let sum_grad = grads.or_insert(arg)?;
+                        let acos_grad = (arg.sqr()?.neg()? + 1.)?.sqrt()?.recip()?.neg()?;
+                        *sum_grad = sum_grad.add(&(&grad * acos_grad)?)?
+                    }
+                    Op::Unary(arg, UnaryOp::Atan) => {
+                        // d/dx atan(x) = 1/(1+x^2)
+                        let sum_grad = grads.or_insert(arg)?;
+                        let atan_grad = (arg.sqr()? + 1.)?.recip()?;
+                        *sum_grad = sum_grad.add(&(&grad * atan_grad)?)?
+                    }
                     Op::Unary(arg, UnaryOp::Tanh) => {
                         let sum_grad = grads.or_insert(arg)?;
                         let minus_dtanh = (node.sqr()? - 1.)?;

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -715,6 +715,15 @@ impl BackendStorage for MetalStorage {
                 ("usign", DType::F32) => contiguous::sign::FLOAT,
                 ("usign", DType::BF16) => contiguous::sign::BFLOAT,
                 ("usign", DType::I64) => contiguous::sign::I64,
+                ("uasin", DType::F16) => contiguous::asin::HALF,
+                ("uasin", DType::F32) => contiguous::asin::FLOAT,
+                ("uasin", DType::BF16) => contiguous::asin::BFLOAT,
+                ("uacos", DType::F16) => contiguous::acos::HALF,
+                ("uacos", DType::F32) => contiguous::acos::FLOAT,
+                ("uacos", DType::BF16) => contiguous::acos::BFLOAT,
+                ("uatan", DType::F16) => contiguous::atan::HALF,
+                ("uatan", DType::F32) => contiguous::atan::FLOAT,
+                ("uatan", DType::BF16) => contiguous::atan::BFLOAT,
                 (name, dtype) => {
                     crate::bail!("Metal contiguous unary {name} {dtype:?} not implemented")
                 }
@@ -787,6 +796,16 @@ impl BackendStorage for MetalStorage {
                 ("urelu", DType::BF16) => strided::relu::BFLOAT,
                 ("uround", DType::BF16) => strided::round::BFLOAT,
                 ("utanh", DType::BF16) => strided::tanh::BFLOAT,
+
+                ("uasin", DType::F32) => strided::asin::FLOAT,
+                ("uasin", DType::F16) => strided::asin::HALF,
+                ("uasin", DType::BF16) => strided::asin::BFLOAT,
+                ("uacos", DType::F32) => strided::acos::FLOAT,
+                ("uacos", DType::F16) => strided::acos::HALF,
+                ("uacos", DType::BF16) => strided::acos::BFLOAT,
+                ("uatan", DType::F32) => strided::atan::FLOAT,
+                ("uatan", DType::F16) => strided::atan::HALF,
+                ("uatan", DType::BF16) => strided::atan::BFLOAT,
 
                 (name, dtype) => {
                     crate::bail!("Metal strided unary {name} {dtype:?} not implemented")

--- a/candle-core/src/mkl.rs
+++ b/candle-core/src/mkl.rs
@@ -16,6 +16,12 @@ mod ffi {
         pub fn vdCos(n: c_int, a: *const c_double, y: *mut c_double);
         pub fn vsSqrt(n: c_int, a: *const c_float, y: *mut c_float);
         pub fn vdSqrt(n: c_int, a: *const c_double, y: *mut c_double);
+        pub fn vsAsin(n: c_int, a: *const c_float, y: *mut c_float);
+        pub fn vdAsin(n: c_int, a: *const c_double, y: *mut c_double);
+        pub fn vsAcos(n: c_int, a: *const c_float, y: *mut c_float);
+        pub fn vdAcos(n: c_int, a: *const c_double, y: *mut c_double);
+        pub fn vsAtan(n: c_int, a: *const c_float, y: *mut c_float);
+        pub fn vdAtan(n: c_int, a: *const c_double, y: *mut c_double);
 
         pub fn vsAdd(n: c_int, a: *const c_float, b: *const c_float, y: *mut c_float);
         pub fn vdAdd(n: c_int, a: *const c_double, b: *const c_double, y: *mut c_double);
@@ -404,6 +410,66 @@ macro_rules! binary_op {
         }
     };
 }
+#[inline]
+pub fn vs_asin(a: &[f32], y: &mut [f32]) {
+    let a_len = a.len();
+    let y_len = y.len();
+    if a_len != y_len {
+        panic!("a and y have different lengths {a_len} <> {y_len}")
+    }
+    unsafe { ffi::vsAsin(a_len as i32, a.as_ptr(), y.as_mut_ptr()) }
+}
+
+#[inline]
+pub fn vd_asin(a: &[f64], y: &mut [f64]) {
+    let a_len = a.len();
+    let y_len = y.len();
+    if a_len != y_len {
+        panic!("a and y have different lengths {a_len} <> {y_len}")
+    }
+    unsafe { ffi::vdAsin(a_len as i32, a.as_ptr(), y.as_mut_ptr()) }
+}
+
+#[inline]
+pub fn vs_acos(a: &[f32], y: &mut [f32]) {
+    let a_len = a.len();
+    let y_len = y.len();
+    if a_len != y_len {
+        panic!("a and y have different lengths {a_len} <> {y_len}")
+    }
+    unsafe { ffi::vsAcos(a_len as i32, a.as_ptr(), y.as_mut_ptr()) }
+}
+
+#[inline]
+pub fn vd_acos(a: &[f64], y: &mut [f64]) {
+    let a_len = a.len();
+    let y_len = y.len();
+    if a_len != y_len {
+        panic!("a and y have different lengths {a_len} <> {y_len}")
+    }
+    unsafe { ffi::vdAcos(a_len as i32, a.as_ptr(), y.as_mut_ptr()) }
+}
+
+#[inline]
+pub fn vs_atan(a: &[f32], y: &mut [f32]) {
+    let a_len = a.len();
+    let y_len = y.len();
+    if a_len != y_len {
+        panic!("a and y have different lengths {a_len} <> {y_len}")
+    }
+    unsafe { ffi::vsAtan(a_len as i32, a.as_ptr(), y.as_mut_ptr()) }
+}
+
+#[inline]
+pub fn vd_atan(a: &[f64], y: &mut [f64]) {
+    let a_len = a.len();
+    let y_len = y.len();
+    if a_len != y_len {
+        panic!("a and y have different lengths {a_len} <> {y_len}")
+    }
+    unsafe { ffi::vdAtan(a_len as i32, a.as_ptr(), y.as_mut_ptr()) }
+}
+
 binary_op!(vs_add, f32, vsAdd);
 binary_op!(vd_add, f64, vdAdd);
 binary_op!(vs_sub, f32, vsSub);

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -55,6 +55,10 @@ pub enum UnaryOp {
     Log,
     Sin,
     Cos,
+    Tanh,
+    Asin,
+    Acos,
+    Atan,
     Abs,
     Neg,
     Recip,
@@ -65,7 +69,6 @@ pub enum UnaryOp {
     Erf,
     Relu,
     Silu,
-    Tanh,
     Floor,
     Ceil,
     Round,
@@ -257,6 +260,10 @@ pub struct Exp;
 pub struct Log;
 pub struct Sin;
 pub struct Cos;
+pub struct Tanh;
+pub struct Asin;
+pub struct Acos;
+pub struct Atan;
 pub struct Abs;
 pub struct Neg;
 pub struct Recip;
@@ -267,7 +274,6 @@ pub struct GeluErf;
 pub struct Erf;
 pub struct Relu;
 pub struct Silu;
-pub struct Tanh;
 pub struct Floor;
 pub struct Ceil;
 pub struct Round;
@@ -506,6 +512,9 @@ unary_op!(Log, "log", v, v.ln(), vs_ln, vd_ln);
 unary_op!(Sin, "sin", v, v.sin(), vs_sin, vd_sin);
 unary_op!(Cos, "cos", v, v.cos(), vs_cos, vd_cos);
 unary_op!(Tanh, "tanh", v, v.tanh(), vs_tanh, vd_tanh);
+unary_op!(Asin, "asin", v, v.asin(), vs_asin, vd_asin);
+unary_op!(Acos, "acos", v, v.acos(), vs_acos, vd_acos);
+unary_op!(Atan, "atan", v, v.atan(), vs_atan, vd_atan);
 unary_op!(Neg, "neg", v, -v);
 unary_op!(Recip, "recip", v, v.recip());
 unary_op!(Sqr, "sqr", v, v * v, vs_sqr, vd_sqr);

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -635,6 +635,9 @@ impl Tensor {
     unary_op!(sin, Sin);
     unary_op!(cos, Cos);
     unary_op!(tanh, Tanh);
+    unary_op!(asin, Asin);
+    unary_op!(acos, Acos);
+    unary_op!(atan, Atan);
     unary_op!(abs, Abs);
     unary_op!(sqr, Sqr);
     unary_op!(sqrt, Sqrt);

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -285,6 +285,68 @@ fn unary_grad(device: &Device) -> Result<()> {
         [1.0881, 0.9277, 1.0527, 0.5747],
     );
 
+    // Testing inverse trig functions
+    // Using values in [-1, 1] for asin and acos
+    //
+    // import torch
+    // x = torch.tensor([0.5, -0.5, 0.9, 0.0], requires_grad=True)
+    // y = x.asin()
+    // print(y)
+    // loss = y.sum()
+    // loss.backward()
+    // print(x.grad)
+    let trig_x = Var::new(&[0.5f32, -0.5, 0.9, 0.0], device)?;
+    let y = trig_x.asin()?;
+    let grads = y.backward()?;
+    let grad_x = grads.get(&trig_x).context("no grad for x")?;
+    assert_eq!(
+        test_utils::to_vec1_round(&y, 4)?,
+        [0.5236, -0.5236, 1.1198, 0.0]
+    );
+    assert_eq!(
+        test_utils::to_vec1_round(grad_x, 4)?,
+        [1.1547, 1.1547, 2.2942, 1.0],
+    );
+
+    // import torch
+    // x = torch.tensor([0.5, -0.5, 0.9, 0.0], requires_grad=True)
+    // y = x.acos()
+    // print(y)
+    // loss = y.sum()
+    // loss.backward()
+    // print(x.grad)
+    let y = trig_x.acos()?;
+    let grads = y.backward()?;
+    let grad_x = grads.get(&trig_x).context("no grad for x")?;
+    assert_eq!(
+        test_utils::to_vec1_round(&y, 4)?,
+        [1.0472, 2.0944, 0.4510, 1.5708]
+    );
+    assert_eq!(
+        test_utils::to_vec1_round(grad_x, 4)?,
+        [-1.1547, -1.1547, -2.2942, -1.0],
+    );
+
+    // import torch
+    // x = torch.tensor([0.5, -0.5, 2.0, 0.0], requires_grad=True)
+    // y = x.atan()
+    // print(y)
+    // loss = y.sum()
+    // loss.backward()
+    // print(x.grad)
+    let atan_x = Var::new(&[0.5f32, -0.5, 2.0, 0.0], device)?;
+    let y = atan_x.atan()?;
+    let grads = y.backward()?;
+    let grad_x = grads.get(&atan_x).context("no grad for x")?;
+    assert_eq!(
+        test_utils::to_vec1_round(&y, 4)?,
+        [0.4636, -0.4636, 1.1071, 0.0]
+    );
+    assert_eq!(
+        test_utils::to_vec1_round(grad_x, 4)?,
+        [0.8, 0.8, 0.2, 1.0],
+    );
+
     if device.is_cpu() {
         let x = Var::new(&[[[1f32, 2., 3.], [4., 5., 6.], [7., 8., 9.]]], device)?;
         let y = x.interpolate1d(12)?.reshape(36)?;

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -315,6 +315,22 @@ fn unary_op(device: &Device) -> Result<()> {
         test_utils::to_vec1_round(&y, 4)?,
         [-1.2642, -1.7293, 0.0000, 3.0000]
     );
+
+    // Test inverse trig functions (asin, acos, atan)
+    let trig_tensor = Tensor::new(&[0.0f32, 0.5, -0.5, 0.9, -0.9], device)?;
+    assert_eq!(
+        test_utils::to_vec1_round(&trig_tensor.asin()?, 4)?,
+        [0.0, 0.5236, -0.5236, 1.1198, -1.1198]
+    );
+    assert_eq!(
+        test_utils::to_vec1_round(&trig_tensor.acos()?, 4)?,
+        [1.5708, 1.0472, 2.0944, 0.451, 2.6906]
+    );
+    let atan_tensor = Tensor::new(&[0.0f32, 1.0, -1.0, 2.0, -2.0], device)?;
+    assert_eq!(
+        test_utils::to_vec1_round(&atan_tensor.atan()?, 4)?,
+        [0.0, 0.7854, -0.7854, 1.1071, -1.1071]
+    );
     Ok(())
 }
 

--- a/candle-kernels/src/cuda_utils.cuh
+++ b/candle-kernels/src/cuda_utils.cuh
@@ -151,6 +151,12 @@ __device__ __forceinline__ float absg(float a) { return fabsf(a); }
 __device__ __forceinline__ double absg(double a) { return fabs(a); }
 __device__ __forceinline__ float copysigng(float a, float b) { return copysignf(a, b); }
 __device__ __forceinline__ double copysigng(double a, double b) { return copysign(a, b); }
+__device__ __forceinline__ float asing(float a) { return asinf(a); }
+__device__ __forceinline__ double asing(double a) { return asin(a); }
+__device__ __forceinline__ float acosg(float a) { return acosf(a); }
+__device__ __forceinline__ double acosg(double a) { return acos(a); }
+__device__ __forceinline__ float atang(float a) { return atanf(a); }
+__device__ __forceinline__ double atang(double a) { return atan(a); }
 
 __device__ __forceinline__ int64_t ming(int64_t a, int64_t b) { return min(a, b); }
 __device__ __forceinline__ int64_t maxg(int64_t a, int64_t b) { return max(a, b); }
@@ -177,6 +183,9 @@ __device__ __forceinline__ __half logg(__half a) { return hlog(a); }
 __device__ __forceinline__ __half expg(__half a) { return hexp(a); }
 __device__ __forceinline__ __half absg(__half a) { return __habs(a); }
 __device__ __forceinline__ __half copysigng(__half a, __half b) { return __float2half(copysignf(__half2float(a), __half2float(b))); }
+__device__ __forceinline__ __half asing(__half a) { return __float2half(asinf(__half2float(a))); }
+__device__ __forceinline__ __half acosg(__half a) { return __float2half(acosf(__half2float(a))); }
+__device__ __forceinline__ __half atang(__half a) { return __float2half(atanf(__half2float(a))); }
 #endif
 
 #if __CUDA_ARCH__ >= 800
@@ -198,6 +207,9 @@ __device__ __forceinline__ __nv_bfloat16 logg(__nv_bfloat16 a) { return hlog(a);
 __device__ __forceinline__ __nv_bfloat16 expg(__nv_bfloat16 a) { return hexp(a); }
 __device__ __forceinline__ __nv_bfloat16 absg(__nv_bfloat16 a) { return __habs(a); }
 __device__ __forceinline__ __nv_bfloat16 copysigng(__nv_bfloat16 a, __nv_bfloat16 b) { return __float2bfloat16(copysignf(__bfloat162float(a), __bfloat162float(b))); }
+__device__ __forceinline__ __nv_bfloat16 asing(__nv_bfloat16 a) { return __float2bfloat16(asinf(__bfloat162float(a))); }
+__device__ __forceinline__ __nv_bfloat16 acosg(__nv_bfloat16 a) { return __float2bfloat16(acosf(__bfloat162float(a))); }
+__device__ __forceinline__ __nv_bfloat16 atang(__nv_bfloat16 a) { return __float2bfloat16(atanf(__bfloat162float(a))); }
 
 #define F8E4M3_TO_FLOAT(x) __half2float(__nv_cvt_fp8_to_halfraw(x.__x, __NV_E4M3))
 
@@ -219,6 +231,9 @@ __device__ __forceinline__ __nv_fp8_e4m3 logg(__nv_fp8_e4m3 a) { return __nv_fp8
 __device__ __forceinline__ __nv_fp8_e4m3 expg(__nv_fp8_e4m3 a) { return __nv_fp8_e4m3(expf(F8E4M3_TO_FLOAT(a))); }
 __device__ __forceinline__ __nv_fp8_e4m3 absg(__nv_fp8_e4m3 a) { return __nv_fp8_e4m3(fabsf(F8E4M3_TO_FLOAT(a))); }
 __device__ __forceinline__ __nv_fp8_e4m3 copysigng(__nv_fp8_e4m3 a, __nv_fp8_e4m3 b) { return __nv_fp8_e4m3(copysignf(F8E4M3_TO_FLOAT(a), F8E4M3_TO_FLOAT(b))); }
+__device__ __forceinline__ __nv_fp8_e4m3 asing(__nv_fp8_e4m3 a) { return __nv_fp8_e4m3(asinf(F8E4M3_TO_FLOAT(a))); }
+__device__ __forceinline__ __nv_fp8_e4m3 acosg(__nv_fp8_e4m3 a) { return __nv_fp8_e4m3(acosf(F8E4M3_TO_FLOAT(a))); }
+__device__ __forceinline__ __nv_fp8_e4m3 atang(__nv_fp8_e4m3 a) { return __nv_fp8_e4m3(atanf(F8E4M3_TO_FLOAT(a))); }
 
 
 #endif

--- a/candle-kernels/src/unary.cu
+++ b/candle-kernels/src/unary.cu
@@ -122,6 +122,9 @@ UNARY_OP(__nv_bfloat16, usilu_bf16, silu_fwd(x))
 UNARY_OP1(__nv_bfloat16, upowf_bf16, powg(x, param))
 UNARY_OP(__nv_bfloat16, usign_bf16, sign_(x))
 UNARY_OP(__nv_bfloat16, usigmoid_bf16, sigmoid_fwd(x))
+UNARY_OP(__nv_bfloat16, uasin_bf16, asing(x))
+UNARY_OP(__nv_bfloat16, uacos_bf16, acosg(x))
+UNARY_OP(__nv_bfloat16, uatan_bf16, atang(x))
 #endif
 
 #if __CUDA_ARCH__ >= 890
@@ -151,6 +154,9 @@ UNARY_OP(__nv_fp8_e4m3, usilu_fp8_e4m3, __nv_fp8_e4m3(silu_fwd(F8E4M3_TO_FLOAT(x
 UNARY_OP1(__nv_fp8_e4m3, upowf_fp8_e4m3, powg(x, param))
 UNARY_OP(__nv_fp8_e4m3, usign_fp8_e4m3, __nv_fp8_e4m3(sign_(F8E4M3_TO_FLOAT(x))))
 UNARY_OP(__nv_fp8_e4m3, usigmoid_fp8_e4m3, __nv_fp8_e4m3(sigmoid_fwd(F8E4M3_TO_FLOAT(x))))
+UNARY_OP(__nv_fp8_e4m3, uasin_fp8_e4m3, asing(x))
+UNARY_OP(__nv_fp8_e4m3, uacos_fp8_e4m3, acosg(x))
+UNARY_OP(__nv_fp8_e4m3, uatan_fp8_e4m3, atang(x))
 #endif
 
 #if __CUDA_ARCH__ >= 530
@@ -178,6 +184,9 @@ UNARY_OP(__half, usilu_f16, silu_fwd(x))
 UNARY_OP1(__half, upowf_f16, powg(x, param))
 UNARY_OP(__half, usign_f16, sign_(x))
 UNARY_OP(__half, usigmoid_f16, sigmoid_fwd(x))
+UNARY_OP(__half, uasin_f16, asing(x))
+UNARY_OP(__half, uacos_f16, acosg(x))
+UNARY_OP(__half, uatan_f16, atang(x))
 #endif
 
 UNARY_OP(uint8_t, ucopy_u8, x)
@@ -231,3 +240,9 @@ UNARY_OP(float, usign_f32, sign_(x))
 UNARY_OP(double, usign_f64, sign_(x))
 UNARY_OP(float, usigmoid_f32, sigmoid_fwd(x))
 UNARY_OP(double, usigmoid_f64, sigmoid_fwd(x))
+UNARY_OP(float, uasin_f32, asing(x))
+UNARY_OP(double, uasin_f64, asing(x))
+UNARY_OP(float, uacos_f32, acosg(x))
+UNARY_OP(double, uacos_f64, acosg(x))
+UNARY_OP(float, uatan_f32, atang(x))
+UNARY_OP(double, uatan_f64, atang(x))

--- a/candle-metal-kernels/src/kernels/unary.rs
+++ b/candle-metal-kernels/src/kernels/unary.rs
@@ -9,7 +9,7 @@ use objc2_metal::{MTLResourceUsage, MTLSize};
 
 ops!(
     cos, sin, exp, sqr, sqrt, neg, log, gelu, abs, ceil, floor, relu, round, erf, gelu_erf, tanh,
-    recip, silu, sign, sigmoid, const_set
+    recip, silu, sign, sigmoid, asin, acos, atan, const_set
 );
 
 #[allow(clippy::too_many_arguments)]

--- a/candle-metal-kernels/src/metal_src/unary.metal
+++ b/candle-metal-kernels/src/metal_src/unary.metal
@@ -197,6 +197,9 @@ define_unary_op(usigmoid, sigmoid(x));
 // tanh may create NaN on large values, e.g. 45 rather than outputting 1.
 // This has been an issue for the encodec example.
 define_unary_op(utanh, precise::tanh(x));
+define_unary_op(uasin, asin(x));
+define_unary_op(uacos, acos(x));
+define_unary_op(uatan, atan(x));
 
 // Macros to help initialize kernels
 #define init_kernel(name, func, ...) \
@@ -246,6 +249,9 @@ init_unary_float(erf, uerf);
 init_unary_float(sign, usign);
 init_unary_float(sigmoid, usigmoid);
 init_unary_float(tanh, utanh);
+init_unary_float(asin, uasin);
+init_unary_float(acos, uacos);
+init_unary_float(atan, uatan);
 
 // Initialize copy2d kernels
 init_copy2d(f32, float);


### PR DESCRIPTION
## Summary

Adds `asin`, `acos`, and `atan` with full autodiff support across all backends.

## Changes

| Layer | Files |
|-------|-------|
| Core API | `tensor.rs`, `op.rs` |
| Autodiff | `backprop.rs` |
| CPU | `mkl.rs`, `accelerate.rs` |
| CUDA | `cuda_utils.cuh`, `unary.cu` |
| Metal | `unary.metal`, `unary.rs`, `metal_backend/mod.rs` |
| Tests | `tensor_tests.rs`, `grad_tests.rs` |

## Backend Coverage

| Backend | f32 | f64 | f16 | bf16 | fp8 |
|---------|-----|-----|-----|------|-----|
| CPU | ✓ | ✓ | ✓ | ✓ | ✓ |
| CUDA | ✓ | ✓ | ✓ | ✓ | ✓ |
| Metal | ✓ | — | ✓ | ✓ | — |
| MKL | ✓ | ✓ | — | — | — |
| Accelerate | ✓ | ✓ | — | — | — |

## Gradients

```
d/dx asin(x) = 1/√(1-x²)
d/dx acos(x) = -1/√(1-x²)  
d/dx atan(x) = 1/(1+x²)
```

Test values validated against PyTorch.

## Usage

```rust
let t = Tensor::new(&[0.0f32, 0.5, -0.5], &Device::Cpu)?;
let asin = t.asin()?;  // [0.0, 0.5236, -0.5236]
let acos = t.acos()?;  // [1.5708, 1.0472, 2.0944]
let atan = t.atan()?;  // [0.0, 0.4636, -0.4636]
```

Closes #3270