### PR TITLE
feat(aarch64): use SDOT instruction for quantized matmul 

### DIFF
--- a/candle-core/src/quantized/neon.rs
+++ b/candle-core/src/quantized/neon.rs
@@ -13,10 +13,24 @@ use core::arch::aarch64::*;
 
 #[inline(always)]
 unsafe fn vdotq_s32(a: int8x16_t, b: int8x16_t) -> int32x4_t {
-    // TODO: dotprod
-    let p0 = vmull_s8(vget_low_s8(a), vget_low_s8(b));
-    let p1 = vmull_s8(vget_high_s8(a), vget_high_s8(b));
-    vaddq_s32(vpaddlq_s16(p0), vpaddlq_s16(p1))
+    #[cfg(target_feature = "dotprod")]
+    {
+        let mut c = vdupq_n_s32(0);
+        core::arch::asm!(
+            "sdot {0:v}.4s, {1:v}.16b, {2:v}.16b",
+            inlateout(vreg) c,
+            in(vreg) a,
+            in(vreg) b,
+            options(pure, nomem, nostack),
+        );
+        c
+    }
+    #[cfg(not(target_feature = "dotprod"))]
+    {
+        let p0 = vmull_s8(vget_low_s8(a), vget_low_s8(b));
+        let p1 = vmull_s8(vget_high_s8(a), vget_high_s8(b));
+        vaddq_s32(vpaddlq_s16(p0), vpaddlq_s16(p1))
+    }
 }
 
 #[inline(always)]


### PR DESCRIPTION

When the target supports the ARM dotprod feature (ARMv8.2-A+), use the SDOT (Signed Dot Product) instruction via inline assembly for the vdotq_s32 helper. This replaces the existing vmull_s8 + vpaddlq_s16 sequence with a single SDOT instruction, which computes four 8-bit dot products simultaneously.

On RK3588 Cortex-A76 cores, this reduces quantized GGUF matmul from ~190ms to ~108ms per step for Q8_0 models — a ~43% speedup.

The original fallback path is preserved behind #[cfg(not(target_feature))] for CPUs without dotprod support (e.g., Cortex-A55 in 32-bit mode).

Build with: RUSTFLAGS='-C target-feature=+dotprod' cargo build --release