### PR TITLE
docs: add candle-video to Useful External Resources (Fixes #3295)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ And then head over to
   ergonomic LoRA implementation for Candle. `candle-lora` has      
   out-of-the-box LoRA support for many models from Candle, which can be found
   [here](https://github.com/EricLBuehler/candle-lora/tree/master/candle-lora-transformers/examples).
+- [`candle-video`](https://github.com/FerrisMind/candle-video): Rust library for text-to-video generation (LTX-Video and related models) built on Candle, focused on fast, Python-free inference.
 - [`optimisers`](https://github.com/KGrewal1/optimisers): A collection of optimisers
   including SGD with momentum, AdaGrad, AdaDelta, AdaMax, NAdam, RAdam, and RMSprop.
 - [`candle-vllm`](https://github.com/EricLBuehler/candle-vllm): Efficient platform for inference and


### PR DESCRIPTION
**What**
- Add `candle-video` to “Useful External Resources” in [README](https://github.com/huggingface/candle/blob/main/README.md). 

**Why**
- Requested in [#3295](https://github.com/huggingface/candle/issues/3295).

**Issue**
- `Fixes #3295 `

**Verification**
- Checked README renders correctly;