### PR TITLE
fix: disable bf16 WMMA kernels on pre-Ampere GPUs

### DIFF
--- a/candle-kernels/src/moe/moe_wmma.cu
+++ b/candle-kernels/src/moe/moe_wmma.cu
@@ -274,11 +274,14 @@ extern "C" void moe_gemm_wmma(
             // we use smaller M_tile and larger N_tile for decoding
             LAUNCH_MOE_WMMA(half, 8, 32, 1)
         }
-    } else if (data_type == 1) { // bfloat16
+    }
+#ifndef NO_BF16_KERNEL
+    else if (data_type == 1) { // bfloat16
         if (is_prefill) {
             LAUNCH_MOE_WMMA(nv_bfloat16, 16, 16, 2)
         } else {
             LAUNCH_MOE_WMMA(nv_bfloat16, 8, 32, 1)
         }
     }
+#endif
 }


### PR DESCRIPTION
## Summary

Fixes #3366

- **Add `#ifndef NO_BF16_KERNEL` guards to `moe_wmma.cu`** — `moe_wmma_gguf.cu` already had these guards but `moe_wmma.cu` was missing them, causing compilation failures on pre-Ampere GPUs
- **Wire up `-DNO_BF16_KERNEL` in `build.rs`** — detect compute capability via `cudaforge::detect_compute_cap()` and pass the define when compute cap < 80

## Problem

bf16 WMMA fragment types (`nv_bfloat16` with `nvcuda::wmma`) require compute capability >= 8.0 (Ampere). On sm_75 (Turing/T4) and older GPUs, compiling these fragments produces "incomplete type" errors:

```
error: incomplete type "nvcuda::wmma::fragment<nvcuda::wmma::matrix_a, 16, 16, 16, nv_bfloat16, nvcuda::wmma::row_major>" is not allowed
```

The `NO_BF16_KERNEL` preprocessor guard was already present in `moe_wmma_gguf.cu` but:
1. It was never actually passed by the build script
2. `moe_wmma.cu` was missing the guard entirely

## Test plan

- [x] Build candle-kernels on a T4 (sm_75) — compiles successfully with bf16 WMMA kernels excluded
- [ ] Build on an A100/A10 (sm_80+) — bf16 WMMA kernels should still be compiled as before