### PR TITLE
fix(metal): seed buffer allocated as 4 bytes instead of 8 (u64)

### DIFF
--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -1932,7 +1932,7 @@ impl BackendDevice for MetalDevice {
             device
                 .new_buffer_with_data(
                     [299792458u64].as_ptr() as *const c_void,
-                    4,
+                    std::mem::size_of::<u64>(),
                     RESOURCE_OPTIONS,
                 )
                 .map_err(MetalError::from)?,


### PR DESCRIPTION
## Problem

The Metal seed buffer is allocated with 4 bytes but stores a `u64` (8 bytes):

```rust
.new_buffer_with_data(
    [299792458u64].as_ptr() as *const c_void,
    4,   // BUG: should be 8 (sizeof u64)
    RESOURCE_OPTIONS,
)
```

The Metal RNG kernel declares the seed as `seed_buffer { atomic_uint seed[2]; }` (8 bytes). `atomic_load_seed` reads both halves:

```metal
uint x = atomic_load_explicit(&sb->seed[0], memory_order_relaxed);
uint y = atomic_load_explicit(&sb->seed[1], memory_order_relaxed);  // reads undefined memory
return static_cast<ulong>(x) << 32 | y;
```

Since `seed[1]` reads undefined memory past the 4-byte buffer, the RNG produces different results on each run even with the same seed via `set_seed()`. This makes `Tensor::randn` non-deterministic on Metal.

This is also likely the root cause of the `stable-diffusion` error in #2832:
> `Metal seed must be less than or equal to u32::MAX`

Since only 4 bytes are allocated, seeds larger than `u32::MAX` overflow the buffer.

## Fix

```rust
std::mem::size_of::<u64>()  // 8 bytes, matching the u64 seed type
```

One-line change. No behavioral difference for seeds that fit in 32 bits — the fix ensures the full 64-bit seed is stored and read correctly.

## Testing

- Verified `set_seed(1337)` + `Tensor::randn` produces identical results across runs on Apple M3 Max
- Previously produced different results every run