### PR TITLE
fix: bf16 and f16 dtypes

### DIFF
--- a/candle-examples/examples/paddleocr-vl/README.md
+++ b/candle-examples/examples/paddleocr-vl/README.md
@@ -28,7 +28,7 @@ maintaining fast inference speeds.
 | `--revision` | Model revision | `main` |
 | `--max-length` | Maximum generation length | `1024` |
 | `--cpu` | Run on CPU | `false` |
-| `--bf16` | Use bfloat16 precision | `false` |
+| `--dtype` | Model precision: `f32`, `f16`, or `bf16` | `bf16` |
 | `--seed` | Random seed | `299792458` |
 
 \* Either `--image` or `--video` is required (mutually exclusive).


### PR DESCRIPTION
This fixes issue https://github.com/huggingface/candle/issues/3348 and adds support for f16.

The vision model requires `f32` as per the [reference implementation](https://github.com/PaddlePaddle/PaddleOCR), however using `--dtype f16` or `--dtype bf16` one can realized space efficiency while using the text model.