### PR TITLE
fix(qwen): correct local weight path joining

### DIFF
--- a/candle-examples/examples/qwen/main.rs
+++ b/candle-examples/examples/qwen/main.rs
@@ -308,7 +308,7 @@ fn main() -> Result<()> {
             {
                 candle_examples::hub_load_local_safetensors(path, "model.safetensors.index.json")?
             } else {
-                vec!["model.safetensors".into()]
+                vec![std::path::Path::new(&path).join("model.safetensors")]
             }
         }
         None => match args.model {


### PR DESCRIPTION
### Problem
The qwen example fails when using a local --weight-path due to incorrect path joining.

### Solution
Fix path resolution so local weight paths work correctly.

### Impact
- Fixes runtime error in qwen example
- No breaking changes
