### PR TITLE
fix(metal): GPU-native dequantization for quantized matmul precision

### DIFF
--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -33,76 +33,125 @@ impl QMetalStorage {
         &self.buffer
     }
 
-    pub fn dequantize(&self, elem_count: usize) -> Result<MetalStorage> {
+    /// Dequantize a quantized tensor to F32 using GPU kernels.
+    ///
+    /// Uses Metal `kernel_get_rows_*` to dequantize directly on GPU, avoiding
+    /// the CPU roundtrip. Falls back to CPU for unsupported dtypes (Q8_1, Q8K).
+    fn dequantize_on_gpu(&self, n_rows: usize, n_cols: usize) -> Result<MetalStorage> {
+        let elem_count = n_rows * n_cols;
+
+        // Check if this dtype is supported by GPU dequantize kernels
+        let kernel_dtype: candle_metal_kernels::GgmlDType = self.dtype.into();
+        let gpu_supported = !matches!(
+            self.dtype,
+            GgmlDType::Q8_1 | GgmlDType::Q8K
+        );
+
+        if !gpu_supported {
+            // Fall back to CPU dequantize for unsupported types
+            return self.dequantize_cpu(elem_count);
+        }
+
+        // Allocate F32 output buffer on GPU
+        let output_size = elem_count * 4; // f32 = 4 bytes
+        let dst_buffer = self.device.allocate_zeros(output_size)?;
+
+        // Create sequential index buffer [0, 1, ..., n_rows-1] as i32
+        let indices: Vec<i32> = (0..n_rows as i32).collect();
+        let indices_buffer = self.device.new_buffer_with_data(&indices)?;
+
+        // Dispatch the GPU dequantize kernel
+        {
+            let encoder = self.device.command_encoder()?;
+            candle_metal_kernels::call_dequantize_f32(
+                self.device.device(),
+                &encoder,
+                self.device.kernels(),
+                kernel_dtype,
+                n_rows,
+                n_cols,
+                &self.buffer,
+                &dst_buffer,
+                &indices_buffer,
+            )
+            .map_err(|e| crate::Error::Metal(e.into()))?;
+            // encoder dropped here → status returns to Available
+        }
+
+        Ok(MetalStorage::new(
+            dst_buffer,
+            self.device.clone(),
+            elem_count,
+            DType::F32,
+        ))
+    }
+
+    /// CPU-based dequantization fallback for dtypes not supported by GPU kernels.
+    fn dequantize_cpu(&self, elem_count: usize) -> Result<MetalStorage> {
         use crate::quantized::k_quants::GgmlType;
 
-        let buffer = self.device.allocate_buffer(self.buffer.length())?;
-        let blit = self.device.blit_command_encoder()?;
-        blit.set_label("blit_to_cpu");
-        blit.copy_from_buffer(&self.buffer, 0, &buffer, 0, self.buffer.length());
-        blit.end_encoding();
         self.device.wait_until_completed()?;
-        let mut out = vec![0.0; elem_count];
+        let mut out = vec![0.0f32; elem_count];
         let block_len = elem_count / self.dtype.block_size();
         match self.dtype {
             GgmlDType::F32 => {
-                let vec: Vec<f32> = read_to_vec(&buffer, block_len);
+                let vec: Vec<f32> = read_to_vec(&self.buffer, block_len);
                 f32::to_float(&vec, &mut out);
             }
             GgmlDType::F16 => {
-                let vec: Vec<half::f16> = read_to_vec(&buffer, block_len);
+                let vec: Vec<half::f16> = read_to_vec(&self.buffer, block_len);
                 half::f16::to_float(&vec, &mut out);
             }
             GgmlDType::BF16 => {
-                let vec: Vec<half::bf16> = read_to_vec(&buffer, block_len);
+                let vec: Vec<half::bf16> = read_to_vec(&self.buffer, block_len);
                 half::bf16::to_float(&vec, &mut out);
             }
             GgmlDType::Q4_0 => {
-                let vec: Vec<crate::quantized::BlockQ4_0> = read_to_vec(&buffer, block_len);
+                let vec: Vec<crate::quantized::BlockQ4_0> = read_to_vec(&self.buffer, block_len);
                 crate::quantized::BlockQ4_0::to_float(&vec, &mut out);
             }
             GgmlDType::Q4_1 => {
-                let vec: Vec<crate::quantized::BlockQ4_1> = read_to_vec(&buffer, block_len);
+                let vec: Vec<crate::quantized::BlockQ4_1> = read_to_vec(&self.buffer, block_len);
                 crate::quantized::BlockQ4_1::to_float(&vec, &mut out);
             }
             GgmlDType::Q5_0 => {
-                let vec: Vec<crate::quantized::BlockQ5_0> = read_to_vec(&buffer, block_len);
+                let vec: Vec<crate::quantized::BlockQ5_0> = read_to_vec(&self.buffer, block_len);
                 crate::quantized::BlockQ5_0::to_float(&vec, &mut out);
             }
             GgmlDType::Q5_1 => {
-                let vec: Vec<crate::quantized::BlockQ5_1> = read_to_vec(&buffer, block_len);
+                let vec: Vec<crate::quantized::BlockQ5_1> = read_to_vec(&self.buffer, block_len);
                 crate::quantized::BlockQ5_1::to_float(&vec, &mut out);
             }
             GgmlDType::Q8_0 => {
-                let vec: Vec<crate::quantized::BlockQ8_0> = read_to_vec(&buffer, block_len);
+                let vec: Vec<crate::quantized::BlockQ8_0> = read_to_vec(&self.buffer, block_len);
                 crate::quantized::BlockQ8_0::to_float(&vec, &mut out);
             }
             GgmlDType::Q8_1 => {
-                let vec: Vec<crate::quantized::BlockQ8_1> = read_to_vec(&buffer, block_len);
+                let vec: Vec<crate::quantized::BlockQ8_1> = read_to_vec(&self.buffer, block_len);
                 crate::quantized::BlockQ8_1::to_float(&vec, &mut out);
             }
             GgmlDType::Q2K => {
-                let vec: Vec<crate::quantized::BlockQ2K> = read_to_vec(&buffer, block_len);
+                let vec: Vec<crate::quantized::BlockQ2K> = read_to_vec(&self.buffer, block_len);
                 crate::quantized::BlockQ2K::to_float(&vec, &mut out);
             }
             GgmlDType::Q3K => {
-                let vec: Vec<crate::quantized::BlockQ3K> = read_to_vec(&buffer, block_len);
+                let vec: Vec<crate::quantized::BlockQ3K> = read_to_vec(&self.buffer, block_len);
                 crate::quantized::BlockQ3K::to_float(&vec, &mut out);
             }
             GgmlDType::Q4K => {
-                let vec: Vec<crate::quantized::BlockQ4K> = read_to_vec(&buffer, block_len);
+                let vec: Vec<crate::quantized::BlockQ4K> = read_to_vec(&self.buffer, block_len);
                 crate::quantized::BlockQ4K::to_float(&vec, &mut out);
             }
             GgmlDType::Q5K => {
-                let vec: Vec<crate::quantized::BlockQ5K> = read_to_vec(&buffer, block_len);
+                let vec: Vec<crate::quantized::BlockQ5K> = read_to_vec(&self.buffer, block_len);
                 crate::quantized::BlockQ5K::to_float(&vec, &mut out);
             }
             GgmlDType::Q6K => {
-                let vec: Vec<crate::quantized::BlockQ6K> = read_to_vec(&buffer, block_len);
+                let vec: Vec<crate::quantized::BlockQ6K> = read_to_vec(&self.buffer, block_len);
                 crate::quantized::BlockQ6K::to_float(&vec, &mut out);
             }
             GgmlDType::Q8K => {
-                let vec: Vec<crate::quantized::BlockQ8K> = read_to_vec(&buffer, block_len);
+                let vec: Vec<crate::quantized::BlockQ8K> = read_to_vec(&self.buffer, block_len);
                 crate::quantized::BlockQ8K::to_float(&vec, &mut out);
             }
         }
@@ -114,6 +163,11 @@ impl QMetalStorage {
             elem_count,
             DType::F32,
         ))
+    }
+
+    pub fn dequantize(&self, elem_count: usize) -> Result<MetalStorage> {
+        // Treat as a single row for GPU dequantization
+        self.dequantize_on_gpu(1, elem_count)
     }
 
     pub fn quantize(&mut self, src: &MetalStorage) -> Result<()> {
@@ -186,153 +240,69 @@ impl QMetalStorage {
         self.buffer.length()
     }
 
-    fn fwd_mv(
-        &self,
-        self_shape: &Shape,
-        storage: &MetalStorage,
-        layout: &crate::Layout,
-    ) -> Result<(MetalStorage, Shape)> {
-        use crate::MetalError;
-
-        if !layout.is_contiguous() {
-            crate::bail!("input tensor is not contiguous {layout:?}")
-        }
-        let src_shape = layout.shape();
-        // self is transposed so n is first then k.
-        if src_shape.rank() < 2 {
-            crate::bail!("input tensor has only one dimension {layout:?}")
-        }
-        let (n, k) = self_shape.dims2()?;
-        let mut dst_shape = src_shape.dims().to_vec();
-
-        // We always use a single batch dimension and stack all the tensors in the batch on the
-        // second dimension as the implementation in candle-metal-kernels doesn't handle batch
-        // properly.
-        let m = match dst_shape.len() {
-            3 => dst_shape[0] * dst_shape[1],
-            2 => dst_shape[0],
-            n => crate::bail!("Invalid rank {n} for quantized matmul metal"),
-        };
-        let last_k = dst_shape.pop().unwrap();
-        if last_k != k {
-            crate::bail!("input tensor {layout:?} incompatible with {:?}", self_shape)
-        }
-        dst_shape.push(n);
-        let dst_shape = Shape::from(dst_shape);
-        let device = storage.device().clone();
-        let dst = device.new_buffer(dst_shape.elem_count(), DType::F32, "qmatmul")?;
-        let encoder = device.command_encoder()?;
-        // In some cases it would be better to use the mm variant, though it has its drawbacks
-        // around memory alignment.
-        for batch_id in 0..m {
-            candle_metal_kernels::call_quantized_matmul_mv_t(
-                device.device(),
-                &encoder,
-                device.kernels(),
-                self.dtype.into(),
-                (1, 1, n, k),
-                storage.buffer(),
-                (layout.start_offset() + batch_id * k) * storage.dtype().size_in_bytes(),
-                &self.buffer,
-                batch_id * n * DType::F32.size_in_bytes(),
-                &dst,
-            )
-            .map_err(MetalError::from)?;
-        }
-        let dst_storage = crate::MetalStorage::new(dst, device, dst_shape.elem_count(), DType::F32);
-        Ok((dst_storage, dst_shape))
-    }
-
+    /// Quantized matmul via per-operation dequantization.
+    ///
+    /// Metal's native quantized matmul kernels produce incorrect results for
+    /// diffusion models (precision errors compound across denoising iterations).
+    /// Instead, we dequantize the weight to F32, use standard Metal GEMM, and
+    /// free the temporary F32 copy. Peak extra memory: one layer (~50-200MB).
     pub fn fwd(
         &self,
         self_shape: &Shape,
         storage: &MetalStorage,
         layout: &crate::Layout,
     ) -> Result<(MetalStorage, Shape)> {
-        use crate::MetalError;
-
         if !layout.is_contiguous() {
             crate::bail!("input tensor is not contiguous {layout:?}")
         }
         let src_shape = layout.shape();
-        // self is transposed so n is first then k.
         if src_shape.rank() < 2 {
             crate::bail!("input tensor has only one dimension {layout:?}")
         }
+
+        // self_shape is [n, k] (weight is transposed).
         let n = self_shape.dim(D::Minus2)?;
         let k = self_shape.dim(D::Minus1)?;
-        let mut dst_shape = src_shape.dims().to_vec();
 
-        if src_shape.rank() < self_shape.rank() {
-            crate::bail!(
-                "input rank ({}) must be >= weight rank ({})",
-                src_shape.rank(),
-                self_shape.rank()
-            )
-        }
-
-        if src_shape.dim(D::Minus2)? == 1 {
-            return self.fwd_mv(self_shape, storage, layout);
-        }
-
-        let last_k = dst_shape.pop().unwrap();
+        // Validate input's last dim matches weight's k.
+        let last_k = src_shape.dim(D::Minus1)?;
         if last_k != k {
             crate::bail!("input tensor {layout:?} incompatible with {:?}", self_shape)
         }
-        dst_shape.push(n);
-        let dst_shape = Shape::from(dst_shape);
-        let device = storage.device().clone();
-        let dst = device.new_buffer(dst_shape.elem_count(), DType::F32, "qmatmul")?;
-        let encoder = device.command_encoder()?;
 
-        assert_eq!(storage.dtype(), DType::F32);
+        // Dequantize weight [n, k] to F32 on GPU (no CPU roundtrip)
+        let deq_weight = self.dequantize_on_gpu(n, k)?;
+        let rhs_l = crate::Layout::contiguous_with_offset(self_shape, 0);
 
-        if self_shape.rank() > 4 {
-            crate::bail!("weight rank ({}) must be <= 4", self_shape.rank())
-        }
-        let src0_l = crate::Layout::contiguous(
-            [vec![1; 4 - self_shape.rank()], self_shape.dims().to_vec()].concat(),
-        );
-        let src0_stride = src0_l
-            .stride()
-            .iter()
-            .map(|x| {
-                (*x as f32 * (self.dtype.type_size() as f32 / self.dtype.block_size() as f32))
-                    as usize
-            })
-            .collect::<Vec<_>>();
+        // Compute batch dimensions: everything except the last dim becomes batch.
+        // input: [..., m, k] @ weight^T: [n, k]^T = [..., m, n]
+        let m = src_shape.dim(D::Minus2)?;
+        let b: usize = src_shape.dims().iter().rev().skip(2).product();
+        let b = if b == 0 { 1 } else { b };
 
-        if src_shape.rank() > 4 {
-            crate::bail!("weight rank ({}) must be <= 4", src_shape.rank())
-        }
-        let src1_l = crate::Layout::contiguous(
-            [vec![1; 4 - src_shape.rank()], src_shape.dims().to_vec()].concat(),
-        );
+        // Transpose weight [n, k] -> use as [k, n] for standard matmul.
+        // Standard matmul: [m, k] @ [k, n] = [m, n]
+        // But our weight is [n, k], so we need transposed matmul.
+        // The BackendStorage::matmul does lhs @ rhs with given (b, m, n, k).
+        // It handles transposition via layout strides.
 
-        candle_metal_kernels::call_quantized_matmul_mm_t(
-            device.device(),
-            &encoder,
-            device.kernels(),
-            self.dtype.into(),
-            src0_l.dims(),
-            &src0_stride,
-            &self.buffer,
-            src1_l.dims(),
-            &src1_l
-                .stride()
-                .iter()
-                .map(|x| x * DType::F32.size_in_bytes())
-                .collect::<Vec<_>>(),
-            storage.buffer(),
-            src1_l.start_offset() * storage.dtype().size_in_bytes(),
-            dst_shape.dims(),
-            0,
-            &dst,
-        )
-        .map_err(MetalError::from)?;
+        // Create transposed layout for weight: [n, k] with transposed strides
+        let rhs_t = rhs_l.transpose(0, 1)?;
 
-        let dst_storage = crate::MetalStorage::new(dst, device, dst_shape.elem_count(), DType::F32);
-        Ok((dst_storage, dst_shape))
+        let result = storage.matmul(&deq_weight, (b, m, n, k), layout, &rhs_t)?;
+
+        // Sync to let Metal free the temporary dequantized buffer.
+        // Without this, async command dispatch accumulates hundreds of ~200MB
+        // temporary buffers (one per matmul) before any are freed, causing OOM.
+        drop(deq_weight);
+        self.device.wait_until_completed()?;
+
+        // Build output shape: [..., m, n]
+        let mut dst_dims = src_shape.dims().to_vec();
+        *dst_dims.last_mut().unwrap() = n;
+        let dst_shape = Shape::from(dst_dims);
+
+        Ok((result, dst_shape))
     }
 
     pub fn data(&self) -> Result<Vec<u8>> {
@@ -385,7 +355,7 @@ impl From<GgmlDType> for candle_metal_kernels::GgmlDType {
             GgmlDType::Q8K => candle_metal_kernels::GgmlDType::Q8K,
             GgmlDType::F16 => candle_metal_kernels::GgmlDType::F16,
             GgmlDType::F32 => candle_metal_kernels::GgmlDType::F32,
-            GgmlDType::BF16 => candle_metal_kernels::GgmlDType::F16,
+            GgmlDType::BF16 => candle_metal_kernels::GgmlDType::BF16,
         }
     }
 }

