### PR TITLE
Add Granite-Docling (Idefics3) model with quantized GGUF support

### DIFF
--- a/candle-examples/examples/granite-docling/main.rs
+++ b/candle-examples/examples/granite-docling/main.rs
@@ -1,0 +1,220 @@
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use anyhow::{Error as E, Result};
+use clap::Parser;
+
+use candle::{DType, Device, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::granite_docling::{config::Config, Model};
+use tokenizers::Tokenizer;
+
+const MODEL_ID: &str = "ibm-granite/granite-docling-258M";
+const IMAGE_TOKEN_ID: u32 = 100270;
+const FAKE_TOKEN_AROUND_IMAGE: u32 = 100339;
+const GLOBAL_IMG: u32 = 100340;
+const START_OF_ROLE: u32 = 100264;
+const END_OF_ROLE: u32 = 100265;
+const END_OF_TEXT: u32 = 100257;
+
+#[derive(Parser, Debug)]
+#[command(about = "Granite-Docling: document image to structured markup")]
+struct Args {
+    /// Run on CPU rather than on GPU.
+    #[arg(long)]
+    cpu: bool,
+
+    /// Use bf16 precision (default: f32).
+    #[arg(long)]
+    bf16: bool,
+
+    /// The image file to process.
+    #[arg(long)]
+    image: String,
+
+    /// Optional: path to a local model directory or HF model id.
+    #[arg(long)]
+    model_id: Option<String>,
+
+    /// Maximum number of tokens to generate.
+    #[arg(long, default_value_t = 4096)]
+    max_tokens: usize,
+
+    /// Sampling temperature (0.0 = greedy).
+    #[arg(long, default_value_t = 0.0)]
+    temperature: f64,
+
+    /// The prompt to use. Defaults to a generic document conversion prompt.
+    #[arg(long)]
+    prompt: Option<String>,
+}
+
+/// Load and preprocess an image following HF Idefics3ImageProcessor (no image splitting):
+///   1. Resize to 512x512 square (stretch, matching HF behavior)
+///   2. Rescale [0,255] -> [0,1], normalize with mean=0.5, std=0.5
+/// Returns (1, 3, 512, 512).
+fn load_image(path: &str, max_size: usize, device: &Device) -> Result<Tensor> {
+    let img = image::ImageReader::open(path)?
+        .decode()
+        .map_err(E::msg)?;
+
+    // Convert to RGB, then resize to exactly max_size x max_size (stretch to square)
+    let img = img.to_rgb8();
+    let (orig_w, orig_h) = (img.width(), img.height());
+    let img = image::imageops::resize(
+        &img,
+        max_size as u32,
+        max_size as u32,
+        image::imageops::FilterType::Lanczos3,
+    );
+    println!("Image: {}x{} -> {}x{}", orig_w, orig_h, max_size, max_size);
+
+    // Normalize: [0,255] -> [-1,1]
+    let mut data = vec![0.0f32; 3 * max_size * max_size];
+    for y in 0..max_size {
+        for x in 0..max_size {
+            let pixel = *img.get_pixel(x as u32, y as u32);
+            for c in 0..3 {
+                let idx = c * max_size * max_size + y * max_size + x;
+                data[idx] = (pixel[c] as f32 / 255.0 - 0.5) / 0.5;
+            }
+        }
+    }
+
+    let tensor = Tensor::from_vec(data, (1, 3, max_size, max_size), device)?;
+    Ok(tensor.to_dtype(DType::F32)?)
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let device = candle_examples::device(args.cpu)?;
+    let dtype = if args.bf16 { DType::BF16 } else { DType::F32 };
+    let model_id = args.model_id.as_deref().unwrap_or(MODEL_ID);
+
+    let api = hf_hub::api::sync::Api::new()?;
+    let repo = api.model(model_id.to_string());
+
+    // Load config
+    let config_path = repo.get("config.json")?;
+    let config: Config = serde_json::from_reader(std::fs::File::open(&config_path)?)?;
+    println!(
+        "Config: vision {}x{} patch={}, text hidden={} layers={}, scale_factor={}",
+        config.vision_config.image_size,
+        config.vision_config.image_size,
+        config.vision_config.patch_size,
+        config.text_config.hidden_size,
+        config.text_config.num_hidden_layers,
+        config.scale_factor,
+    );
+
+    // Load tokenizer
+    let tokenizer_path = repo.get("tokenizer.json")?;
+    let tokenizer = Tokenizer::from_file(&tokenizer_path).map_err(E::msg)?;
+
+    // Load model weights
+    let model_path = repo.get("model.safetensors")?;
+    println!("Loading model from {model_path:?}");
+    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_path], dtype, &device)? };
+    let mut model = Model::new(&config, vb)?;
+    println!("Model loaded.");
+
+    // Load and preprocess image
+    let max_size = config.vision_config.image_size;
+    let pixel_values = load_image(&args.image, max_size, &device)?;
+    let pixel_values = pixel_values.to_dtype(dtype)?;
+    println!(
+        "Image: {:?} -> tensor {:?}",
+        args.image,
+        pixel_values.shape()
+    );
+
+    // Build input_ids matching the Granite-Docling chat template:
+    //   <|start_of_role|>user<|end_of_role|>
+    //   <fake_token_around_image><image>*N<fake_token_around_image>
+    //   Convert this page to docling.<|end_of_text|>\n
+    //   <|start_of_role|>assistant<|end_of_role|>
+    let prompt_text = args.prompt.as_deref().unwrap_or(
+        "Convert this page to docling.",
+    );
+    let image_seq_len = config.image_seq_len();
+
+    let user_text = tokenizer.encode("user", false).map_err(E::msg)?;
+    let prompt_enc = tokenizer.encode(prompt_text, false).map_err(E::msg)?;
+    let assistant_text = tokenizer.encode("assistant", false).map_err(E::msg)?;
+
+    let mut input_ids: Vec<u32> = Vec::new();
+    // <|start_of_role|>user<|end_of_role|>
+    input_ids.push(START_OF_ROLE);
+    input_ids.extend_from_slice(user_text.get_ids());
+    input_ids.push(END_OF_ROLE);
+    // <fake_token_around_image><global-img><image>*64<fake_token_around_image>
+    input_ids.push(FAKE_TOKEN_AROUND_IMAGE);
+    input_ids.push(GLOBAL_IMG);
+    input_ids.extend(std::iter::repeat(IMAGE_TOKEN_ID).take(image_seq_len));
+    input_ids.push(FAKE_TOKEN_AROUND_IMAGE);
+    // prompt text
+    input_ids.extend_from_slice(prompt_enc.get_ids());
+    // <|end_of_text|>\n
+    input_ids.push(END_OF_TEXT);
+    // Encode the literal newline that the template adds after <|end_of_text|>
+    let newline_enc = tokenizer.encode("\n", false).map_err(E::msg)?;
+    input_ids.extend_from_slice(newline_enc.get_ids());
+    // <|start_of_role|>assistant<|end_of_role|>
+    input_ids.push(START_OF_ROLE);
+    input_ids.extend_from_slice(assistant_text.get_ids());
+    input_ids.push(END_OF_ROLE);
+
+    let input_ids_tensor = Tensor::new(&input_ids[..], &device)?.unsqueeze(0)?;
+    println!(
+        "Input: {} total tokens ({} image placeholders)",
+        input_ids.len(),
+        image_seq_len,
+    );
+
+    // Initial forward pass with image
+    let logits = model.setup(&pixel_values, &input_ids_tensor)?;
+    let temperature = if args.temperature > 0.0 {
+        Some(args.temperature)
+    } else {
+        None
+    };
+    let mut logits_processor =
+        candle_transformers::generation::LogitsProcessor::new(42, temperature, None);
+
+    // Get first generated token from last position
+    let logits_last = logits.squeeze(0)?.get(logits.dim(1)? - 1)?;
+
+    let mut token = logits_processor.sample(&logits_last)?;
+
+    let mut generated = vec![token];
+    print_token(&tokenizer, token);
+
+    // Autoregressive generation loop
+    for _ in 1..args.max_tokens {
+        let input = Tensor::new(&[token], &device)?.unsqueeze(0)?;
+        let logits = model.forward(&input)?;
+        let logits_last = logits.squeeze(0)?.get(logits.dim(1)? - 1)?;
+        token = logits_processor.sample(&logits_last)?;
+
+        if token == config.eos_token_id || token == END_OF_TEXT {
+            break;
+        }
+        generated.push(token);
+        print_token(&tokenizer, token);
+    }
+
+    println!();
+    println!("Generated {} tokens.", generated.len());
+    Ok(())
+}
+
+fn print_token(tokenizer: &Tokenizer, token: u32) {
+    if let Ok(text) = tokenizer.decode(&[token], false) {
+        use std::io::Write;
+        print!("{text}");
+        let _ = std::io::stdout().flush();
+    }
+}

--- a/candle-examples/examples/granite-docling/main.rs
+++ b/candle-examples/examples/granite-docling/main.rs
@@ -9,10 +9,15 @@ use clap::Parser;
 
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::models::granite_docling::{config::Config, Model};
+use candle_transformers::models::granite_docling::{
+    config::{Config, QuantizedVisionConfig, TextConfig},
+    Model,
+    quantized::Model as QuantizedModel,
+};
 use tokenizers::Tokenizer;
 
 const MODEL_ID: &str = "ibm-granite/granite-docling-258M";
+const QUANTIZED_MODEL_ID: &str = "ggml-org/granite-docling-258M-GGUF";
 const IMAGE_TOKEN_ID: u32 = 100270;
 const FAKE_TOKEN_AROUND_IMAGE: u32 = 100339;
 const GLOBAL_IMG: u32 = 100340;
@@ -62,6 +67,10 @@ struct Args {
     /// Disable image splitting (single 512x512 view of entire page).
     #[arg(long)]
     no_split: bool,
+
+    /// Use quantized GGUF weights (Q8_0).
+    #[arg(long)]
+    quantized: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -263,59 +272,128 @@ fn build_input_ids_single(
 }
 
 // ---------------------------------------------------------------------------
+// Model wrapper (dispatches between f32 and quantized)
+// ---------------------------------------------------------------------------
+
+enum ModelWrapper {
+    F32(Model),
+    Quantized(QuantizedModel),
+}
+
+impl ModelWrapper {
+    fn setup(&mut self, pixel_values: &Tensor, input_ids: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::F32(m) => Ok(m.setup(pixel_values, input_ids)?),
+            Self::Quantized(m) => Ok(m.setup(pixel_values, input_ids)?),
+        }
+    }
+
+    fn forward(&mut self, input_ids: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::F32(m) => Ok(m.forward(input_ids)?),
+            Self::Quantized(m) => Ok(m.forward(input_ids)?),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 fn main() -> Result<()> {
     let args = Args::parse();
     let device = candle_examples::device(args.cpu)?;
-    let dtype = if args.bf16 { DType::BF16 } else { DType::F32 };
-    let model_id = args.model_id.as_deref().unwrap_or(MODEL_ID);
-
     let api = hf_hub::api::sync::Api::new()?;
-    let repo = api.model(model_id.to_string());
 
-    // Load config
-    let config_path = repo.get("config.json")?;
-    let config: Config = serde_json::from_reader(std::fs::File::open(&config_path)?)?;
-    let tile_size = config.vision_config.image_size;
-    let image_seq_len = config.image_seq_len();
-    println!(
-        "Config: vision {}x{} patch={}, text hidden={} layers={}, scale_factor={}",
-        tile_size, tile_size,
-        config.vision_config.patch_size,
-        config.text_config.hidden_size,
-        config.text_config.num_hidden_layers,
-        config.scale_factor,
-    );
-
-    // Load tokenizer
-    let tokenizer_path = repo.get("tokenizer.json")?;
+    // Load tokenizer (from base model repo, always needed)
+    let base_repo = api.model(MODEL_ID.to_string());
+    let tokenizer_path = base_repo.get("tokenizer.json")?;
     let tokenizer = Tokenizer::from_file(&tokenizer_path).map_err(E::msg)?;
 
-    // Load model weights
-    let model_path = repo.get("model.safetensors")?;
-    println!("Loading model from {model_path:?}");
-    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_path], dtype, &device)? };
-    let mut model = Model::new(&config, vb)?;
-    println!("Model loaded.");
+    // Load model — either f32/bf16 safetensors or quantized GGUF
+    let (mut model, tile_size, image_seq_len) = if args.quantized {
+        let model_id = args.model_id.as_deref().unwrap_or(QUANTIZED_MODEL_ID);
+        let repo = api.model(model_id.to_string());
 
-    // Load and preprocess image
+        let text_path = repo.get("granite-docling-258M-Q8_0.gguf")?;
+        let vision_path = repo.get("mmproj-granite-docling-258M-Q8_0.gguf")?;
+
+        println!("Loading quantized model...");
+        println!("  Text:   {text_path:?}");
+        println!("  Vision: {vision_path:?}");
+
+        use candle_transformers::quantized_var_builder::VarBuilder as QVarBuilder;
+        let text_vb = QVarBuilder::from_gguf(&text_path, &device)?;
+        let vision_vb = QVarBuilder::from_gguf(&vision_path, &device)?;
+
+        // Read configs from GGUF metadata
+        let text_gguf = {
+            let mut f = std::fs::File::open(&text_path)?;
+            candle::quantized::gguf_file::Content::read(&mut f)?
+        };
+        let vision_gguf = {
+            let mut f = std::fs::File::open(&vision_path)?;
+            candle::quantized::gguf_file::Content::read(&mut f)?
+        };
+
+        let text_cfg = TextConfig::from_gguf(&text_gguf.metadata)?;
+        let vision_cfg = QuantizedVisionConfig::from_gguf(&vision_gguf.metadata)?;
+
+        let tile_size = vision_cfg.image_size;
+        let image_seq_len = vision_cfg.image_seq_len();
+
+        println!(
+            "Config: vision {}x{} patch={}, text hidden={} layers={}, scale_factor={}",
+            tile_size, tile_size, vision_cfg.patch_size,
+            text_cfg.hidden_size, text_cfg.num_hidden_layers, vision_cfg.scale_factor,
+        );
+
+        let model = QuantizedModel::new(vision_vb, &vision_cfg, text_vb, &text_cfg, IMAGE_TOKEN_ID)?;
+        println!("Model loaded (quantized Q8_0).");
+
+        (ModelWrapper::Quantized(model), tile_size, image_seq_len)
+    } else {
+        let dtype = if args.bf16 { DType::BF16 } else { DType::F32 };
+        let model_id = args.model_id.as_deref().unwrap_or(MODEL_ID);
+        let repo = api.model(model_id.to_string());
+
+        let config_path = repo.get("config.json")?;
+        let config: Config = serde_json::from_reader(std::fs::File::open(&config_path)?)?;
+        let tile_size = config.vision_config.image_size;
+        let image_seq_len = config.image_seq_len();
+
+        println!(
+            "Config: vision {}x{} patch={}, text hidden={} layers={}, scale_factor={}",
+            tile_size, tile_size, config.vision_config.patch_size,
+            config.text_config.hidden_size, config.text_config.num_hidden_layers, config.scale_factor,
+        );
+
+        let model_path = repo.get("model.safetensors")?;
+        println!("Loading model from {model_path:?}");
+        let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_path], dtype, &device)? };
+        let model = Model::new(&config, vb)?;
+        println!("Model loaded (f32).");
+
+        (ModelWrapper::F32(model), tile_size, image_seq_len)
+    };
+
+    // Load and preprocess image (shared between both paths)
     let raw_img = image::ImageReader::open(&args.image)?
         .decode()
         .map_err(E::msg)?
         .to_rgb8();
 
     let prompt_text = args.prompt.as_deref().unwrap_or("Convert this page to docling.");
