### PR TITLE
Remove unwrap()s from candle-metal-kernels/src/metal/device.rs

### DIFF
--- a/candle-metal-kernels/src/err.rs
+++ b/candle-metal-kernels/src/err.rs
@@ -14,6 +14,8 @@ pub enum MetalKernelError {
     UnsupportedDTypeForOp(&'static str, &'static str),
     #[error("Failed to create compute function")]
     FailedToCreateComputeFunction,
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
     #[error("Failed to create metal resource: {0}")]
     FailedToCreateResource(String),
     #[error("Failed to create pipeline")]

--- a/candle-metal-kernels/src/metal/device.rs
+++ b/candle-metal-kernels/src/metal/device.rs
@@ -77,7 +77,8 @@ impl Device {
         length: usize,
         options: MTLResourceOptions,
     ) -> Result<Buffer, MetalKernelError> {
-        let pointer = ptr::NonNull::new(pointer as *mut c_void).unwrap();
+        let pointer = ptr::NonNull::new(pointer as *mut c_void)
+            .ok_or_else(|| MetalKernelError::InvalidInput("Null pointer".to_string()))?;
         unsafe {
             self.as_ref()
                 .newBufferWithBytes_length_options(pointer, length, options)
@@ -96,7 +97,7 @@ impl Device {
         let raw = self
             .as_ref()
             .newLibraryWithSource_options_error(&NSString::from_str(source), options)
-            .unwrap();
+            .map_err(|e| MetalKernelError::LoadLibraryError(e.to_string()))?;
 
         Ok(Library::new(raw))
     }
@@ -108,13 +109,14 @@ impl Device {
         let raw = self
             .as_ref()
             .newComputePipelineStateWithFunction_error(function.as_ref())
-            .unwrap();
+            .map_err(|e| MetalKernelError::FailedToCreatePipeline(e.to_string()))?;
         Ok(ComputePipeline::new(raw))
     }
 
     pub fn new_command_queue(&self) -> Result<CommandQueue, MetalKernelError> {
-        let raw = self.as_ref().newCommandQueue().unwrap();
-        Ok(raw)
+        self.as_ref()
+            .newCommandQueue()
+            .ok_or_else(|| MetalKernelError::FailedToCreateResource("CommandQueue".to_string()))
     }
 
     pub fn recommended_max_working_set_size(&self) -> usize {


### PR DESCRIPTION
Replace unwrap() calls with proper error propagation, to avoid crashing the caller if Metal fails to initialize