### PR TITLE
Fix: use MTLCopyAllDevices() for reliable Metal device enumeration

### DIFF
--- a/candle-metal-kernels/src/metal/device.rs
+++ b/candle-metal-kernels/src/metal/device.rs
@@ -48,15 +48,6 @@ impl Device {
     }
 
     /// Returns all Metal devices in the system.
-    ///
-    /// Uses [`MTLCopyAllDevices`] which on macOS calls the real FFI that
-    /// reliably enumerates devices in all process contexts (tmux, SSH, CI).
-    /// On iOS/tvOS/visionOS, `objc2-metal` provides a shim that wraps
-    /// `MTLCreateSystemDefaultDevice` in an array.
-    ///
-    /// `MTLCreateSystemDefaultDevice` requires CoreGraphics and can return
-    /// nil in non-GUI contexts even when Metal hardware is present.
-    /// See <https://developer.apple.com/documentation/metal/1433401-mtlcreatesystemdefaultdevice>.
     pub fn all() -> Vec<Self> {
         MTLCopyAllDevices()
             .to_vec()
@@ -67,18 +58,12 @@ impl Device {
 
     /// Returns the system default Metal device, if available.
     ///
-    /// Falls back to [`MTLCopyAllDevices`] if `MTLCreateSystemDefaultDevice`
-    /// returns nil (can happen on macOS in non-GUI contexts).
+    /// Falls back to first device from `all` if `MTLCreateSystemDefaultDevice`
+    /// returns nil.
     pub fn system_default() -> Option<Self> {
         MTLCreateSystemDefaultDevice()
             .map(|raw| Device { raw })
-            .or_else(|| {
-                MTLCopyAllDevices()
-                    .to_vec()
-                    .into_iter()
-                    .next()
-                    .map(|raw| Device { raw })
-            })
+            .or_else(|| Device::all().first())
     }
 
     pub fn new_buffer(

--- a/candle-metal-kernels/src/metal/device.rs
+++ b/candle-metal-kernels/src/metal/device.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use objc2::{rc::Retained, runtime::AnyObject, runtime::ProtocolObject};
 use objc2_foundation::NSString;
-use objc2_metal::{MTLCompileOptions, MTLCreateSystemDefaultDevice, MTLDevice};
+use objc2_metal::{MTLCompileOptions, MTLCopyAllDevices, MTLCreateSystemDefaultDevice, MTLDevice};
 use std::{ffi::c_void, ptr};
 
 /// Metal device type classification based on Apple Silicon architecture.
@@ -47,15 +47,38 @@ impl Device {
         self.as_ref().registryID()
     }
 
+    /// Returns all Metal devices in the system.
+    ///
+    /// Uses [`MTLCopyAllDevices`] which on macOS calls the real FFI that
+    /// reliably enumerates devices in all process contexts (tmux, SSH, CI).
+    /// On iOS/tvOS/visionOS, `objc2-metal` provides a shim that wraps
+    /// `MTLCreateSystemDefaultDevice` in an array.
+    ///
+    /// `MTLCreateSystemDefaultDevice` requires CoreGraphics and can return
+    /// nil in non-GUI contexts even when Metal hardware is present.
+    /// See <https://developer.apple.com/documentation/metal/1433401-mtlcreatesystemdefaultdevice>.
     pub fn all() -> Vec<Self> {
-        MTLCreateSystemDefaultDevice()
+        MTLCopyAllDevices()
+            .to_vec()
             .into_iter()
             .map(|raw| Device { raw })
             .collect()
     }
 
+    /// Returns the system default Metal device, if available.
+    ///
+    /// Falls back to [`MTLCopyAllDevices`] if `MTLCreateSystemDefaultDevice`
+    /// returns nil (can happen on macOS in non-GUI contexts).
     pub fn system_default() -> Option<Self> {
-        MTLCreateSystemDefaultDevice().map(|raw| Device { raw })
+        MTLCreateSystemDefaultDevice()
+            .map(|raw| Device { raw })
+            .or_else(|| {
+                MTLCopyAllDevices()
+                    .to_vec()
+                    .into_iter()
+                    .next()
+                    .map(|raw| Device { raw })
+            })
     }
 
     pub fn new_buffer(

--- a/candle-metal-kernels/src/metal/device.rs
+++ b/candle-metal-kernels/src/metal/device.rs
@@ -63,7 +63,7 @@ impl Device {
     pub fn system_default() -> Option<Self> {
         MTLCreateSystemDefaultDevice()
             .map(|raw| Device { raw })
-            .or_else(|| Device::all().first())
+            .or_else(|| Device::all().first().cloned())
     }
 
     pub fn new_buffer(


### PR DESCRIPTION
## Summary

`Device::all()` now uses `MTLCopyAllDevices()` instead of `MTLCreateSystemDefaultDevice()`, and `Device::system_default()` falls back to `MTLCopyAllDevices()` when `MTLCreateSystemDefaultDevice()` returns nil.

## Problem

`Device::all()` currently calls `MTLCreateSystemDefaultDevice()`, which has two issues:

1. **Wrong semantics**: `MTLCreateSystemDefaultDevice()` returns at most one device. A method called `all()` should return all available devices.

2. **Returns nil in non-GUI contexts**: Apple's documentation for [`MTLCreateSystemDefaultDevice()`](https://developer.apple.com/documentation/metal/1433401-mtlcreatesystemdefaultdevice) states:

   > *"In macOS, in order for the system to provide a default Metal device object, you must link to the CoreGraphics framework. You usually need to do this explicitly if you're writing apps that don't use graphics by default, such as command line tools."*

   Even with CoreGraphics linked, the function still returns nil in certain process contexts (tmux sessions, SSH, CI runners) where Metal GPUs are physically present. This causes `candle-core`'s `Device::new_metal(0)` to panic, since it calls `Device::all().swap_remove(0)` on an empty vec.

## Fix

`Device::all()` now uses [`MTLCopyAllDevices()`](https://developer.apple.com/documentation/metal/mtlcopyalldevices()) which:

- Returns **all** Metal devices in the system (correct `all()` semantics)
- Has no CoreGraphics linkage requirement
- Does not trigger automatic GPU switching — per Apple's `MTLDevice.h` header: *"this API will not cause the system to switch devices and leaves the decision about which GPU to use up to the application based on whatever criteria it deems appropriate"*

No `#[cfg(target_os)]` gating is needed. The `objc2-metal` crate already handles the platform differences internally: on macOS it calls the real `MTLCopyAllDevices` FFI, and on iOS/tvOS/visionOS it provides a [compile-time shim](https://docs.rs/objc2-metal/0.3.2/src/objc2_metal/device.rs.html) that wraps `MTLCreateSystemDefaultDevice` in an array (since `MTLCopyAllDevices` was only added to those platforms in iOS 18.0 / tvOS 18.0 / visionOS 2.0, see `API_AVAILABLE(macos(10.11), macCatalyst(13.0), ios(18.0))` in Apple's `MTLDevice.h`).

`Device::system_default()` also gains a fallback to `MTLCopyAllDevices()` when `MTLCreateSystemDefaultDevice()` returns nil.

## Reproduction

On any Mac with Metal support, run a candle program that calls `Device::new_metal(0)` from within a tmux session or headless SSH connection. Without this fix, `Device::all()` returns an empty vec and panics.

## References

- Fixes issue #3369
- [`MTLCreateSystemDefaultDevice()` — Apple Developer Documentation](https://developer.apple.com/documentation/metal/1433401-mtlcreatesystemdefaultdevice) — documents CoreGraphics requirement and optional return type
- [`MTLCopyAllDevices()` — Apple Developer Documentation](https://developer.apple.com/documentation/metal/mtlcopyalldevices()) — device enumeration, non-optional return
- [Apple `MTLDevice.h` header](https://developer.apple.com/documentation/metal/mtldevice) — `MTLCopyAllDevices` doc comment: *"On iOS, tvOS and visionOS, this API returns an array containing the same device that MTLCreateSystemDefaultDevice would have returned, or an empty array if it would have failed."*
- [`objc2-metal` platform shim source](https://docs.rs/objc2-metal/0.3.2/src/objc2_metal/device.rs.html) — shows the compile-time fallback on non-macOS platforms
- [Metal Best Practices: Persistent Objects](https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/PersistentObjects.html) — recommends `MTLCopyAllDevices()` for multi-GPU macOS
- [actions/runner-images#1779](https://github.com/actions/runner-images/issues/1779) — `MTLCreateSystemDefaultDevice` returns nil in GitHub Actions macOS runners
