### PR TITLE
Add candle-mi library to useful libraries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ And then head over to
 - [`atoma-infer`](https://github.com/atoma-network/atoma-infer): A Rust library for fast inference at scale, leveraging FlashAttention2 for efficient attention computation, PagedAttention for efficient KV-cache memory management, and multi-GPU support. It is OpenAI api compatible.
 - [`llms-from-scratch-rs`](https://github.com/nerdai/llms-from-scratch-rs): A comprehensive Rust translation of the code from Sebastian Raschka's Build an LLM from Scratch book.
 - [`vllm.rs`](https://github.com/guoqingbao/vllm.rs): A minimalist vLLM implementation in Rust based on Candle.
+- [`candle-mi`](https://github.com/PCfVW/candle-mi): Mechanistic interpretability for language models in Rust. Hook-based activation capture, sparse autoencoders, causal tracing, and paper replications (Gurnee et al., Meng et al.) with VRAM-aware chunking for consumer GPUs.
+
 
 If you have an addition to this list, please submit a pull request.
 

--- a/README.md
+++ b/README.md
@@ -193,8 +193,7 @@ And then head over to
 - [`atoma-infer`](https://github.com/atoma-network/atoma-infer): A Rust library for fast inference at scale, leveraging FlashAttention2 for efficient attention computation, PagedAttention for efficient KV-cache memory management, and multi-GPU support. It is OpenAI api compatible.
 - [`llms-from-scratch-rs`](https://github.com/nerdai/llms-from-scratch-rs): A comprehensive Rust translation of the code from Sebastian Raschka's Build an LLM from Scratch book.
 - [`vllm.rs`](https://github.com/guoqingbao/vllm.rs): A minimalist vLLM implementation in Rust based on Candle.
-- [`candle-mi`](https://github.com/PCfVW/candle-mi): Mechanistic interpretability for language models in Rust. Hook-based activation capture, sparse autoencoders, causal tracing, and paper replications (Gurnee et al., Meng et al.) with VRAM-aware chunking for consumer GPUs.
-
+- [`candle-mi`](https://github.com/mi-for-the-rust-of-us/candle-mi): Mechanistic interpretability for language models in Rust. TransformerLens-style hook points built into the forward pass (capture plus typed interventions), attention knockout and steering, logit lens, cross-layer transcoders and SAEs — over a config-driven generic transformer (LLaMA, Qwen, Gemma, Phi-3, StarCoder2), RWKV-6/7, and masked-diffusion LMs. Runs on consumer GPUs.
 
 If you have an addition to this list, please submit a pull request.
 


### PR DESCRIPTION
Hi,

This adds `candle-mi` to *Useful External Resources*, following [discussion #3368](https://github.com/huggingface/candle/discussions/3368):

> "I think that `candle-mi` would be a great name. Additionally, you can open a PR to add this crate into the `Useful External Resources` of the readme." — @EricLBuehler

**What it is.** Mechanistic interpretability for language models in Rust — as far as I can tell still the only Rust crate for it; the Python ecosystem has TransformerLens, nnsight and pyvene. TransformerLens-style hook points are built into the forward pass (capture plus typed interventions, zero overhead when inactive), with attention knockout and steering, logit lens, cross-layer transcoders and SAEs, over a config-driven generic transformer (LLaMA, Qwen, Gemma, Phi-3, StarCoder2), RWKV-6/7, and masked-diffusion LMs. Everything runs on consumer hardware (developed on an RTX 5060 Ti 16GB).

[crates.io](https://crates.io/crates/candle-mi) (v0.1.21) · [docs.rs](https://docs.rs/candle-mi)

**Since I opened this PR**, using candle-mi in anger has fed back into candle itself:

- [#3819](https://github.com/huggingface/candle/pull/3819) — `AdamW::step_t`, `set_step_t` and `moments`, so training runs can be checkpointed
- [#3822](https://github.com/huggingface/candle/pull/3822) — `GradStore`: store the first gradient instead of adding it into fresh zeros
- [#3823](https://github.com/huggingface/candle/pull/3823) — an analytic backward for the fused `softmax_last_dim` and `layer_norm`, addressing [issue #3011](https://github.com/huggingface/candle/issues/3011) and deferring to the open [#3613](https://github.com/huggingface/candle/pull/3613) and [#3724](https://github.com/huggingface/candle/pull/3724)

The diff is one line. Thanks for candle! It's been a pleasure to work with for this kind of research. :)

-- Éric Jacopin.