--- a/candle-metal-kernels/src/kernels/mod.rs
+++ b/candle-metal-kernels/src/kernels/mod.rs
@@ -21,7 +21,9 @@ pub use convolution::*;
 pub use fill::*;
 pub use indexing::*;
 pub use mlx_gemm::{call_mlx_gemm, GemmDType};
-pub use quantized::{call_quantized_matmul_mm_t, call_quantized_matmul_mv_t, GgmlDType};
+pub use quantized::{
+    call_dequantize_f32, call_quantized_matmul_mm_t, call_quantized_matmul_mv_t, GgmlDType,
+};
 pub use random::*;
 pub use reduce::*;
 pub use sdpa::{call_sdpa_full, call_sdpa_vector, call_sdpa_vector_2pass, SdpaDType};

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -283,6 +283,139 @@ pub fn call_quantized_matmul_mm_t(
     Ok(())
 }
 
+/// Dequantize a quantized tensor to F32 using Metal GPU kernels.
+///
+/// Uses `kernel_get_rows_*` to dequantize all rows of a quantized weight tensor
+/// directly on the GPU, avoiding the CPU roundtrip of `QMetalStorage::dequantize()`.
+///
+/// Parameters:
+/// - `n_rows`: number of rows in the weight tensor
+/// - `n_cols`: number of columns (elements per row, must be multiple of block_size)
+/// - `src`: quantized source buffer
+/// - `dst`: pre-allocated F32 output buffer (n_rows * n_cols * 4 bytes)
+/// - `indices`: buffer containing sequential i32 indices [0, 1, ..., n_rows-1]
+#[allow(clippy::too_many_arguments)]
+pub fn call_dequantize_f32(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    dtype: GgmlDType,
+    n_rows: usize,
+    n_cols: usize,
+    src: &Buffer,
+    dst: &Buffer,
+    indices: &Buffer,
+) -> Result<(), MetalKernelError> {
+    let name = match dtype {
+        GgmlDType::Q4_0 => "kernel_get_rows_q4_0",
+        GgmlDType::Q4_1 => "kernel_get_rows_q4_1",
+        GgmlDType::Q5_0 => "kernel_get_rows_q5_0",
+        GgmlDType::Q5_1 => "kernel_get_rows_q5_1",
+        GgmlDType::Q8_0 => "kernel_get_rows_q8_0",
+        GgmlDType::Q2K => "kernel_get_rows_q2_K",
+        GgmlDType::Q3K => "kernel_get_rows_q3_K",
+        GgmlDType::Q4K => "kernel_get_rows_q4_K",
+        GgmlDType::Q5K => "kernel_get_rows_q5_K",
+        GgmlDType::Q6K => "kernel_get_rows_q6_K",
+        GgmlDType::F16 => "kernel_get_rows_f16",
+        GgmlDType::BF16 => "kernel_get_rows_bf16",
+        GgmlDType::F32 => "kernel_get_rows_f32",
+        GgmlDType::Q8_1 => {
+            return Err(MetalKernelError::UnsupportedDTypeForOp("Q8_1", "dequantize"))
+        }
+        GgmlDType::Q8K => {
+            return Err(MetalKernelError::UnsupportedDTypeForOp("Q8K", "dequantize"))
+        }
+    };
+
+    // Compute byte strides for the kernel
+    let block_size = dtype_block_size(dtype);
+    let type_size = dtype_type_size(dtype);
+    // nb01 = byte stride per row in quantized source
+    let nb01: u64 = (n_cols / block_size * type_size) as u64;
+    // nb02 = byte stride per batch (single batch = all rows)
+    let nb02: u64 = n_rows as u64 * nb01;
+    // ne00 = number of output elements per row
+    let ne00: i64 = n_cols as i64;
+    // ne10 = number of indices (= number of rows)
+    let ne10: i64 = n_rows as i64;
+    // nb10 = stride between indices in bytes (sizeof(i32) = 4)
+    let nb10: u64 = 4;
+    // nb11 = batch stride for indices (single batch)
+    let nb11: u64 = n_rows as u64 * 4;
+    // nb1 = output row stride in bytes
+    let nb1: u64 = n_cols as u64 * 4;
+    // nb2 = output batch stride in bytes
+    let nb2: u64 = n_rows as u64 * n_cols as u64 * 4;
+
+    let pipeline = kernels.load_pipeline(device, Source::Quantized, name)?;
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    set_params!(
+        encoder,
+        (src, indices, dst, ne00, nb01, nb02, ne10, nb10, nb11, nb1, nb2)
+    );
+    encoder.use_resource(src, MTLResourceUsage::Read);
+    encoder.use_resource(indices, MTLResourceUsage::Read);
+    encoder.use_resource(dst, MTLResourceUsage::Write);
+
+    let thread_groups_count = MTLSize {
+        width: n_rows,
+        height: 1,
+        depth: 1,
+    };
+    let threads_per_threadgroup = MTLSize {
+        width: 32,
+        height: 1,
+        depth: 1,
+    };
+
+    encoder.dispatch_thread_groups(thread_groups_count, threads_per_threadgroup);
+    Ok(())
+}
+
+/// Block size for each GGML dtype.
+fn dtype_block_size(dtype: GgmlDType) -> usize {
+    match dtype {
+        GgmlDType::F32 => 1,
+        GgmlDType::F16 | GgmlDType::BF16 => 1,
+        GgmlDType::Q4_0 => 32,
+        GgmlDType::Q4_1 => 32,
+        GgmlDType::Q5_0 => 32,
+        GgmlDType::Q5_1 => 32,
+        GgmlDType::Q8_0 => 32,
+        GgmlDType::Q8_1 => 32,
+        GgmlDType::Q2K => 256,
+        GgmlDType::Q3K => 256,
+        GgmlDType::Q4K => 256,
+        GgmlDType::Q5K => 256,
+        GgmlDType::Q6K => 256,
+        GgmlDType::Q8K => 256,
+    }
+}
+
+/// Type size in bytes for each GGML dtype block.
+fn dtype_type_size(dtype: GgmlDType) -> usize {
+    match dtype {
+        GgmlDType::F32 => 4,
+        GgmlDType::F16 | GgmlDType::BF16 => 2,
+        GgmlDType::Q4_0 => 18,   // 2 (delta) + 16 (qs)
+        GgmlDType::Q4_1 => 20,   // 2 (delta) + 2 (min) + 16 (qs)
+        GgmlDType::Q5_0 => 22,   // 2 (delta) + 4 (qh) + 16 (qs)
+        GgmlDType::Q5_1 => 24,   // 2 (delta) + 2 (min) + 4 (qh) + 16 (qs)
+        GgmlDType::Q8_0 => 34,   // 2 (delta) + 32 (qs)
+        GgmlDType::Q8_1 => 40,   // 4 (delta) + 4 (sum) + 32 (qs)
+        GgmlDType::Q2K => 84,    // block_q2_K
+        GgmlDType::Q3K => 110,   // block_q3_K
+        GgmlDType::Q4K => 144,   // block_q4_K
+        GgmlDType::Q5K => 176,   // block_q5_K
+        GgmlDType::Q6K => 210,   // block_q6_K
+        GgmlDType::Q8K => 292,   // block_q8_K
+    }
+}
+
 fn divide(m: usize, b: usize) -> usize {
     m.div_ceil(b)
 }


