### PR TITLE
fix: make Qwen3 Model::clear_kv_cache public

### DIFF
--- a/candle-transformers/src/models/qwen3.rs
+++ b/candle-transformers/src/models/qwen3.rs
@@ -308,7 +308,7 @@ impl Model {
         })
     }
 
-    fn clear_kv_cache(&mut self) {
+    pub fn clear_kv_cache(&mut self) {
         for l in &mut self.layers {
             l.clear_kv_cache();
         }


### PR DESCRIPTION
Makes `clear_kv_cache` public on the Qwen3 `Model` struct, consistent with other model implementations (e.g. Llama, Phi, Mistral) that expose this method publicly.

Without this, downstream users cannot clear the KV cache between generations.