+    let pv_dtype = if args.quantized { DType::F32 } else if args.bf16 { DType::BF16 } else { DType::F32 };
 
     let (pixel_values, input_ids) = if args.no_split {
         let tiles = load_single(&raw_img, tile_size);
-        let pv = tiles_to_tensor(&tiles, tile_size, dtype, &device)?;
+        let pv = tiles_to_tensor(&tiles, tile_size, pv_dtype, &device)?;
         let ids = build_input_ids_single(&tokenizer, prompt_text, image_seq_len)?;
         (pv, ids)
     } else {
         let (n_rows, n_cols, tiles) = split_image(&raw_img, tile_size, 2048);
-        let pv = tiles_to_tensor(&tiles, tile_size, dtype, &device)?;
+        let pv = tiles_to_tensor(&tiles, tile_size, pv_dtype, &device)?;
         let ids = build_input_ids_split(&tokenizer, prompt_text, image_seq_len, n_rows, n_cols)?;
         (pv, ids)
     };
@@ -341,6 +419,7 @@ fn main() -> Result<()> {
         candle_transformers::generation::LogitsProcessor::new(42, temperature, None);
 
     let logits_last = logits.squeeze(0)?.get(logits.dim(1)? - 1)?;
+
     let mut token = logits_processor.sample(&logits_last)?;
     let mut generated = vec![token];
     print_token(&tokenizer, token);
@@ -352,7 +431,7 @@ fn main() -> Result<()> {
         let logits_last = logits.squeeze(0)?.get(logits.dim(1)? - 1)?;
         token = logits_processor.sample(&logits_last)?;
 
-        if token == config.eos_token_id || token == END_OF_TEXT {
+        if token == END_OF_TEXT {
             break;
         }
         generated.push(token);

--- a/candle-examples/examples/granite-docling/main.rs
+++ b/candle-examples/examples/granite-docling/main.rs
@@ -11,8 +11,8 @@ use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::granite_docling::{
     config::{Config, QuantizedVisionConfig, TextConfig},
-    Model,
     quantized::Model as QuantizedModel,
+    Model,
 };
 use tokenizers::Tokenizer;
 
@@ -79,11 +79,7 @@ struct Args {
 
 /// Resize an RGB image to exactly (w, h) and normalize to [-1, 1].
 /// Returns tensor of shape (3, h, w).
-fn resize_and_normalize(
-    img: &image::RgbImage,
-    w: u32,
-    h: u32,
-) -> Vec<f32> {
+fn resize_and_normalize(img: &image::RgbImage, w: u32, h: u32) -> Vec<f32> {
     let resized = image::imageops::resize(img, w, h, image::imageops::FilterType::Lanczos3);
     let (w, h) = (w as usize, h as usize);
     let mut data = vec![0.0f32; 3 * h * w];
@@ -127,11 +123,18 @@ fn split_image(
     // Step 3: resize to exact grid dimensions
     let grid_w = (n_cols * tile_size) as u32;
     let grid_h = (n_rows * tile_size) as u32;
-    let resized = image::imageops::resize(img, grid_w, grid_h, image::imageops::FilterType::Lanczos3);
+    let resized =
+        image::imageops::resize(img, grid_w, grid_h, image::imageops::FilterType::Lanczos3);
 
     println!(
         "Image splitting: {}x{} -> {}x{} grid ({}x{} tiles = {} + 1 global)",
-        img.width(), img.height(), grid_w, grid_h, n_rows, n_cols, n_rows * n_cols,
+        img.width(),
+        img.height(),
+        grid_w,
+        grid_h,
+        n_rows,
+        n_cols,
+        n_rows * n_cols,
     );
 
     // Step 4: extract tiles
@@ -157,9 +160,16 @@ fn split_image(
 fn load_single(img: &image::RgbImage, tile_size: usize) -> Vec<Vec<f32>> {
     println!(
         "No splitting: {}x{} -> {}x{}",
-        img.width(), img.height(), tile_size, tile_size,
+        img.width(),
+        img.height(),
+        tile_size,
+        tile_size,
     );
-    vec![resize_and_normalize(img, tile_size as u32, tile_size as u32)]
+    vec![resize_and_normalize(
+        img,
+        tile_size as u32,
+        tile_size as u32,
+    )]
 }
 
 /// Stack tile data into a single tensor of shape (num_tiles, 3, H, W).
@@ -216,21 +226,19 @@ fn build_input_ids_split(
     ids.extend_from_slice(user_text.get_ids());
     ids.push(END_OF_ROLE);
 
-    for row in 0..n_rows {
-        for col in 0..n_cols {
+    for row_tokens in ROW_COL_TOKENS.iter().take(n_rows) {
+        for &token_id in row_tokens.iter().take(n_cols) {
             ids.push(FAKE_TOKEN_AROUND_IMAGE);
-            ids.push(ROW_COL_TOKENS[row][col]);
-            ids.extend(std::iter::repeat(IMAGE_TOKEN_ID).take(image_seq_len));
+            ids.push(token_id);
+            ids.extend(std::iter::repeat_n(IMAGE_TOKEN_ID, image_seq_len));
         }
-        // \n after each row
         ids.extend_from_slice(newline_enc.get_ids());
     }
 
-    // \n<fake><global-img><image>*64<fake>
     ids.extend_from_slice(newline_enc.get_ids());
     ids.push(FAKE_TOKEN_AROUND_IMAGE);
     ids.push(GLOBAL_IMG);
-    ids.extend(std::iter::repeat(IMAGE_TOKEN_ID).take(image_seq_len));
+    ids.extend(std::iter::repeat_n(IMAGE_TOKEN_ID, image_seq_len));
     ids.push(FAKE_TOKEN_AROUND_IMAGE);
 
     // prompt text
@@ -265,7 +273,7 @@ fn build_input_ids_single(
     ids.push(END_OF_ROLE);
     ids.push(FAKE_TOKEN_AROUND_IMAGE);
     ids.push(GLOBAL_IMG);
-    ids.extend(std::iter::repeat(IMAGE_TOKEN_ID).take(image_seq_len));
+    ids.extend(std::iter::repeat_n(IMAGE_TOKEN_ID, image_seq_len));
     ids.push(FAKE_TOKEN_AROUND_IMAGE);
     ids.extend_from_slice(prompt_enc.get_ids());
     ids.push(END_OF_TEXT);
@@ -351,11 +359,16 @@ fn main() -> Result<()> {
 
         println!(
             "Config: vision {}x{} patch={}, text hidden={} layers={}, scale_factor={}",
-            tile_size, tile_size, vision_cfg.patch_size,
-            text_cfg.hidden_size, text_cfg.num_hidden_layers, vision_cfg.scale_factor,
+            tile_size,
+            tile_size,
+            vision_cfg.patch_size,
+            text_cfg.hidden_size,
+            text_cfg.num_hidden_layers,
+            vision_cfg.scale_factor,
         );
 
-        let model = QuantizedModel::new(vision_vb, &vision_cfg, text_vb, &text_cfg, IMAGE_TOKEN_ID)?;
+        let model =
+            QuantizedModel::new(vision_vb, &vision_cfg, text_vb, &text_cfg, IMAGE_TOKEN_ID)?;
         println!("Model loaded (quantized Q8_0).");
 
         (ModelWrapper::Quantized(model), tile_size, image_seq_len)
@@ -371,8 +384,12 @@ fn main() -> Result<()> {
 
         println!(
             "Config: vision {}x{} patch={}, text hidden={} layers={}, scale_factor={}",
-            tile_size, tile_size, config.vision_config.patch_size,
-            config.text_config.hidden_size, config.text_config.num_hidden_layers, config.scale_factor,
+            tile_size,
+            tile_size,
+            config.vision_config.patch_size,
+            config.text_config.hidden_size,
+            config.text_config.num_hidden_layers,
+            config.scale_factor,
         );
 
         let model_path = repo.get("model.safetensors")?;
@@ -390,8 +407,17 @@ fn main() -> Result<()> {
         .map_err(E::msg)?
         .to_rgb8();
 
-    let prompt_text = args.prompt.as_deref().unwrap_or("Convert this page to docling.");
-    let pv_dtype = if args.quantized { DType::F32 } else if args.bf16 { DType::BF16 } else { DType::F32 };
+    let prompt_text = args
+        .prompt
+        .as_deref()
+        .unwrap_or("Convert this page to docling.");
+    let pv_dtype = if args.quantized {
+        DType::F32
+    } else if args.bf16 {
+        DType::BF16
+    } else {
+        DType::F32
+    };
 
     let (pixel_values, input_ids) = if args.no_split {
         let tiles = load_single(&raw_img, tile_size);

--- a/candle-examples/examples/granite-docling/main.rs
+++ b/candle-examples/examples/granite-docling/main.rs
@@ -20,6 +20,14 @@ const START_OF_ROLE: u32 = 100264;
 const END_OF_ROLE: u32 = 100265;
 const END_OF_TEXT: u32 = 100257;
 
+// Row/col marker token IDs (non-contiguous in vocabulary)
+const ROW_COL_TOKENS: [[u32; 4]; 4] = [
+    [100258, 100259, 100261, 100262], // row 1: col 1-4
+    [100263, 100267, 100268, 100341], // row 2: col 1-4
+    [100342, 100343, 100344, 100345], // row 3: col 1-4
+    [100346, 100347, 100348, 100349], // row 4: col 1-4
+];
+
 #[derive(Parser, Debug)]
 #[command(about = "Granite-Docling: document image to structured markup")]
 struct Args {
@@ -50,43 +58,213 @@ struct Args {
     /// The prompt to use. Defaults to a generic document conversion prompt.
     #[arg(long)]
     prompt: Option<String>,
+
+    /// Disable image splitting (single 512x512 view of entire page).
+    #[arg(long)]
+    no_split: bool,
 }
 
-/// Load and preprocess an image following HF Idefics3ImageProcessor (no image splitting):
-///   1. Resize to 512x512 square (stretch, matching HF behavior)
-///   2. Rescale [0,255] -> [0,1], normalize with mean=0.5, std=0.5
-/// Returns (1, 3, 512, 512).
-fn load_image(path: &str, max_size: usize, device: &Device) -> Result<Tensor> {
-    let img = image::ImageReader::open(path)?
-        .decode()
-        .map_err(E::msg)?;
+// ---------------------------------------------------------------------------
+// Image preprocessing
+// ---------------------------------------------------------------------------
 
-    // Convert to RGB, then resize to exactly max_size x max_size (stretch to square)
-    let img = img.to_rgb8();
-    let (orig_w, orig_h) = (img.width(), img.height());
-    let img = image::imageops::resize(
-        &img,
-        max_size as u32,
-        max_size as u32,
-        image::imageops::FilterType::Lanczos3,
-    );
-    println!("Image: {}x{} -> {}x{}", orig_w, orig_h, max_size, max_size);
-
-    // Normalize: [0,255] -> [-1,1]
-    let mut data = vec![0.0f32; 3 * max_size * max_size];
-    for y in 0..max_size {
-        for x in 0..max_size {
-            let pixel = *img.get_pixel(x as u32, y as u32);
+/// Resize an RGB image to exactly (w, h) and normalize to [-1, 1].
+/// Returns tensor of shape (3, h, w).
+fn resize_and_normalize(
+    img: &image::RgbImage,
+    w: u32,
+    h: u32,
+) -> Vec<f32> {
+    let resized = image::imageops::resize(img, w, h, image::imageops::FilterType::Lanczos3);
+    let (w, h) = (w as usize, h as usize);
+    let mut data = vec![0.0f32; 3 * h * w];
+    for y in 0..h {
+        for x in 0..w {
+            let pixel = *resized.get_pixel(x as u32, y as u32);
             for c in 0..3 {
-                let idx = c * max_size * max_size + y * max_size + x;
-                data[idx] = (pixel[c] as f32 / 255.0 - 0.5) / 0.5;
+                data[c * h * w + y * w + x] = (pixel[c] as f32 / 255.0 - 0.5) / 0.5;
             }
         }
     }
-
-    let tensor = Tensor::from_vec(data, (1, 3, max_size, max_size), device)?;
-    Ok(tensor.to_dtype(DType::F32)?)
+    data
 }
+
+/// Split an image into tiles following HF Idefics3ImageProcessor:
+///   1. Resize so longest edge = max_long_edge (2048 default)
+///   2. Compute grid dimensions that fit in tile_size (512) tiles
+///   3. Resize to exact grid dimensions
+///   4. Extract tiles + one global view resized to tile_size x tile_size
+///
+/// Returns (num_tiles + 1 global, grid_rows, grid_cols, Vec<tile_data>)
+/// where each tile_data is (3, tile_size, tile_size) flattened.
+fn split_image(
+    img: &image::RgbImage,
+    tile_size: usize,
+    max_long_edge: usize,
+) -> (usize, usize, Vec<Vec<f32>>) {
+    let (orig_w, orig_h) = (img.width() as f64, img.height() as f64);
+    let tile = tile_size as f64;
+
+    // Step 1: compute target size (longest edge = max_long_edge)
+    let longest = orig_w.max(orig_h);
+    let scale = (max_long_edge as f64) / longest;
+    let scaled_w = (orig_w * scale).round();
+    let scaled_h = (orig_h * scale).round();
+
+    // Step 2: compute grid dimensions
+    let n_cols = (scaled_w / tile).ceil() as usize;
+    let n_rows = (scaled_h / tile).ceil() as usize;
+
+    // Step 3: resize to exact grid dimensions
+    let grid_w = (n_cols * tile_size) as u32;
+    let grid_h = (n_rows * tile_size) as u32;
+    let resized = image::imageops::resize(img, grid_w, grid_h, image::imageops::FilterType::Lanczos3);
+
+    println!(
+        "Image splitting: {}x{} -> {}x{} grid ({}x{} tiles = {} + 1 global)",
+        img.width(), img.height(), grid_w, grid_h, n_rows, n_cols, n_rows * n_cols,
+    );
+
+    // Step 4: extract tiles
+    let ts = tile_size as u32;
+    let mut tiles: Vec<Vec<f32>> = Vec::new();
+    for row in 0..n_rows {
+        for col in 0..n_cols {
+            let x0 = (col as u32) * ts;
+            let y0 = (row as u32) * ts;
+            let sub = image::imageops::crop_imm(&resized, x0, y0, ts, ts).to_image();
+            tiles.push(resize_and_normalize(&sub, ts, ts));
+        }
+    }
+
+    // Step 5: global view (entire image resized to tile_size x tile_size)
+    let global = resize_and_normalize(img, ts, ts);
+    tiles.push(global);
+
+    (n_rows, n_cols, tiles)
+}
+
+/// Load image without splitting — single 512x512 view.
+fn load_single(img: &image::RgbImage, tile_size: usize) -> Vec<Vec<f32>> {
+    println!(
+        "No splitting: {}x{} -> {}x{}",
+        img.width(), img.height(), tile_size, tile_size,
+    );
+    vec![resize_and_normalize(img, tile_size as u32, tile_size as u32)]
+}
+
+/// Stack tile data into a single tensor of shape (num_tiles, 3, H, W).
+fn tiles_to_tensor(
+    tiles: &[Vec<f32>],
+    tile_size: usize,
+    dtype: DType,
+    device: &Device,
+) -> Result<Tensor> {
+    let n = tiles.len();
+    let tile_elems = 3 * tile_size * tile_size;
+    let mut all_data = Vec::with_capacity(n * tile_elems);
+    for tile in tiles {
+        all_data.extend_from_slice(tile);
+    }
+    let tensor = Tensor::from_vec(all_data, (n, 3, tile_size, tile_size), device)?;
+    Ok(tensor.to_dtype(dtype)?)
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+/// Build input_ids for split images following the Granite-Docling chat template:
+///   <|start_of_role|>user<|end_of_role|>
+///   <fake><row_1_col_1><image>*64 <fake><row_1_col_2><image>*64 ... \n
+///   <fake><row_2_col_1><image>*64 ... \n
+///   ...
+///   \n<fake><global-img><image>*64<fake>
+///   prompt text<|end_of_text|>\n
+///   <|start_of_role|>assistant<|end_of_role|>
+fn build_input_ids_split(
+    tokenizer: &Tokenizer,
+    prompt_text: &str,
+    image_seq_len: usize,
+    n_rows: usize,
+    n_cols: usize,
+) -> Result<Vec<u32>> {
+    let user_text = tokenizer.encode("user", false).map_err(E::msg)?;
+    let prompt_enc = tokenizer.encode(prompt_text, false).map_err(E::msg)?;
+    let assistant_text = tokenizer.encode("assistant", false).map_err(E::msg)?;
+    let newline_enc = tokenizer.encode("\n", false).map_err(E::msg)?;
+
+    let mut ids: Vec<u32> = Vec::new();
+
+    // <|start_of_role|>user<|end_of_role|>
+    ids.push(START_OF_ROLE);
+    ids.extend_from_slice(user_text.get_ids());
+    ids.push(END_OF_ROLE);
+
+    // Tile rows
+    for row in 0..n_rows {
+        for col in 0..n_cols {
+            ids.push(FAKE_TOKEN_AROUND_IMAGE);
+            ids.push(ROW_COL_TOKENS[row][col]);
+            ids.extend(std::iter::repeat(IMAGE_TOKEN_ID).take(image_seq_len));
+        }
+        // \n after each row
+        ids.extend_from_slice(newline_enc.get_ids());
+    }
+
+    // \n<fake><global-img><image>*64<fake>
+    ids.extend_from_slice(newline_enc.get_ids());
+    ids.push(FAKE_TOKEN_AROUND_IMAGE);
+    ids.push(GLOBAL_IMG);
+    ids.extend(std::iter::repeat(IMAGE_TOKEN_ID).take(image_seq_len));
+    ids.push(FAKE_TOKEN_AROUND_IMAGE);
+
+    // prompt text
+    ids.extend_from_slice(prompt_enc.get_ids());
+
+    // <|end_of_text|>\n
+    ids.push(END_OF_TEXT);
+    ids.extend_from_slice(newline_enc.get_ids());
+
+    // <|start_of_role|>assistant<|end_of_role|>
+    ids.push(START_OF_ROLE);
+    ids.extend_from_slice(assistant_text.get_ids());
+    ids.push(END_OF_ROLE);
+
+    Ok(ids)
+}
+
+/// Build input_ids for single image (no splitting).
+fn build_input_ids_single(
+    tokenizer: &Tokenizer,
+    prompt_text: &str,
+    image_seq_len: usize,
+) -> Result<Vec<u32>> {
+    let user_text = tokenizer.encode("user", false).map_err(E::msg)?;
+    let prompt_enc = tokenizer.encode(prompt_text, false).map_err(E::msg)?;
+    let assistant_text = tokenizer.encode("assistant", false).map_err(E::msg)?;
+    let newline_enc = tokenizer.encode("\n", false).map_err(E::msg)?;
+
+    let mut ids: Vec<u32> = Vec::new();
+    ids.push(START_OF_ROLE);
+    ids.extend_from_slice(user_text.get_ids());
+    ids.push(END_OF_ROLE);
+    ids.push(FAKE_TOKEN_AROUND_IMAGE);
+    ids.push(GLOBAL_IMG);
+    ids.extend(std::iter::repeat(IMAGE_TOKEN_ID).take(image_seq_len));
+    ids.push(FAKE_TOKEN_AROUND_IMAGE);
+    ids.extend_from_slice(prompt_enc.get_ids());
+    ids.push(END_OF_TEXT);
+    ids.extend_from_slice(newline_enc.get_ids());
+    ids.push(START_OF_ROLE);
+    ids.extend_from_slice(assistant_text.get_ids());
+    ids.push(END_OF_ROLE);
+    Ok(ids)
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
 
 fn main() -> Result<()> {
     let args = Args::parse();
@@ -100,10 +278,11 @@ fn main() -> Result<()> {
     // Load config
     let config_path = repo.get("config.json")?;
     let config: Config = serde_json::from_reader(std::fs::File::open(&config_path)?)?;
+    let tile_size = config.vision_config.image_size;
+    let image_seq_len = config.image_seq_len();
     println!(
         "Config: vision {}x{} patch={}, text hidden={} layers={}, scale_factor={}",
-        config.vision_config.image_size,
-        config.vision_config.image_size,
+        tile_size, tile_size,
         config.vision_config.patch_size,
         config.text_config.hidden_size,
         config.text_config.num_hidden_layers,
@@ -122,57 +301,34 @@ fn main() -> Result<()> {
     println!("Model loaded.");
 
     // Load and preprocess image
-    let max_size = config.vision_config.image_size;
-    let pixel_values = load_image(&args.image, max_size, &device)?;
-    let pixel_values = pixel_values.to_dtype(dtype)?;
+    let raw_img = image::ImageReader::open(&args.image)?
+        .decode()
+        .map_err(E::msg)?
+        .to_rgb8();
+
+    let prompt_text = args.prompt.as_deref().unwrap_or("Convert this page to docling.");
+
+    let (pixel_values, input_ids) = if args.no_split {
+        let tiles = load_single(&raw_img, tile_size);
+        let pv = tiles_to_tensor(&tiles, tile_size, dtype, &device)?;
+        let ids = build_input_ids_single(&tokenizer, prompt_text, image_seq_len)?;
+        (pv, ids)
+    } else {
+        let (n_rows, n_cols, tiles) = split_image(&raw_img, tile_size, 2048);
+        let pv = tiles_to_tensor(&tiles, tile_size, dtype, &device)?;
+        let ids = build_input_ids_split(&tokenizer, prompt_text, image_seq_len, n_rows, n_cols)?;
+        (pv, ids)
+    };
+
+    let n_image_tokens = input_ids.iter().filter(|&&id| id == IMAGE_TOKEN_ID).count();
     println!(
-        "Image: {:?} -> tensor {:?}",
-        args.image,
-        pixel_values.shape()
+        "Input: {} tokens ({} image placeholders, {} tiles)",
+        input_ids.len(),
+        n_image_tokens,
+        pixel_values.dim(0)?,
     );
-
-    // Build input_ids matching the Granite-Docling chat template:
-    //   <|start_of_role|>user<|end_of_role|>
-    //   <fake_token_around_image><image>*N<fake_token_around_image>
-    //   Convert this page to docling.<|end_of_text|>\n
-    //   <|start_of_role|>assistant<|end_of_role|>
-    let prompt_text = args.prompt.as_deref().unwrap_or(
-        "Convert this page to docling.",
-    );
-    let image_seq_len = config.image_seq_len();
-
-    let user_text = tokenizer.encode("user", false).map_err(E::msg)?;
-    let prompt_enc = tokenizer.encode(prompt_text, false).map_err(E::msg)?;
-    let assistant_text = tokenizer.encode("assistant", false).map_err(E::msg)?;
-
-    let mut input_ids: Vec<u32> = Vec::new();
-    // <|start_of_role|>user<|end_of_role|>
-    input_ids.push(START_OF_ROLE);
-    input_ids.extend_from_slice(user_text.get_ids());
-    input_ids.push(END_OF_ROLE);
-    // <fake_token_around_image><global-img><image>*64<fake_token_around_image>
-    input_ids.push(FAKE_TOKEN_AROUND_IMAGE);
-    input_ids.push(GLOBAL_IMG);
-    input_ids.extend(std::iter::repeat(IMAGE_TOKEN_ID).take(image_seq_len));
-    input_ids.push(FAKE_TOKEN_AROUND_IMAGE);
-    // prompt text
-    input_ids.extend_from_slice(prompt_enc.get_ids());
-    // <|end_of_text|>\n
-    input_ids.push(END_OF_TEXT);
-    // Encode the literal newline that the template adds after <|end_of_text|>
-    let newline_enc = tokenizer.encode("\n", false).map_err(E::msg)?;
-    input_ids.extend_from_slice(newline_enc.get_ids());
-    // <|start_of_role|>assistant<|end_of_role|>
-    input_ids.push(START_OF_ROLE);
-    input_ids.extend_from_slice(assistant_text.get_ids());
-    input_ids.push(END_OF_ROLE);
 
     let input_ids_tensor = Tensor::new(&input_ids[..], &device)?.unsqueeze(0)?;
-    println!(
-        "Input: {} total tokens ({} image placeholders)",
-        input_ids.len(),
-        image_seq_len,
-    );
 
     // Initial forward pass with image
     let logits = model.setup(&pixel_values, &input_ids_tensor)?;
@@ -184,11 +340,8 @@ fn main() -> Result<()> {
     let mut logits_processor =
         candle_transformers::generation::LogitsProcessor::new(42, temperature, None);
 
-    // Get first generated token from last position
     let logits_last = logits.squeeze(0)?.get(logits.dim(1)? - 1)?;
-
     let mut token = logits_processor.sample(&logits_last)?;
-
     let mut generated = vec![token];
     print_token(&tokenizer, token);
 

--- a/candle-examples/examples/granite-docling/main.rs
+++ b/candle-examples/examples/granite-docling/main.rs
@@ -203,14 +203,19 @@ fn build_input_ids_split(
     let assistant_text = tokenizer.encode("assistant", false).map_err(E::msg)?;
     let newline_enc = tokenizer.encode("\n", false).map_err(E::msg)?;
 
+    if n_rows > 4 || n_cols > 4 {
+        anyhow::bail!(
+            "Image splits into {n_rows}x{n_cols} grid, but max supported is 4x4. \
+             Use a lower resolution image or --no-split."
+        );
+    }
+
     let mut ids: Vec<u32> = Vec::new();
 
-    // <|start_of_role|>user<|end_of_role|>
     ids.push(START_OF_ROLE);
     ids.extend_from_slice(user_text.get_ids());
     ids.push(END_OF_ROLE);
 
-    // Tile rows
     for row in 0..n_rows {
         for col in 0..n_cols {
             ids.push(FAKE_TOKEN_AROUND_IMAGE);
@@ -322,22 +327,24 @@ fn main() -> Result<()> {
         println!("  Text:   {text_path:?}");
         println!("  Vision: {vision_path:?}");
 
+        // Read each GGUF once: extract metadata for config + load tensors for VarBuilder
+        use candle::quantized::gguf_file;
         use candle_transformers::quantized_var_builder::VarBuilder as QVarBuilder;
-        let text_vb = QVarBuilder::from_gguf(&text_path, &device)?;
-        let vision_vb = QVarBuilder::from_gguf(&vision_path, &device)?;
 
-        // Read configs from GGUF metadata
-        let text_gguf = {
+        let (text_vb, text_cfg) = {
             let mut f = std::fs::File::open(&text_path)?;
-            candle::quantized::gguf_file::Content::read(&mut f)?
+            let content = gguf_file::Content::read(&mut f)?;
+            let cfg = TextConfig::from_gguf(&content.metadata)?;
+            let vb = QVarBuilder::from_gguf(&text_path, &device)?;
+            (vb, cfg)
         };
-        let vision_gguf = {
+        let (vision_vb, vision_cfg) = {
             let mut f = std::fs::File::open(&vision_path)?;
-            candle::quantized::gguf_file::Content::read(&mut f)?
+            let content = gguf_file::Content::read(&mut f)?;
+            let cfg = QuantizedVisionConfig::from_gguf(&content.metadata)?;
+            let vb = QVarBuilder::from_gguf(&vision_path, &device)?;
+            (vb, cfg)
         };
-
-        let text_cfg = TextConfig::from_gguf(&text_gguf.metadata)?;
-        let vision_cfg = QuantizedVisionConfig::from_gguf(&vision_gguf.metadata)?;
 
         let tile_size = vision_cfg.image_size;
         let image_seq_len = vision_cfg.image_seq_len();

--- a/candle-transformers/src/models/granite_docling/config.rs
+++ b/candle-transformers/src/models/granite_docling/config.rs
@@ -61,10 +61,6 @@ impl TextConfig {
     pub fn head_dim(&self) -> usize {
         self.head_dim
     }
-
-    pub fn num_kv_groups(&self) -> usize {
-        self.num_attention_heads / self.num_key_value_heads
-    }
 }
 
 #[derive(serde::Deserialize, Clone, Debug)]

--- a/candle-transformers/src/models/granite_docling/config.rs
+++ b/candle-transformers/src/models/granite_docling/config.rs
@@ -1,0 +1,103 @@
+//! Configuration for Granite-Docling (Idefics3) model.
+//!
+//! Architecture: SigLIP vision encoder → pixel shuffle connector → Llama-style causal decoder.
+//!
+//! References:
+//! - [Model Card](https://huggingface.co/ibm-granite/granite-docling-258M)
+
+use crate::models::siglip;
+
+fn default_hidden_act() -> candle_nn::Activation {
+    candle_nn::Activation::Silu
+}
+
+fn default_rope_theta() -> f64 {
+    100_000.0
+}
+
+fn default_rms_norm_eps() -> f64 {
+    1e-5
+}
+
+fn default_max_position_embeddings() -> usize {
+    8192
+}
+
+fn default_scale_factor() -> usize {
+    4
+}
+
+#[derive(serde::Deserialize, Clone, Debug)]
+pub struct TextConfig {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    #[serde(default = "default_head_dim")]
+    pub head_dim: usize,
+    #[serde(default = "default_hidden_act")]
+    pub hidden_act: candle_nn::Activation,
+    #[serde(default = "default_max_position_embeddings")]
+    pub max_position_embeddings: usize,
+    #[serde(default = "default_rms_norm_eps")]
+    pub rms_norm_eps: f64,
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f64,
+    #[serde(default)]
+    pub attention_bias: bool,
+    #[serde(default)]
+    pub mlp_bias: bool,
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+}
+
+fn default_head_dim() -> usize {
+    64
+}
+
+impl TextConfig {
+    pub fn head_dim(&self) -> usize {
+        self.head_dim
+    }
+
+    pub fn num_kv_groups(&self) -> usize {
+        self.num_attention_heads / self.num_key_value_heads
+    }
+}
+
+#[derive(serde::Deserialize, Clone, Debug)]
+pub struct Config {
+    pub vision_config: siglip::VisionConfig,
+    pub text_config: TextConfig,
+    #[serde(default = "default_scale_factor")]
+    pub scale_factor: usize,
+    #[serde(default)]
+    pub image_token_id: u32,
+    #[serde(default)]
+    pub bos_token_id: u32,
+    #[serde(default)]
+    pub eos_token_id: u32,
+    #[serde(default)]
+    pub pad_token_id: u32,
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+    #[serde(default)]
+    pub vocab_size: usize,
+}
+
+impl Config {
+    /// Number of image tokens after pixel shuffle downsampling.
+    /// = num_patches / scale_factor^2
+    pub fn image_seq_len(&self) -> usize {
+        let num_patches = self.vision_config.num_patches();
+        num_patches / (self.scale_factor * self.scale_factor)
+    }
+
+    /// Dimension of vision features after pixel shuffle (before linear projection).
+    /// = vision_hidden_size * scale_factor^2
+    pub fn connector_input_dim(&self) -> usize {
+        self.vision_config.hidden_size * self.scale_factor * self.scale_factor
+    }
+}

--- a/candle-transformers/src/models/granite_docling/config.rs
+++ b/candle-transformers/src/models/granite_docling/config.rs
@@ -87,6 +87,89 @@ pub struct Config {
     pub vocab_size: usize,
 }
 
+impl TextConfig {
+    /// Build TextConfig from GGUF metadata keys (llama.* namespace).
+    pub fn from_gguf(
+        metadata: &std::collections::HashMap<String, candle::quantized::gguf_file::Value>,
+    ) -> candle::Result<Self> {
+        let get = |key: &str| {
+            metadata
+                .get(key)
+                .ok_or_else(|| candle::Error::Msg(format!("missing GGUF metadata: {key}")))
+        };
+        Ok(Self {
+            vocab_size: get("llama.vocab_size")?.to_u32()? as usize,
+            hidden_size: get("llama.embedding_length")?.to_u32()? as usize,
+            intermediate_size: get("llama.feed_forward_length")?.to_u32()? as usize,
+            num_hidden_layers: get("llama.block_count")?.to_u32()? as usize,
+            num_attention_heads: get("llama.attention.head_count")?.to_u32()? as usize,
+            num_key_value_heads: get("llama.attention.head_count_kv")?.to_u32()? as usize,
+            head_dim: get("llama.attention.key_length")?.to_u32()? as usize,
+            hidden_act: candle_nn::Activation::Silu,
+            max_position_embeddings: get("llama.context_length")?.to_u32()? as usize,
+            rms_norm_eps: get("llama.attention.layer_norm_rms_epsilon")?.to_f32()? as f64,
+            rope_theta: get("llama.rope.freq_base")?.to_f32()? as f64,
+            attention_bias: false,
+            mlp_bias: false,
+            tie_word_embeddings: true,
+        })
+    }
+}
+
+/// Vision-related config extracted from mmproj GGUF metadata.
+#[derive(Clone, Debug)]
+pub struct QuantizedVisionConfig {
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub image_size: usize,
+    pub patch_size: usize,
+    pub layer_norm_eps: f64,
+    pub projection_dim: usize,
+    pub scale_factor: usize,
+}
+
+impl QuantizedVisionConfig {
+    /// Build from mmproj GGUF metadata keys (clip.vision.* namespace).
+    pub fn from_gguf(
+        metadata: &std::collections::HashMap<String, candle::quantized::gguf_file::Value>,
+    ) -> candle::Result<Self> {
+        let get = |key: &str| {
+            metadata
+                .get(key)
+                .ok_or_else(|| candle::Error::Msg(format!("missing GGUF metadata: {key}")))
+        };
+        Ok(Self {
+            hidden_size: get("clip.vision.embedding_length")?.to_u32()? as usize,
+            intermediate_size: get("clip.vision.feed_forward_length")?.to_u32()? as usize,
+            num_hidden_layers: get("clip.vision.block_count")?.to_u32()? as usize,
+            num_attention_heads: get("clip.vision.attention.head_count")?.to_u32()? as usize,
+            image_size: get("clip.vision.image_size")?.to_u32()? as usize,
+            patch_size: get("clip.vision.patch_size")?.to_u32()? as usize,
+            layer_norm_eps: get("clip.vision.attention.layer_norm_epsilon")?.to_f32()? as f64,
+            projection_dim: get("clip.vision.projection_dim")?.to_u32()? as usize,
+            scale_factor: get("clip.vision.projector.scale_factor")?.to_u32()? as usize,
+        })
+    }
+
+    pub fn num_patches(&self) -> usize {
+        (self.image_size / self.patch_size).pow(2)
+    }
+
+    pub fn head_dim(&self) -> usize {
+        self.hidden_size / self.num_attention_heads
+    }
+
+    pub fn image_seq_len(&self) -> usize {
+        self.num_patches() / (self.scale_factor * self.scale_factor)
+    }
+
+    pub fn connector_input_dim(&self) -> usize {
+        self.hidden_size * self.scale_factor * self.scale_factor
+    }
+}
+
 impl Config {
     /// Number of image tokens after pixel shuffle downsampling.
     /// = num_patches / scale_factor^2

--- a/candle-transformers/src/models/granite_docling/mod.rs
+++ b/candle-transformers/src/models/granite_docling/mod.rs
@@ -28,7 +28,7 @@ pub fn pixel_shuffle(xs: &Tensor, scale_factor: usize) -> Result<Tensor> {
     if h * w != seq_len {
         candle::bail!("pixel shuffle requires square patch grid, got {seq_len} patches (sqrt={h})");
     }
-    if h % s != 0 {
+    if !h.is_multiple_of(s) {
         candle::bail!("patch grid size {h} not divisible by scale_factor {s}");
     }
 
@@ -133,11 +133,8 @@ pub struct Model {
 
 impl Model {
     pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
-        let vision_model = siglip::VisionModel::new(
-            &cfg.vision_config,
-            false,
-            vb.pp("model.vision_model"),
-        )?;
+        let vision_model =
+            siglip::VisionModel::new(&cfg.vision_config, false, vb.pp("model.vision_model"))?;
         let connector = Connector::new(cfg, vb.pp("model.connector"))?;
         let text_model = TextModel::new(&cfg.text_config, vb.pp("model.text_model"))?;
         Ok(Self {
@@ -159,8 +156,12 @@ impl Model {
         self.text_model.clear_kv_cache();
         let image_features = self.encode_image(pixel_values)?;
         let text_embeds = self.text_model.embed_tokens().forward(input_ids)?;
-        let input_embeds =
-            merge_image_tokens(&text_embeds, &image_features, input_ids, self.image_token_id)?;
+        let input_embeds = merge_image_tokens(
+            &text_embeds,
+            &image_features,
+            input_ids,
+            self.image_token_id,
+        )?;
         self.text_model.forward_embeds(&input_embeds)
     }
 

--- a/candle-transformers/src/models/granite_docling/mod.rs
+++ b/candle-transformers/src/models/granite_docling/mod.rs
@@ -17,14 +17,80 @@ use candle_nn::{linear_no_bias, VarBuilder};
 use config::Config;
 use text::TextModel;
 
+/// Idefics3 pixel shuffle: spatially downsample vision tokens.
+///   (B, H*W, D) → (B, H/s * W/s, D * s²)
+/// Shared by both f32 and quantized paths.
+pub fn pixel_shuffle(xs: &Tensor, scale_factor: usize) -> Result<Tensor> {
+    let (b, seq_len, dim) = xs.dims3()?;
+    let s = scale_factor;
+    let h = (seq_len as f64).sqrt() as usize;
+    let w = h;
+    if h * w != seq_len {
+        candle::bail!("pixel shuffle requires square patch grid, got {seq_len} patches (sqrt={h})");
+    }
+    if h % s != 0 {
+        candle::bail!("patch grid size {h} not divisible by scale_factor {s}");
+    }
+
+    let xs = xs.reshape((b, h, w, dim))?;
+    let xs = xs.reshape((b, h, w / s, dim * s))?;
+    let xs = xs.permute((0, 2, 1, 3))?;
+    let xs = xs.reshape((b, h / s, w / s, dim * s * s))?;
+    xs.reshape((b, (h / s) * (w / s), dim * s * s))
+}
+
+/// Replace `<image>` placeholder token embeddings with projected vision features.
+/// Identifies contiguous runs of image/text tokens and uses sliced Tensor::cat
+/// instead of per-token allocation.
+/// Shared by both f32 and quantized paths.
+pub fn merge_image_tokens(
+    text_embeds: &Tensor,
+    image_features: &Tensor,
+    input_ids: &Tensor,
+    image_token_id: u32,
+) -> Result<Tensor> {
+    let (b, seq_len, _hidden) = text_embeds.dims3()?;
+    let input_ids_vec = input_ids.flatten_all()?.to_vec1::<u32>()?;
+    let text_embeds = text_embeds.to_dtype(image_features.dtype())?;
+
+    let mut batch_results = Vec::with_capacity(b);
+    for batch_idx in 0..b {
+        let ids = &input_ids_vec[batch_idx * seq_len..(batch_idx + 1) * seq_len];
+        let mut segments: Vec<Tensor> = Vec::new();
+        let mut img_idx = 0;
+        let mut pos = 0;
+
+        while pos < seq_len {
+            if ids[pos] == image_token_id {
+                // Count contiguous image tokens
+                let start = pos;
+                while pos < seq_len && ids[pos] == image_token_id {
+                    pos += 1;
+                }
+                let count = pos - start;
+                let available = count.min(image_features.dim(1)? - img_idx);
+                if available > 0 {
+                    segments.push(image_features.i((batch_idx, img_idx..img_idx + available))?);
+                    img_idx += available;
+                }
+            } else {
+                // Count contiguous text tokens
+                let start = pos;
+                while pos < seq_len && ids[pos] != image_token_id {
+                    pos += 1;
+                }
+                segments.push(text_embeds.i((batch_idx, start..pos))?);
+            }
+        }
+
+        let batch_embeds = Tensor::cat(&segments, 0)?.unsqueeze(0)?;
+        batch_results.push(batch_embeds);
+    }
+    Tensor::cat(&batch_results, 0)
+}
+
 // ---------------------------------------------------------------------------
-// Pixel Shuffle Connector
-//
-// Spatially downsamples vision tokens by rearranging patch features:
-//   (B, H*W, D) -> reshape -> (B, H/s * W/s, D * s^2) -> linear -> (B, N, text_hidden)
-//
-// For granite-docling-258M with scale_factor=4:
-//   (B, 1024, 768) -> (B, 64, 12288) -> linear -> (B, 64, 576)
+// Connector (f32 path)
 // ---------------------------------------------------------------------------
 
 #[derive(Clone, Debug)]
@@ -44,40 +110,17 @@ impl Connector {
             scale_factor: cfg.scale_factor,
         })
     }
-
-    /// Pixel shuffle matching HuggingFace Idefics3Connector.pixel_shuffle exactly:
-    ///   (B, H*W, D) → view(B, H, W, D) → view(B, H, W/s, D*s)
-    ///   → permute(0,2,1,3) → reshape(B, H/s, W/s, D*s²) → view(B, N, D*s²)
-    fn pixel_shuffle(&self, xs: &Tensor) -> Result<Tensor> {
-        let (b, seq_len, dim) = xs.dims3()?;
-        let s = self.scale_factor;
-        let h = (seq_len as f64).sqrt() as usize;
-        let w = h;
-        assert_eq!(h * w, seq_len, "pixel shuffle requires square patch grid");
-        assert_eq!(h % s, 0, "patch grid must be divisible by scale_factor");
-
-        // (B, H*W, D) → (B, H, W, D)
-        let xs = xs.reshape((b, h, w, dim))?;
-        // (B, H, W, D) → (B, H, W/s, D*s) — merge s adjacent width patches
-        let xs = xs.reshape((b, h, w / s, dim * s))?;
-        // (B, H, W/s, D*s) → (B, W/s, H, D*s) — transpose H and W/s
-        let xs = xs.permute((0, 2, 1, 3))?;
-        // (B, W/s, H, D*s) → (B, H/s, W/s, D*s²) — merge s adjacent height rows
-        let xs = xs.reshape((b, h / s, w / s, dim * s * s))?;
-        // (B, H/s, W/s, D*s²) → (B, N, D*s²)
-        xs.reshape((b, (h / s) * (w / s), dim * s * s))
-    }
 }
 
 impl Module for Connector {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let xs = self.pixel_shuffle(xs)?;
+        let xs = pixel_shuffle(xs, self.scale_factor)?;
         xs.apply(&self.modality_projection)
     }
 }
 
 // ---------------------------------------------------------------------------
-// Idefics3ForConditionalGeneration
+// Idefics3ForConditionalGeneration (f32 path)
 // ---------------------------------------------------------------------------
 
 #[derive(Clone, Debug)]
@@ -92,7 +135,7 @@ impl Model {
     pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
         let vision_model = siglip::VisionModel::new(
             &cfg.vision_config,
-            false, // no pooling head — we need all patch tokens
+            false,
             vb.pp("model.vision_model"),
         )?;
         let connector = Connector::new(cfg, vb.pp("model.connector"))?;
@@ -105,70 +148,24 @@ impl Model {
         })
     }
 
-    /// Encode images through the vision encoder and connector.
-    /// Input: (num_images, 3, H, W) — multiple tiles from image splitting.
-    /// Returns (1, num_images * image_seq_len, text_hidden_size) — flattened for token merging.
     pub fn encode_image(&self, pixel_values: &Tensor) -> Result<Tensor> {
-        let vision_out = self.vision_model.forward(pixel_values)?; // (N, 1024, 768)
-        let connected = self.connector.forward(&vision_out)?; // (N, 64, 576)
+        let vision_out = self.vision_model.forward(pixel_values)?;
+        let connected = self.connector.forward(&vision_out)?;
         let (n, seq, hidden) = connected.dims3()?;
         connected.reshape((1, n * seq, hidden))
     }
 
-    /// Initial forward pass: encode image, merge with text token embeddings
-    /// at <image> token positions, run through decoder.
-    /// Returns logits (B, seq, vocab).
     pub fn setup(&mut self, pixel_values: &Tensor, input_ids: &Tensor) -> Result<Tensor> {
         self.text_model.clear_kv_cache();
-
         let image_features = self.encode_image(pixel_values)?;
         let text_embeds = self.text_model.embed_tokens().forward(input_ids)?;
-
-        // Replace <image> placeholder tokens with actual image embeddings
         let input_embeds =
-            self.merge_image_tokens(&text_embeds, &image_features, input_ids)?;
-
+            merge_image_tokens(&text_embeds, &image_features, input_ids, self.image_token_id)?;
         self.text_model.forward_embeds(&input_embeds)
     }
 
-    /// Subsequent forward passes during autoregressive generation (no image).
-    /// Returns logits (B, 1, vocab).
     pub fn forward(&mut self, input_ids: &Tensor) -> Result<Tensor> {
         self.text_model.forward(input_ids)
-    }
-
-    /// Replace <image> token embeddings with projected vision features.
-    /// Builds a new embedding tensor where <image> placeholder positions
-    /// are filled with the corresponding projected vision tokens.
-    fn merge_image_tokens(
-        &self,
-        text_embeds: &Tensor,
-        image_features: &Tensor,
-        input_ids: &Tensor,
-    ) -> Result<Tensor> {
-        let (b, seq_len, _hidden) = text_embeds.dims3()?;
-        let image_seq_len = image_features.dim(1)?;
-        let input_ids_vec = input_ids.flatten_all()?.to_vec1::<u32>()?;
-        let text_embeds = text_embeds.to_dtype(image_features.dtype())?;
-
-        let mut batch_results = Vec::with_capacity(b);
-        for batch_idx in 0..b {
-            let mut img_idx = 0;
-            let mut tokens = Vec::with_capacity(seq_len);
-            for pos in 0..seq_len {
-                if input_ids_vec[batch_idx * seq_len + pos] == self.image_token_id
-                    && img_idx < image_seq_len
-                {
-                    tokens.push(image_features.i((batch_idx, img_idx))?.unsqueeze(0)?);
-                    img_idx += 1;
-                } else {
-                    tokens.push(text_embeds.i((batch_idx, pos))?.unsqueeze(0)?);
-                }
-            }
-            let batch_embeds = Tensor::cat(&tokens, 0)?.unsqueeze(0)?;
-            batch_results.push(batch_embeds);
-        }
-        Tensor::cat(&batch_results, 0)
     }
 
     pub fn clear_kv_cache(&mut self) {

--- a/candle-transformers/src/models/granite_docling/mod.rs
+++ b/candle-transformers/src/models/granite_docling/mod.rs
@@ -1,0 +1,173 @@
+//! Granite-Docling (Idefics3) model for document understanding.
+//!
+//! Converts document page images into structured DocTags markup.
+//! Architecture: SigLIP vision encoder → pixel shuffle connector → Llama-style causal decoder.
+//!
+//! References:
+//! - [Model Card](https://huggingface.co/ibm-granite/granite-docling-258M)
+//! - [Idefics3 (HuggingFace)](https://huggingface.co/docs/transformers/model_doc/idefics3)
+
+pub mod config;
+pub mod text;
+
+use crate::models::siglip;
+use candle::{IndexOp, Module, Result, Tensor};
+use candle_nn::{linear_no_bias, VarBuilder};
+use config::Config;
+use text::TextModel;
+
+// ---------------------------------------------------------------------------
+// Pixel Shuffle Connector
+//
+// Spatially downsamples vision tokens by rearranging patch features:
+//   (B, H*W, D) -> reshape -> (B, H/s * W/s, D * s^2) -> linear -> (B, N, text_hidden)
+//
+// For granite-docling-258M with scale_factor=4:
+//   (B, 1024, 768) -> (B, 64, 12288) -> linear -> (B, 64, 576)
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct Connector {
+    modality_projection: candle_nn::Linear,
+    scale_factor: usize,
+}
+
+impl Connector {
+    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let input_dim = cfg.connector_input_dim();
+        let output_dim = cfg.text_config.hidden_size;
+        let modality_projection =
+            linear_no_bias(input_dim, output_dim, vb.pp("modality_projection.proj"))?;
+        Ok(Self {
+            modality_projection,
+            scale_factor: cfg.scale_factor,
+        })
+    }
+
+    /// Pixel shuffle matching HuggingFace Idefics3Connector.pixel_shuffle exactly:
+    ///   (B, H*W, D) → view(B, H, W, D) → view(B, H, W/s, D*s)
+    ///   → permute(0,2,1,3) → reshape(B, H/s, W/s, D*s²) → view(B, N, D*s²)
+    fn pixel_shuffle(&self, xs: &Tensor) -> Result<Tensor> {
+        let (b, seq_len, dim) = xs.dims3()?;
+        let s = self.scale_factor;
+        let h = (seq_len as f64).sqrt() as usize;
+        let w = h;
+        assert_eq!(h * w, seq_len, "pixel shuffle requires square patch grid");
+        assert_eq!(h % s, 0, "patch grid must be divisible by scale_factor");
+
+        // (B, H*W, D) → (B, H, W, D)
+        let xs = xs.reshape((b, h, w, dim))?;
+        // (B, H, W, D) → (B, H, W/s, D*s) — merge s adjacent width patches
+        let xs = xs.reshape((b, h, w / s, dim * s))?;
+        // (B, H, W/s, D*s) → (B, W/s, H, D*s) — transpose H and W/s
+        let xs = xs.permute((0, 2, 1, 3))?;
+        // (B, W/s, H, D*s) → (B, H/s, W/s, D*s²) — merge s adjacent height rows
+        let xs = xs.reshape((b, h / s, w / s, dim * s * s))?;
+        // (B, H/s, W/s, D*s²) → (B, N, D*s²)
+        xs.reshape((b, (h / s) * (w / s), dim * s * s))
+    }
+}
+
+impl Module for Connector {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let xs = self.pixel_shuffle(xs)?;
+        xs.apply(&self.modality_projection)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Idefics3ForConditionalGeneration
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub struct Model {
+    vision_model: siglip::VisionModel,
+    connector: Connector,
+    text_model: TextModel,
+    image_token_id: u32,
+}
+
+impl Model {
+    pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let vision_model = siglip::VisionModel::new(
+            &cfg.vision_config,
+            false, // no pooling head — we need all patch tokens
+            vb.pp("model.vision_model"),
+        )?;
+        let connector = Connector::new(cfg, vb.pp("model.connector"))?;
+        let text_model = TextModel::new(&cfg.text_config, vb.pp("model.text_model"))?;
+        Ok(Self {
+            vision_model,
+            connector,
+            text_model,
+            image_token_id: cfg.image_token_id,
+        })
+    }
+
+    /// Encode an image through the vision encoder and connector.
+    /// Returns (B, image_seq_len, text_hidden_size) tensor.
+    pub fn encode_image(&self, pixel_values: &Tensor) -> Result<Tensor> {
+        let vision_out = self.vision_model.forward(pixel_values)?;
+        self.connector.forward(&vision_out)
+    }
+
+    /// Initial forward pass: encode image, merge with text token embeddings
+    /// at <image> token positions, run through decoder.
+    /// Returns logits (B, seq, vocab).
+    pub fn setup(&mut self, pixel_values: &Tensor, input_ids: &Tensor) -> Result<Tensor> {
+        self.text_model.clear_kv_cache();
+
+        let image_features = self.encode_image(pixel_values)?;
+        let text_embeds = self.text_model.embed_tokens().forward(input_ids)?;
+
+        // Replace <image> placeholder tokens with actual image embeddings
+        let input_embeds =
+            self.merge_image_tokens(&text_embeds, &image_features, input_ids)?;
+
+        self.text_model.forward_embeds(&input_embeds)
+    }
+
+    /// Subsequent forward passes during autoregressive generation (no image).
+    /// Returns logits (B, 1, vocab).
+    pub fn forward(&mut self, input_ids: &Tensor) -> Result<Tensor> {
+        self.text_model.forward(input_ids)
+    }
+
+    /// Replace <image> token embeddings with projected vision features.
+    /// Builds a new embedding tensor where <image> placeholder positions
+    /// are filled with the corresponding projected vision tokens.
+    fn merge_image_tokens(
+        &self,
+        text_embeds: &Tensor,
+        image_features: &Tensor,
+        input_ids: &Tensor,
+    ) -> Result<Tensor> {
+        let (b, seq_len, _hidden) = text_embeds.dims3()?;
+        let image_seq_len = image_features.dim(1)?;
+        let input_ids_vec = input_ids.flatten_all()?.to_vec1::<u32>()?;
+        let text_embeds = text_embeds.to_dtype(image_features.dtype())?;
+
+        let mut batch_results = Vec::with_capacity(b);
+        for batch_idx in 0..b {
+            let mut img_idx = 0;
+            let mut tokens = Vec::with_capacity(seq_len);
+            for pos in 0..seq_len {
+                if input_ids_vec[batch_idx * seq_len + pos] == self.image_token_id
+                    && img_idx < image_seq_len
+                {
+                    tokens.push(image_features.i((batch_idx, img_idx))?.unsqueeze(0)?);
+                    img_idx += 1;
+                } else {
+                    tokens.push(text_embeds.i((batch_idx, pos))?.unsqueeze(0)?);
+                }
+            }
+            let batch_embeds = Tensor::cat(&tokens, 0)?.unsqueeze(0)?;
+            batch_results.push(batch_embeds);
+        }
+        Tensor::cat(&batch_results, 0)
+    }
+
+    pub fn clear_kv_cache(&mut self) {
+        self.text_model.clear_kv_cache();
+    }
+}

--- a/candle-transformers/src/models/granite_docling/mod.rs
+++ b/candle-transformers/src/models/granite_docling/mod.rs
@@ -8,6 +8,7 @@
 //! - [Idefics3 (HuggingFace)](https://huggingface.co/docs/transformers/model_doc/idefics3)
 
 pub mod config;
+pub mod quantized;
 pub mod text;
 
 use crate::models::siglip;

--- a/candle-transformers/src/models/granite_docling/mod.rs
+++ b/candle-transformers/src/models/granite_docling/mod.rs
@@ -104,11 +104,14 @@ impl Model {
         })
     }
 
-    /// Encode an image through the vision encoder and connector.
-    /// Returns (B, image_seq_len, text_hidden_size) tensor.
+    /// Encode images through the vision encoder and connector.
+    /// Input: (num_images, 3, H, W) — multiple tiles from image splitting.
+    /// Returns (1, num_images * image_seq_len, text_hidden_size) — flattened for token merging.
     pub fn encode_image(&self, pixel_values: &Tensor) -> Result<Tensor> {
-        let vision_out = self.vision_model.forward(pixel_values)?;
-        self.connector.forward(&vision_out)
+        let vision_out = self.vision_model.forward(pixel_values)?; // (N, 1024, 768)
+        let connected = self.connector.forward(&vision_out)?; // (N, 64, 576)
+        let (n, seq, hidden) = connected.dims3()?;
+        connected.reshape((1, n * seq, hidden))
     }
 
     /// Initial forward pass: encode image, merge with text token embeddings

--- a/candle-transformers/src/models/granite_docling/quantized.rs
+++ b/candle-transformers/src/models/granite_docling/quantized.rs
@@ -1,0 +1,505 @@
+//! Quantized Granite-Docling model loading from GGUF weights.
+//!
+//! Loads two GGUF files:
+//! - Text decoder GGUF (llama architecture, `blk.*` tensor names)
+//! - Vision mmproj GGUF (`v.blk.*` + `mm.model.fc.*` tensor names)
+
+use super::config::{QuantizedVisionConfig, TextConfig};
+use crate::models::quantized_siglip;
+use crate::quantized_nn::{self, Embedding, Linear, RmsNorm};
+use crate::quantized_var_builder::VarBuilder;
+use candle::{DType, Device, IndexOp, Module, Result, Tensor};
+
+// ---------------------------------------------------------------------------
+// Pixel Shuffle Connector
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct Connector {
+    modality_projection: Linear,
+    scale_factor: usize,
+}
+
+impl Connector {
+    fn new(cfg: &QuantizedVisionConfig, vb: VarBuilder) -> Result<Self> {
+        let input_dim = cfg.connector_input_dim();
+        let output_dim = cfg.projection_dim;
+        let modality_projection =
+            quantized_nn::linear_no_bias(input_dim, output_dim, vb.pp("model.fc"))?;
+        Ok(Self {
+            modality_projection,
+            scale_factor: cfg.scale_factor,
+        })
+    }
+
+    fn pixel_shuffle(&self, xs: &Tensor) -> Result<Tensor> {
+        let (b, seq_len, dim) = xs.dims3()?;
+        let s = self.scale_factor;
+        let h = (seq_len as f64).sqrt() as usize;
+        let w = h;
+
+        let xs = xs.reshape((b, h, w, dim))?;
+        let xs = xs.reshape((b, h, w / s, dim * s))?;
+        let xs = xs.permute((0, 2, 1, 3))?;
+        let xs = xs.reshape((b, h / s, w / s, dim * s * s))?;
+        xs.reshape((b, (h / s) * (w / s), dim * s * s))
+    }
+}
+
+impl Module for Connector {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let xs = self.pixel_shuffle(xs)?;
+        xs.apply(&self.modality_projection)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rotary Position Embeddings
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct RotaryEmbedding {
+    cos: Tensor,
+    sin: Tensor,
+}
+
+impl RotaryEmbedding {
+    fn new(cfg: &TextConfig, dtype: DType, dev: &Device) -> Result<Self> {
+        let head_dim = cfg.head_dim();
+        let max_seq = cfg.max_position_embeddings;
+        let theta = cfg.rope_theta;
+
+        let inv_freq: Vec<f32> = (0..head_dim)
+            .step_by(2)
+            .map(|i| 1.0 / (theta as f32).powf(i as f32 / head_dim as f32))
+            .collect();
+        let inv_freq = Tensor::new(inv_freq.as_slice(), dev)?;
+        let positions =
+            Tensor::arange(0u32, max_seq as u32, dev)?.to_dtype(DType::F32)?;
+        let freqs = positions.unsqueeze(1)?.matmul(&inv_freq.unsqueeze(0)?)?;
+        let cos = freqs.cos()?.to_dtype(dtype)?;
+        let sin = freqs.sin()?.to_dtype(dtype)?;
+        Ok(Self { cos, sin })
+    }
+
+    fn apply(&self, q: &Tensor, k: &Tensor, offset: usize) -> Result<(Tensor, Tensor)> {
+        let seq_len = q.dim(2)?;
+        let cos = self.cos.narrow(0, offset, seq_len)?;
+        let sin = self.sin.narrow(0, offset, seq_len)?;
+        // GGUF weights are permuted for llama.cpp's interleaved RoPE convention
+        let q_embed = candle_nn::rotary_emb::rope_i(&q.contiguous()?, &cos, &sin)?;
+        let k_embed = candle_nn::rotary_emb::rope_i(&k.contiguous()?, &cos, &sin)?;
+        Ok((q_embed, k_embed))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// KV Cache
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct KvCache {
+    k: Option<Tensor>,
+    v: Option<Tensor>,
+}
+
+impl KvCache {
+    fn new() -> Self {
+        Self { k: None, v: None }
+    }
+
+    fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor)> {
+        let (k, v) = match (self.k.as_ref(), self.v.as_ref()) {
+            (Some(prev_k), Some(prev_v)) => {
+                let k = Tensor::cat(&[prev_k, k], 2)?;
+                let v = Tensor::cat(&[prev_v, v], 2)?;
+                (k, v)
+            }
+            _ => (k.clone(), v.clone()),
+        };
+        self.k = Some(k.clone());
+        self.v = Some(v.clone());
+        Ok((k, v))
+    }
+
+    fn current_len(&self) -> usize {
+        self.k.as_ref().map_or(0, |k| k.dim(2).unwrap_or(0))
+    }
+
+    fn clear(&mut self) {
+        self.k = None;
+        self.v = None;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Quantized Attention (GQA)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct Attention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    o_proj: Linear,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    kv_cache: KvCache,
+}
+
+impl Attention {
+    fn new(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let h = cfg.hidden_size;
+        let head_dim = cfg.head_dim();
+        let num_heads = cfg.num_attention_heads;
+        let num_kv_heads = cfg.num_key_value_heads;
+
+        let q_proj = quantized_nn::linear_no_bias(h, num_heads * head_dim, vb.pp("attn_q"))?;
+        let k_proj = quantized_nn::linear_no_bias(h, num_kv_heads * head_dim, vb.pp("attn_k"))?;
+        let v_proj = quantized_nn::linear_no_bias(h, num_kv_heads * head_dim, vb.pp("attn_v"))?;
+        let o_proj =
+            quantized_nn::linear_no_bias(num_heads * head_dim, h, vb.pp("attn_output"))?;
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            kv_cache: KvCache::new(),
+        })
+    }
+
+    fn forward(
+        &mut self,
+        xs: &Tensor,
+        rotary: &RotaryEmbedding,
+        attention_mask: Option<&Tensor>,
+    ) -> Result<Tensor> {
+        let (b, seq_len, _) = xs.dims3()?;
+        let offset = self.kv_cache.current_len();
+
+        let q = self.q_proj.forward(xs)?;
+        let k = self.k_proj.forward(xs)?;
+        let v = self.v_proj.forward(xs)?;
+
+        let q = q
+            .reshape((b, seq_len, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let k = k
+            .reshape((b, seq_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let v = v
+            .reshape((b, seq_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        let (q, k) = rotary.apply(&q, &k, offset)?;
+        let (k, v) = self.kv_cache.append(&k, &v)?;
+
+        // GQA: repeat KV heads
+        let k = self.repeat_kv(k)?;
+        let v = self.repeat_kv(v)?;
+
+        let scale = (self.head_dim as f64).sqrt();
+        let attn = q.matmul(&k.t()?)? / scale;
+        let attn = match attention_mask {
+            Some(mask) => attn?.broadcast_add(mask)?,
+            None => attn?,
+        };
+        let attn = candle_nn::ops::softmax_last_dim(&attn)?;
+        let out = attn.matmul(&v)?;
+
+        out.transpose(1, 2)?
+            .reshape((b, seq_len, ()))?
+            .apply(&self.o_proj)
+    }
+
+    fn repeat_kv(&self, x: Tensor) -> Result<Tensor> {
+        let n_rep = self.num_heads / self.num_kv_heads;
+        if n_rep == 1 {
+            return Ok(x);
+        }
+        let (b, num_kv_heads, seq_len, head_dim) = x.dims4()?;
+        x.unsqueeze(2)?
+            .expand((b, num_kv_heads, n_rep, seq_len, head_dim))?
+            .reshape((b, num_kv_heads * n_rep, seq_len, head_dim))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Quantized MLP (SiLU-gated)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct Mlp {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+}
+
+impl Mlp {
+    fn new(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let h = cfg.hidden_size;
+        let i = cfg.intermediate_size;
+        let gate_proj = quantized_nn::linear_no_bias(h, i, vb.pp("ffn_gate"))?;
+        let up_proj = quantized_nn::linear_no_bias(h, i, vb.pp("ffn_up"))?;
+        let down_proj = quantized_nn::linear_no_bias(i, h, vb.pp("ffn_down"))?;
+        Ok(Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+        })
+    }
+}
+
+impl Module for Mlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let gate = self
+            .gate_proj
+            .forward(xs)?
+            .apply(&candle_nn::Activation::Silu)?;
+        let up = self.up_proj.forward(xs)?;
+        (gate * up)?.apply(&self.down_proj)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decoder Layer
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct DecoderLayer {
+    self_attn: Attention,
+    mlp: Mlp,
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+}
+
+impl DecoderLayer {
+    fn new(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let self_attn = Attention::new(cfg, vb.clone())?;
+        let mlp = Mlp::new(cfg, vb.clone())?;
+        let input_layernorm = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("attn_norm"))?;
+        let post_attention_layernorm =
+            RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("ffn_norm"))?;
+        Ok(Self {
+            self_attn,
+            mlp,
+            input_layernorm,
+            post_attention_layernorm,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        xs: &Tensor,
+        rotary: &RotaryEmbedding,
+        attention_mask: Option<&Tensor>,
+    ) -> Result<Tensor> {
+        let residual = xs;
+        let xs = self.input_layernorm.forward(xs)?;
+        let xs = self.self_attn.forward(&xs, rotary, attention_mask)?;
+        let xs = (residual + xs)?;
+        let residual = &xs;
+        let xs = self.post_attention_layernorm.forward(&xs)?;
+        let xs = self.mlp.forward(&xs)?;
+        residual + xs
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Quantized Text Model
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct TextModel {
+    embed_tokens: Embedding,
+    layers: Vec<DecoderLayer>,
+    norm: RmsNorm,
+    rotary: RotaryEmbedding,
+    dtype: DType,
+}
+
+impl TextModel {
+    fn new(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let dtype = DType::F32; // quantized models compute in f32
+        let embed_tokens = Embedding::new(cfg.vocab_size, cfg.hidden_size, vb.pp("token_embd"))?;
+
+        let vb_layers = vb.pp("blk");
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        for i in 0..cfg.num_hidden_layers {
+            layers.push(DecoderLayer::new(cfg, vb_layers.pp(i))?);
+        }
+
+        let norm = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("output_norm"))?;
+        let rotary = RotaryEmbedding::new(cfg, dtype, vb.device())?;
+
+        Ok(Self {
+            embed_tokens,
+            layers,
+            norm,
+            rotary,
+            dtype,
+        })
+    }
+
+    fn embed_tokens(&self) -> &Embedding {
+        &self.embed_tokens
+    }
+
+    fn causal_mask(&self, seq_len: usize, past_kv_len: usize, device: &Device) -> Result<Tensor> {
+        let total_len = past_kv_len + seq_len;
+        let mask: Vec<f32> = (0..seq_len)
+            .flat_map(|i| {
+                (0..total_len).map(move |j| {
+                    if j > past_kv_len + i {
+                        f32::NEG_INFINITY
+                    } else {
+                        0.0
+                    }
+                })
+            })
+            .collect();
+        Tensor::from_vec(mask, (1, 1, seq_len, total_len), device)?.to_dtype(self.dtype)
+    }
+
+    fn forward(&mut self, input_ids: &Tensor) -> Result<Tensor> {
+        let xs = self.embed_tokens.forward(input_ids)?;
+        self.forward_embeds(&xs)
+    }
+
+    fn forward_embeds(&mut self, xs: &Tensor) -> Result<Tensor> {
+        let (_, seq_len, _) = xs.dims3()?;
+        let past_kv_len = self.layers[0].self_attn.kv_cache.current_len();
+
+        let mask = if seq_len == 1 {
+            None
+        } else {
+            Some(self.causal_mask(seq_len, past_kv_len, xs.device())?)
+        };
+
+        let mut hidden = xs.clone();
+        for layer in self.layers.iter_mut() {
+            hidden = layer.forward(&hidden, &self.rotary, mask.as_ref())?;
+        }
+
+        let hidden = self.norm.forward(&hidden)?;
+
+        // Tied embeddings
+        let w = self.embed_tokens.embeddings();
+        hidden.broadcast_matmul(&w.t()?)
+    }
+
+    fn clear_kv_cache(&mut self) {
+        for layer in self.layers.iter_mut() {
+            layer.self_attn.kv_cache.clear();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level Quantized Model
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct Model {
+    vision_model: quantized_siglip::VisionModel,
+    connector: Connector,
+    text_model: TextModel,
+    image_token_id: u32,
+}
+
+impl Model {
+    /// Load from two GGUF files: vision mmproj + text decoder.
+    pub fn new(
+        vision_vb: VarBuilder,
+        vision_cfg: &QuantizedVisionConfig,
+        text_vb: VarBuilder,
+        text_cfg: &TextConfig,
+        image_token_id: u32,
+    ) -> Result<Self> {
+        let vision_model = quantized_siglip::VisionModel::new(
+            vision_cfg.hidden_size,
+            vision_cfg.intermediate_size,
+            vision_cfg.num_hidden_layers,
+            vision_cfg.num_attention_heads,
+            vision_cfg.image_size,
+            vision_cfg.patch_size,
+            vision_cfg.layer_norm_eps,
+            vision_vb.pp("v"),
+        )?;
+
+        let connector = Connector::new(vision_cfg, vision_vb.pp("mm"))?;
+        let text_model = TextModel::new(text_cfg, text_vb)?;
+
+        Ok(Self {
+            vision_model,
+            connector,
+            text_model,
+            image_token_id,
+        })
+    }
+
+    pub fn encode_image(&self, pixel_values: &Tensor) -> Result<Tensor> {
+        let vision_out = self.vision_model.forward(pixel_values)?;
+        let connected = self.connector.forward(&vision_out)?;
+        let (n, seq, hidden) = connected.dims3()?;
+        connected.reshape((1, n * seq, hidden))
+    }
+
+    pub fn setup(&mut self, pixel_values: &Tensor, input_ids: &Tensor) -> Result<Tensor> {
+        self.text_model.clear_kv_cache();
+
+        let image_features = self.encode_image(pixel_values)?;
+        let text_embeds = self.text_model.embed_tokens().forward(input_ids)?;
+
+        let input_embeds =
+            self.merge_image_tokens(&text_embeds, &image_features, input_ids)?;
+
+        self.text_model.forward_embeds(&input_embeds)
+    }
+
+    pub fn forward(&mut self, input_ids: &Tensor) -> Result<Tensor> {
+        self.text_model.forward(input_ids)
+    }
+
+    fn merge_image_tokens(
+        &self,
+        text_embeds: &Tensor,
+        image_features: &Tensor,
+        input_ids: &Tensor,
+    ) -> Result<Tensor> {
+        let (b, seq_len, _hidden) = text_embeds.dims3()?;
+        let image_seq_len = image_features.dim(1)?;
+        let input_ids_vec = input_ids.flatten_all()?.to_vec1::<u32>()?;
+        let text_embeds = text_embeds.to_dtype(image_features.dtype())?;
+
+        let mut batch_results = Vec::with_capacity(b);
+        for batch_idx in 0..b {
+            let mut img_idx = 0;
+            let mut tokens = Vec::with_capacity(seq_len);
+            for pos in 0..seq_len {
+                if input_ids_vec[batch_idx * seq_len + pos] == self.image_token_id
+                    && img_idx < image_seq_len
+                {
+                    tokens.push(image_features.i((batch_idx, img_idx))?.unsqueeze(0)?);
+                    img_idx += 1;
+                } else {
+                    tokens.push(text_embeds.i((batch_idx, pos))?.unsqueeze(0)?);
+                }
+            }
+            let batch_embeds = Tensor::cat(&tokens, 0)?.unsqueeze(0)?;
+            batch_results.push(batch_embeds);
+        }
+        Tensor::cat(&batch_results, 0)
+    }
+
+    pub fn clear_kv_cache(&mut self) {
+        self.text_model.clear_kv_cache();
+    }
+}

--- a/candle-transformers/src/models/granite_docling/quantized.rs
+++ b/candle-transformers/src/models/granite_docling/quantized.rs
@@ -5,10 +5,11 @@
 //! - Vision mmproj GGUF (`v.blk.*` + `mm.model.fc.*` tensor names)
 
 use super::config::{QuantizedVisionConfig, TextConfig};
+use super::{merge_image_tokens, pixel_shuffle};
 use crate::models::quantized_siglip;
 use crate::quantized_nn::{self, Embedding, Linear, RmsNorm};
 use crate::quantized_var_builder::VarBuilder;
-use candle::{DType, Device, IndexOp, Module, Result, Tensor};
+use candle::{DType, Device, Module, Result, Tensor};
 
 // ---------------------------------------------------------------------------
 // Pixel Shuffle Connector
@@ -31,24 +32,11 @@ impl Connector {
             scale_factor: cfg.scale_factor,
         })
     }
-
-    fn pixel_shuffle(&self, xs: &Tensor) -> Result<Tensor> {
-        let (b, seq_len, dim) = xs.dims3()?;
-        let s = self.scale_factor;
-        let h = (seq_len as f64).sqrt() as usize;
-        let w = h;
-
-        let xs = xs.reshape((b, h, w, dim))?;
-        let xs = xs.reshape((b, h, w / s, dim * s))?;
-        let xs = xs.permute((0, 2, 1, 3))?;
-        let xs = xs.reshape((b, h / s, w / s, dim * s * s))?;
-        xs.reshape((b, (h / s) * (w / s), dim * s * s))
-    }
 }
 
 impl Module for Connector {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let xs = self.pixel_shuffle(xs)?;
+        let xs = pixel_shuffle(xs, self.scale_factor)?;
         xs.apply(&self.modality_projection)
     }
 }
@@ -423,16 +411,7 @@ impl Model {
         text_cfg: &TextConfig,
         image_token_id: u32,
     ) -> Result<Self> {
-        let vision_model = quantized_siglip::VisionModel::new(
-            vision_cfg.hidden_size,
-            vision_cfg.intermediate_size,
-            vision_cfg.num_hidden_layers,
-            vision_cfg.num_attention_heads,
-            vision_cfg.image_size,
-            vision_cfg.patch_size,
-            vision_cfg.layer_norm_eps,
-            vision_vb.pp("v"),
-        )?;
+        let vision_model = quantized_siglip::VisionModel::new(vision_cfg, vision_vb.pp("v"))?;
 
         let connector = Connector::new(vision_cfg, vision_vb.pp("mm"))?;
         let text_model = TextModel::new(text_cfg, text_vb)?;
@@ -454,49 +433,15 @@ impl Model {
 
     pub fn setup(&mut self, pixel_values: &Tensor, input_ids: &Tensor) -> Result<Tensor> {
         self.text_model.clear_kv_cache();
-
         let image_features = self.encode_image(pixel_values)?;
         let text_embeds = self.text_model.embed_tokens().forward(input_ids)?;
-
         let input_embeds =
-            self.merge_image_tokens(&text_embeds, &image_features, input_ids)?;
-
+            merge_image_tokens(&text_embeds, &image_features, input_ids, self.image_token_id)?;
         self.text_model.forward_embeds(&input_embeds)
     }
 
     pub fn forward(&mut self, input_ids: &Tensor) -> Result<Tensor> {
         self.text_model.forward(input_ids)
-    }
-
-    fn merge_image_tokens(
-        &self,
-        text_embeds: &Tensor,
-        image_features: &Tensor,
-        input_ids: &Tensor,
-    ) -> Result<Tensor> {
-        let (b, seq_len, _hidden) = text_embeds.dims3()?;
-        let image_seq_len = image_features.dim(1)?;
-        let input_ids_vec = input_ids.flatten_all()?.to_vec1::<u32>()?;
-        let text_embeds = text_embeds.to_dtype(image_features.dtype())?;
-
-        let mut batch_results = Vec::with_capacity(b);
-        for batch_idx in 0..b {
-            let mut img_idx = 0;
-            let mut tokens = Vec::with_capacity(seq_len);
-            for pos in 0..seq_len {
-                if input_ids_vec[batch_idx * seq_len + pos] == self.image_token_id
-                    && img_idx < image_seq_len
-                {
-                    tokens.push(image_features.i((batch_idx, img_idx))?.unsqueeze(0)?);
-                    img_idx += 1;
-                } else {
-                    tokens.push(text_embeds.i((batch_idx, pos))?.unsqueeze(0)?);
-                }
-            }
-            let batch_embeds = Tensor::cat(&tokens, 0)?.unsqueeze(0)?;
-            batch_results.push(batch_embeds);
-        }
-        Tensor::cat(&batch_results, 0)
     }
 
     pub fn clear_kv_cache(&mut self) {

--- a/candle-transformers/src/models/granite_docling/quantized.rs
+++ b/candle-transformers/src/models/granite_docling/quantized.rs
@@ -62,8 +62,7 @@ impl RotaryEmbedding {
             .map(|i| 1.0 / (theta as f32).powf(i as f32 / head_dim as f32))
             .collect();
         let inv_freq = Tensor::new(inv_freq.as_slice(), dev)?;
-        let positions =
-            Tensor::arange(0u32, max_seq as u32, dev)?.to_dtype(DType::F32)?;
+        let positions = Tensor::arange(0u32, max_seq as u32, dev)?.to_dtype(DType::F32)?;
         let freqs = positions.unsqueeze(1)?.matmul(&inv_freq.unsqueeze(0)?)?;
         let cos = freqs.cos()?.to_dtype(dtype)?;
         let sin = freqs.sin()?.to_dtype(dtype)?;
@@ -146,8 +145,7 @@ impl Attention {
         let q_proj = quantized_nn::linear_no_bias(h, num_heads * head_dim, vb.pp("attn_q"))?;
         let k_proj = quantized_nn::linear_no_bias(h, num_kv_heads * head_dim, vb.pp("attn_k"))?;
         let v_proj = quantized_nn::linear_no_bias(h, num_kv_heads * head_dim, vb.pp("attn_v"))?;
-        let o_proj =
-            quantized_nn::linear_no_bias(num_heads * head_dim, h, vb.pp("attn_output"))?;
+        let o_proj = quantized_nn::linear_no_bias(num_heads * head_dim, h, vb.pp("attn_output"))?;
 
         Ok(Self {
             q_proj,
@@ -435,8 +433,12 @@ impl Model {
         self.text_model.clear_kv_cache();
         let image_features = self.encode_image(pixel_values)?;
         let text_embeds = self.text_model.embed_tokens().forward(input_ids)?;
-        let input_embeds =
-            merge_image_tokens(&text_embeds, &image_features, input_ids, self.image_token_id)?;
+        let input_embeds = merge_image_tokens(
+            &text_embeds,
+            &image_features,
+            input_ids,
+            self.image_token_id,
+        )?;
         self.text_model.forward_embeds(&input_embeds)
     }
 

--- a/candle-transformers/src/models/granite_docling/text.rs
+++ b/candle-transformers/src/models/granite_docling/text.rs
@@ -1,0 +1,398 @@
+//! Standalone Llama-style causal decoder for Granite-Docling.
+//!
+//! Self-contained implementation (GQA, RoPE, SiLU-gated MLP, RMSNorm, KV cache)
+//! to allow future CPU flash attention and interlaced weight optimizations
+//! without coupling to the general-purpose Llama model.
+
+use super::config::TextConfig;
+use candle::{DType, Device, Module, Result, Tensor};
+use candle_nn::{linear_no_bias as linear, embedding, Linear, VarBuilder};
+
+// ---------------------------------------------------------------------------
+// RMS Norm
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct RmsNorm {
+    weight: Tensor,
+    eps: f64,
+}
+
+impl RmsNorm {
+    fn new(size: usize, eps: f64, vb: VarBuilder) -> Result<Self> {
+        let weight = vb.get(size, "weight")?;
+        Ok(Self { weight, eps })
+    }
+}
+
+impl Module for RmsNorm {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        candle_nn::ops::rms_norm(xs, &self.weight, self.eps as f32)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rotary Position Embeddings
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct RotaryEmbedding {
+    cos: Tensor,
+    sin: Tensor,
+}
+
+impl RotaryEmbedding {
+    fn new(cfg: &TextConfig, dtype: DType, dev: &Device) -> Result<Self> {
+        let head_dim = cfg.head_dim();
+        let max_seq = cfg.max_position_embeddings;
+        let theta = cfg.rope_theta;
+
+        let inv_freq: Vec<f32> = (0..head_dim)
+            .step_by(2)
+            .map(|i| 1.0 / (theta as f32).powf(i as f32 / head_dim as f32))
+            .collect();
+        let inv_freq = Tensor::new(inv_freq.as_slice(), dev)?;
+        let positions = Tensor::arange(0u32, max_seq as u32, dev)?
+            .to_dtype(DType::F32)?;
+        // (max_seq, head_dim/2)
+        let freqs = positions
+            .unsqueeze(1)?
+            .matmul(&inv_freq.unsqueeze(0)?)?;
+        let cos = freqs.cos()?.to_dtype(dtype)?;
+        let sin = freqs.sin()?.to_dtype(dtype)?;
+        Ok(Self { cos, sin })
+    }
+
+    fn apply(&self, q: &Tensor, k: &Tensor, offset: usize) -> Result<(Tensor, Tensor)> {
+        let seq_len = q.dim(2)?;
+        let cos = self.cos.narrow(0, offset, seq_len)?;
+        let sin = self.sin.narrow(0, offset, seq_len)?;
+        let q_embed = candle_nn::rotary_emb::rope(q, &cos, &sin)?;
+        let k_embed = candle_nn::rotary_emb::rope(k, &cos, &sin)?;
+        Ok((q_embed, k_embed))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// KV Cache
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct KvCache {
+    k: Option<Tensor>,
+    v: Option<Tensor>,
+}
+
+impl KvCache {
+    fn new() -> Self {
+        Self { k: None, v: None }
+    }
+
+    fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor)> {
+        let (k, v) = match (self.k.as_ref(), self.v.as_ref()) {
+            (Some(prev_k), Some(prev_v)) => {
+                let k = Tensor::cat(&[prev_k, k], 2)?;
+                let v = Tensor::cat(&[prev_v, v], 2)?;
+                (k, v)
+            }
+            _ => (k.clone(), v.clone()),
+        };
+        self.k = Some(k.clone());
+        self.v = Some(v.clone());
+        Ok((k, v))
+    }
+
+    fn current_len(&self) -> usize {
+        self.k.as_ref().map_or(0, |k| k.dim(2).unwrap_or(0))
+    }
+
+    fn clear(&mut self) {
+        self.k = None;
+        self.v = None;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Attention (Grouped Query Attention)
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct Attention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    o_proj: Linear,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    kv_cache: KvCache,
+}
+
+impl Attention {
+    fn new(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let h = cfg.hidden_size;
+        let head_dim = cfg.head_dim();
+        let num_heads = cfg.num_attention_heads;
+        let num_kv_heads = cfg.num_key_value_heads;
+
+        let q_proj = linear(h, num_heads * head_dim, vb.pp("q_proj"))?;
+        let k_proj = linear(h, num_kv_heads * head_dim, vb.pp("k_proj"))?;
+        let v_proj = linear(h, num_kv_heads * head_dim, vb.pp("v_proj"))?;
+        let o_proj = linear(num_heads * head_dim, h, vb.pp("o_proj"))?;
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            kv_cache: KvCache::new(),
+        })
+    }
+
+    fn forward(
+        &mut self,
+        xs: &Tensor,
+        rotary: &RotaryEmbedding,
+        attention_mask: Option<&Tensor>,
+    ) -> Result<Tensor> {
+        let (b, seq_len, _) = xs.dims3()?;
+        let offset = self.kv_cache.current_len();
+
+        let q = self.q_proj.forward(xs)?;
+        let k = self.k_proj.forward(xs)?;
+        let v = self.v_proj.forward(xs)?;
+
+        // (B, seq, heads, head_dim) -> (B, heads, seq, head_dim)
+        let q = q
+            .reshape((b, seq_len, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let k = k
+            .reshape((b, seq_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let v = v
+            .reshape((b, seq_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        let (q, k) = rotary.apply(&q, &k, offset)?;
+        let (k, v) = self.kv_cache.append(&k, &v)?;
+
+        // GQA: repeat KV heads to match Q heads
+        let k = self.repeat_kv(k)?;
+        let v = self.repeat_kv(v)?;
+
+        let scale = (self.head_dim as f64).sqrt();
+        let attn = q.matmul(&k.t()?)? / scale;
+        let attn = match attention_mask {
+            Some(mask) => attn?.broadcast_add(mask)?,
+            None => attn?,
+        };
+        let attn = candle_nn::ops::softmax_last_dim(&attn)?;
+        let out = attn.matmul(&v)?;
+
+        // (B, heads, seq, head_dim) -> (B, seq, hidden)
+        out.transpose(1, 2)?
+            .reshape((b, seq_len, ()))?
+            .apply(&self.o_proj)
+    }
+
+    fn repeat_kv(&self, x: Tensor) -> Result<Tensor> {
+        let n_rep = self.num_heads / self.num_kv_heads;
+        if n_rep == 1 {
+            return Ok(x);
+        }
+        let (b, num_kv_heads, seq_len, head_dim) = x.dims4()?;
+        x.unsqueeze(2)?
+            .expand((b, num_kv_heads, n_rep, seq_len, head_dim))?
+            .reshape((b, num_kv_heads * n_rep, seq_len, head_dim))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Feed-forward (SiLU-gated MLP)
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct Mlp {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+}
+
+impl Mlp {
+    fn new(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let h = cfg.hidden_size;
+        let i = cfg.intermediate_size;
+        let gate_proj = linear(h, i, vb.pp("gate_proj"))?;
+        let up_proj = linear(h, i, vb.pp("up_proj"))?;
+        let down_proj = linear(i, h, vb.pp("down_proj"))?;
+        Ok(Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+        })
+    }
+}
+
+impl Module for Mlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let gate = self.gate_proj.forward(xs)?.apply(&candle_nn::Activation::Silu)?;
+        let up = self.up_proj.forward(xs)?;
+        (gate * up)?.apply(&self.down_proj)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decoder Layer
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct DecoderLayer {
+    self_attn: Attention,
+    mlp: Mlp,
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+}
+
+impl DecoderLayer {
+    fn new(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let self_attn = Attention::new(cfg, vb.pp("self_attn"))?;
+        let mlp = Mlp::new(cfg, vb.pp("mlp"))?;
+        let input_layernorm =
+            RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
+        let post_attention_layernorm =
+            RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("post_attention_layernorm"))?;
+        Ok(Self {
+            self_attn,
+            mlp,
+            input_layernorm,
+            post_attention_layernorm,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        xs: &Tensor,
+        rotary: &RotaryEmbedding,
+        attention_mask: Option<&Tensor>,
+    ) -> Result<Tensor> {
+        let residual = xs;
+        let xs = self.input_layernorm.forward(xs)?;
+        let xs = self.self_attn.forward(&xs, rotary, attention_mask)?;
+        let xs = (residual + xs)?;
+        let residual = &xs;
+        let xs = self.post_attention_layernorm.forward(&xs)?;
+        let xs = self.mlp.forward(&xs)?;
+        residual + xs
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Text Model (full decoder)
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub struct TextModel {
+    embed_tokens: candle_nn::Embedding,
+    layers: Vec<DecoderLayer>,
+    norm: RmsNorm,
+    lm_head: Option<Linear>,
+    rotary: RotaryEmbedding,
+    dtype: DType,
+}
+
+impl TextModel {
+    pub fn new(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let dtype = vb.dtype();
+        let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, vb.pp("embed_tokens"))?;
+
+        let vb_layers = vb.pp("layers");
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        for i in 0..cfg.num_hidden_layers {
+            layers.push(DecoderLayer::new(cfg, vb_layers.pp(i))?);
+        }
+
+        let norm = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("norm"))?;
+
+        let lm_head = if cfg.tie_word_embeddings {
+            None
+        } else {
+            Some(linear(cfg.hidden_size, cfg.vocab_size, vb.pp("lm_head"))?)
+        };
+
+        let rotary = RotaryEmbedding::new(cfg, dtype, vb.device())?;
+
+        Ok(Self {
+            embed_tokens,
+            layers,
+            norm,
+            lm_head,
+            rotary,
+            dtype,
+        })
+    }
+
+    pub fn embed_tokens(&self) -> &candle_nn::Embedding {
+        &self.embed_tokens
+    }
+
+    fn causal_mask(&self, seq_len: usize, past_kv_len: usize, device: &Device) -> Result<Tensor> {
+        let total_len = past_kv_len + seq_len;
+        let mask: Vec<f32> = (0..seq_len)
+            .flat_map(|i| {
+                (0..total_len).map(move |j| {
+                    if j > past_kv_len + i {
+                        f32::NEG_INFINITY
+                    } else {
+                        0.0
+                    }
+                })
+            })
+            .collect();
+        Tensor::from_vec(mask, (1, 1, seq_len, total_len), device)?.to_dtype(self.dtype)
+    }
+
+    /// Forward pass from token IDs. Returns logits (B, seq, vocab).
+    pub fn forward(&mut self, input_ids: &Tensor) -> Result<Tensor> {
+        let xs = self.embed_tokens.forward(input_ids)?;
+        self.forward_embeds(&xs)
+    }
+
+    /// Forward pass from already-embedded inputs. Returns logits (B, seq, vocab).
+    pub fn forward_embeds(&mut self, xs: &Tensor) -> Result<Tensor> {
+        let (_, seq_len, _) = xs.dims3()?;
+        let past_kv_len = self.layers[0].self_attn.kv_cache.current_len();
+
+        let mask = if seq_len == 1 {
+            None
+        } else {
+            Some(self.causal_mask(seq_len, past_kv_len, xs.device())?)
+        };
+
+        let mut hidden = xs.clone();
+        for layer in self.layers.iter_mut() {
+            hidden = layer.forward(&hidden, &self.rotary, mask.as_ref())?;
+        }
+
+        let hidden = self.norm.forward(&hidden)?;
+
+        match &self.lm_head {
+            Some(lm_head) => hidden.apply(lm_head),
+            None => {
+                // Tied embeddings: use embed_tokens weight as lm_head
+                let w = self.embed_tokens.embeddings();
+                hidden.broadcast_matmul(&w.t()?)
+            }
+        }
+    }
+
+    pub fn clear_kv_cache(&mut self) {
+        for layer in self.layers.iter_mut() {
+            layer.self_attn.kv_cache.clear();
+        }
+    }
+}

--- a/candle-transformers/src/models/granite_docling/text.rs
+++ b/candle-transformers/src/models/granite_docling/text.rs
@@ -6,7 +6,7 @@
 
 use super::config::TextConfig;
 use candle::{DType, Device, Module, Result, Tensor};
-use candle_nn::{linear_no_bias as linear, embedding, Linear, VarBuilder};
+use candle_nn::{embedding, linear_no_bias as linear, Linear, VarBuilder};
 
 // ---------------------------------------------------------------------------
 // RMS Norm
@@ -52,12 +52,9 @@ impl RotaryEmbedding {
             .map(|i| 1.0 / (theta as f32).powf(i as f32 / head_dim as f32))
             .collect();
         let inv_freq = Tensor::new(inv_freq.as_slice(), dev)?;
-        let positions = Tensor::arange(0u32, max_seq as u32, dev)?
-            .to_dtype(DType::F32)?;
+        let positions = Tensor::arange(0u32, max_seq as u32, dev)?.to_dtype(DType::F32)?;
         // (max_seq, head_dim/2)
-        let freqs = positions
-            .unsqueeze(1)?
-            .matmul(&inv_freq.unsqueeze(0)?)?;
+        let freqs = positions.unsqueeze(1)?.matmul(&inv_freq.unsqueeze(0)?)?;
         let cos = freqs.cos()?.to_dtype(dtype)?;
         let sin = freqs.sin()?.to_dtype(dtype)?;
         Ok(Self { cos, sin })
@@ -240,7 +237,10 @@ impl Mlp {
 
 impl Module for Mlp {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let gate = self.gate_proj.forward(xs)?.apply(&candle_nn::Activation::Silu)?;
+        let gate = self
+            .gate_proj
+            .forward(xs)?
+            .apply(&candle_nn::Activation::Silu)?;
         let up = self.up_proj.forward(xs)?;
         (gate * up)?.apply(&self.down_proj)
     }
@@ -264,8 +264,11 @@ impl DecoderLayer {
         let mlp = Mlp::new(cfg, vb.pp("mlp"))?;
         let input_layernorm =
             RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
-        let post_attention_layernorm =
-            RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("post_attention_layernorm"))?;
+        let post_attention_layernorm = RmsNorm::new(
+            cfg.hidden_size,
+            cfg.rms_norm_eps,
+            vb.pp("post_attention_layernorm"),
+        )?;
         Ok(Self {
             self_attn,
             mlp,

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -104,6 +104,7 @@ pub mod quantized_qwen3_moe;
 pub mod quantized_recurrent_gemma;
 pub mod quantized_rwkv_v5;
 pub mod quantized_rwkv_v6;
+pub mod quantized_siglip;
 pub mod quantized_stable_lm;
 pub mod quantized_t5;
 pub mod qwen2;

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -48,6 +48,7 @@ pub mod gemma3;
 pub mod glm4;
 pub mod glm4_new;
 pub mod granite;
+pub mod granite_docling;
 pub mod granitemoehybrid;
 pub mod helium;
 pub mod hiera;

--- a/candle-transformers/src/models/quantized_siglip.rs
+++ b/candle-transformers/src/models/quantized_siglip.rs
@@ -1,0 +1,270 @@
+//! Quantized SigLIP vision encoder for GGUF weights.
+//!
+//! Loads from llama.cpp GGUF mmproj files using the standard `v.blk.*` tensor naming.
+//! Reusable by any Idefics3/SigLIP-based multimodal model (Granite-Docling, SmolVLM, etc.).
+
+use candle::{Module, Result, Tensor};
+use crate::quantized_nn::{self, Linear};
+use crate::quantized_var_builder::VarBuilder;
+
+// ---------------------------------------------------------------------------
+// Attention
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct Attention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    out_proj: Linear,
+    num_heads: usize,
+    head_dim: usize,
+    scale: f64,
+}
+
+impl Attention {
+    fn new(hidden_size: usize, num_heads: usize, vb: VarBuilder) -> Result<Self> {
+        let head_dim = hidden_size / num_heads;
+        let q_proj = quantized_nn::linear(hidden_size, hidden_size, vb.pp("attn_q"))?;
+        let k_proj = quantized_nn::linear(hidden_size, hidden_size, vb.pp("attn_k"))?;
+        let v_proj = quantized_nn::linear(hidden_size, hidden_size, vb.pp("attn_v"))?;
+        let out_proj = quantized_nn::linear(hidden_size, hidden_size, vb.pp("attn_out"))?;
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            out_proj,
+            num_heads,
+            head_dim,
+            scale: (head_dim as f64).powf(-0.5),
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let (b, seq_len, _) = xs.dims3()?;
+        let q = self.q_proj.forward(xs)?;
+        let k = self.k_proj.forward(xs)?;
+        let v = self.v_proj.forward(xs)?;
+
+        let shape = (b, seq_len, self.num_heads, self.head_dim);
+        let q = q.reshape(shape)?.transpose(1, 2)?.contiguous()?;
+        let k = k.reshape(shape)?.transpose(1, 2)?.contiguous()?;
+        let v = v.reshape(shape)?.transpose(1, 2)?.contiguous()?;
+
+        let attn = (q.matmul(&k.t()?)? * self.scale)?;
+        let attn = candle_nn::ops::softmax_last_dim(&attn)?;
+        attn.matmul(&v)?
+            .transpose(1, 2)?
+            .reshape((b, seq_len, ()))?
+            .apply(&self.out_proj)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MLP
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct Mlp {
+    fc1: Linear,
+    fc2: Linear,
+}
+
+impl Mlp {
+    fn new(hidden_size: usize, intermediate_size: usize, vb: VarBuilder) -> Result<Self> {
+        let fc1 = quantized_nn::linear(hidden_size, intermediate_size, vb.pp("ffn_up"))?;
+        let fc2 = quantized_nn::linear(intermediate_size, hidden_size, vb.pp("ffn_down"))?;
+        Ok(Self { fc1, fc2 })
+    }
+}
+
+impl Module for Mlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        xs.apply(&self.fc1)?
+            .apply(&candle_nn::Activation::GeluPytorchTanh)?
+            .apply(&self.fc2)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encoder Layer
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct EncoderLayer {
+    self_attn: Attention,
+    layer_norm1: candle_nn::LayerNorm,
+    mlp: Mlp,
+    layer_norm2: candle_nn::LayerNorm,
+}
+
+impl EncoderLayer {
+    fn new(
+        hidden_size: usize,
+        intermediate_size: usize,
+        num_heads: usize,
+        layer_norm_eps: f64,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let self_attn = Attention::new(hidden_size, num_heads, vb.clone())?;
+        let layer_norm1 = quantized_nn::layer_norm(hidden_size, layer_norm_eps, vb.pp("ln1"))?;
+        let mlp = Mlp::new(hidden_size, intermediate_size, vb.clone())?;
+        let layer_norm2 = quantized_nn::layer_norm(hidden_size, layer_norm_eps, vb.pp("ln2"))?;
+        Ok(Self {
+            self_attn,
+            layer_norm1,
+            mlp,
+            layer_norm2,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let residual = xs;
+        let xs = xs.apply(&self.layer_norm1)?;
+        let xs = self.self_attn.forward(&xs)?;
+        let xs = (residual + xs)?;
+        let residual = &xs;
+        let xs = xs.apply(&self.layer_norm2)?.apply(&self.mlp)?;
+        residual + xs
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vision Embeddings
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct VisionEmbeddings {
+    patch_embedding_weight: Tensor,
+    patch_embedding_bias: Tensor,
+    position_embedding: Tensor,
+    patch_size: usize,
+    hidden_size: usize,
+}
+
+impl VisionEmbeddings {
+    fn new(
+        hidden_size: usize,
+        image_size: usize,
+        patch_size: usize,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let num_patches_per_side = image_size / patch_size;
+        // Patch embedding stored as (patch_size, patch_size, 3, hidden_size) in GGUF
+        let patch_embedding_weight = vb
+            .get_no_shape("patch_embd.weight")?
+            .dequantize(vb.device())?;
+        let patch_embedding_bias = vb
+            .get_no_shape("patch_embd.bias")?
+            .dequantize(vb.device())?;
+        // Position embedding stored as (hidden_size, num_patches) in GGUF
+        let position_embedding = vb
+            .get_no_shape("position_embd.weight")?
+            .dequantize(vb.device())?;
+        // Reshape position embedding: (hidden_size, num_patches) -> (1, num_patches, hidden_size)
+        let position_embedding = if position_embedding.dim(0)? == hidden_size {
+            position_embedding.t()?.unsqueeze(0)?
+        } else {
+            position_embedding.unsqueeze(0)?
+        };
+
+        // GGUF stores patch_embd.weight with dims [16, 16, 3, 768] in GGUF order.
+        // Candle loads this as shape (768, 3, 16, 16) which is already Conv2d layout
+        // (out_channels, in_channels, kH, kW). No reshape needed.
+        let patch_embedding_weight = if patch_embedding_weight.dims() == [hidden_size, 3, patch_size, patch_size] {
+            patch_embedding_weight
+        } else {
+            // Fallback: reshape from GGUF (patch_size, patch_size, 3, hidden_size) -> Conv2d
+            patch_embedding_weight
+                .reshape((patch_size, patch_size, 3, hidden_size))?
+                .permute((3, 2, 0, 1))?
+                .contiguous()?
+        };
+
+        let _ = num_patches_per_side; // used implicitly via position_embedding shape
+        Ok(Self {
+            patch_embedding_weight,
+            patch_embedding_bias,
+            position_embedding,
+            patch_size,
+            hidden_size,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let (_b, _c, _h, _w) = xs.dims4()?;
+        // Manual Conv2d with stride = patch_size
+        let embeddings = xs.conv2d(
+            &self.patch_embedding_weight,
+            0,              // padding
+            self.patch_size, // stride
+            1,              // dilation
+            1,              // groups
+        )?;
+        let embeddings = embeddings.broadcast_add(
+            &self.patch_embedding_bias.reshape((1, self.hidden_size, 1, 1))?,
+        )?;
+        // (B, hidden, H/p, W/p) -> (B, num_patches, hidden)
+        let embeddings = embeddings.flatten_from(2)?.transpose(1, 2)?;
+        // Add position embeddings
+        embeddings.broadcast_add(&self.position_embedding)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vision Model (public)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct VisionModel {
+    embeddings: VisionEmbeddings,
+    layers: Vec<EncoderLayer>,
+    post_layernorm: candle_nn::LayerNorm,
+}
+
+impl VisionModel {
+    pub fn new(
+        hidden_size: usize,
+        intermediate_size: usize,
+        num_hidden_layers: usize,
+        num_attention_heads: usize,
+        image_size: usize,
+        patch_size: usize,
+        layer_norm_eps: f64,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let embeddings =
+            VisionEmbeddings::new(hidden_size, image_size, patch_size, vb.clone())?;
+
+        let vb_layers = vb.pp("blk");
+        let mut layers = Vec::with_capacity(num_hidden_layers);
+        for i in 0..num_hidden_layers {
+            layers.push(EncoderLayer::new(
+                hidden_size,
+                intermediate_size,
+                num_attention_heads,
+                layer_norm_eps,
+                vb_layers.pp(i),
+            )?);
+        }
+
+        let post_layernorm =
+            quantized_nn::layer_norm(hidden_size, layer_norm_eps, vb.pp("post_ln"))?;
+
+        Ok(Self {
+            embeddings,
+            layers,
+            post_layernorm,
+        })
+    }
+}
+
+impl Module for VisionModel {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let mut hidden = self.embeddings.forward(xs)?;
+        for layer in &self.layers {
+            hidden = layer.forward(&hidden)?;
+        }
+        hidden.apply(&self.post_layernorm)
+    }
+}

--- a/candle-transformers/src/models/quantized_siglip.rs
+++ b/candle-transformers/src/models/quantized_siglip.rs
@@ -3,9 +3,9 @@
 //! Loads from llama.cpp GGUF mmproj files using the standard `v.blk.*` tensor naming.
 //! Reusable by any Idefics3/SigLIP-based multimodal model (Granite-Docling, SmolVLM, etc.).
 
-use candle::{Module, Result, Tensor};
 use crate::quantized_nn::{self, Linear};
 use crate::quantized_var_builder::VarBuilder;
+use candle::{Module, Result, Tensor};
 
 // ---------------------------------------------------------------------------
 // Attention
@@ -171,15 +171,16 @@ impl VisionEmbeddings {
         // GGUF stores patch_embd.weight with dims [16, 16, 3, 768] in GGUF order.
         // Candle loads this as shape (768, 3, 16, 16) which is already Conv2d layout
         // (out_channels, in_channels, kH, kW). No reshape needed.
-        let patch_embedding_weight = if patch_embedding_weight.dims() == [hidden_size, 3, patch_size, patch_size] {
-            patch_embedding_weight
-        } else {
-            // Fallback: reshape from GGUF (patch_size, patch_size, 3, hidden_size) -> Conv2d
-            patch_embedding_weight
-                .reshape((patch_size, patch_size, 3, hidden_size))?
-                .permute((3, 2, 0, 1))?
-                .contiguous()?
-        };
+        let patch_embedding_weight =
+            if patch_embedding_weight.dims() == [hidden_size, 3, patch_size, patch_size] {
+                patch_embedding_weight
+            } else {
+                // Fallback: reshape from GGUF (patch_size, patch_size, 3, hidden_size) -> Conv2d
+                patch_embedding_weight
+                    .reshape((patch_size, patch_size, 3, hidden_size))?
+                    .permute((3, 2, 0, 1))?
+                    .contiguous()?
+            };
 
         Ok(Self {
             patch_embedding_weight,
@@ -195,14 +196,17 @@ impl VisionEmbeddings {
         // Manual Conv2d with stride = patch_size
         let embeddings = xs.conv2d(
             &self.patch_embedding_weight,
-            0,              // padding
+            0,               // padding
             self.patch_size, // stride
-            1,              // dilation
-            1,              // groups
+            1,               // dilation
+            1,               // groups
         )?;
-        let embeddings = embeddings.broadcast_add(
-            &self.patch_embedding_bias.reshape((1, self.hidden_size, 1, 1))?,
-        )?;
+        let embeddings = embeddings.broadcast_add(&self.patch_embedding_bias.reshape((
+            1,
+            self.hidden_size,
+            1,
+            1,
+        ))?)?;
         // (B, hidden, H/p, W/p) -> (B, num_patches, hidden)
         let embeddings = embeddings.flatten_from(2)?.transpose(1, 2)?;
         // Add position embeddings
@@ -222,7 +226,10 @@ pub struct VisionModel {
 }
 
 impl VisionModel {
-    pub fn new(cfg: &crate::models::granite_docling::config::QuantizedVisionConfig, vb: VarBuilder) -> Result<Self> {
+    pub fn new(
+        cfg: &crate::models::granite_docling::config::QuantizedVisionConfig,
+        vb: VarBuilder,
+    ) -> Result<Self> {
         let hidden_size = cfg.hidden_size;
         let embeddings =
             VisionEmbeddings::new(hidden_size, cfg.image_size, cfg.patch_size, vb.clone())?;

--- a/candle-transformers/src/models/quantized_siglip.rs
+++ b/candle-transformers/src/models/quantized_siglip.rs
@@ -149,7 +149,7 @@ impl VisionEmbeddings {
         patch_size: usize,
         vb: VarBuilder,
     ) -> Result<Self> {
-        let num_patches_per_side = image_size / patch_size;
+        let _num_patches_per_side = image_size / patch_size;
         // Patch embedding stored as (patch_size, patch_size, 3, hidden_size) in GGUF
         let patch_embedding_weight = vb
             .get_no_shape("patch_embd.weight")?
@@ -181,7 +181,6 @@ impl VisionEmbeddings {
                 .contiguous()?
         };
 
-        let _ = num_patches_per_side; // used implicitly via position_embedding shape
         Ok(Self {
             patch_embedding_weight,
             patch_embedding_bias,
@@ -223,33 +222,25 @@ pub struct VisionModel {
 }
 
 impl VisionModel {
-    pub fn new(
-        hidden_size: usize,
-        intermediate_size: usize,
-        num_hidden_layers: usize,
-        num_attention_heads: usize,
-        image_size: usize,
-        patch_size: usize,
-        layer_norm_eps: f64,
-        vb: VarBuilder,
-    ) -> Result<Self> {
+    pub fn new(cfg: &crate::models::granite_docling::config::QuantizedVisionConfig, vb: VarBuilder) -> Result<Self> {
+        let hidden_size = cfg.hidden_size;
         let embeddings =
-            VisionEmbeddings::new(hidden_size, image_size, patch_size, vb.clone())?;
+            VisionEmbeddings::new(hidden_size, cfg.image_size, cfg.patch_size, vb.clone())?;
 
         let vb_layers = vb.pp("blk");
-        let mut layers = Vec::with_capacity(num_hidden_layers);
-        for i in 0..num_hidden_layers {
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        for i in 0..cfg.num_hidden_layers {
             layers.push(EncoderLayer::new(
                 hidden_size,
-                intermediate_size,
-                num_attention_heads,
-                layer_norm_eps,
+                cfg.intermediate_size,
+                cfg.num_attention_heads,
+                cfg.layer_norm_eps,
                 vb_layers.pp(i),
             )?);
         }
 
         let post_layernorm =
-            quantized_nn::layer_norm(hidden_size, layer_norm_eps, vb.pp("post_ln"))?;
+            quantized_nn::layer_norm(hidden_size, cfg.layer_norm_eps, vb.pp("post_ln"))?;
 
         Ok(Self {
             embeddings,


### PR DESCRIPTION
Implements IBM's Granite-Docling-258M document understanding model, which converts document page images into structured DocTags markup.

- Architecture: SigLIP vision encoder → pixel shuffle connector → standalone Llama-style causal decoder
- Weight formats: f32/bf16 safetensors and Q8_0 GGUF (two-file: text decoder + vision mmproj)
- Image splitting: Idefics3-style tiling (e.g., 4x3 grid + global view) for high-resolution document pages
- New reusable module: quantized_siglip.rs — quantized SigLIP vision encoder for GGUF mmproj files, usable by other Idefics3-based models
- Correct Lanczos3 resampling: The HF config specifies Lanczos for image preprocessing but PyTorch's torchvision backend falls back to Bicubic. Our implementation uses the intended Lanczos3, producing more faithful results for document text
- Validated: Output matches HuggingFace Python reference implementation token-for-token (f32) and structurally (Q8_0)