### PR TITLE
Fall back to the latest CUDA version if cudarc version discovery fails

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ cudarc = { version = "0.19.0", features = [
     "f16",
     "f8",
     "cuda-version-from-build-system",
+    "fallback-latest",
     "dynamic-linking",
 ], default-features = false }
 fancy-regex = "0.17.0"


### PR DESCRIPTION
With the cuda-version-from-build-system feature, cudarc tries to call nvcc to get the CUDA toolkit version during build. If nvcc is unavailable in the build environment, the build fails. Enabling the fallback-latest feature allows the build to succeed, with bindings selected for the latest version.