### PR TITLE
fix(qwen3): make clear_kv_cache method public to prevent shape mismatch

### DIFF
--- a/candle-transformers/src/models/qwen3.rs
+++ b/candle-transformers/src/models/qwen3.rs
@@ -275,7 +275,7 @@ impl DecoderLayer {
         x + h2
     }
 
-    fn clear_kv_cache(&mut self) {
+    pub fn clear_kv_cache(&mut self) {
         self.self_attn.clear_kv_cache();
     }
 }
@@ -308,7 +308,7 @@ impl Model {
         })
     }
 
-    fn clear_kv_cache(&mut self) {
+    pub fn clear_kv_cache(&mut self) {
         for l in &mut self.layers {
             l.clear_kv_cache();
         }


### PR DESCRIPTION
Motivation
When using the base `Qwen3Model` directly (for example, for custom embeddings) and performing sequential `forward` passes, the `ConcatKvCache` accumulates tokens from previous passes. If the user passes `offset = 0` on subsequent passes (assuming a fresh start or sequence), the attention mask is generated with the new sequence length, but the KV cache keys contain the accumulated length. This causes a `shape mismatch in broadcast_add` panic in the attention layer.
See issue #2819 for a detailed breakdown of the exact same crash when using pipelines.
 Fix
The `ModelForCausalLM` already exposes `pub fn clear_kv_cache()`, but the base `Model` had it as private (`fn clear_kv_cache`). This PR simply changes the visibility of `clear_kv_cache` on `Model` and `DecoderLayer` to `pub`, allowing users to manually clear the KV cache between independent generation/embedding passes to prevent cross-contamination and shape mismatch panics.
 Validation & Real-World Usage
This fix has been fully validated and deployed in a real-world production environment ([memory-mcp-1file](https://github.com/pomazanbohdan/memory-mcp-1file)). 
You can see the exact implementation where this public method is used to stabilize batched Qwen3 embedding generation here:
👉 [Commit fixing the KV Cache accumulation in our project using this patch](https://github.com/pomazanbohdan/memory-mcp-1file/commit/c50b3975121fe610a7a9c1d1ff41a7d68a13cdf8)
*Note: The root cause analysis and this fix were deeply investigated, cross-validated, and tested collaboratively using Gemini 3.1 Pro and Sonnet  4.6 Sonnet (via META-analysis).*
Fixes #2819