### PR DESCRIPTION
## Problem

Metal's fused quantized matmul kernels (`kernel_mul_mm_*`) accumulate in half precision (F16). For single-pass inference (LLMs), this is fine. For iterative workloads like diffusion model denoising (20-50 steps), the precision errors compound across iterations and produce incorrect results (washed-out or garbage images).

CUDA doesn't have this problem because for large matrices it dequantizes on GPU using dedicated kernels, then uses cuBLAS GEMM at full precision.

## Fix

Metal already has `kernel_get_rows_*` GPU dequantize kernels in `quantized.metal` — they just had no Rust dispatch function. This PR:

1. **Adds `call_dequantize_f32()`** in `candle-metal-kernels` — dispatches `kernel_get_rows_*` to dequantize a full quantized tensor to F32 on the GPU
2. **Adds `dequantize_on_gpu()`** in `candle-core` — uses the new dispatch to dequantize without a CPU roundtrip
3. **Updates `QMetalStorage::fwd()`** — dequantizes weight to F32 on GPU, uses standard Metal GEMM, frees the temporary copy
4. **Fixes BF16 mapping bug** — `GgmlDType::BF16` was incorrectly mapped to `candle_metal_kernels::GgmlDType::F16`
5. **Falls back to CPU** for unsupported dtypes (Q8_1, Q8K)

### Memory impact

Per-matmul overhead on Apple Silicon:
- Largest typical layer (e.g. FLUX [3072, 18432]): ~225 MB temporary F32 buffer
- Freed immediately after GEMM + sync via `wait_until_completed()`
- GGUF model stays in quantized form — no additional persistent memory

### Tradeoffs

This trades some throughput for correctness on Metal. The fused kernels are faster (no temporary allocation) but produce incorrect results for iterative inference. The approach matches what CUDA already does for large matrices.

## Files changed

| File | Change |
|------|--------|
| `candle-metal-kernels/src/kernels/quantized.rs` | Add `call_dequantize_f32()` + dtype helpers |
| `candle-metal-kernels/src/kernels/mod.rs` | Export new function |
| `candle-core/src/quantized/metal.rs` | `dequantize_on_gpu()`, updated `fwd()`, `dequantize()`, BF16 fix |

## Testing

- Verified GGUF FLUX inference on Apple M3 Max produces correct, clear images (previously garbage)
- Same seed produces identical results across runs
- `cargo test` passes