### PR TITLE
Add ACE-Step 1.5 music generation model and example

### DIFF
--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -24,6 +24,7 @@ cudarc = { workspace = true, optional = true }
 half = { workspace = true, optional = true }
 hf-hub = { workspace = true, features = ["tokio"] }
 image = { workspace = true }
+zip = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
 num-traits = { workspace = true }
 minijinja = { version = "2", features = ["loader"] }

--- a/candle-examples/examples/ace-step/README.md
+++ b/candle-examples/examples/ace-step/README.md
@@ -238,9 +238,24 @@ cargo run --example ace-step --release --features metal -- \
 For short latents (`T_latent <= chunk`) tiling short-circuits to a plain
 forward pass, so there is no overhead on small durations.
 
-Note: the diffusion pass itself (DiT self-attention) is still O(T²) in
-sequence length, so tiled VAE does not make *arbitrarily* long generation
-possible — it just removes the VAE decoder as the binding memory limit.
+### DiT sliding-window self-attention
+
+Half of the DiT's 24 layers are configured as `sliding_attention` with a
+window of 128 positions, alternating with `full_attention` layers. On those
+sliding layers the self-attention is computed in query chunks with local KV
+slices of size `window + 2*window`, so the full `L×L` score matrix is never
+materialized. Peak per-layer memory on the attention scores drops from
+O(L²) to O(L·W) — roughly two orders of magnitude at 60 s and above.
+
+This activates automatically when `L > sliding_window`. On shorter
+sequences the window covers everything and the layer falls back to full
+attention. The other half of the layers remain full-attention (they need
+global context) and still scale O(L²); they are the next binding limit
+past ~2-minute tracks.
+
+Together with tiled VAE, this means the practical ceiling for generation
+length is set by the full-attention DiT layers, not by the decoder or the
+sliding layers.
 
 ## First run
 

--- a/candle-examples/examples/ace-step/README.md
+++ b/candle-examples/examples/ace-step/README.md
@@ -207,7 +207,40 @@ region is regenerated according to the text prompt.
 --cfg-interval-start   CFG guidance applied when timestep >= this (default: 0.0)
 --cfg-interval-end     CFG guidance applied when timestep <= this (default: 1.0)
 --infer-method         "ode" (deterministic, default) or "sde" (stochastic)
+--vae-chunk-frames     Latent frames per VAE-decode chunk; 0 = built-in default (128 ≈ 5.1s of audio)
+--vae-chunk-overlap    Latent-frame overlap on each side of a VAE-decode chunk; 0 = default (16)
 ```
+
+## Long-duration generation: tiled VAE decoding
+
+The VAE decoder is the biggest memory consumer after latent denoising — its
+widest intermediate activation scales linearly with output length. At 30+
+seconds of 48 kHz stereo this intermediate tensor alone can exceed 10–20 GB
+and trigger OOM on consumer GPUs.
+
+To work around this, the decoder runs by default in **tiled** mode: the
+latent is split along the time axis into overlapping chunks, each chunk is
+decoded independently, the overlap regions are trimmed, and the cores are
+concatenated. Because the decoder is fully convolutional with local padding
+and its receptive field is well under the default 16-frame overlap, the
+stitched output is numerically equivalent to a single full-length decode.
+
+Defaults (`--vae-chunk-frames 128 --vae-chunk-overlap 16`) cut peak decoder
+memory by roughly an order of magnitude on 30 s+ tracks. If you still hit
+OOM, shrink the chunk:
+
+```bash
+cargo run --example ace-step --release --features metal -- \
+    --prompt "..." --duration 60 \
+    --vae-chunk-frames 64 --vae-chunk-overlap 16
+```
+
+For short latents (`T_latent <= chunk`) tiling short-circuits to a plain
+forward pass, so there is no overhead on small durations.
+
+Note: the diffusion pass itself (DiT self-attention) is still O(T²) in
+sequence length, so tiled VAE does not make *arbitrarily* long generation
+possible — it just removes the VAE decoder as the binding memory limit.
 
 ## First run
 

--- a/candle-examples/examples/ace-step/README.md
+++ b/candle-examples/examples/ace-step/README.md
@@ -1,0 +1,290 @@
+# candle-ace-step: music generation with ACE-Step 1.5
+
+Candle implementation of [ACE-Step 1.5](https://github.com/ace-step/ACE-Step-1.5),
+a music generation foundation model based on a Diffusion Transformer (DiT)
+architecture with text conditioning.
+
+- [HuggingFace Model Hub](https://huggingface.co/ACE-Step)
+- [GitHub Repository](https://github.com/ace-step/ACE-Step-1.5)
+- [Technical Report](https://arxiv.org/abs/2602.00744)
+
+ACE-Step generates stereo 48kHz music audio from text prompts and optional
+lyrics. Two inference modes are supported:
+
+- **DiT-only** (`--infer-type dit`): text encoder → DiT → VAE. Best with
+  base/sft models.
+- **LM+DiT** (`--infer-type lm-dit`): a Qwen3 language model first generates
+  chain-of-thought metadata and audio codes, then the DiT produces audio
+  conditioned on these codes. Best with turbo models for higher quality.
+  LM metadata (BPM, keyscale, caption, language) is fed back into the DiT
+  text encoder for richer conditioning.
+
+## Supported models
+
+| Model | Params | Steps | HuggingFace repo |
+|-------|--------|-------|------------------|
+| Base | 2B | 50 | [`ACE-Step/acestep-v15-base`](https://huggingface.co/ACE-Step/acestep-v15-base) |
+| SFT | 2B | 50 | [`ACE-Step/acestep-v15-sft`](https://huggingface.co/ACE-Step/acestep-v15-sft) |
+| Turbo (shift3) | 2B | 8 | [`ACE-Step/acestep-v15-turbo-shift3`](https://huggingface.co/ACE-Step/acestep-v15-turbo-shift3) |
+| XL Base | 4B | 50 | [`ACE-Step/acestep-v15-xl-base`](https://huggingface.co/ACE-Step/acestep-v15-xl-base) |
+| XL SFT | 4B | 50 | [`ACE-Step/acestep-v15-xl-sft`](https://huggingface.co/ACE-Step/acestep-v15-xl-sft) |
+| XL Turbo | 4B | 8 | [`ACE-Step/acestep-v15-xl-turbo`](https://huggingface.co/ACE-Step/acestep-v15-xl-turbo) |
+
+The **SFT** (supervised fine-tuned) variant is recommended for best quality
+in DiT-only mode. **Turbo** models are best used with the LM+DiT pipeline.
+
+### Language models (for LM+DiT mode)
+
+| Model | Params | HuggingFace repo |
+|-------|--------|------------------|
+| LM 0.6B | 0.6B | [`ACE-Step/acestep-5Hz-lm-0.6B`](https://huggingface.co/ACE-Step/acestep-5Hz-lm-0.6B) |
+| LM 1.7B | 1.7B | [`ACE-Step/acestep-5Hz-lm-1.7B`](https://huggingface.co/ACE-Step/acestep-5Hz-lm-1.7B) |
+| LM 4B | 4B | [`ACE-Step/acestep-5Hz-lm-4B`](https://huggingface.co/ACE-Step/acestep-5Hz-lm-4B) |
+
+The LM is automatically unloaded after generating audio codes to free GPU
+memory before the DiT denoising pass.
+
+See the full [ACE-Step model collection](https://huggingface.co/ACE-Step) for
+additional variants.
+
+## Running the model
+
+Generate a 10-second music clip on Metal (macOS):
+
+```bash
+cargo run --example ace-step --release --features metal -- \
+    --prompt "pop dance electronic synthesizer. energetic, happy, party" \
+    --duration 10 --model ACE-Step/acestep-v15-sft \
+    --out-file output.wav
+```
+
+On CUDA:
+
+```bash
+cargo run --example ace-step --release --features cuda -- \
+    --prompt "acoustic guitar melody with soft piano accompaniment" \
+    --duration 15 --model ACE-Step/acestep-v15-sft \
+    --out-file output.wav
+```
+
+On CPU (slower):
+
+```bash
+cargo run --example ace-step --release -- \
+    --prompt "jazz piano solo" --duration 10 --cpu \
+    --model ACE-Step/acestep-v15-sft --out-file output.wav
+```
+
+With the turbo model (8 steps, faster):
+
+```bash
+cargo run --example ace-step --release --features metal -- \
+    --prompt "cinematic orchestral epic" --duration 10 \
+    --model ACE-Step/acestep-v15-turbo-shift3 --out-file output.wav
+```
+
+### Lyrics
+
+Pass lyrics as a string or as a path to a text file:
+
+```bash
+# Inline lyrics
+cargo run --example ace-step --release --features metal -- \
+    --prompt "pop ballad" --lyrics "[Verse]\nHello world\n[Chorus]\nLa la la" \
+    --duration 30
+
+# From file
+cargo run --example ace-step --release --features metal -- \
+    --prompt "pop ballad" --lyrics lyrics.txt \
+    --duration 30
+```
+
+If the `--lyrics` value is a path to an existing file, its contents are loaded
+automatically. Otherwise it is used as literal lyrics text.
+
+### LM+DiT pipeline (recommended for turbo models)
+
+The LM generates chain-of-thought metadata (BPM, key, style, caption,
+language) and audio codes that condition the DiT for higher quality
+generation. The metadata is fed back into the DiT text prompt:
+
+```bash
+cargo run --example ace-step --release --features metal -- \
+    --infer-type lm-dit \
+    --lm-model ACE-Step/acestep-5Hz-lm-0.6B \
+    --model ACE-Step/acestep-v15-turbo-shift3 \
+    --prompt "pop dance electronic synthesizer, energetic" \
+    --duration 30 --out-file output.wav
+```
+
+With custom LM sampling parameters:
+
+```bash
+cargo run --example ace-step --release --features metal -- \
+    --infer-type lm-dit \
+    --lm-model ACE-Step/acestep-5Hz-lm-0.6B \
+    --model ACE-Step/acestep-v15-turbo-shift3 \
+    --prompt "jazz piano trio" --lyrics lyrics.txt \
+    --temperature 0.9 --top-p 0.95 \
+    --duration 15 --seed 42
+```
+
+### Cover mode (reference audio conditioning)
+
+Provide a reference WAV file to guide the generation style:
+
+```bash
+cargo run --example ace-step --release --features metal -- \
+    --prompt "electronic remix" \
+    --reference-audio original_song.wav \
+    --model ACE-Step/acestep-v15-sft \
+    --duration 30 --out-file cover.wav
+```
+
+Use `--timbre-audio` to supply a separate timbre source (matching Python's
+`reference_audio` vs `src_audio` separation). Without it, the reference
+audio is used for both structure and timbre:
+
+```bash
+cargo run --example ace-step --release --features metal -- \
+    --prompt "electronic remix" \
+    --reference-audio melody_source.wav \
+    --timbre-audio singer_voice.wav \
+    --infer-type lm-dit --lm-model ACE-Step/acestep-5Hz-lm-0.6B \
+    --model ACE-Step/acestep-v15-turbo-shift3 \
+    --duration 30 --out-file cover.wav
+```
+
+Use `--audio-cover-strength` (0.0-1.0) to control how much of the
+denoising process uses the cover condition before switching to text-only:
+
+```bash
+cargo run --example ace-step --release --features metal -- \
+    --reference-audio original.wav --audio-cover-strength 0.7 \
+    --prompt "jazz remix" --duration 30
+```
+
+For best cover quality, combine with LM mode
+(`--infer-type lm-dit --lm-model ACE-Step/acestep-5Hz-lm-0.6B`).
+
+### Repaint mode (selective re-generation)
+
+Regenerate a specific time region while preserving the rest:
+
+```bash
+cargo run --example ace-step --release --features metal -- \
+    --repaint-audio source.wav --repaint-start 3 --repaint-end 7 \
+    --prompt "energetic drum solo" --duration 10 --out-file repainted.wav
+```
+
+The original audio outside `[3s, 7s]` is preserved; only the specified
+region is regenerated according to the text prompt.
+
+## Options
+
+```
+--prompt               Text describing the desired music style
+--lyrics               Lyrics text or path to a lyrics file (default: instrumental)
+--duration             Audio duration in seconds (default: 10)
+--model                HuggingFace DiT model repo (default: ACE-Step/acestep-v15-sft)
+--num-steps            Denoising steps (default: 50, auto 8 for turbo)
+--guidance-scale       CFG/APG guidance strength (default: 5.0)
+--shift                Timestep schedule shift factor (default: 1.0)
+--seed                 Random seed for reproducibility
+--out-file             Output WAV file path (default: ace_step_output.wav)
+--cpu                  Force CPU execution
+--tracing              Enable tracing profiler
+--infer-type           "dit" (default) or "lm-dit" (LM+DiT pipeline)
+--lm-model             HuggingFace LM repo (for lm-dit mode)
+--temperature          LM sampling temperature (default: 0.85)
+--top-p                LM top-p nucleus sampling threshold
+--reference-audio      WAV file for cover mode — structural source (melody/rhythm)
+--timbre-audio         Separate WAV for timbre; if omitted, uses reference-audio
+--repaint-audio        WAV file for repaint mode (selective re-generation)
+--repaint-start        Repaint region start in seconds (default: 0)
+--repaint-end          Repaint region end in seconds
+--audio-cover-strength Cover condition fraction (0.0-1.0, default: 1.0)
+--cfg-interval-start   CFG guidance applied when timestep >= this (default: 0.0)
+--cfg-interval-end     CFG guidance applied when timestep <= this (default: 1.0)
+--infer-method         "ode" (deterministic, default) or "sde" (stochastic)
+```
+
+## First run
+
+On the first run, model weights are automatically downloaded from HuggingFace
+Hub (~5GB for 2B DiT models, ~9GB for XL). Sharded models (XL DiT, LM 4B)
+are handled transparently via `model.safetensors.index.json`. After download,
+weights are cached locally.
+
+When using `--infer-type lm-dit`, the LM model weights are also downloaded
+(~1.3GB for 0.6B, ~3.5GB for 1.7B, ~8GB for 4B). The LM is unloaded after
+generating audio codes to free memory for the DiT pass.
+
+The model also requires a `silence_latent.pt` file which is downloaded from
+the model repo and parsed automatically.
+
+## Audio post-processing
+
+Output audio is post-processed with:
+
+1. **BS1770 loudness normalization** to -14 LUFS per channel with `tanh`
+   compressor for consistent loudness across generations
+2. **Peak clamp** to [-1, 1]
+3. **50ms fade-out** at the end to avoid clicks
+
+## Architecture overview
+
+### DiT-only mode (default)
+
+```
+Text prompt --> Qwen3-Embedding-0.6B --> text_hidden_states
+                                              |
+Lyrics -----> embed_tokens --> LyricEncoder --+
+                                              v
+                                    ConditionEncoder
+                                         |
+                                         v
+                              encoder_hidden_states
+                                         |
+Random noise                             |
+     |                                   v
+     +--------> DiT (24/32 layers) <-----+
+     |          - Self-attention (sliding/full)
+     |          - Cross-attention
+     |          - AdaLN-Zero from timestep
+     |          x 50 Euler ODE steps + APG
+     v
+Clean latent --> AutoencoderOobleck --> loudness norm --> 48kHz stereo WAV
+```
+
+### LM+DiT mode (`--infer-type lm-dit`)
+
+```
+                         Phase 1: CoT                  Phase 2: Codes
+Text prompt ──> Qwen3 LM ──> <think>              ──> <|audio_code_N|>...
+                              bpm: 120                       |
+                              caption: ...                   v
+                              duration: 30            parse code values
+                              keyscale: C major              |
+                              language: en                   v
+                              timesignature: 4      ResidualFSQ.indices_to_codes
+                              </think>                       |
+                                                             v
+                           [LM unloaded]            AudioTokenDetokenizer
+                                                             |
+                                                             v
+                                                    lm_hints_25Hz (latents)
+                                                             |
+LM metadata ──> caption/bpm/key/language (fed back to DiT text input)
+                       |
+Text prompt + LM meta ──> Qwen3-Embedding --> ConditionEncoder  |
+                                         |                      |
+                                         v                      v
+                              encoder_hidden_states + lm_hints_25Hz
+                                         |
+Random noise                             |
+     |                                   v
+     +--------> DiT (8 turbo steps) <----+
+     v
+Clean latent --> AutoencoderOobleck --> loudness norm --> 48kHz stereo WAV
+```

--- a/candle-examples/examples/ace-step/main.rs
+++ b/candle-examples/examples/ace-step/main.rs
@@ -95,6 +95,15 @@ struct Args {
     /// Sampling method: "ode" (deterministic) or "sde" (stochastic)
     #[arg(long, default_value = "ode")]
     infer_method: String,
+    /// Latent frames per VAE-decoder chunk (tiled decode). Lower = less peak
+    /// memory at the cost of compute overhead. Set to 0 to let the decoder
+    /// pick its default (128 frames ≈ 5.1 s of audio).
+    #[arg(long, default_value_t = 0)]
+    vae_chunk_frames: usize,
+    /// Overlap in latent frames on each side of a VAE-decoder chunk. Must
+    /// satisfy `chunk > 2 * overlap`. Set to 0 to use the default (16).
+    #[arg(long, default_value_t = 0)]
+    vae_chunk_overlap: usize,
 }
 
 /// Write stereo `(2, T)` tensor as 16-bit WAV with loudness normalization,
@@ -395,6 +404,8 @@ fn main() -> Result<()> {
         audio_cover_strength: args.audio_cover_strength,
         cfg_interval: (args.cfg_interval_start, args.cfg_interval_end),
         infer_method,
+        vae_chunk_frames: (args.vae_chunk_frames > 0).then_some(args.vae_chunk_frames),
+        vae_chunk_overlap: (args.vae_chunk_overlap > 0).then_some(args.vae_chunk_overlap),
     };
 
     let t = std::time::Instant::now();

--- a/candle-examples/examples/ace-step/main.rs
+++ b/candle-examples/examples/ace-step/main.rs
@@ -1,0 +1,436 @@
+//! ACE-Step 1.5 music generation example.
+//!
+//! ```bash
+//! # DiT-only (base/sft)
+//! cargo run --release --example ace-step --features metal -- \
+//!     --prompt "A gentle acoustic guitar melody" --duration 10
+//!
+//! # LM+DiT (turbo)
+//! cargo run --release --example ace-step --features metal -- \
+//!     --infer-type lm-dit --lm-model ACE-Step/acestep-5Hz-lm-0.6B \
+//!     --model ACE-Step/acestep-v15-turbo-shift3 \
+//!     --prompt "A gentle guitar" --duration 30
+//!
+//! # Cover mode
+//! cargo run --release --example ace-step --features metal -- \
+//!     --reference-audio original.wav --prompt "electronic remix" --duration 30
+//! ```
+
+mod pipeline;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+use anyhow::Result;
+use candle::{DType, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::ace_step::{lm::LmConfig, sampling, AceStepConfig, VaeConfig};
+use clap::Parser;
+use hf_hub::{api::sync::Api, Repo};
+use pipeline::{AceStepPipeline, GenerationParams, LmMetadata};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "ACE-Step 1.5 Text2Music generation")]
+struct Args {
+    #[arg(
+        long,
+        default_value = "A gentle acoustic guitar melody with soft piano accompaniment"
+    )]
+    prompt: String,
+    #[arg(long, default_value = "")]
+    lyrics: String,
+    #[arg(long, default_value_t = 10.0)]
+    duration: f64,
+    #[arg(long)]
+    cpu: bool,
+    #[arg(long)]
+    seed: Option<u64>,
+    #[arg(long)]
+    num_steps: Option<usize>,
+    #[arg(long, default_value_t = 5.0)]
+    guidance_scale: f64,
+    #[arg(long, default_value_t = 1.0)]
+    shift: f64,
+    #[arg(long, default_value = "ace_step_output.wav")]
+    out_file: String,
+    #[arg(long, default_value = "ACE-Step/acestep-v15-sft")]
+    model: String,
+    #[arg(long)]
+    tracing: bool,
+    /// "dit" (default) or "lm-dit"
+    #[arg(long, default_value = "dit")]
+    infer_type: String,
+    #[arg(long)]
+    lm_model: Option<String>,
+    #[arg(long, default_value_t = 0.85)]
+    temperature: f64,
+    #[arg(long)]
+    top_p: Option<f64>,
+    /// Reference audio WAV for cover mode (structural source)
+    #[arg(long)]
+    reference_audio: Option<String>,
+    /// Separate timbre audio WAV for cover mode; if omitted, uses reference-audio
+    #[arg(long)]
+    timbre_audio: Option<String>,
+    /// Source audio WAV for repaint mode (selectively regenerate a region)
+    #[arg(long)]
+    repaint_audio: Option<String>,
+    /// Repaint region start time in seconds
+    #[arg(long, default_value_t = 0.0)]
+    repaint_start: f64,
+    /// Repaint region end time in seconds (required with --repaint-audio)
+    #[arg(long)]
+    repaint_end: Option<f64>,
+    /// Cover condition strength (0.0–1.0); at this fraction of steps, switches to non-cover condition
+    #[arg(long, default_value_t = 1.0)]
+    audio_cover_strength: f64,
+    /// CFG interval start (guidance applied when timestep >= this)
+    #[arg(long, default_value_t = 0.0)]
+    cfg_interval_start: f64,
+    /// CFG interval end (guidance applied when timestep <= this)
+    #[arg(long, default_value_t = 1.0)]
+    cfg_interval_end: f64,
+    /// Sampling method: "ode" (deterministic) or "sde" (stochastic)
+    #[arg(long, default_value = "ode")]
+    infer_method: String,
+}
+
+/// Write stereo `(2, T)` tensor as 16-bit WAV with loudness normalization,
+/// peak clamp, and fade-out.
+fn write_stereo_wav(path: &str, audio: &Tensor, sample_rate: u32) -> Result<()> {
+    let audio = audio.to_dtype(DType::F32)?;
+
+    // BS1770 loudness normalization to -14 LUFS per channel.
+    // VAE output can be very quiet or uneven — this brings it to a
+    // consistent broadcast-standard level.
+    let left = candle_examples::audio::normalize_loudness(&audio.get(0)?, sample_rate, true)?;
+    let right = candle_examples::audio::normalize_loudness(&audio.get(1)?, sample_rate, true)?;
+
+    let mut left = left.to_vec1::<f32>()?;
+    let mut right = right.to_vec1::<f32>()?;
+    for s in left.iter_mut().chain(right.iter_mut()) {
+        *s = s.clamp(-1.0, 1.0);
+    }
+    // 50ms fade-out at end to avoid click
+    let fade = (sample_rate as usize / 20).min(left.len());
+    for i in 0..fade {
+        let g = 1.0 - (i as f32 / fade as f32); // 1→0
+        let idx = left.len() - fade + i;
+        left[idx] *= g;
+        right[idx] *= g;
+    }
+    let mut f = std::fs::File::create(path)?;
+    candle_examples::wav::write_pcm_as_wav_stereo(&mut f, &[&left, &right], sample_rate)?;
+    Ok(())
+}
+
+/// Load audio file as `(1, 2, T)` tensor, resampling if needed.
+fn load_reference_audio(
+    path: &str,
+    target_sr: u32,
+    dtype: DType,
+    device: &candle::Device,
+) -> Result<Tensor> {
+    let (left, right, sr) = {
+        #[cfg(feature = "symphonia")]
+        {
+            let (ch, sr) = candle_examples::audio::pcm_decode_all_channels(path)?;
+            if ch.len() == 1 {
+                (ch[0].clone(), ch[0].clone(), sr)
+            } else {
+                (ch[0].clone(), ch[1].clone(), sr)
+            }
+        }
+        #[cfg(not(feature = "symphonia"))]
+        {
+            let mut f = std::io::BufReader::new(std::fs::File::open(path)?);
+            let (h, ch) = candle_examples::wav::read_pcm_from_wav::<_, f32>(&mut f)?;
+            if ch.len() == 1 {
+                (ch[0].clone(), ch[0].clone(), h.sample_rate)
+            } else {
+                (ch[0].clone(), ch[1].clone(), h.sample_rate)
+            }
+        }
+    };
+    let (left, right) = if sr != target_sr && sr > 0 {
+        #[cfg(feature = "rubato")]
+        {
+            println!("Resampling {sr}Hz → {target_sr}Hz...");
+            let l: Vec<f32> = candle_examples::audio::resample(&left, sr, target_sr)?
+                .into_iter()
+                .map(|v| v as f32)
+                .collect();
+            let r: Vec<f32> = candle_examples::audio::resample(&right, sr, target_sr)?
+                .into_iter()
+                .map(|v| v as f32)
+                .collect();
+            (l, r)
+        }
+        #[cfg(not(feature = "rubato"))]
+        {
+            println!(
+                "Warning: {sr}Hz audio, model expects {target_sr}Hz. Enable 'rubato' feature."
+            );
+            (left, right)
+        }
+    } else {
+        (left, right)
+    };
+
+    let n = left.len();
+    let d = &candle::Device::Cpu;
+    let audio = Tensor::stack(
+        &[
+            &Tensor::from_vec(left, n, d)?,
+            &Tensor::from_vec(right, n, d)?,
+        ],
+        0,
+    )?
+    .unsqueeze(0)?;
+    Ok(audio.to_dtype(dtype)?.to_device(device)?)
+}
+
+fn main() -> Result<()> {
+    use tracing_chrome::ChromeLayerBuilder;
+    use tracing_subscriber::prelude::*;
+
+    let args = Args::parse();
+    let lyrics = if !args.lyrics.is_empty() && std::path::Path::new(&args.lyrics).is_file() {
+        std::fs::read_to_string(&args.lyrics)?
+    } else {
+        args.lyrics.clone()
+    };
+    let _guard = if args.tracing {
+        let (cl, g) = ChromeLayerBuilder::new().build();
+        tracing_subscriber::registry().with(cl).init();
+        Some(g)
+    } else {
+        None
+    };
+
+    let device = candle_examples::device(args.cpu)?;
+    // BF16 matches the original model weights dtype, saving ~50% memory.
+    // F16 is insufficient (DiT produces silence, LM overflows).
+    let dtype = if device.is_cpu() {
+        DType::F32
+    } else {
+        DType::BF16
+    };
+    let is_turbo = args.model.contains("turbo");
+    let needs_encoder = args.reference_audio.is_some()
+        || args.repaint_audio.is_some()
+        || args.timbre_audio.is_some();
+
+    // Auto-detect shift from model name if not explicitly set
+    let shift = if (args.shift - 1.0).abs() < 1e-6 && is_turbo {
+        if args.model.contains("shift3") {
+            3.0
+        } else if args.model.contains("shift2") {
+            2.0
+        } else if args.model.contains("shift1") {
+            1.0
+        } else {
+            3.0
+        }
+    } else {
+        args.shift
+    };
+
+    println!(
+        "Model: {}, device: {:?}, dtype: {:?}, duration: {}s{}",
+        args.model,
+        device,
+        dtype,
+        args.duration,
+        if is_turbo {
+            format!(", shift: {shift}")
+        } else {
+            String::new()
+        },
+    );
+
+    // ---- Download files ----
+    let api = Api::new()?;
+    let main_repo = api.repo(Repo::model(args.model.clone()));
+    let shared_repo = api.repo(Repo::model("ACE-Step/Ace-Step1.5".to_string()));
+
+    // DiT weights: single file for 2B models, sharded for XL (4B)
+    let dit_weight_files: Vec<std::path::PathBuf> = match main_repo.get("model.safetensors") {
+        Ok(p) => vec![p],
+        Err(_) => {
+            candle_examples::hub_load_safetensors(&main_repo, "model.safetensors.index.json")?
+        }
+    };
+    let dit_config_file = main_repo.get("config.json")?;
+    let silence_latent_pt = main_repo.get("silence_latent.pt")?;
+    let vae_weights = shared_repo.get("vae/diffusion_pytorch_model.safetensors")?;
+    let vae_config_file = shared_repo.get("vae/config.json")?;
+    let text_encoder_weights = shared_repo.get("Qwen3-Embedding-0.6B/model.safetensors")?;
+    let text_encoder_config_file = shared_repo.get("Qwen3-Embedding-0.6B/config.json")?;
+    let tokenizer_file = shared_repo.get("Qwen3-Embedding-0.6B/tokenizer.json")?;
+
+    // ---- Load pipeline ----
+    println!("Loading models...");
+    let dit_config: AceStepConfig =
+        serde_json::from_reader(std::fs::File::open(&dit_config_file)?)?;
+    let vae_config: VaeConfig = serde_json::from_reader(std::fs::File::open(&vae_config_file)?)?;
+    let text_config: candle_transformers::models::qwen3::Config =
+        serde_json::from_reader(std::fs::File::open(&text_encoder_config_file)?)?;
+
+    let dit_refs: Vec<&std::path::Path> = dit_weight_files.iter().map(|p| p.as_path()).collect();
+    let dit_vb = unsafe { VarBuilder::from_mmaped_safetensors(&dit_refs, dtype, &device)? };
+    let vae_vb = unsafe { VarBuilder::from_mmaped_safetensors(&[&vae_weights], dtype, &device)? };
+    let text_vb =
+        unsafe { VarBuilder::from_mmaped_safetensors(&[&text_encoder_weights], dtype, &device)? };
+    let text_vb = text_vb.rename_f(|n| n.strip_prefix("model.").unwrap_or(n).to_string());
+
+    let silence_latent = pipeline::load_silence_latent(
+        &silence_latent_pt,
+        dit_config.audio_acoustic_hidden_dim,
+        dtype,
+        &device,
+    )?;
+
+    let mut pipeline = AceStepPipeline::new(
+        &dit_config,
+        &vae_config,
+        &text_config,
+        dit_vb,
+        vae_vb,
+        text_vb,
+        &tokenizer_file,
+        silence_latent,
+        needs_encoder,
+    )?;
+
+    // ---- Optional LM pipeline ----
+    let (lm_hints, lm_metadata) = if args.infer_type == "lm-dit" {
+        let lm_repo_name = args
+            .lm_model
+            .as_deref()
+            .unwrap_or("ACE-Step/acestep-5Hz-lm-0.6B");
+        println!("Loading LM: {lm_repo_name}...");
+        let lm_repo = api.repo(Repo::model(lm_repo_name.to_string()));
+        let lm_config: candle_transformers::models::qwen3::Config =
+            serde_json::from_reader(std::fs::File::open(lm_repo.get("config.json")?)?)?;
+        let lm_weight_files: Vec<std::path::PathBuf> = match lm_repo.get("model.safetensors") {
+            Ok(p) => vec![p],
+            Err(_) => {
+                candle_examples::hub_load_safetensors(&lm_repo, "model.safetensors.index.json")?
+            }
+        };
+        let lm_refs: Vec<&std::path::Path> = lm_weight_files.iter().map(|p| p.as_path()).collect();
+        let lm_vb = unsafe { VarBuilder::from_mmaped_safetensors(&lm_refs, dtype, &device)? };
+        pipeline.load_lm(&lm_config, lm_vb, &lm_repo.get("tokenizer.json")?)?;
+
+        let lm_cfg = LmConfig {
+            temperature: args.temperature,
+            top_p: args.top_p,
+            seed: args.seed.unwrap_or(42),
+            ..Default::default()
+        };
+
+        println!("Generating audio codes...");
+        let t = std::time::Instant::now();
+        let (hints, metadata) =
+            pipeline.generate_lm_hints(&args.prompt, &lyrics, args.duration, &lm_cfg)?;
+        println!(
+            "LM: {:.2}s, metadata: {:?}",
+            t.elapsed().as_secs_f32(),
+            metadata
+        );
+        println!("LM hints: {:?}", hints.shape());
+
+        // Feed LM metadata back into DiT text prompt (matching Python's
+        // _update_metadata_from_lm → _extract_caption_and_language flow).
+        let lm_meta = LmMetadata {
+            bpm: metadata.get("bpm").cloned(),
+            timesignature: metadata.get("timesignature").cloned(),
+            keyscale: metadata.get("keyscale").cloned(),
+            caption: metadata.get("caption").cloned(),
+            language: metadata
+                .get("language")
+                .or_else(|| metadata.get("vocal_language"))
+                .cloned(),
+        };
+
+        // Free LM weights before DiT denoising to reclaim GPU memory.
+        pipeline.unload_lm();
+
+        (Some(hints), Some(lm_meta))
+    } else {
+        if is_turbo {
+            println!("Hint: turbo models work best with --infer-type lm-dit --lm-model ACE-Step/acestep-5Hz-lm-0.6B");
+        }
+        (None, None)
+    };
+
+    // ---- Generate ----
+    let infer_method = match args.infer_method.as_str() {
+        "sde" => sampling::InferMethod::Sde,
+        _ => sampling::InferMethod::Ode,
+    };
+
+    let params = GenerationParams {
+        duration_secs: args.duration,
+        seed: args.seed,
+        num_steps: args.num_steps,
+        guidance_scale: args.guidance_scale,
+        shift,
+        is_turbo,
+        lm_hints_25hz: lm_hints,
+        lm_metadata,
+        audio_cover_strength: args.audio_cover_strength,
+        cfg_interval: (args.cfg_interval_start, args.cfg_interval_end),
+        infer_method,
+    };
+
+    let t = std::time::Instant::now();
+    let output = if let Some(ref path) = args.repaint_audio {
+        let end = args.repaint_end.unwrap_or(args.duration);
+        println!(
+            "Repaint mode: {path} [{:.1}s..{:.1}s]...",
+            args.repaint_start, end
+        );
+        let src_audio =
+            load_reference_audio(path, vae_config.sampling_rate as u32, dtype, &device)?;
+        pipeline.repaint(
+            &args.prompt,
+            &lyrics,
+            &src_audio,
+            args.repaint_start,
+            end,
+            &params,
+        )?
+    } else if let Some(ref path) = args.reference_audio {
+        if params.lm_hints_25hz.is_none() {
+            println!(
+                "Note: cover mode works best with LM. Add --infer-type lm-dit \
+                 --lm-model ACE-Step/acestep-5Hz-lm-0.6B for proper remixing."
+            );
+        }
+        println!("Encoding reference audio: {path}...");
+        let ref_audio =
+            load_reference_audio(path, vae_config.sampling_rate as u32, dtype, &device)?;
+        let timbre = args
+            .timbre_audio
+            .as_ref()
+            .map(|p| {
+                println!("Encoding timbre audio: {p}...");
+                load_reference_audio(p, vae_config.sampling_rate as u32, dtype, &device)
+            })
+            .transpose()?;
+        println!("Cover mode: denoising...");
+        pipeline.cover(&args.prompt, &lyrics, &ref_audio, timbre.as_ref(), &params)?
+    } else {
+        println!("Denoising...");
+        pipeline.text2music(&args.prompt, &lyrics, &params)?
+    };
+    println!("Generation: {:.2}s", t.elapsed().as_secs_f32());
+
+    write_stereo_wav(&args.out_file, &output.audio, output.sample_rate)?;
+    println!("Saved {} ({:.1}s audio)", args.out_file, args.duration);
+    Ok(())
+}

--- a/candle-examples/examples/ace-step/main.rs
+++ b/candle-examples/examples/ace-step/main.rs
@@ -359,7 +359,17 @@ fn main() -> Result<()> {
         // Free LM weights before DiT denoising to reclaim GPU memory.
         pipeline.unload_lm();
 
-        (Some(hints), Some(lm_meta))
+        // LM audio code hints are only effective with turbo models (which were
+        // distilled to use them). Base/SFT models benefit from LM metadata
+        // (caption, BPM, keyscale) but produce noise when LM hints replace
+        // the silence context — matching the Python pipeline behaviour where
+        // non-turbo models always run with infer_type="dit".
+        let lm_hints = if is_turbo { Some(hints) } else {
+            println!("Note: non-turbo model — using LM metadata only (hints skipped)");
+            None
+        };
+
+        (lm_hints, Some(lm_meta))
     } else {
         if is_turbo {
             println!("Hint: turbo models work best with --infer-type lm-dit --lm-model ACE-Step/acestep-5Hz-lm-0.6B");

--- a/candle-examples/examples/ace-step/pipeline.rs
+++ b/candle-examples/examples/ace-step/pipeline.rs
@@ -4,7 +4,7 @@
 //! conditioning, DiT denoising, and VAE decoding internally.
 
 use anyhow::Result;
-use candle::{DType, Device, Module, Tensor};
+use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::ace_step::{
     lm::{LmConfig, LmPipeline, TokenIds},
@@ -49,6 +49,13 @@ pub struct GenerationParams {
     pub cfg_interval: (f64, f64),
     /// ODE (deterministic) or SDE (stochastic) sampling.
     pub infer_method: sampling::InferMethod,
+    /// Latent frames per VAE-decoder chunk. `None` uses the built-in default
+    /// (128 frames ≈ 5.1 s of audio). Lower values cut peak decode memory at
+    /// the cost of more compute overhead; raise when memory is ample.
+    pub vae_chunk_frames: Option<usize>,
+    /// Overlap in latent frames on each side of a VAE-decoder chunk. `None`
+    /// uses the default (16). Must satisfy `chunk > 2 * overlap`.
+    pub vae_chunk_overlap: Option<usize>,
 }
 
 impl Default for GenerationParams {
@@ -65,6 +72,8 @@ impl Default for GenerationParams {
             audio_cover_strength: 1.0,
             cfg_interval: (0.0, 1.0),
             infer_method: sampling::InferMethod::Ode,
+            vae_chunk_frames: None,
+            vae_chunk_overlap: None,
         }
     }
 }
@@ -599,7 +608,11 @@ impl AceStepPipeline {
             self.dtype,
         )?;
 
-        let audio = self.vae_decoder.forward(&xt.transpose(1, 2)?)?;
+        let audio = self.vae_decoder.tiled_decode(
+            &xt.transpose(1, 2)?,
+            params.vae_chunk_frames,
+            params.vae_chunk_overlap,
+        )?;
         let audio = audio.squeeze(0)?;
 
         Ok(AudioOutput {

--- a/candle-examples/examples/ace-step/pipeline.rs
+++ b/candle-examples/examples/ace-step/pipeline.rs
@@ -489,9 +489,9 @@ impl AceStepPipeline {
 
         let language = metadata.and_then(|m| m.language.as_deref()).unwrap_or("en");
         let lyric_text = if lyrics.is_empty() {
-            format!("# Languages\n{language}\n\n# Lyric\n[Instrumental]\n<|endoftext|>")
+            format!("# Languages\n{language}\n\n# Lyric\n[Instrumental]<|endoftext|>")
         } else {
-            format!("# Languages\n{language}\n\n# Lyric\n{lyrics}\n<|endoftext|>")
+            format!("# Languages\n{language}\n\n# Lyric\n{lyrics}<|endoftext|>")
         };
         let lyric_encoding = self
             .tokenizer

--- a/candle-examples/examples/ace-step/pipeline.rs
+++ b/candle-examples/examples/ace-step/pipeline.rs
@@ -1,0 +1,633 @@
+//! High-level ACE-Step pipeline with text encoder inside.
+//!
+//! Accepts raw text prompts — handles tokenization, text encoding,
+//! conditioning, DiT denoising, and VAE decoding internally.
+
+use anyhow::Result;
+use candle::{DType, Device, Module, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::ace_step::{
+    lm::{LmConfig, LmPipeline, TokenIds},
+    model::{AceStepConditionGenerationModel, ConditionInputs, GenerateOptions},
+    sampling,
+    vae::{AutoencoderOobleck, OobleckDecoder},
+    AceStepConfig, VaeConfig,
+};
+use candle_transformers::models::qwen3;
+
+/// Metadata from LM CoT output, used to enrich the DiT text prompt.
+///
+/// When the LM generates chain-of-thought metadata (BPM, keyscale, etc.),
+/// these values should be fed back into the DiT caption — matching the Python
+/// `_dict_to_meta_string` / `_extract_caption_and_language` flow.
+#[derive(Default)]
+pub struct LmMetadata {
+    pub bpm: Option<String>,
+    pub timesignature: Option<String>,
+    pub keyscale: Option<String>,
+    /// LM-generated caption — replaces the user prompt in the DiT text input.
+    pub caption: Option<String>,
+    /// Language code for lyrics (default: "en").
+    pub language: Option<String>,
+}
+
+/// Generation parameters.
+pub struct GenerationParams {
+    pub duration_secs: f64,
+    pub seed: Option<u64>,
+    pub num_steps: Option<usize>,
+    pub guidance_scale: f64,
+    pub shift: f64,
+    pub is_turbo: bool,
+    /// Precomputed LM hints at 25Hz `(1, T, acoustic_dim)`.
+    pub lm_hints_25hz: Option<Tensor>,
+    /// LM-generated metadata to enrich the DiT text prompt.
+    pub lm_metadata: Option<LmMetadata>,
+    /// Fraction of denoising steps using cover condition (0.0–1.0).
+    pub audio_cover_strength: f64,
+    /// Timestep range for CFG/APG guidance.
+    pub cfg_interval: (f64, f64),
+    /// ODE (deterministic) or SDE (stochastic) sampling.
+    pub infer_method: sampling::InferMethod,
+}
+
+impl Default for GenerationParams {
+    fn default() -> Self {
+        Self {
+            duration_secs: 10.0,
+            seed: None,
+            num_steps: None,
+            guidance_scale: 5.0,
+            shift: 1.0,
+            is_turbo: false,
+            lm_hints_25hz: None,
+            lm_metadata: None,
+            audio_cover_strength: 1.0,
+            cfg_interval: (0.0, 1.0),
+            infer_method: sampling::InferMethod::Ode,
+        }
+    }
+}
+
+/// Stereo audio output.
+pub struct AudioOutput {
+    /// Stereo waveform `(2, T)` in `[-1, 1]`, 48 kHz.
+    pub audio: Tensor,
+    pub sample_rate: u32,
+}
+
+/// High-level pipeline: text prompt → stereo audio.
+pub struct AceStepPipeline {
+    model: AceStepConditionGenerationModel,
+    text_encoder: qwen3::Model,
+    tokenizer: tokenizers::Tokenizer,
+    vae_decoder: OobleckDecoder,
+    vae_encoder: Option<AutoencoderOobleck>,
+    lm: Option<LmState>,
+    silence_latent: Tensor,
+    dit_config: AceStepConfig,
+    vae_config: VaeConfig,
+    device: Device,
+    dtype: DType,
+}
+
+struct LmState {
+    pipeline: LmPipeline,
+    tokenizer: tokenizers::Tokenizer,
+}
+
+impl AceStepPipeline {
+    /// Load all components.
+    ///
+    /// - `dit_vb` / `vae_vb` / `text_vb`: VarBuilders for each model
+    /// - `text_config`: Qwen3 config (for the embedding model, NOT the LM)
+    /// - `tokenizer_path`: `tokenizer.json` for the text encoder
+    /// - `silence_latent`: `(1, T, acoustic_dim)` pre-loaded
+    /// - `load_encoder`: load VAE encoder for cover mode
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        dit_config: &AceStepConfig,
+        vae_config: &VaeConfig,
+        text_config: &qwen3::Config,
+        dit_vb: VarBuilder,
+        vae_vb: VarBuilder,
+        text_vb: VarBuilder,
+        tokenizer_path: &std::path::Path,
+        silence_latent: Tensor,
+        load_encoder: bool,
+    ) -> Result<Self> {
+        let device = dit_vb.device().clone();
+        let dtype = dit_vb.dtype();
+
+        let text_encoder = qwen3::Model::new(text_config, text_vb)?;
+        let tokenizer = tokenizers::Tokenizer::from_file(tokenizer_path)
+            .map_err(|e| anyhow::anyhow!("tokenizer: {e}"))?;
+        let model = AceStepConditionGenerationModel::new(dit_config, dit_vb)?;
+        let vae_decoder = OobleckDecoder::new(vae_config, vae_vb.pp("decoder"))?;
+        let vae_encoder = if load_encoder {
+            Some(AutoencoderOobleck::new(vae_config, vae_vb)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            model,
+            text_encoder,
+            tokenizer,
+            vae_decoder,
+            vae_encoder,
+            lm: None,
+            silence_latent,
+            dit_config: dit_config.clone(),
+            vae_config: vae_config.clone(),
+            device,
+            dtype,
+        })
+    }
+
+    /// Number of latent frames for a given duration.
+    pub fn latent_frames(&self, duration_secs: f64) -> usize {
+        let hop = self.vae_config.hop_length();
+        (duration_secs * self.vae_config.sampling_rate as f64 / hop as f64).ceil() as usize
+    }
+
+    /// Generate music from a text prompt and optional lyrics.
+    pub fn text2music(
+        &mut self,
+        prompt: &str,
+        lyrics: &str,
+        params: &GenerationParams,
+    ) -> Result<AudioOutput> {
+        let (text_hs, text_mask, lyric_hs, lyric_mask) = self.encode_text(
+            prompt,
+            lyrics,
+            params.duration_secs,
+            params.lm_metadata.as_ref(),
+        )?;
+
+        let latent_frames = self.latent_frames(params.duration_secs);
+        let timbre_frames = 750.min(self.silence_latent.dim(1)?);
+
+        self.generate_inner(
+            &text_hs,
+            &text_mask,
+            &lyric_hs,
+            &lyric_mask,
+            &self.silence_latent.narrow(1, 0, latent_frames)?,
+            &self.silence_latent.narrow(1, 0, timbre_frames)?,
+            params,
+            latent_frames,
+        )
+    }
+
+    /// Generate a cover conditioned on reference audio `(1, 2, T)` at 48kHz.
+    ///
+    /// - `reference_audio`: structural source (melody/rhythm)
+    /// - `timbre_audio`: optional separate timbre source; if `None`, uses
+    ///   `reference_audio` for both structure and timbre (Python separates these
+    ///   as `src_audio` vs `reference_audio`)
+    ///
+    /// When `params.lm_hints_25hz` is set, uses the LM-derived hints with
+    /// `is_covers=true` (tokenize/detokenize path in prepare_condition).
+    /// Otherwise, uses raw reference latents directly as context (no lossy
+    /// FSQ round-trip).
+    pub fn cover(
+        &mut self,
+        prompt: &str,
+        lyrics: &str,
+        reference_audio: &Tensor,
+        timbre_audio: Option<&Tensor>,
+        params: &GenerationParams,
+    ) -> Result<AudioOutput> {
+        let (text_hs, text_mask, lyric_hs, lyric_mask) = self.encode_text(
+            prompt,
+            lyrics,
+            params.duration_secs,
+            params.lm_metadata.as_ref(),
+        )?;
+
+        let vae = self
+            .vae_encoder
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("VAE encoder not loaded (pass load_encoder=true)"))?;
+        let ref_latent = vae.encode_mean(reference_audio)?.transpose(1, 2)?;
+
+        let latent_frames = self.latent_frames(params.duration_secs);
+        let ref_len = ref_latent.dim(1)?;
+
+        let src_latents = if ref_len >= latent_frames {
+            ref_latent.narrow(1, 0, latent_frames)?
+        } else {
+            let pad = self.silence_latent.narrow(1, 0, latent_frames - ref_len)?;
+            Tensor::cat(&[&ref_latent, &pad], 1)?
+        };
+
+        // Timbre: use separate timbre audio if provided, otherwise reference audio
+        let refer_audio_packed = if let Some(timbre) = timbre_audio {
+            let timbre_latent = vae.encode_mean(timbre)?.transpose(1, 2)?;
+            let timbre_len = timbre_latent.dim(1)?;
+            let timbre_frames = 750.min(timbre_len);
+            timbre_latent.narrow(1, 0, timbre_frames)?
+        } else {
+            let timbre_frames = 750.min(ref_len);
+            ref_latent.narrow(1, 0, timbre_frames)?
+        };
+
+        // Only enable is_covers (tokenize/detokenize path) when LM hints
+        // are provided. Without LM hints, raw reference latents go directly
+        // into context — the lossy FSQ round-trip on raw VAE latents produces
+        // poor results.
+        self.generate_inner(
+            &text_hs,
+            &text_mask,
+            &lyric_hs,
+            &lyric_mask,
+            &src_latents,
+            &refer_audio_packed,
+            params,
+            latent_frames,
+        )
+    }
+
+    /// Selectively re-generate a region of existing audio while preserving the rest.
+    ///
+    /// - `source_audio`: original stereo waveform `(1, 2, T)` at 48kHz
+    /// - `start_secs` / `end_secs`: time range to regenerate (seconds)
+    ///
+    /// The preserved regions keep the original audio latents; the repaint region
+    /// is replaced with silence and the chunk_mask signals the DiT to generate new
+    /// content there.
+    pub fn repaint(
+        &mut self,
+        prompt: &str,
+        lyrics: &str,
+        source_audio: &Tensor,
+        start_secs: f64,
+        end_secs: f64,
+        params: &GenerationParams,
+    ) -> Result<AudioOutput> {
+        let (text_hs, text_mask, lyric_hs, lyric_mask) = self.encode_text(
+            prompt,
+            lyrics,
+            params.duration_secs,
+            params.lm_metadata.as_ref(),
+        )?;
+
+        let vae = self
+            .vae_encoder
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("VAE encoder not loaded (pass load_encoder=true)"))?;
+        let src_latent = vae.encode_mean(source_audio)?.transpose(1, 2)?; // (1, T_lat, D)
+
+        let latent_frames = self.latent_frames(params.duration_secs);
+        let hop = self.vae_config.hop_length() as f64;
+        let sr = self.vae_config.sampling_rate as f64;
+
+        // Convert time range to latent frame indices
+        let start_frame = ((start_secs * sr / hop).floor() as usize).min(latent_frames);
+        let end_frame = ((end_secs * sr / hop).ceil() as usize).min(latent_frames);
+
+        anyhow::ensure!(
+            end_frame > start_frame,
+            "repaint region is empty: {start_secs}s..{end_secs}s → frames {start_frame}..{end_frame}"
+        );
+
+        // Crop/pad source latents to target length
+        let src_len = src_latent.dim(1)?;
+        let mut src_latents = if src_len >= latent_frames {
+            src_latent.narrow(1, 0, latent_frames)?
+        } else {
+            let pad = self.silence_latent.narrow(1, 0, latent_frames - src_len)?;
+            Tensor::cat(&[&src_latent, &pad], 1)?
+        };
+
+        // Replace repaint region with silence in src_latents
+        let silence_region = self
+            .silence_latent
+            .narrow(1, start_frame, end_frame - start_frame)?;
+        // Build: [original[:start], silence[start:end], original[end:]]
+        let parts: Vec<Tensor> = if start_frame > 0 && end_frame < latent_frames {
+            vec![
+                src_latents.narrow(1, 0, start_frame)?,
+                silence_region,
+                src_latents.narrow(1, end_frame, latent_frames - end_frame)?,
+            ]
+        } else if start_frame == 0 {
+            vec![
+                silence_region,
+                src_latents.narrow(1, end_frame, latent_frames - end_frame)?,
+            ]
+        } else {
+            vec![src_latents.narrow(1, 0, start_frame)?, silence_region]
+        };
+        src_latents = Tensor::cat(&parts.iter().collect::<Vec<_>>(), 1)?;
+
+        // Timbre from original audio (first 750 frames)
+        let timbre_frames = 750.min(src_len);
+        let refer_audio_packed = src_latent.narrow(1, 0, timbre_frames)?;
+
+        // Build chunk_mask: 0 = preserve, 1 = regenerate
+        let acoustic_dim = self.dit_config.audio_acoustic_hidden_dim;
+        let chunk_mask_dim = self.dit_config.in_channels - 2 * acoustic_dim;
+        let mut mask_data = vec![0.0f32; latent_frames * chunk_mask_dim];
+        for t in start_frame..end_frame {
+            for c in 0..chunk_mask_dim {
+                mask_data[t * chunk_mask_dim + c] = 1.0;
+            }
+        }
+        let chunk_masks =
+            Tensor::from_vec(mask_data, (1, latent_frames, chunk_mask_dim), &self.device)?
+                .to_dtype(self.dtype)?;
+
+        self.generate_inner_with_mask(
+            &text_hs,
+            &text_mask,
+            &lyric_hs,
+            &lyric_mask,
+            &src_latents,
+            &refer_audio_packed,
+            &chunk_masks,
+            params,
+            latent_frames,
+        )
+    }
+
+    /// Unload the LM model to free GPU/RAM memory before DiT denoising.
+    ///
+    /// The LM (~1.2 GB for 0.6B, ~3.5 GB for 1.7B) is only needed for
+    /// `generate_lm_hints()`. Dropping it before the DiT pass frees memory
+    /// for the denoising loop.
+    pub fn unload_lm(&mut self) {
+        self.lm = None;
+    }
+
+    /// Load the 5Hz LM model for audio code generation.
+    ///
+    /// Call once before `generate_lm_hints()`. The LM weights and tokenizer
+    /// are loaded from a HuggingFace repo (e.g. `ACE-Step/acestep-5Hz-lm-0.6B`).
+    pub fn load_lm(
+        &mut self,
+        lm_config: &qwen3::Config,
+        lm_vb: VarBuilder,
+        lm_tokenizer_path: &std::path::Path,
+    ) -> Result<()> {
+        let lm_model = qwen3::ModelForCausalLM::new(lm_config, lm_vb)?;
+        let lm_tokenizer = tokenizers::Tokenizer::from_file(lm_tokenizer_path)
+            .map_err(|e| anyhow::anyhow!("LM tokenizer: {e}"))?;
+        let token_ids = TokenIds::discover(|s| {
+            let enc = lm_tokenizer
+                .encode(s, false)
+                .map_err(|e| candle::Error::Msg(format!("encode {s:?}: {e}")))?;
+            Ok(enc.get_ids().to_vec())
+        })?;
+        let pipeline = LmPipeline::new(lm_model, token_ids, self.device.clone());
+        self.lm = Some(LmState {
+            pipeline,
+            tokenizer: lm_tokenizer,
+        });
+        Ok(())
+    }
+
+    /// Generate LM audio codes and convert to 25Hz latent hints.
+    ///
+    /// Returns `(lm_hints_tensor, metadata)`. The hints can be passed as
+    /// `GenerationParams.lm_hints_25hz` to `text2music()` or `cover()`.
+    pub fn generate_lm_hints(
+        &mut self,
+        prompt: &str,
+        lyrics: &str,
+        duration_secs: f64,
+        lm_config: &LmConfig,
+    ) -> Result<(Tensor, std::collections::BTreeMap<String, String>)> {
+        let lm = self
+            .lm
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("LM not loaded — call load_lm() first"))?;
+
+        let prompt_text = LmPipeline::format_prompt(prompt, lyrics);
+        let prompt_enc = lm
+            .tokenizer
+            .encode(prompt_text.as_str(), false)
+            .map_err(|e| anyhow::anyhow!("LM encode: {e}"))?;
+
+        let decode_fn = |t: u32| -> candle::Result<String> {
+            lm.tokenizer
+                .decode(&[t], false)
+                .map_err(|e| candle::Error::Msg(format!("{e}")))
+        };
+        let encode_fn = |s: &str| -> candle::Result<Vec<u32>> {
+            let e = lm
+                .tokenizer
+                .encode(s, false)
+                .map_err(|e| candle::Error::Msg(format!("{e}")))?;
+            Ok(e.get_ids().to_vec())
+        };
+
+        let output = lm.pipeline.generate(
+            prompt_enc.get_ids(),
+            duration_secs,
+            lm_config,
+            &decode_fn,
+            &encode_fn,
+        )?;
+
+        anyhow::ensure!(
+            !output.audio_codes.is_empty(),
+            "LM generated no audio codes"
+        );
+        let hints = self.audio_codes_to_latents(&output.audio_codes)?;
+        Ok((hints, output.metadata))
+    }
+
+    /// Convert LM-generated audio codes to 25Hz latent hints.
+    pub fn audio_codes_to_latents(&self, codes: &[i64]) -> Result<Tensor> {
+        let code_tensor = Tensor::new(codes, &self.device)?
+            .unsqueeze(0)?
+            .unsqueeze(2)?;
+        let quantized = self.model.tokenizer.get_output_from_indices(&code_tensor)?;
+        let quantized = quantized.to_dtype(self.dtype)?;
+        Ok(self.model.detokenizer.forward(&quantized)?)
+    }
+
+    // ---- Internals ----
+
+    fn encode_text(
+        &mut self,
+        prompt: &str,
+        lyrics: &str,
+        duration_secs: f64,
+        metadata: Option<&LmMetadata>,
+    ) -> Result<(Tensor, Tensor, Tensor, Tensor)> {
+        // Use LM-generated caption if available, otherwise user prompt.
+        let caption = metadata
+            .and_then(|m| m.caption.as_deref())
+            .unwrap_or(prompt);
+
+        // Build metas string from LM metadata or defaults.
+        let bpm = metadata.and_then(|m| m.bpm.as_deref()).unwrap_or("N/A");
+        let timesig = metadata
+            .and_then(|m| m.timesignature.as_deref())
+            .unwrap_or("N/A");
+        let keyscale = metadata
+            .and_then(|m| m.keyscale.as_deref())
+            .unwrap_or("N/A");
+
+        let caption_text = format!(
+            "# Instruction\nFill the audio semantic mask based on the given conditions:\n\n\
+             # Caption\n{caption}\n\n# Metas\n\
+             - bpm: {bpm}\n- timesignature: {timesig}\n- keyscale: {keyscale}\n- duration: {} seconds\n\
+             <|endoftext|>",
+            duration_secs as u32
+        );
+        let encoding = self
+            .tokenizer
+            .encode(caption_text.as_str(), true)
+            .map_err(|e| anyhow::anyhow!("tokenization: {e}"))?;
+        let prompt_tokens = Tensor::new(encoding.get_ids(), &self.device)?.unsqueeze(0)?;
+        let text_hidden_states = self.text_encoder.forward(&prompt_tokens, 0)?;
+        self.text_encoder.clear_kv_cache();
+
+        let language = metadata.and_then(|m| m.language.as_deref()).unwrap_or("en");
+        let lyric_text = if lyrics.is_empty() {
+            format!("# Languages\n{language}\n\n# Lyric\n[Instrumental]\n<|endoftext|>")
+        } else {
+            format!("# Languages\n{language}\n\n# Lyric\n{lyrics}\n<|endoftext|>")
+        };
+        let lyric_encoding = self
+            .tokenizer
+            .encode(lyric_text.as_str(), true)
+            .map_err(|e| anyhow::anyhow!("lyric tokenization: {e}"))?;
+        let lyric_tokens = Tensor::new(lyric_encoding.get_ids(), &self.device)?.unsqueeze(0)?;
+        let lyric_hidden_states = self.text_encoder.embed_tokens(&lyric_tokens)?;
+
+        let text_mask = Tensor::new(encoding.get_attention_mask(), &self.device)?
+            .unsqueeze(0)?
+            .to_dtype(self.dtype)?;
+        let lyric_mask = Tensor::new(lyric_encoding.get_attention_mask(), &self.device)?
+            .unsqueeze(0)?
+            .to_dtype(self.dtype)?;
+
+        Ok((
+            text_hidden_states,
+            text_mask,
+            lyric_hidden_states,
+            lyric_mask,
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn generate_inner(
+        &mut self,
+        text_hidden_states: &Tensor,
+        text_attention_mask: &Tensor,
+        lyric_hidden_states: &Tensor,
+        lyric_attention_mask: &Tensor,
+        src_latents: &Tensor,
+        refer_audio_packed: &Tensor,
+        params: &GenerationParams,
+        latent_frames: usize,
+    ) -> Result<AudioOutput> {
+        let acoustic_dim = self.dit_config.audio_acoustic_hidden_dim;
+        let chunk_mask_dim = self.dit_config.in_channels - 2 * acoustic_dim;
+        let chunk_masks =
+            Tensor::ones((1, latent_frames, chunk_mask_dim), self.dtype, &self.device)?;
+
+        self.generate_inner_with_mask(
+            text_hidden_states,
+            text_attention_mask,
+            lyric_hidden_states,
+            lyric_attention_mask,
+            src_latents,
+            refer_audio_packed,
+            &chunk_masks,
+            params,
+            latent_frames,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn generate_inner_with_mask(
+        &mut self,
+        text_hidden_states: &Tensor,
+        text_attention_mask: &Tensor,
+        lyric_hidden_states: &Tensor,
+        lyric_attention_mask: &Tensor,
+        src_latents: &Tensor,
+        refer_audio_packed: &Tensor,
+        chunk_masks: &Tensor,
+        params: &GenerationParams,
+        latent_frames: usize,
+    ) -> Result<AudioOutput> {
+        let is_cover = params.lm_hints_25hz.is_some();
+
+        let condition = self.model.prepare_condition(&ConditionInputs {
+            text_hidden_states,
+            text_attention_mask,
+            lyric_hidden_states,
+            lyric_attention_mask,
+            refer_audio_packed,
+            refer_audio_order_mask: &Tensor::zeros((1,), DType::I64, &self.device)?,
+            src_latents,
+            chunk_masks,
+            silence_latent: &self.silence_latent.narrow(1, 0, latent_frames)?,
+            is_covers: &Tensor::from_vec(vec![if is_cover { 1u8 } else { 0u8 }], 1, &self.device)?,
+            precomputed_lm_hints_25hz: params.lm_hints_25hz.as_ref(),
+            audio_codes: None,
+            non_cover_text_hidden_states: None,
+            non_cover_text_attention_mask: None,
+        })?;
+
+        let num_steps = params
+            .num_steps
+            .unwrap_or(if params.is_turbo { 8 } else { 50 });
+
+        let xt = self.model.generate_latents(
+            &condition,
+            None,
+            &GenerateOptions {
+                seed: params.seed,
+                num_steps,
+                guidance_scale: params.guidance_scale,
+                shift: params.shift,
+                is_turbo: params.is_turbo,
+                audio_cover_strength: params.audio_cover_strength,
+                cfg_interval: params.cfg_interval,
+                infer_method: params.infer_method,
+                ..Default::default()
+            },
+            &self.device,
+            self.dtype,
+        )?;
+
+        let audio = self.vae_decoder.forward(&xt.transpose(1, 2)?)?;
+        let audio = audio.squeeze(0)?;
+
+        Ok(AudioOutput {
+            audio,
+            sample_rate: self.vae_config.sampling_rate as u32,
+        })
+    }
+}
+
+/// Load silence_latent from PyTorch `.pt` file → `(1, T, acoustic_dim)`.
+pub fn load_silence_latent(
+    path: &std::path::Path,
+    acoustic_dim: usize,
+    dtype: DType,
+    device: &Device,
+) -> Result<Tensor> {
+    let file = std::fs::File::open(path)?;
+    let mut archive = zip::ZipArchive::new(std::io::BufReader::new(file))?;
+    let mut raw = Vec::new();
+    std::io::Read::read_to_end(&mut archive.by_name("silence_latent/data/0")?, &mut raw)?;
+    let n_elements = raw.len() / 4;
+    let t_len = n_elements / acoustic_dim;
+    let cpu = Device::Cpu;
+    Ok(
+        Tensor::from_raw_buffer(&raw, DType::F32, &[1, acoustic_dim, t_len], &cpu)?
+            .transpose(1, 2)?
+            .contiguous()?
+            .to_dtype(dtype)?
+            .to_device(device)?,
+    )
+}

--- a/candle-examples/src/audio.rs
+++ b/candle-examples/src/audio.rs
@@ -108,6 +108,87 @@ pub fn pcm_decode<P: AsRef<std::path::Path>>(path: P) -> Result<(Vec<f32>, u32)>
     Ok((pcm_data, sample_rate))
 }
 
+/// Decode all channels from an audio file (WAV, FLAC, MP3, OGG, etc.).
+///
+/// Returns `(channels, sample_rate)` where `channels[i]` contains the samples
+/// for channel `i`. For stereo files, `channels.len() == 2`.
+#[cfg(feature = "symphonia")]
+pub fn pcm_decode_all_channels<P: AsRef<std::path::Path>>(
+    path: P,
+) -> Result<(Vec<Vec<f32>>, u32)> {
+    use symphonia::core::audio::{AudioBufferRef, Signal};
+    use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
+    use symphonia::core::conv::FromSample;
+
+    let src = std::fs::File::open(path).map_err(candle::Error::wrap)?;
+    let mss = symphonia::core::io::MediaSourceStream::new(Box::new(src), Default::default());
+    let hint = symphonia::core::probe::Hint::new();
+    let meta_opts: symphonia::core::meta::MetadataOptions = Default::default();
+    let fmt_opts: symphonia::core::formats::FormatOptions = Default::default();
+    let probed = symphonia::default::get_probe()
+        .format(&hint, mss, &fmt_opts, &meta_opts)
+        .map_err(candle::Error::wrap)?;
+    let mut format = probed.format;
+    let track = format
+        .tracks()
+        .iter()
+        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+        .ok_or_else(|| candle::Error::Msg("no supported audio tracks".to_string()))?;
+    let n_channels = track
+        .codec_params
+        .channels
+        .map_or(1, |ch| ch.count())
+        .max(1);
+    let mut decoder = symphonia::default::get_codecs()
+        .make(&track.codec_params, &DecoderOptions::default())
+        .map_err(|_| candle::Error::Msg("unsupported codec".to_string()))?;
+    let track_id = track.id;
+    let sample_rate = track.codec_params.sample_rate.unwrap_or(0);
+    let mut channels: Vec<Vec<f32>> = (0..n_channels).map(|_| Vec::new()).collect();
+
+    fn conv_ch<T>(
+        channels: &mut [Vec<f32>],
+        data: std::borrow::Cow<symphonia::core::audio::AudioBuffer<T>>,
+    ) where
+        T: symphonia::core::sample::Sample,
+        f32: symphonia::core::conv::FromSample<T>,
+    {
+        for (ch, buf) in channels.iter_mut().enumerate() {
+            if ch < data.spec().channels.count() {
+                buf.extend(data.chan(ch).iter().map(|v| f32::from_sample(*v)));
+            }
+        }
+    }
+
+    while let Ok(packet) = format.next_packet() {
+        while !format.metadata().is_latest() {
+            format.metadata().pop();
+        }
+        if packet.track_id() != track_id {
+            continue;
+        }
+        match decoder.decode(&packet).map_err(candle::Error::wrap)? {
+            AudioBufferRef::F32(buf) => {
+                for (ch, c) in channels.iter_mut().enumerate() {
+                    if ch < buf.spec().channels.count() {
+                        c.extend(buf.chan(ch));
+                    }
+                }
+            }
+            AudioBufferRef::U8(data) => conv_ch(&mut channels, data),
+            AudioBufferRef::U16(data) => conv_ch(&mut channels, data),
+            AudioBufferRef::U24(data) => conv_ch(&mut channels, data),
+            AudioBufferRef::U32(data) => conv_ch(&mut channels, data),
+            AudioBufferRef::S8(data) => conv_ch(&mut channels, data),
+            AudioBufferRef::S16(data) => conv_ch(&mut channels, data),
+            AudioBufferRef::S24(data) => conv_ch(&mut channels, data),
+            AudioBufferRef::S32(data) => conv_ch(&mut channels, data),
+            AudioBufferRef::F64(data) => conv_ch(&mut channels, data),
+        }
+    }
+    Ok((channels, sample_rate))
+}
+
 #[cfg(feature = "rubato")]
 pub fn resample(pcm_in: &[f32], sr_in: u32, sr_out: u32) -> Result<Vec<f32>> {
     use rubato::Resampler;

--- a/candle-examples/src/wav.rs
+++ b/candle-examples/src/wav.rs
@@ -75,6 +75,12 @@ pub fn write_pcm_as_wav_stereo<W: Write, S: Sample>(
     channels: &[&[S]],
     sample_rate: u32,
 ) -> std::io::Result<()> {
+    if channels.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "channels must not be empty",
+        ));
+    }
     let n_channels = channels.len() as u16;
     let n_frames = channels[0].len();
     let data_bytes = (n_frames * n_channels as usize * 2) as u32;
@@ -145,8 +151,21 @@ pub fn read_pcm_from_wav<R: Read + Seek, S: Sample>(
         let size = u32::from_le_bytes(ch[4..8].try_into().unwrap()) as usize;
 
         if &id == b"fmt " {
+            if size < 16 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("fmt chunk too small: {size} bytes (need >= 16)"),
+                ));
+            }
             let mut fmt = vec![0u8; size];
             r.read_exact(&mut fmt)?;
+            let audio_format = u16::from_le_bytes(fmt[0..2].try_into().unwrap());
+            if audio_format != 1 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unsupported WAV format: {audio_format} (only PCM/1 supported)"),
+                ));
+            }
             header.channels = u16::from_le_bytes(fmt[2..4].try_into().unwrap());
             header.sample_rate = u32::from_le_bytes(fmt[4..8].try_into().unwrap());
             header.bits_per_sample = u16::from_le_bytes(fmt[14..16].try_into().unwrap());

--- a/candle-examples/src/wav.rs
+++ b/candle-examples/src/wav.rs
@@ -83,6 +83,12 @@ pub fn write_pcm_as_wav_stereo<W: Write, S: Sample>(
     }
     let n_channels = channels.len() as u16;
     let n_frames = channels[0].len();
+    if channels.iter().any(|ch| ch.len() != n_frames) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "all channels must have the same number of frames",
+        ));
+    }
     let data_bytes = (n_frames * n_channels as usize * 2) as u32;
     let block_align = n_channels * 2;
     let bytes_per_second = sample_rate * block_align as u32;

--- a/candle-examples/src/wav.rs
+++ b/candle-examples/src/wav.rs
@@ -2,11 +2,15 @@ use std::io::prelude::*;
 
 pub trait Sample {
     fn to_i16(&self) -> i16;
+    fn from_i16(v: i16) -> Self;
 }
 
 impl Sample for f32 {
     fn to_i16(&self) -> i16 {
         (self.clamp(-1.0, 1.0) * 32767.0) as i16
+    }
+    fn from_i16(v: i16) -> Self {
+        v as f32 / 32768.0
     }
 }
 
@@ -14,14 +18,21 @@ impl Sample for f64 {
     fn to_i16(&self) -> i16 {
         (self.clamp(-1.0, 1.0) * 32767.0) as i16
     }
+    fn from_i16(v: i16) -> Self {
+        v as f64 / 32768.0
+    }
 }
 
 impl Sample for i16 {
     fn to_i16(&self) -> i16 {
         *self
     }
+    fn from_i16(v: i16) -> Self {
+        v
+    }
 }
 
+/// Write mono PCM samples as a WAV file (16-bit, single channel).
 pub fn write_pcm_as_wav<W: Write, S: Sample>(
     w: &mut W,
     samples: &[S],
@@ -53,4 +64,130 @@ pub fn write_pcm_as_wav<W: Write, S: Sample>(
         w.write_all(&sample.to_i16().to_le_bytes())?
     }
     Ok(())
+}
+
+/// Write multi-channel PCM samples as a WAV file (16-bit).
+///
+/// `channels` is a slice of per-channel sample slices, all the same length.
+/// For stereo: `&[&left[..], &right[..]]`.
+pub fn write_pcm_as_wav_stereo<W: Write, S: Sample>(
+    w: &mut W,
+    channels: &[&[S]],
+    sample_rate: u32,
+) -> std::io::Result<()> {
+    let n_channels = channels.len() as u16;
+    let n_frames = channels[0].len();
+    let data_bytes = (n_frames * n_channels as usize * 2) as u32;
+    let block_align = n_channels * 2;
+    let bytes_per_second = sample_rate * block_align as u32;
+
+    // RIFF header
+    w.write_all(b"RIFF")?;
+    w.write_all(&(36 + data_bytes).to_le_bytes())?;
+    w.write_all(b"WAVE")?;
+
+    // fmt chunk
+    w.write_all(b"fmt ")?;
+    w.write_all(&16u32.to_le_bytes())?;
+    w.write_all(&1u16.to_le_bytes())?; // PCM
+    w.write_all(&n_channels.to_le_bytes())?;
+    w.write_all(&sample_rate.to_le_bytes())?;
+    w.write_all(&bytes_per_second.to_le_bytes())?;
+    w.write_all(&block_align.to_le_bytes())?;
+    w.write_all(&16u16.to_le_bytes())?; // bits per sample
+
+    // data chunk (interleaved)
+    w.write_all(b"data")?;
+    w.write_all(&data_bytes.to_le_bytes())?;
+    for frame in 0..n_frames {
+        for ch in channels {
+            w.write_all(&ch[frame].to_i16().to_le_bytes())?;
+        }
+    }
+    Ok(())
+}
+
+/// Header information from a WAV file.
+pub struct WavHeader {
+    pub sample_rate: u32,
+    pub channels: u16,
+    pub bits_per_sample: u16,
+}
+
+/// Read a 16-bit PCM WAV file and return per-channel sample vectors.
+///
+/// Returns `(header, channels)` where `channels[i]` contains the samples for
+/// channel `i`. Mono files have one channel, stereo files have two, etc.
+pub fn read_pcm_from_wav<R: Read + Seek, S: Sample>(
+    r: &mut R,
+) -> std::io::Result<(WavHeader, Vec<Vec<S>>)> {
+    // RIFF header (12 bytes)
+    let mut riff = [0u8; 12];
+    r.read_exact(&mut riff)?;
+    if &riff[0..4] != b"RIFF" || &riff[8..12] != b"WAVE" {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "not a WAV file"));
+    }
+
+    let mut header = WavHeader {
+        sample_rate: 0,
+        channels: 0,
+        bits_per_sample: 0,
+    };
+    let mut data_buf = Vec::new();
+
+    // Walk chunks
+    loop {
+        let mut ch = [0u8; 8];
+        if r.read_exact(&mut ch).is_err() {
+            break;
+        }
+        let id: [u8; 4] = ch[0..4].try_into().unwrap();
+        let size = u32::from_le_bytes(ch[4..8].try_into().unwrap()) as usize;
+
+        if &id == b"fmt " {
+            let mut fmt = vec![0u8; size];
+            r.read_exact(&mut fmt)?;
+            header.channels = u16::from_le_bytes(fmt[2..4].try_into().unwrap());
+            header.sample_rate = u32::from_le_bytes(fmt[4..8].try_into().unwrap());
+            header.bits_per_sample = u16::from_le_bytes(fmt[14..16].try_into().unwrap());
+        } else if &id == b"data" {
+            data_buf.resize(size, 0u8);
+            r.read_exact(&mut data_buf)?;
+            break;
+        } else {
+            // Skip unknown chunk (RIFF chunks are padded to even size)
+            let skip = ((size + 1) & !1) as i64;
+            r.seek(std::io::SeekFrom::Current(skip))?;
+        }
+    }
+
+    if data_buf.is_empty() || header.channels == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "no data chunk found in WAV",
+        ));
+    }
+    if header.bits_per_sample != 16 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "only 16-bit WAV supported, got {}-bit",
+                header.bits_per_sample
+            ),
+        ));
+    }
+
+    let nc = header.channels as usize;
+    let n_frames = data_buf.len() / (2 * nc);
+    let mut channels: Vec<Vec<S>> = (0..nc).map(|_| Vec::with_capacity(n_frames)).collect();
+
+    for frame in 0..n_frames {
+        for (ch, channel) in channels.iter_mut().enumerate() {
+            let idx = (frame * nc + ch) * 2;
+            let sample = i16::from_le_bytes([data_buf[idx], data_buf[idx + 1]]);
+            channel.push(S::from_i16(sample));
+        }
+    }
+
+    Ok((header, channels))
 }

--- a/candle-transformers/src/models/ace_step/condition.rs
+++ b/candle-transformers/src/models/ace_step/condition.rs
@@ -1,0 +1,831 @@
+//! Condition encoders for ACE-Step 1.5.
+//!
+//! This module implements the conditioning pipeline that processes text descriptions,
+//! lyrics, and timbre (reference audio) into condition tensors consumed by the DiT
+//! diffusion model.
+//!
+//! The main entry point is [`ConditionEncoder`], which orchestrates:
+//! - A simple linear projection for text encoder hidden states.
+//! - A [`LyricEncoder`] (8-layer bidirectional transformer) for lyric embeddings.
+//! - A [`TimbreEncoder`] (4-layer bidirectional transformer with CLS pooling) for
+//!   reference audio embeddings.
+//!
+//! All encoder layers share the same architecture: pre-norm (RmsNorm) bidirectional
+//! GQA attention followed by a gated SiLU MLP, matching the Qwen3 block design.
+
+use crate::models::with_tracing::{linear_b, linear_no_bias, Linear, RmsNorm};
+use crate::utils::repeat_kv;
+use candle::{DType, Device, Module, Result, Tensor};
+use candle_nn::{Activation, VarBuilder};
+
+use super::AceStepConfig;
+
+// ---------------------------------------------------------------------------
+// RotaryEmbedding (standalone for encoder, same algorithm as the DiT variant)
+// ---------------------------------------------------------------------------
+
+/// Precomputed sin/cos tables for rotary position embeddings.
+///
+/// The encoder uses its own instance because it may have a different head dimension
+/// or maximum sequence length than the DiT backbone.
+#[derive(Debug, Clone)]
+pub struct RotaryEmbedding {
+    sin: Tensor,
+    cos: Tensor,
+}
+
+impl RotaryEmbedding {
+    /// Build the sin/cos lookup tables up to `max_seq_len` positions.
+    pub fn new(
+        dtype: DType,
+        head_dim: usize,
+        max_seq_len: usize,
+        rope_theta: f64,
+        dev: &Device,
+    ) -> Result<Self> {
+        let inv_freq: Vec<_> = (0..head_dim)
+            .step_by(2)
+            .map(|i| 1f32 / rope_theta.powf(i as f64 / head_dim as f64) as f32)
+            .collect();
+        let inv_freq_len = inv_freq.len();
+        let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?.to_dtype(DType::F32)?;
+        let t = Tensor::arange(0u32, max_seq_len as u32, dev)?
+            .to_dtype(DType::F32)?
+            .reshape((max_seq_len, 1))?;
+        let freqs = t.matmul(&inv_freq)?;
+        Ok(Self {
+            sin: freqs.sin()?.to_dtype(dtype)?,
+            cos: freqs.cos()?.to_dtype(dtype)?,
+        })
+    }
+
+    /// Apply RoPE to Q and K tensors of shape `(B, H, L, D)`.
+    pub fn apply(&self, q: &Tensor, k: &Tensor, offset: usize) -> Result<(Tensor, Tensor)> {
+        let (_, _, seq_len, _) = q.dims4()?;
+        let cos = self.cos.narrow(0, offset, seq_len)?;
+        let sin = self.sin.narrow(0, offset, seq_len)?;
+        let q_embed = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
+        let k_embed = candle_nn::rotary_emb::rope(&k.contiguous()?, &cos, &sin)?;
+        Ok((q_embed, k_embed))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EncoderMLP
+// ---------------------------------------------------------------------------
+
+/// Gated SiLU MLP identical to the Qwen3 feed-forward block.
+///
+/// ```text
+/// output = down_proj(silu(gate_proj(x)) * up_proj(x))
+/// ```
+#[derive(Debug, Clone)]
+pub struct EncoderMLP {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+    act_fn: Activation,
+}
+
+impl EncoderMLP {
+    pub fn new(cfg: &AceStepConfig, vb: VarBuilder) -> Result<Self> {
+        let hidden = cfg.encoder_hidden_size();
+        let intermediate = cfg.encoder_intermediate_size();
+        Ok(Self {
+            gate_proj: linear_no_bias(hidden, intermediate, vb.pp("gate_proj"))?,
+            up_proj: linear_no_bias(hidden, intermediate, vb.pp("up_proj"))?,
+            down_proj: linear_no_bias(intermediate, hidden, vb.pp("down_proj"))?,
+            act_fn: cfg.hidden_act,
+        })
+    }
+}
+
+impl Module for EncoderMLP {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let gate = x.apply(&self.gate_proj)?.apply(&self.act_fn)?;
+        let up = x.apply(&self.up_proj)?;
+        (gate * up)?.apply(&self.down_proj)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EncoderAttention
+// ---------------------------------------------------------------------------
+
+/// Bidirectional grouped-query attention for encoder layers.
+///
+/// Uses per-head RmsNorm on Q and K (Qwen3 style) and rotary position
+/// embeddings. No KV cache is needed because the encoder runs a single
+/// forward pass over the full sequence.
+#[derive(Debug, Clone)]
+pub struct EncoderAttention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    o_proj: Linear,
+    q_norm: RmsNorm,
+    k_norm: RmsNorm,
+    num_heads: usize,
+    num_kv_heads: usize,
+    num_kv_groups: usize,
+    head_dim: usize,
+    hidden_size: usize,
+}
+
+impl EncoderAttention {
+    pub fn new(cfg: &AceStepConfig, vb: VarBuilder) -> Result<Self> {
+        let head_dim = cfg.head_dim;
+        let num_heads = cfg.encoder_num_attention_heads();
+        let num_kv_heads = cfg.encoder_num_key_value_heads();
+        let num_kv_groups = num_heads / num_kv_heads;
+        let hidden = cfg.encoder_hidden_size();
+
+        let q_proj = linear_b(
+            hidden,
+            num_heads * head_dim,
+            cfg.attention_bias,
+            vb.pp("q_proj"),
+        )?;
+        let k_proj = linear_b(
+            hidden,
+            num_kv_heads * head_dim,
+            cfg.attention_bias,
+            vb.pp("k_proj"),
+        )?;
+        let v_proj = linear_b(
+            hidden,
+            num_kv_heads * head_dim,
+            cfg.attention_bias,
+            vb.pp("v_proj"),
+        )?;
+        let o_proj = linear_b(
+            num_heads * head_dim,
+            hidden,
+            cfg.attention_bias,
+            vb.pp("o_proj"),
+        )?;
+
+        let q_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
+        let k_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
+
+        let hidden_size = head_dim * num_heads;
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            q_norm,
+            k_norm,
+            num_heads,
+            num_kv_heads,
+            num_kv_groups,
+            head_dim,
+            hidden_size,
+        })
+    }
+
+    /// Run bidirectional self-attention.
+    ///
+    /// * `x` - input tensor of shape `(B, L, D)`.
+    /// * `mask` - optional additive attention mask `(B, 1, L, L)` where `-inf`
+    ///   blocks attention. Pass `None` for fully bidirectional attention.
+    /// * `rotary` - precomputed rotary embedding tables.
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        mask: Option<&Tensor>,
+        rotary: &RotaryEmbedding,
+    ) -> Result<Tensor> {
+        let (b, l, _) = x.dims3()?;
+
+        // Project
+        let q = self.q_proj.forward(x)?;
+        let k = self.k_proj.forward(x)?;
+        let v = self.v_proj.forward(x)?;
+
+        // Reshape to (B, H, L, D)
+        let q = q
+            .reshape((b, l, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let k = k
+            .reshape((b, l, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let v = v
+            .reshape((b, l, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        // Per-head RmsNorm
+        let q = self.q_norm.forward(&q.flatten(0, 2)?)?.reshape((
+            b,
+            self.num_heads,
+            l,
+            self.head_dim,
+        ))?;
+        let k = self.k_norm.forward(&k.flatten(0, 2)?)?.reshape((
+            b,
+            self.num_kv_heads,
+            l,
+            self.head_dim,
+        ))?;
+
+        // Rotary position embeddings
+        let (q, k) = rotary.apply(&q, &k, 0)?;
+
+        // GQA key/value expansion
+        let k = repeat_kv(k, self.num_kv_groups)?.contiguous()?;
+        let v = repeat_kv(v, self.num_kv_groups)?.contiguous()?;
+
+        // Scaled dot-product attention
+        let scale = 1.0 / (self.head_dim as f64).sqrt();
+        let mut scores = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
+        if let Some(m) = mask {
+            scores = scores.broadcast_add(m)?;
+        }
+        let probs = candle_nn::ops::softmax_last_dim(&scores)?;
+        let ctx = probs.matmul(&v)?;
+
+        // Reshape back and output projection
+        ctx.transpose(1, 2)?
+            .reshape((b, l, self.hidden_size))?
+            .apply(&self.o_proj)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EncoderLayer
+// ---------------------------------------------------------------------------
+
+/// A single bidirectional pre-norm transformer layer.
+///
+/// ```text
+/// x = x + self_attn(input_layernorm(x))
+/// x = x + mlp(post_attention_layernorm(x))
+/// ```
+///
+/// Layers alternate between sliding-window and full attention based on
+/// `attention_type`, which controls the mask passed to the attention block.
+#[derive(Debug, Clone)]
+pub struct EncoderLayer {
+    self_attn: EncoderAttention,
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+    mlp: EncoderMLP,
+    attention_type: String,
+}
+
+impl EncoderLayer {
+    pub fn new(cfg: &AceStepConfig, attention_type: &str, vb: VarBuilder) -> Result<Self> {
+        let hidden = cfg.encoder_hidden_size();
+        Ok(Self {
+            self_attn: EncoderAttention::new(cfg, vb.pp("self_attn"))?,
+            input_layernorm: RmsNorm::new(hidden, cfg.rms_norm_eps, vb.pp("input_layernorm"))?,
+            post_attention_layernorm: RmsNorm::new(
+                hidden,
+                cfg.rms_norm_eps,
+                vb.pp("post_attention_layernorm"),
+            )?,
+            mlp: EncoderMLP::new(cfg, vb.pp("mlp"))?,
+            attention_type: attention_type.to_string(),
+        })
+    }
+
+    /// Returns the attention type for this layer (`"sliding_attention"` or
+    /// `"full_attention"`), used to select the appropriate mask.
+    pub fn attention_type(&self) -> &str {
+        &self.attention_type
+    }
+
+    /// Forward pass with pre-norm residual connections.
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        mask: Option<&Tensor>,
+        rotary: &RotaryEmbedding,
+    ) -> Result<Tensor> {
+        // Self-attention with residual
+        let residual = x.clone();
+        let h = self.input_layernorm.forward(x)?;
+        let h = self.self_attn.forward(&h, mask, rotary)?;
+        let x = (residual + h)?;
+
+        // MLP with residual
+        let residual = x.clone();
+        let h = self.post_attention_layernorm.forward(&x)?;
+        let h = h.apply(&self.mlp)?;
+        residual + h
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bidirectional attention mask helpers
+// ---------------------------------------------------------------------------
+
+/// Build a bidirectional sliding-window mask.
+///
+/// Positions outside the window receive `-inf`; positions inside receive `0`.
+/// The returned tensor has shape `(1, 1, seq_len, seq_len)`.
+fn sliding_window_mask(
+    seq_len: usize,
+    window: usize,
+    dtype: DType,
+    dev: &Device,
+) -> Result<Tensor> {
+    let minf = f32::NEG_INFINITY;
+    let mask: Vec<f32> = (0..seq_len)
+        .flat_map(|i| {
+            (0..seq_len).map(move |j| {
+                if (i as i64 - j as i64).unsigned_abs() as usize <= window {
+                    0.0
+                } else {
+                    minf
+                }
+            })
+        })
+        .collect();
+    Tensor::from_slice(&mask, (1, 1, seq_len, seq_len), dev)?.to_dtype(dtype)
+}
+
+/// Build an attention mask from a padding mask, optionally combined with a
+/// sliding window constraint.
+///
+/// * `attention_mask` - `(B, L)` with `1` for valid tokens, `0` for padding.
+/// * `sliding_window` - if `Some(w)`, restricts attention to a local window.
+///
+/// Returns `(B, 1, L, L)` additive mask.
+fn build_bidirectional_mask(
+    attention_mask: &Tensor,
+    seq_len: usize,
+    sliding_window: Option<usize>,
+    dtype: DType,
+    dev: &Device,
+) -> Result<Tensor> {
+    let (b, _) = attention_mask.dims2()?;
+
+    // Padding mask: convert (B, L) 1/0 mask → (B, 1, 1, L) with 0.0 for valid, -inf for padding.
+    let pad_mask = attention_mask
+        .reshape((b, 1, 1, seq_len))?
+        .to_dtype(DType::F32)?;
+    // Use where_cond to avoid 0 * -inf = NaN
+    let zeros = Tensor::zeros_like(&pad_mask)?;
+    let neginf = Tensor::full(f32::NEG_INFINITY, pad_mask.shape(), dev)?.to_dtype(DType::F32)?;
+    let pad_mask_bool = pad_mask.gt(&zeros)?; // true for valid (mask==1)
+    let pad_mask = pad_mask_bool.where_cond(&zeros, &neginf)?; // 0.0 for valid, -inf for padding
+
+    let mask = match sliding_window {
+        Some(w) => {
+            let sw = sliding_window_mask(seq_len, w, DType::F32, dev)?;
+            // Combine: both must allow the position
+            pad_mask.broadcast_add(&sw)?
+        }
+        None => pad_mask
+            .broadcast_as((b, 1, seq_len, seq_len))?
+            .contiguous()?,
+    };
+    mask.to_dtype(dtype)
+}
+
+// ---------------------------------------------------------------------------
+// LyricEncoder
+// ---------------------------------------------------------------------------
+
+/// Bidirectional transformer encoder for lyric embeddings.
+///
+/// Takes pre-embedded lyric token features (from a text encoder) and refines
+/// them through 8 layers of bidirectional self-attention.
+///
+/// Weight prefix: `lyric_encoder.*`
+#[derive(Debug, Clone)]
+pub struct LyricEncoder {
+    embed_tokens: Linear,
+    layers: Vec<EncoderLayer>,
+    norm: RmsNorm,
+    rotary_emb: RotaryEmbedding,
+    sliding_window: Option<usize>,
+    dtype: DType,
+    device: Device,
+}
+
+impl LyricEncoder {
+    pub fn new(cfg: &AceStepConfig, vb: VarBuilder) -> Result<Self> {
+        let enc_hidden = cfg.encoder_hidden_size();
+
+        // Linear projection from text embedding dim to encoder hidden size (with bias).
+        let embed_tokens = linear_b(cfg.text_hidden_dim, enc_hidden, true, vb.pp("embed_tokens"))?;
+
+        let num_layers = cfg.num_lyric_encoder_hidden_layers;
+        let mut layers = Vec::with_capacity(num_layers);
+        let vb_l = vb.pp("layers");
+        for i in 0..num_layers {
+            let attn_type = if i % 2 == 0 {
+                "sliding_attention"
+            } else {
+                "full_attention"
+            };
+            layers.push(EncoderLayer::new(cfg, attn_type, vb_l.pp(i))?);
+        }
+
+        let norm = RmsNorm::new(enc_hidden, cfg.rms_norm_eps, vb.pp("norm"))?;
+
+        let rotary_emb = RotaryEmbedding::new(
+            vb.dtype(),
+            cfg.head_dim,
+            cfg.max_position_embeddings,
+            cfg.rope_theta,
+            vb.device(),
+        )?;
+
+        let sliding_window = if cfg.use_sliding_window {
+            Some(cfg.sliding_window)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            embed_tokens,
+            layers,
+            norm,
+            rotary_emb,
+            sliding_window,
+            dtype: vb.dtype(),
+            device: vb.device().clone(),
+        })
+    }
+
+    /// Encode lyric embeddings.
+    ///
+    /// * `inputs_embeds` - `(B, T, text_hidden_dim)` pre-embedded lyric tokens.
+    /// * `attention_mask` - `(B, T)` with `1` for valid tokens, `0` for padding.
+    ///
+    /// Returns `(B, T, encoder_hidden_size)`.
+    pub fn forward(&self, inputs_embeds: &Tensor, attention_mask: &Tensor) -> Result<Tensor> {
+        let (_, seq_len, _) = inputs_embeds.dims3()?;
+
+        let mut hidden = self.embed_tokens.forward(inputs_embeds)?;
+
+        for layer in &self.layers {
+            let sw = match layer.attention_type() {
+                "sliding_attention" => self.sliding_window,
+                _ => None,
+            };
+            let mask =
+                build_bidirectional_mask(attention_mask, seq_len, sw, self.dtype, &self.device)?;
+            hidden = layer.forward(&hidden, Some(&mask), &self.rotary_emb)?;
+        }
+
+        self.norm.forward(&hidden)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TimbreEncoder
+// ---------------------------------------------------------------------------
+
+/// Bidirectional transformer encoder for timbre (reference audio) embeddings.
+///
+/// Uses a learned CLS token prepended to the input sequence. After processing,
+/// the CLS token representation (position 0) is extracted as the timbre summary.
+///
+/// Weight prefix: `timbre_encoder.*`
+#[derive(Debug, Clone)]
+pub struct TimbreEncoder {
+    embed_tokens: Linear,
+    layers: Vec<EncoderLayer>,
+    norm: RmsNorm,
+    rotary_emb: RotaryEmbedding,
+    /// CLS token prepended to timbre sequence (XL models only).
+    special_token: Tensor,
+    /// Whether to prepend the CLS special_token (true for XL, false for 2B).
+    use_cls: bool,
+    sliding_window: Option<usize>,
+    dtype: DType,
+    device: Device,
+}
+
+impl TimbreEncoder {
+    pub fn new(cfg: &AceStepConfig, vb: VarBuilder) -> Result<Self> {
+        let enc_hidden = cfg.encoder_hidden_size();
+
+        // Linear projection from timbre embedding dim to encoder hidden size (with bias).
+        let embed_tokens = linear_b(
+            cfg.timbre_hidden_dim,
+            enc_hidden,
+            true,
+            vb.pp("embed_tokens"),
+        )?;
+
+        let num_layers = cfg.num_timbre_encoder_hidden_layers;
+        let mut layers = Vec::with_capacity(num_layers);
+        let vb_l = vb.pp("layers");
+        for i in 0..num_layers {
+            let attn_type = if i % 2 == 0 {
+                "sliding_attention"
+            } else {
+                "full_attention"
+            };
+            layers.push(EncoderLayer::new(cfg, attn_type, vb_l.pp(i))?);
+        }
+
+        let norm = RmsNorm::new(enc_hidden, cfg.rms_norm_eps, vb.pp("norm"))?;
+
+        // XL models prepend a CLS special token to the timbre sequence.
+        // Base/2B models have this commented out in Python.
+        let special_token = vb.get((1, 1, enc_hidden), "special_token")?;
+
+        let rotary_emb = RotaryEmbedding::new(
+            vb.dtype(),
+            cfg.head_dim,
+            cfg.max_position_embeddings,
+            cfg.rope_theta,
+            vb.device(),
+        )?;
+
+        let sliding_window = if cfg.use_sliding_window {
+            Some(cfg.sliding_window)
+        } else {
+            None
+        };
+
+        // XL models have encoder_hidden_size != hidden_size and use the CLS token.
+        let use_cls = cfg.encoder_hidden_size.is_some();
+
+        Ok(Self {
+            embed_tokens,
+            layers,
+            norm,
+            rotary_emb,
+            special_token,
+            use_cls,
+            sliding_window,
+            dtype: vb.dtype(),
+            device: vb.device().clone(),
+        })
+    }
+
+    /// Unpack packed timbre embeddings into per-batch format.
+    ///
+    /// Matches the Python `unpack_timbre_embeddings` exactly:
+    /// * `timbre_embs_packed` - `(N, D)` embeddings from each reference audio segment.
+    /// * `refer_audio_order_mask` - `(N,)` 1D integer tensor mapping each segment
+    ///   to its batch index (0..B-1).
+    ///
+    /// Returns `(timbre_embs, timbre_mask)`:
+    /// - `timbre_embs`: `(B, max_count, D)` gathered embeddings.
+    /// - `timbre_mask`: `(B, max_count)` integer mask (1=valid, 0=padding).
+    fn unpack_timbre_embeddings(
+        &self,
+        timbre_embs_packed: &Tensor,
+        refer_audio_order_mask: &Tensor,
+    ) -> Result<(Tensor, Tensor)> {
+        let (n, d) = timbre_embs_packed.dims2()?;
+        let mask_1d = refer_audio_order_mask.flatten_all()?;
+
+        // B = max(order_mask) + 1
+        let b = (mask_1d.max(0)?.to_scalar::<i64>()? + 1) as usize;
+
+        // Count elements per batch and find max_count
+        let mask_vec = mask_1d.to_vec1::<i64>()?;
+        let mut counts = vec![0usize; b];
+        for &idx in &mask_vec {
+            counts[idx as usize] += 1;
+        }
+        let max_count = *counts.iter().max().unwrap_or(&1);
+
+        // Build the output by placing each embedding at the right (batch, position)
+        let mut position_in_batch = vec![0usize; b];
+        let mut result = vec![0f32; b * max_count * d];
+        let mut mask_out = vec![0i64; b * max_count];
+
+        let packed_data = timbre_embs_packed.to_dtype(DType::F32)?.to_vec2::<f32>()?;
+        for i in 0..n {
+            let batch_idx = mask_vec[i] as usize;
+            let pos = position_in_batch[batch_idx];
+            position_in_batch[batch_idx] += 1;
+            let dst_offset = (batch_idx * max_count + pos) * d;
+            result[dst_offset..dst_offset + d].copy_from_slice(&packed_data[i]);
+            mask_out[batch_idx * max_count + pos] = 1;
+        }
+
+        let timbre_embs =
+            Tensor::from_vec(result, (b, max_count, d), &self.device)?.to_dtype(self.dtype)?;
+        let timbre_mask =
+            Tensor::from_vec(mask_out, (b, max_count), &self.device)?.to_dtype(self.dtype)?;
+
+        Ok((timbre_embs, timbre_mask))
+    }
+
+    /// Encode timbre reference audio segments.
+    ///
+    /// * `refer_audio_packed` - `(N, T, timbre_hidden_dim)` packed reference
+    ///   audio features for all segments across the batch.
+    /// * `refer_audio_order_mask` - `(N,)` 1D integer tensor mapping each
+    ///   segment to its batch index (0..B-1).
+    ///
+    /// Returns `(timbre_embs, timbre_mask)`:
+    /// - `timbre_embs`: `(B, max_count, encoder_hidden_size)`.
+    /// - `timbre_mask`: `(B, max_count)` integer mask.
+    pub fn forward(
+        &self,
+        refer_audio_packed: &Tensor,
+        refer_audio_order_mask: &Tensor,
+    ) -> Result<(Tensor, Tensor)> {
+        let (n, _t, _) = refer_audio_packed.dims3()?;
+
+        // Project input features: (N, T, timbre_dim) -> (N, T, hidden_size)
+        let mut x = self.embed_tokens.forward(refer_audio_packed)?;
+
+        // XL models prepend a CLS special_token for timbre aggregation.
+        if self.use_cls {
+            let cls = self
+                .special_token
+                .broadcast_as((n, 1, x.dim(2)?))?
+                .contiguous()?;
+            x = Tensor::cat(&[&cls, &x], 1)?;
+        }
+
+        let seq_len = x.dim(1)?;
+
+        // Build attention mask
+        let ones = Tensor::ones((n, seq_len), self.dtype, &self.device)?;
+
+        for layer in &self.layers {
+            let sw = match layer.attention_type() {
+                "sliding_attention" => self.sliding_window,
+                _ => None,
+            };
+            let mask = build_bidirectional_mask(&ones, seq_len, sw, self.dtype, &self.device)?;
+            x = layer.forward(&x, Some(&mask), &self.rotary_emb)?;
+        }
+
+        x = self.norm.forward(&x)?;
+
+        // Extract position 0 as the timbre summary: (N, T, D) -> (N, D)
+        let embeds = x.narrow(1, 0, 1)?.squeeze(1)?;
+
+        self.unpack_timbre_embeddings(&embeds, refer_audio_order_mask)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// pack_sequences
+// ---------------------------------------------------------------------------
+
+/// Pack two (hidden, mask) pairs: concatenate, then reorder so valid tokens
+/// (mask=1) come before padding tokens (mask=0) in each batch element.
+///
+/// Uses a CPU-side stable gather (valid tokens first in original order, then
+/// padding tokens) to match Python's `argsort(descending=True, stable=True)`.
+/// Length computation uses I64 to avoid BF16 precision loss for long sequences.
+///
+/// * `hidden1` - `(B, L1, D)`
+/// * `hidden2` - `(B, L2, D)`
+/// * `mask1` - `(B, L1)` float with 1.0=valid, 0.0=padding
+/// * `mask2` - `(B, L2)` float
+///
+/// Returns `(hidden, mask)` with shapes `(B, L1+L2, D)` and `(B, L1+L2)`.
+pub fn pack_sequences(
+    hidden1: &Tensor,
+    hidden2: &Tensor,
+    mask1: &Tensor,
+    mask2: &Tensor,
+) -> Result<(Tensor, Tensor)> {
+    let hidden_cat = Tensor::cat(&[hidden1, hidden2], 1)?;
+    let mask_cat = Tensor::cat(&[mask1, mask2], 1)?;
+
+    let (b, l, d) = hidden_cat.dims3()?;
+
+    // Build stable sort indices on CPU: valid positions first (in order),
+    // then padding positions (in order). This is equivalent to Python's
+    // stable descending argsort on a binary mask.
+    let mask_f32 = mask_cat
+        .to_dtype(candle::DType::F32)?
+        .to_device(&candle::Device::Cpu)?;
+    let mask_data = mask_f32.to_vec2::<f32>()?;
+
+    let mut sort_indices = vec![0u32; b * l];
+    let mut valid_counts = vec![0usize; b];
+    for bi in 0..b {
+        let mut valid = Vec::new();
+        let mut invalid = Vec::new();
+        for (j, &val) in mask_data[bi].iter().enumerate().take(l) {
+            if val > 0.5 {
+                valid.push(j as u32);
+            } else {
+                invalid.push(j as u32);
+            }
+        }
+        valid_counts[bi] = valid.len();
+        let offset = bi * l;
+        for (k, &idx) in valid.iter().chain(invalid.iter()).enumerate() {
+            sort_indices[offset + k] = idx;
+        }
+    }
+
+    let sort_idx = Tensor::from_vec(sort_indices, (b, l), hidden_cat.device())?;
+    let idx_expanded = sort_idx
+        .unsqueeze(2)?
+        .broadcast_as((b, l, d))?
+        .contiguous()?;
+    let hidden_sorted = hidden_cat.gather(&idx_expanded, 1)?;
+
+    // Build new mask using integer counts (avoids BF16 precision loss)
+    let mut new_mask_data = vec![0f32; b * l];
+    for bi in 0..b {
+        for j in 0..valid_counts[bi] {
+            new_mask_data[bi * l + j] = 1.0;
+        }
+    }
+    let new_mask =
+        Tensor::from_vec(new_mask_data, (b, l), hidden_cat.device())?.to_dtype(mask1.dtype())?;
+
+    Ok((hidden_sorted, new_mask))
+}
+
+// ---------------------------------------------------------------------------
+// ConditionEncoder
+// ---------------------------------------------------------------------------
+
+/// Top-level condition encoder that produces the cross-attention context for
+/// the DiT diffusion backbone.
+///
+/// Combines three conditioning signals:
+/// 1. **Text** - style/prompt hidden states projected to encoder dimension.
+/// 2. **Lyrics** - lyric token embeddings processed by a bidirectional
+///    transformer.
+/// 3. **Timbre** - reference audio segments encoded with CLS-token pooling.
+///
+/// The outputs are packed into a single sequence with an accompanying mask.
+///
+/// Weight prefix: `encoder.*`
+#[derive(Debug, Clone)]
+pub struct ConditionEncoder {
+    text_projector: Linear,
+    lyric_encoder: LyricEncoder,
+    timbre_encoder: TimbreEncoder,
+}
+
+impl ConditionEncoder {
+    pub fn new(cfg: &AceStepConfig, vb: VarBuilder) -> Result<Self> {
+        let enc_hidden = cfg.encoder_hidden_size();
+
+        // Text projector: no bias
+        let text_projector =
+            linear_no_bias(cfg.text_hidden_dim, enc_hidden, vb.pp("text_projector"))?;
+
+        let lyric_encoder = LyricEncoder::new(cfg, vb.pp("lyric_encoder"))?;
+        let timbre_encoder = TimbreEncoder::new(cfg, vb.pp("timbre_encoder"))?;
+
+        Ok(Self {
+            text_projector,
+            lyric_encoder,
+            timbre_encoder,
+        })
+    }
+
+    /// Encode all conditioning inputs into a single packed sequence.
+    ///
+    /// * `text_hidden_states` - `(B, T_text, text_hidden_dim)` from the text encoder.
+    /// * `text_attention_mask` - `(B, T_text)` mask for text tokens.
+    /// * `lyric_hidden_states` - `(B, T_lyric, text_hidden_dim)` pre-embedded lyrics.
+    /// * `lyric_attention_mask` - `(B, T_lyric)` mask for lyric tokens.
+    /// * `refer_audio_packed` - `(N, T_audio, timbre_hidden_dim)` packed reference
+    ///   audio features.
+    /// * `refer_audio_order_mask` - `(N,)` 1D integer tensor mapping each
+    ///   segment to its batch index.
+    ///
+    /// Returns `(enc_hidden, enc_mask)`:
+    /// - `enc_hidden`: `(B, T_lyric + max_ref + T_text, encoder_hidden_size)`.
+    /// - `enc_mask`: `(B, T_lyric + max_ref + T_text)` float mask.
+    pub fn forward(
+        &self,
+        text_hidden_states: &Tensor,
+        text_attention_mask: &Tensor,
+        lyric_hidden_states: &Tensor,
+        lyric_attention_mask: &Tensor,
+        refer_audio_packed: &Tensor,
+        refer_audio_order_mask: &Tensor,
+    ) -> Result<(Tensor, Tensor)> {
+        // Project text hidden states
+        let text = self.text_projector.forward(text_hidden_states)?;
+
+        // Encode lyrics
+        let lyric = self
+            .lyric_encoder
+            .forward(lyric_hidden_states, lyric_attention_mask)?;
+
+        // Encode timbre
+        let (timbre, timbre_mask) = self
+            .timbre_encoder
+            .forward(refer_audio_packed, refer_audio_order_mask)?;
+
+        // Pack lyric + timbre
+        let (enc_hidden, enc_mask) =
+            pack_sequences(&lyric, &timbre, lyric_attention_mask, &timbre_mask)?;
+
+        // Pack (lyric+timbre) + text
+        let (enc_hidden, enc_mask) =
+            pack_sequences(&enc_hidden, &text, &enc_mask, text_attention_mask)?;
+
+        Ok((enc_hidden, enc_mask))
+    }
+}

--- a/candle-transformers/src/models/ace_step/condition.rs
+++ b/candle-transformers/src/models/ace_step/condition.rs
@@ -594,7 +594,7 @@ impl TimbreEncoder {
         // Build the output by placing each embedding at the right (batch, position)
         let mut position_in_batch = vec![0usize; b];
         let mut result = vec![0f32; b * max_count * d];
-        let mut mask_out = vec![0i64; b * max_count];
+        let mut mask_out = vec![0f32; b * max_count];
 
         let packed_data = timbre_embs_packed.to_dtype(DType::F32)?.to_vec2::<f32>()?;
         for i in 0..n {
@@ -603,7 +603,7 @@ impl TimbreEncoder {
             position_in_batch[batch_idx] += 1;
             let dst_offset = (batch_idx * max_count + pos) * d;
             result[dst_offset..dst_offset + d].copy_from_slice(&packed_data[i]);
-            mask_out[batch_idx * max_count + pos] = 1;
+            mask_out[batch_idx * max_count + pos] = 1.0;
         }
 
         let timbre_embs =

--- a/candle-transformers/src/models/ace_step/dit.rs
+++ b/candle-transformers/src/models/ace_step/dit.rs
@@ -1,0 +1,826 @@
+//! Diffusion Transformer (DiT) for the ACE-Step 1.5 music generation model.
+//!
+//! This module implements the core denoising transformer that operates on audio
+//! latents produced by the Oobleck VAE. It uses AdaLN-Zero modulation for
+//! timestep conditioning and cross-attention for text/lyric conditioning.
+//!
+//! The architecture features:
+//! - Patchified input via strided Conv1d / ConvTranspose1d
+//! - Grouped-query attention (GQA) with QK-norm and RoPE
+//! - Alternating sliding-window and full self-attention layers
+//! - Cross-attention to text encoder outputs
+//! - SiLU-gated MLP (same structure as Qwen3)
+//! - AdaLN-Zero modulation from timestep embeddings
+//!
+//! Reference: <https://huggingface.co/ACE-Step/ACE-Step-v1-3.5B>
+
+use crate::models::with_tracing::{linear_b, linear_no_bias, Linear, RmsNorm};
+use crate::utils::repeat_kv;
+use candle::{DType, Device, Module, Result, Tensor, D};
+use candle_nn::{
+    Activation, Conv1d, Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, VarBuilder,
+};
+
+use super::AceStepConfig;
+
+// ---------------------------------------------------------------------------
+// Rotary positional embedding
+// ---------------------------------------------------------------------------
+
+/// Precomputed sin/cos tables for rotary positional embeddings.
+///
+/// Identical to the Qwen3 implementation: positions are mapped through
+/// inverse-frequency bands derived from `rope_theta`, producing a pair of
+/// (sin, cos) tensors of shape `(max_position_embeddings, head_dim/2)`.
+#[derive(Debug, Clone)]
+pub struct RotaryEmbedding {
+    sin: Tensor,
+    cos: Tensor,
+}
+
+impl RotaryEmbedding {
+    /// Creates a new rotary embedding table.
+    ///
+    /// # Arguments
+    /// * `dtype` - Target dtype for the sin/cos tables.
+    /// * `cfg` - Model configuration (uses `head_dim`, `max_position_embeddings`, `rope_theta`).
+    /// * `dev` - Device on which to allocate the tensors.
+    pub fn new(dtype: DType, cfg: &AceStepConfig, dev: &Device) -> Result<Self> {
+        let dim = cfg.head_dim;
+        let max_seq_len = cfg.max_position_embeddings;
+        let inv_freq: Vec<_> = (0..dim)
+            .step_by(2)
+            .map(|i| 1f32 / cfg.rope_theta.powf(i as f64 / dim as f64) as f32)
+            .collect();
+        let inv_freq_len = inv_freq.len();
+        let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?.to_dtype(DType::F32)?;
+        let t = Tensor::arange(0u32, max_seq_len as u32, dev)?
+            .to_dtype(DType::F32)?
+            .reshape((max_seq_len, 1))?;
+        let freqs = t.matmul(&inv_freq)?;
+        Ok(Self {
+            sin: freqs.sin()?.to_dtype(dtype)?,
+            cos: freqs.cos()?.to_dtype(dtype)?,
+        })
+    }
+
+    /// Applies rotary embeddings to query and key tensors.
+    ///
+    /// Both `q` and `k` must have shape `(B, H, L, D)`. The `offset` parameter
+    /// allows indexing into the precomputed tables for incremental decoding
+    /// (unused during diffusion but kept for API consistency).
+    pub fn apply(&self, q: &Tensor, k: &Tensor, offset: usize) -> Result<(Tensor, Tensor)> {
+        let (_, _, seq_len, _) = q.dims4()?;
+        let cos = self.cos.narrow(0, offset, seq_len)?;
+        let sin = self.sin.narrow(0, offset, seq_len)?;
+        let q_embed = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
+        let k_embed = candle_nn::rotary_emb::rope(&k.contiguous()?, &cos, &sin)?;
+        Ok((q_embed, k_embed))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Timestep embedding
+// ---------------------------------------------------------------------------
+
+/// Converts a scalar diffusion timestep into a high-dimensional embedding.
+///
+/// The pipeline is: sinusoidal frequency encoding -> Linear+SiLU -> Linear
+/// producing a per-sample embedding `temb` of shape `(B, hidden_size)`, plus
+/// a 6-way projection `timestep_proj` of shape `(B, 6, hidden_size)` used for
+/// AdaLN-Zero modulation in each transformer layer.
+#[derive(Debug, Clone)]
+pub struct TimestepEmbedding {
+    linear_1: Linear,
+    linear_2: Linear,
+    time_proj: Linear,
+    in_channels: usize,
+    scale: f64,
+}
+
+impl TimestepEmbedding {
+    /// Creates a new timestep embedding module.
+    ///
+    /// # Arguments
+    /// * `hidden_size` - Output dimension for the embedding and the 6-way projection.
+    /// * `vb` - Variable builder scoped to the embedding prefix (e.g. `time_embed`).
+    pub fn new(hidden_size: usize, vb: VarBuilder) -> Result<Self> {
+        let in_channels = 256;
+        let linear_1 = linear_b(in_channels, hidden_size, true, vb.pp("linear_1"))?;
+        let linear_2 = linear_b(hidden_size, hidden_size, true, vb.pp("linear_2"))?;
+        let time_proj = linear_b(hidden_size, hidden_size * 6, true, vb.pp("time_proj"))?;
+        Ok(Self {
+            linear_1,
+            linear_2,
+            time_proj,
+            in_channels,
+            scale: 1000.0,
+        })
+    }
+
+    /// Produces sinusoidal frequency features from a 1-D timestep tensor.
+    ///
+    /// Input `t` has shape `(B,)`. Output has shape `(B, in_channels)`.
+    fn timestep_encoding(&self, t: &Tensor, device: &Device) -> Result<Tensor> {
+        let t = (t * self.scale)?;
+        let half = self.in_channels / 2;
+        let max_period: f64 = 10_000.0;
+        let freqs: Vec<f32> = (0..half)
+            .map(|i| (-max_period.ln() * i as f64 / half as f64).exp() as f32)
+            .collect();
+        let freqs = Tensor::from_vec(freqs, (1, half), device)?.to_dtype(t.dtype())?;
+        let t = t.unsqueeze(D::Minus1)?; // (B, 1)
+        let args = t.broadcast_mul(&freqs)?; // (B, half)
+        let cos = args.cos()?;
+        let sin = args.sin()?;
+        Tensor::cat(&[&cos, &sin], D::Minus1) // (B, in_channels)
+    }
+
+    /// Forward pass.
+    ///
+    /// # Arguments
+    /// * `t` - Diffusion timestep tensor of shape `(B,)`.
+    ///
+    /// # Returns
+    /// * `temb` - Embedding of shape `(B, hidden_size)`.
+    /// * `timestep_proj` - Modulation signals of shape `(B, 6, hidden_size)`.
+    pub fn forward(&self, t: &Tensor) -> Result<(Tensor, Tensor)> {
+        let device = t.device();
+        let t_freq = self.timestep_encoding(t, device)?;
+        let temb = t_freq.apply(&self.linear_1)?.silu()?;
+        let temb = temb.apply(&self.linear_2)?;
+        let hidden_size = temb.dim(D::Minus1)?;
+        let timestep_proj = temb.silu()?.apply(&self.time_proj)?;
+        let b = timestep_proj.dim(0)?;
+        let timestep_proj = timestep_proj.reshape((b, 6, hidden_size))?;
+        Ok((temb, timestep_proj))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MLP (SiLU-gated, same as Qwen3MLP)
+// ---------------------------------------------------------------------------
+
+/// SiLU-gated feed-forward network: `down_proj(silu(gate_proj(x)) * up_proj(x))`.
+#[derive(Debug, Clone)]
+pub struct MLP {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+    act_fn: Activation,
+}
+
+impl MLP {
+    pub fn new(cfg: &AceStepConfig, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            gate_proj: linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("gate_proj"))?,
+            up_proj: linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("up_proj"))?,
+            down_proj: linear_no_bias(cfg.intermediate_size, cfg.hidden_size, vb.pp("down_proj"))?,
+            act_fn: cfg.hidden_act,
+        })
+    }
+}
+
+impl Module for MLP {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let lhs = x.apply(&self.gate_proj)?.apply(&self.act_fn)?;
+        let rhs = x.apply(&self.up_proj)?;
+        (lhs * rhs)?.apply(&self.down_proj)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Attention (self and cross)
+// ---------------------------------------------------------------------------
+
+/// Grouped-query attention with per-head QK-norm.
+///
+/// Supports both self-attention (with RoPE) and cross-attention (Q from hidden
+/// states, K/V from encoder outputs, no RoPE). All projections are bias-free
+/// when `attention_bias` is false in the config.
+///
+/// Cross-attention supports optional KV caching: since encoder hidden states
+/// are constant across denoising steps, the projected+normed+GQA-expanded K/V
+/// can be computed once and reused.
+#[derive(Debug, Clone)]
+pub struct CrossAttentionKvCache {
+    /// `(B, num_heads, S, head_dim)` — ready for Q @ K^T.
+    pub k: Tensor,
+    /// `(B, num_heads, S, head_dim)`.
+    pub v: Tensor,
+}
+
+#[derive(Debug, Clone)]
+pub struct AceStepAttention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    o_proj: Linear,
+    q_norm: RmsNorm,
+    k_norm: RmsNorm,
+    num_heads: usize,
+    num_kv_heads: usize,
+    num_kv_groups: usize,
+    head_dim: usize,
+    hidden_size: usize,
+    is_cross_attention: bool,
+}
+
+impl AceStepAttention {
+    /// Creates a new attention module.
+    ///
+    /// # Arguments
+    /// * `cfg` - Model configuration.
+    /// * `is_cross_attention` - When `true`, K and V projections accept
+    ///   `encoder_hidden_size()` as input dimension rather than `hidden_size`.
+    /// * `vb` - Variable builder scoped to the attention prefix.
+    pub fn new(cfg: &AceStepConfig, is_cross_attention: bool, vb: VarBuilder) -> Result<Self> {
+        let head_dim = cfg.head_dim;
+        let num_heads = cfg.num_attention_heads;
+        let num_kv_heads = cfg.num_key_value_heads;
+        let num_kv_groups = num_heads / num_kv_heads;
+        let hidden_size = head_dim * num_heads;
+
+        // Cross-attention K/V receive encoder states AFTER condition_embedder
+        // projection (hidden_size), not the raw encoder output (encoder_hidden_size).
+        let kv_input_dim = cfg.hidden_size;
+
+        let q_proj = linear_b(
+            cfg.hidden_size,
+            num_heads * head_dim,
+            cfg.attention_bias,
+            vb.pp("q_proj"),
+        )?;
+        let k_proj = linear_b(
+            kv_input_dim,
+            num_kv_heads * head_dim,
+            cfg.attention_bias,
+            vb.pp("k_proj"),
+        )?;
+        let v_proj = linear_b(
+            kv_input_dim,
+            num_kv_heads * head_dim,
+            cfg.attention_bias,
+            vb.pp("v_proj"),
+        )?;
+        let o_proj = linear_b(
+            num_heads * head_dim,
+            cfg.hidden_size,
+            cfg.attention_bias,
+            vb.pp("o_proj"),
+        )?;
+
+        let q_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
+        let k_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            q_norm,
+            k_norm,
+            num_heads,
+            num_kv_heads,
+            num_kv_groups,
+            head_dim,
+            hidden_size,
+            is_cross_attention,
+        })
+    }
+
+    /// Computes (optionally masked) attention.
+    ///
+    /// # Arguments
+    /// * `x` - Hidden states of shape `(B, L, hidden_size)`.
+    /// * `encoder_hidden_states` - For cross-attention: encoder output
+    ///   `(B, S, encoder_hidden_size)`. Ignored for self-attention.
+    /// * `attn_mask` - Additive mask broadcastable to `(B, H, L, S)`, where
+    ///   masked positions contain `f32::NEG_INFINITY`.
+    /// * `rotary` - Rotary embedding to apply to Q and K (self-attention only).
+    ///
+    /// Compute cross-attention K/V cache from encoder hidden states.
+    /// Returns fully processed K, V: projected, normed, GQA-expanded,
+    /// contiguous, shape `(B, num_heads, S, head_dim)`.
+    pub fn compute_kv_cache(
+        &self,
+        encoder_hidden_states: &Tensor,
+    ) -> Result<CrossAttentionKvCache> {
+        let (b, kv_len, _) = encoder_hidden_states.dims3()?;
+        let k = self.k_proj.forward(encoder_hidden_states)?;
+        let v = self.v_proj.forward(encoder_hidden_states)?;
+        let k = k
+            .reshape((b, kv_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let v = v
+            .reshape((b, kv_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let k = {
+            let flat = k.contiguous()?.flatten(0, 1)?;
+            self.k_norm
+                .forward(&flat)?
+                .reshape((b, self.num_kv_heads, kv_len, self.head_dim))?
+        };
+        let k = repeat_kv(k, self.num_kv_groups)?.contiguous()?;
+        let v = repeat_kv(v, self.num_kv_groups)?.contiguous()?;
+        Ok(CrossAttentionKvCache { k, v })
+    }
+
+    /// Forward pass. For cross-attention, pass `kv_cache` to skip K/V
+    /// recomputation (encoder states are constant across denoising steps).
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        encoder_hidden_states: Option<&Tensor>,
+        attn_mask: Option<&Tensor>,
+        rotary: Option<&RotaryEmbedding>,
+        kv_cache: Option<&CrossAttentionKvCache>,
+    ) -> Result<Tensor> {
+        let (b, l, _) = x.dims3()?;
+
+        // Q is always computed fresh from x.
+        let q = self.q_proj.forward(x)?;
+        let q = q
+            .reshape((b, l, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let q = {
+            let flat = q.contiguous()?.flatten(0, 1)?;
+            self.q_norm
+                .forward(&flat)?
+                .reshape((b, self.num_heads, l, self.head_dim))?
+        };
+
+        // K/V: from cache or computed fresh.
+        let (q, k, v) = if let Some(cache) = kv_cache {
+            // Cross-attention with cache — K/V already projected+normed+expanded.
+            (q, cache.k.clone(), cache.v.clone())
+        } else {
+            // Self-attention or cross-attention without cache.
+            let kv_input = if self.is_cross_attention {
+                encoder_hidden_states.expect("cross-attention requires encoder_hidden_states")
+            } else {
+                x
+            };
+            let k = self.k_proj.forward(kv_input)?;
+            let v = self.v_proj.forward(kv_input)?;
+            let kv_len = kv_input.dim(1)?;
+            let k = k
+                .reshape((b, kv_len, self.num_kv_heads, self.head_dim))?
+                .transpose(1, 2)?;
+            let v = v
+                .reshape((b, kv_len, self.num_kv_heads, self.head_dim))?
+                .transpose(1, 2)?;
+            let k = {
+                let flat = k.contiguous()?.flatten(0, 1)?;
+                self.k_norm.forward(&flat)?.reshape((
+                    b,
+                    self.num_kv_heads,
+                    kv_len,
+                    self.head_dim,
+                ))?
+            };
+
+            // RoPE for self-attention only.
+            let (q, k) = match rotary {
+                Some(rope) => rope.apply(&q, &k, 0)?,
+                None => (q, k),
+            };
+
+            let k = repeat_kv(k, self.num_kv_groups)?.contiguous()?;
+            let v = repeat_kv(v, self.num_kv_groups)?.contiguous()?;
+            (q, k, v)
+        };
+
+        // Scaled dot-product attention.
+        let scale = 1.0 / (self.head_dim as f64).sqrt();
+        let mut scores = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
+        if let Some(m) = attn_mask {
+            scores = scores.broadcast_add(m)?;
+        }
+        let probs = candle_nn::ops::softmax_last_dim(&scores)?;
+        let ctx = probs.matmul(&v)?;
+
+        ctx.transpose(1, 2)?
+            .reshape((b, l, self.hidden_size))?
+            .apply(&self.o_proj)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DiT layer (transformer block with AdaLN-Zero)
+// ---------------------------------------------------------------------------
+
+/// A single DiT transformer layer with AdaLN-Zero modulation.
+///
+/// Each layer contains self-attention (with optional sliding window), an
+/// optional cross-attention sub-layer, and a SiLU-gated MLP. Timestep
+/// information is injected via learned shift/scale/gate modulation applied
+/// before self-attention and the MLP.
+#[derive(Debug, Clone)]
+pub struct AceStepDiTLayer {
+    self_attn: AceStepAttention,
+    self_attn_norm: RmsNorm,
+    cross_attn: AceStepAttention,
+    cross_attn_norm: RmsNorm,
+    mlp: MLP,
+    mlp_norm: RmsNorm,
+    scale_shift_table: Tensor,
+    pub attention_type: String,
+}
+
+impl AceStepDiTLayer {
+    /// Creates a new DiT layer.
+    ///
+    /// # Arguments
+    /// * `cfg` - Model configuration.
+    /// * `attention_type` - Either `"sliding_attention"` or `"full_attention"`.
+    ///   Only full-attention layers include cross-attention.
+    /// * `vb` - Variable builder scoped to `layers.{i}`.
+    pub fn new(cfg: &AceStepConfig, attention_type: &str, vb: VarBuilder) -> Result<Self> {
+        let self_attn = AceStepAttention::new(cfg, false, vb.pp("self_attn"))?;
+        let self_attn_norm =
+            RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("self_attn_norm"))?;
+
+        // All layers have cross-attention (use_cross_attention=True in Python)
+        let cross_attn = AceStepAttention::new(cfg, true, vb.pp("cross_attn"))?;
+        let cross_attn_norm =
+            RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("cross_attn_norm"))?;
+
+        let mlp = MLP::new(cfg, vb.pp("mlp"))?;
+        let mlp_norm = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("mlp_norm"))?;
+        let scale_shift_table = vb.get((1, 6, cfg.hidden_size), "scale_shift_table")?;
+
+        Ok(Self {
+            self_attn,
+            self_attn_norm,
+            cross_attn,
+            cross_attn_norm,
+            mlp,
+            mlp_norm,
+            scale_shift_table,
+            #[allow(unused)]
+            attention_type: attention_type.to_string(),
+        })
+    }
+
+    /// Forward pass through one transformer block.
+    ///
+    /// # Arguments
+    /// * `hidden_states` - Input tensor of shape `(B, L, hidden_size)`.
+    /// * `rotary` - Rotary embedding for self-attention.
+    /// * `timestep_proj` - AdaLN modulation of shape `(B, 6, hidden_size)`.
+    /// * `self_attn_mask` - Additive self-attention mask `(1, 1, L, L)`.
+    /// * `encoder_hidden_states` - Projected encoder outputs for cross-attention.
+    /// * `cross_attn_mask` - Additive cross-attention mask `(B, 1, L, S)`.
+    ///
+    /// Compute cross-attention KV cache for this layer.
+    pub fn compute_cross_kv_cache(
+        &self,
+        encoder_hidden_states: &Tensor,
+    ) -> Result<CrossAttentionKvCache> {
+        self.cross_attn.compute_kv_cache(encoder_hidden_states)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn forward(
+        &self,
+        hidden_states: &Tensor,
+        rotary: &RotaryEmbedding,
+        timestep_proj: &Tensor,
+        self_attn_mask: Option<&Tensor>,
+        encoder_hidden_states: Option<&Tensor>,
+        cross_attn_mask: Option<&Tensor>,
+        cross_kv_cache: Option<&CrossAttentionKvCache>,
+    ) -> Result<Tensor> {
+        // Compute AdaLN modulation parameters: 6 vectors from scale_shift_table + temb.
+        let modulation = self
+            .scale_shift_table
+            .broadcast_as(timestep_proj.shape())?
+            .broadcast_add(timestep_proj)?;
+        let chunks = modulation.chunk(6, 1)?;
+        let shift_msa = &chunks[0];
+        let scale_msa = &chunks[1];
+        let gate_msa = &chunks[2];
+        let c_shift_msa = &chunks[3];
+        let c_scale_msa = &chunks[4];
+        let c_gate_msa = &chunks[5];
+
+        // Self-attention with AdaLN (never cached — input changes each step).
+        let norm_x = self.self_attn_norm.forward(hidden_states)?;
+        let norm_x = norm_x
+            .broadcast_mul(&(scale_msa + 1.0)?)?
+            .broadcast_add(shift_msa)?;
+        let attn_out = self
+            .self_attn
+            .forward(&norm_x, None, self_attn_mask, Some(rotary), None)?;
+        let mut hidden_states = (hidden_states + attn_out.broadcast_mul(gate_msa)?)?;
+
+        // Cross-attention (standard residual, no AdaLN modulation).
+        // When kv_cache is provided, K/V are not recomputed from encoder states.
+        let cross_out = {
+            let norm_x = self.cross_attn_norm.forward(&hidden_states)?;
+            self.cross_attn.forward(
+                &norm_x,
+                encoder_hidden_states,
+                cross_attn_mask,
+                None,
+                cross_kv_cache,
+            )?
+        };
+        hidden_states = (&hidden_states + cross_out)?;
+
+        // MLP with AdaLN.
+        let norm_x = self.mlp_norm.forward(&hidden_states)?;
+        let norm_x = norm_x
+            .broadcast_mul(&(c_scale_msa + 1.0)?)?
+            .broadcast_add(c_shift_msa)?;
+        let mlp_out = norm_x.apply(&self.mlp)?;
+        let hidden_states = (hidden_states + mlp_out.broadcast_mul(c_gate_msa)?)?;
+
+        Ok(hidden_states)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mask construction helpers
+// ---------------------------------------------------------------------------
+
+/// Creates a bidirectional sliding-window attention mask.
+///
+/// Returns a tensor of shape `(1, 1, seq_len, seq_len)` with `0.0` for
+/// positions within the window and `f32::NEG_INFINITY` outside it. This
+/// produces non-causal (bidirectional) attention restricted to a local
+/// neighbourhood of `window` positions in each direction.
+pub fn bidirectional_sliding_window_mask(
+    seq_len: usize,
+    window: usize,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    let minf = f32::NEG_INFINITY;
+    let mask: Vec<f32> = (0..seq_len)
+        .flat_map(|i| {
+            (0..seq_len).map(move |j| {
+                if (i as i64 - j as i64).unsigned_abs() as usize <= window {
+                    0f32
+                } else {
+                    minf
+                }
+            })
+        })
+        .collect();
+    Tensor::from_slice(&mask, (1, 1, seq_len, seq_len), device)?.to_dtype(dtype)
+}
+
+/// Converts a 1-D attention mask `(B, S)` of 0/1 values into an additive mask
+/// of shape `(B, 1, 1, S)` suitable for cross-attention, where masked positions
+/// are filled with `f32::NEG_INFINITY`.
+fn expand_cross_attention_mask(mask: &Tensor, dtype: DType) -> Result<Tensor> {
+    // mask: (B, S) with 1 = attend, 0 = ignore
+    // Convert to additive mask: 0.0 for valid, -inf for padding.
+    // Use where_cond to avoid 0 * -inf = NaN.
+    let mask_f32 = mask.to_dtype(DType::F32)?;
+    let zeros = Tensor::zeros_like(&mask_f32)?;
+    let neginf = Tensor::full(f32::NEG_INFINITY, mask_f32.shape(), mask_f32.device())?;
+    let valid = mask_f32.gt(&zeros)?; // true for valid (mask > 0)
+    let additive = valid.where_cond(&zeros, &neginf)?;
+    additive.unsqueeze(1)?.unsqueeze(1)?.to_dtype(dtype) // (B, 1, 1, S)
+}
+
+// ---------------------------------------------------------------------------
+// Top-level DiT model
+// ---------------------------------------------------------------------------
+
+/// The complete Diffusion Transformer model for ACE-Step 1.5.
+///
+/// This model takes noisy audio latents, diffusion timesteps, and text encoder
+/// outputs, and predicts the denoised latent. The input is patchified via a
+/// strided Conv1d and the output is reconstructed via ConvTranspose1d.
+#[derive(Debug, Clone)]
+pub struct AceStepDiTModel {
+    proj_in_conv: Conv1d,
+    time_embed: TimestepEmbedding,
+    time_embed_r: TimestepEmbedding,
+    condition_embedder: Linear,
+    layers: Vec<AceStepDiTLayer>,
+    rotary_emb: RotaryEmbedding,
+    norm_out: RmsNorm,
+    proj_out_conv: ConvTranspose1d,
+    scale_shift_table: Tensor,
+    patch_size: usize,
+    use_sliding_window: bool,
+    sliding_window: usize,
+    /// Per-layer cross-attention KV cache (populated on first forward call).
+    cross_kv_caches: Vec<Option<CrossAttentionKvCache>>,
+}
+
+impl AceStepDiTModel {
+    /// Loads the DiT model from pretrained weights.
+    ///
+    /// The `vb` should be scoped to the `decoder` prefix in the safetensors
+    /// checkpoint (e.g., `vb.pp("decoder")`).
+    pub fn new(cfg: &AceStepConfig, vb: VarBuilder) -> Result<Self> {
+        let patch_size = cfg.patch_size;
+        let hidden_size = cfg.hidden_size;
+
+        // Patchify convolution: (B, C, T) -> (B, hidden, T/patch)
+        let proj_in_conv = candle_nn::conv1d(
+            cfg.in_channels,
+            hidden_size,
+            patch_size,
+            Conv1dConfig {
+                stride: patch_size,
+                ..Default::default()
+            },
+            vb.pp("proj_in").pp("1"),
+        )?;
+
+        let time_embed = TimestepEmbedding::new(hidden_size, vb.pp("time_embed"))?;
+        let time_embed_r = TimestepEmbedding::new(hidden_size, vb.pp("time_embed_r"))?;
+
+        let condition_embedder = linear_b(
+            cfg.encoder_hidden_size(),
+            hidden_size,
+            true,
+            vb.pp("condition_embedder"),
+        )?;
+
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        let vb_l = vb.pp("layers");
+        for i in 0..cfg.num_hidden_layers {
+            let attn_type = cfg
+                .layer_types
+                .get(i)
+                .map(|s| s.as_str())
+                .unwrap_or("full_attention");
+            layers.push(AceStepDiTLayer::new(cfg, attn_type, vb_l.pp(i))?);
+        }
+
+        let rotary_emb = RotaryEmbedding::new(vb.dtype(), cfg, vb.device())?;
+        let norm_out = RmsNorm::new(hidden_size, cfg.rms_norm_eps, vb.pp("norm_out"))?;
+
+        // De-patchify transposed convolution: (B, hidden, T/patch) -> (B, out_ch, T)
+        let proj_out_conv = candle_nn::conv_transpose1d(
+            hidden_size,
+            cfg.audio_acoustic_hidden_dim,
+            patch_size,
+            ConvTranspose1dConfig {
+                stride: patch_size,
+                ..Default::default()
+            },
+            vb.pp("proj_out").pp("1"),
+        )?;
+
+        let scale_shift_table = vb.get((1, 2, hidden_size), "scale_shift_table")?;
+
+        Ok(Self {
+            proj_in_conv,
+            time_embed,
+            time_embed_r,
+            condition_embedder,
+            layers,
+            rotary_emb,
+            norm_out,
+            proj_out_conv,
+            scale_shift_table,
+            patch_size,
+            use_sliding_window: cfg.use_sliding_window,
+            sliding_window: cfg.sliding_window,
+            cross_kv_caches: (0..cfg.num_hidden_layers).map(|_| None).collect(),
+        })
+    }
+
+    /// Denoises audio latents conditioned on timestep and text embeddings.
+    ///
+    /// # Arguments
+    /// * `hidden_states` - Noisy latents of shape `(B, T, audio_acoustic_hidden_dim)`.
+    /// * `timestep` - Diffusion timestep tensor of shape `(B,)`.
+    /// * `timestep_r` - Reference timestep tensor of shape `(B,)`.
+    /// * `_attention_mask` - Unused padding mask for the latent sequence.
+    /// * `encoder_hidden_states` - Text encoder output `(B, S, encoder_hidden_size)`.
+    /// * `encoder_attention_mask` - Boolean mask for encoder tokens `(B, S)`.
+    /// * `context_latents` - Context latent tensor `(B, T, timbre_hidden_dim)` concatenated
+    ///   along the channel dimension with `hidden_states`.
+    ///
+    /// # Returns
+    /// Predicted denoised latent of shape `(B, T, audio_acoustic_hidden_dim)`.
+    #[allow(clippy::too_many_arguments)]
+    /// Clear the cross-attention KV cache. Call this when encoder hidden states
+    /// change (e.g. new prompt, or between separate generations).
+    pub fn clear_kv_cache(&mut self) {
+        for c in &mut self.cross_kv_caches {
+            *c = None;
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn forward(
+        &mut self,
+        hidden_states: &Tensor,
+        timestep: &Tensor,
+        timestep_r: &Tensor,
+        _attention_mask: Option<&Tensor>,
+        encoder_hidden_states: &Tensor,
+        encoder_attention_mask: Option<&Tensor>,
+        context_latents: &Tensor,
+    ) -> Result<Tensor> {
+        let dtype = hidden_states.dtype();
+        let device = hidden_states.device();
+
+        // Timestep embeddings: combine main and reference timestep signals.
+        let (temb_t, proj_t) = self.time_embed.forward(timestep)?;
+        let delta = (timestep - timestep_r)?;
+        let (temb_r, proj_r) = self.time_embed_r.forward(&delta)?;
+        let temb = (&temb_t + &temb_r)?;
+        let timestep_proj = (&proj_t + &proj_r)?;
+        // Concatenate context latents with noisy latents along channel dim.
+        let hidden_states = Tensor::cat(&[context_latents, hidden_states], D::Minus1)?;
+
+        // Pad sequence length to a multiple of patch_size.
+        let (b, orig_len, c) = hidden_states.dims3()?;
+        let hidden_states = if orig_len % self.patch_size != 0 {
+            let pad_len = self.patch_size - (orig_len % self.patch_size);
+            let padding = Tensor::zeros((b, pad_len, c), dtype, device)?;
+            Tensor::cat(&[&hidden_states, &padding], 1)?
+        } else {
+            hidden_states
+        };
+
+        // Patchify: transpose to (B, C, T) for Conv1d, then back to (B, T/patch, hidden).
+        let hidden_states = hidden_states
+            .transpose(1, 2)?
+            .apply(&self.proj_in_conv)?
+            .transpose(1, 2)?;
+        // Project encoder hidden states to model dimension.
+        let encoder_hidden_states = encoder_hidden_states.apply(&self.condition_embedder)?;
+
+        let seq_len = hidden_states.dim(1)?;
+
+        // Build self-attention masks (bidirectional).
+        let sliding_mask = if self.use_sliding_window && seq_len > self.sliding_window {
+            Some(bidirectional_sliding_window_mask(
+                seq_len,
+                self.sliding_window,
+                device,
+                dtype,
+            )?)
+        } else {
+            None
+        };
+
+        // Build cross-attention mask from encoder attention mask.
+        let cross_attn_mask = match encoder_attention_mask {
+            Some(mask) => Some(expand_cross_attention_mask(mask, dtype)?),
+            None => None,
+        };
+
+        // Build cross-attention KV cache on first call (encoder states are constant).
+        for (i, layer) in self.layers.iter().enumerate() {
+            if self.cross_kv_caches[i].is_none() {
+                self.cross_kv_caches[i] =
+                    Some(layer.compute_cross_kv_cache(&encoder_hidden_states)?);
+            }
+        }
+
+        // Process through transformer layers.
+        let mut hidden_states = hidden_states;
+        for (i, layer) in self.layers.iter().enumerate() {
+            let self_mask = if layer.attention_type == "sliding_attention" {
+                sliding_mask.as_ref()
+            } else {
+                None
+            };
+            hidden_states = layer.forward(
+                &hidden_states,
+                &self.rotary_emb,
+                &timestep_proj,
+                self_mask,
+                Some(&encoder_hidden_states),
+                cross_attn_mask.as_ref(),
+                self.cross_kv_caches[i].as_ref(),
+            )?;
+        }
+
+        // Output AdaLN: modulate with temb before final projection.
+        // scale_shift_table: (1, 2, hidden), temb: (B, hidden) -> unsqueeze -> (B, 1, hidden)
+        // Broadcast both to (B, 2, hidden) via broadcast_add
+        let temb_unsqueezed = temb.unsqueeze(1)?; // (B, 1, hidden_size)
+        let out_modulation = self.scale_shift_table.broadcast_add(&temb_unsqueezed)?; // (B, 2, hidden)
+        let chunks = out_modulation.chunk(2, 1)?;
+        let shift = &chunks[0]; // (B, 1, hidden_size)
+        let scale = &chunks[1]; // (B, 1, hidden_size)
+        let hidden_states = self.norm_out.forward(&hidden_states)?;
+        let hidden_states = hidden_states
+            .broadcast_mul(&(scale + 1.0)?)?
+            .broadcast_add(shift)?;
+
+        // De-patchify: transpose to (B, hidden, T/patch), conv_transpose, transpose back.
+        let hidden_states = hidden_states
+            .transpose(1, 2)? // (B, hidden, T/patch)
+            .apply(&self.proj_out_conv)? // (B, out_ch, T_reconstructed)
+            .transpose(1, 2)?; // (B, T_reconstructed, out_ch)
+
+        // Crop to original sequence length.
+        hidden_states.narrow(1, 0, orig_len)
+    }
+}

--- a/candle-transformers/src/models/ace_step/dit.rs
+++ b/candle-transformers/src/models/ace_step/dit.rs
@@ -24,6 +24,27 @@ use candle_nn::{
 use super::AceStepConfig;
 
 // ---------------------------------------------------------------------------
+// Attention mask variant
+// ---------------------------------------------------------------------------
+
+/// How an attention layer should be masked.
+///
+/// `None` attends to every key (standard full bidirectional attention).
+/// `Additive` uses an explicit additive mask tensor broadcastable to
+/// `(B, H, Lq, Lk)` with `-inf` at positions to suppress — used by
+/// cross-attention for padding masks.
+/// `Sliding { window }` restricts each query to keys within `±window`
+/// positions and is computed in query chunks so the full `Lq×Lk` matrix is
+/// never materialized. Peak memory drops from O(L²) to O(L·W) on sliding
+/// self-attention layers.
+#[derive(Debug, Clone, Copy)]
+pub enum AttnMask<'a> {
+    None,
+    Additive(&'a Tensor),
+    Sliding { window: usize },
+}
+
+// ---------------------------------------------------------------------------
 // Rotary positional embedding
 // ---------------------------------------------------------------------------
 
@@ -295,8 +316,9 @@ impl AceStepAttention {
     /// * `x` - Hidden states of shape `(B, L, hidden_size)`.
     /// * `encoder_hidden_states` - For cross-attention: encoder output
     ///   `(B, S, encoder_hidden_size)`. Ignored for self-attention.
-    /// * `attn_mask` - Additive mask broadcastable to `(B, H, L, S)`, where
-    ///   masked positions contain `f32::NEG_INFINITY`.
+    /// * `attn_mask` - How to mask scores: `None` for full attention,
+    ///   `Additive` with a tensor of `-inf`/0 values (used for cross-attention
+    ///   padding), or `Sliding` which triggers chunked local attention.
     /// * `rotary` - Rotary embedding to apply to Q and K (self-attention only).
     ///
     /// Compute cross-attention K/V cache from encoder hidden states.
@@ -332,7 +354,7 @@ impl AceStepAttention {
         &self,
         x: &Tensor,
         encoder_hidden_states: Option<&Tensor>,
-        attn_mask: Option<&Tensor>,
+        attn_mask: AttnMask<'_>,
         rotary: Option<&RotaryEmbedding>,
         kv_cache: Option<&CrossAttentionKvCache>,
     ) -> Result<Tensor> {
@@ -393,19 +415,92 @@ impl AceStepAttention {
             (q, k, v)
         };
 
-        // Scaled dot-product attention.
         let scale = 1.0 / (self.head_dim as f64).sqrt();
-        let mut scores = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
-        if let Some(m) = attn_mask {
-            scores = scores.broadcast_add(m)?;
-        }
-        let probs = candle_nn::ops::softmax_last_dim(&scores)?;
-        let ctx = probs.matmul(&v)?;
+        let ctx = match attn_mask {
+            // Sliding-window self-attention: avoid materializing the full
+            // Lq×Lk matrix by computing attention in query chunks with local
+            // KV slices. Only applies when the sequence is longer than the
+            // window; otherwise full attention is equivalent and cheaper.
+            AttnMask::Sliding { window } if l > window => {
+                sliding_window_attention(&q, &k, &v, window, scale)?
+            }
+            AttnMask::Sliding { .. } | AttnMask::None => {
+                let scores = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
+                let probs = candle_nn::ops::softmax_last_dim(&scores)?;
+                probs.matmul(&v)?
+            }
+            AttnMask::Additive(m) => {
+                let scores = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
+                let scores = scores.broadcast_add(m)?;
+                let probs = candle_nn::ops::softmax_last_dim(&scores)?;
+                probs.matmul(&v)?
+            }
+        };
 
         ctx.transpose(1, 2)?
             .reshape((b, l, self.hidden_size))?
             .apply(&self.o_proj)
     }
+}
+
+/// Chunked sliding-window attention over pre-RoPE'd `(B, H, L, D)` tensors.
+///
+/// Splits Q along the sequence axis into chunks of size `window`. For each
+/// chunk covering positions `[p, p+cq)` only the keys/values in the range
+/// `[max(0, p-window), min(L, p+cq+window))` are considered, and a small
+/// chunk-local additive mask enforces the exact `|q_pos - k_pos| ≤ window`
+/// bidirectional rule. This yields the same result as a full-attention pass
+/// with `bidirectional_sliding_window_mask`, but never allocates the L×L
+/// scores matrix.
+fn sliding_window_attention(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    window: usize,
+    scale: f64,
+) -> Result<Tensor> {
+    let (_, _, l, _) = q.dims4()?;
+    let device = q.device().clone();
+    let dtype = q.dtype();
+    let chunk_size = window.max(1);
+    let minf = f32::NEG_INFINITY;
+
+    let mut chunks: Vec<Tensor> = Vec::with_capacity(l.div_ceil(chunk_size));
+    let mut p = 0;
+    while p < l {
+        let cq = chunk_size.min(l - p);
+        let kv_start = p.saturating_sub(window);
+        let kv_end = (p + cq + window).min(l);
+        let kv_len = kv_end - kv_start;
+
+        let q_chunk = q.narrow(2, p, cq)?;
+        let k_chunk = k.narrow(2, kv_start, kv_len)?;
+        let v_chunk = v.narrow(2, kv_start, kv_len)?;
+
+        let scores = (q_chunk.matmul(&k_chunk.transpose(2, 3)?)? * scale)?;
+
+        // Build a chunk-local (cq × kv_len) additive mask. The window rule is
+        // |q_abs - k_abs| <= window, where q_abs = p + i and k_abs = kv_start + j.
+        let mut mask_data = Vec::with_capacity(cq * kv_len);
+        for i in 0..cq {
+            let q_abs = p + i;
+            for j in 0..kv_len {
+                let k_abs = kv_start + j;
+                let within = q_abs.abs_diff(k_abs) <= window;
+                mask_data.push(if within { 0f32 } else { minf });
+            }
+        }
+        let mask = Tensor::from_vec(mask_data, (1, 1, cq, kv_len), &device)?.to_dtype(dtype)?;
+        let scores = scores.broadcast_add(&mask)?;
+
+        let probs = candle_nn::ops::softmax_last_dim(&scores)?;
+        let ctx_chunk = probs.matmul(&v_chunk)?;
+        chunks.push(ctx_chunk);
+
+        p += cq;
+    }
+
+    Tensor::cat(&chunks.iter().collect::<Vec<_>>(), 2)
 }
 
 // ---------------------------------------------------------------------------
@@ -471,9 +566,11 @@ impl AceStepDiTLayer {
     /// * `hidden_states` - Input tensor of shape `(B, L, hidden_size)`.
     /// * `rotary` - Rotary embedding for self-attention.
     /// * `timestep_proj` - AdaLN modulation of shape `(B, 6, hidden_size)`.
-    /// * `self_attn_mask` - Additive self-attention mask `(1, 1, L, L)`.
+    /// * `self_attn_mask` - Self-attention masking mode (see [`AttnMask`]):
+    ///   `Sliding { window }` for half the layers, `None` for the rest.
     /// * `encoder_hidden_states` - Projected encoder outputs for cross-attention.
-    /// * `cross_attn_mask` - Additive cross-attention mask `(B, 1, L, S)`.
+    /// * `cross_attn_mask` - Cross-attention masking mode, typically
+    ///   `Additive` with a padding mask or `None`.
     ///
     /// Compute cross-attention KV cache for this layer.
     pub fn compute_cross_kv_cache(
@@ -489,9 +586,9 @@ impl AceStepDiTLayer {
         hidden_states: &Tensor,
         rotary: &RotaryEmbedding,
         timestep_proj: &Tensor,
-        self_attn_mask: Option<&Tensor>,
+        self_attn_mask: AttnMask<'_>,
         encoder_hidden_states: Option<&Tensor>,
-        cross_attn_mask: Option<&Tensor>,
+        cross_attn_mask: AttnMask<'_>,
         cross_kv_cache: Option<&CrossAttentionKvCache>,
     ) -> Result<Tensor> {
         // Compute AdaLN modulation parameters: 6 vectors from scale_shift_table + temb.
@@ -758,22 +855,19 @@ impl AceStepDiTModel {
 
         let seq_len = hidden_states.dim(1)?;
 
-        // Build self-attention masks (bidirectional).
-        let sliding_mask = if self.use_sliding_window && seq_len > self.sliding_window {
-            Some(bidirectional_sliding_window_mask(
-                seq_len,
-                self.sliding_window,
-                device,
-                dtype,
-            )?)
-        } else {
-            None
-        };
+        // Self-attention kind: sliding-window layers use chunked local
+        // attention when the sequence actually exceeds the window (otherwise
+        // the window covers everything and full attention is equivalent).
+        let sliding_active = self.use_sliding_window && seq_len > self.sliding_window;
 
         // Build cross-attention mask from encoder attention mask.
-        let cross_attn_mask = match encoder_attention_mask {
+        let cross_mask_tensor = match encoder_attention_mask {
             Some(mask) => Some(expand_cross_attention_mask(mask, dtype)?),
             None => None,
+        };
+        let cross_attn_mask = match cross_mask_tensor.as_ref() {
+            Some(m) => AttnMask::Additive(m),
+            None => AttnMask::None,
         };
 
         // Build cross-attention KV cache on first call (encoder states are constant).
@@ -787,10 +881,12 @@ impl AceStepDiTModel {
         // Process through transformer layers.
         let mut hidden_states = hidden_states;
         for (i, layer) in self.layers.iter().enumerate() {
-            let self_mask = if layer.attention_type == "sliding_attention" {
-                sliding_mask.as_ref()
+            let self_mask = if sliding_active && layer.attention_type == "sliding_attention" {
+                AttnMask::Sliding {
+                    window: self.sliding_window,
+                }
             } else {
-                None
+                AttnMask::None
             };
             hidden_states = layer.forward(
                 &hidden_states,
@@ -798,7 +894,7 @@ impl AceStepDiTModel {
                 &timestep_proj,
                 self_mask,
                 Some(&encoder_hidden_states),
-                cross_attn_mask.as_ref(),
+                cross_attn_mask,
                 self.cross_kv_caches[i].as_ref(),
             )?;
         }
@@ -824,5 +920,105 @@ impl AceStepDiTModel {
 
         // Crop to original sequence length.
         hidden_states.narrow(1, 0, orig_len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reference implementation: full Q·Kᵀ with an explicit sliding-window
+    /// additive mask, softmax, then matmul with V. Used as ground truth for
+    /// [`sliding_window_attention`] equivalence tests.
+    fn dense_sliding_attention(
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        window: usize,
+        scale: f64,
+    ) -> Result<Tensor> {
+        let (_, _, l, _) = q.dims4()?;
+        let mask = bidirectional_sliding_window_mask(l, window, q.device(), q.dtype())?;
+        let scores = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
+        let scores = scores.broadcast_add(&mask)?;
+        let probs = candle_nn::ops::softmax_last_dim(&scores)?;
+        probs.matmul(v)
+    }
+
+    fn random_qkv(
+        b: usize,
+        h: usize,
+        l: usize,
+        d: usize,
+        device: &Device,
+    ) -> Result<(Tensor, Tensor, Tensor)> {
+        let q = Tensor::randn(0f32, 1.0, (b, h, l, d), device)?;
+        let k = Tensor::randn(0f32, 1.0, (b, h, l, d), device)?;
+        let v = Tensor::randn(0f32, 1.0, (b, h, l, d), device)?;
+        Ok((q, k, v))
+    }
+
+    fn max_abs_diff(a: &Tensor, b: &Tensor) -> Result<f32> {
+        (a - b)?.abs()?.flatten_all()?.max(0)?.to_scalar::<f32>()
+    }
+
+    #[test]
+    fn sliding_attention_matches_dense_mask() -> Result<()> {
+        let device = Device::Cpu;
+        let (b, h, l, d, window) = (2, 2, 200, 32, 16);
+        let (q, k, v) = random_qkv(b, h, l, d, &device)?;
+        let scale = 1.0 / (d as f64).sqrt();
+
+        let dense = dense_sliding_attention(&q, &k, &v, window, scale)?;
+        let chunked = sliding_window_attention(&q, &k, &v, window, scale)?;
+
+        assert_eq!(dense.dims(), chunked.dims());
+        let diff = max_abs_diff(&dense, &chunked)?;
+        assert!(diff < 1e-5, "sliding vs dense diff too large: {diff}");
+        Ok(())
+    }
+
+    #[test]
+    fn sliding_attention_shape_at_boundaries() -> Result<()> {
+        // The chunk iteration must terminate and produce full-length output
+        // for several sequence lengths near the window boundary.
+        let device = Device::Cpu;
+        let (b, h, d, window) = (1, 1, 8, 16);
+        for l in [window + 1, window * 2, window * 2 + 1, window * 3 + 5] {
+            let (q, k, v) = random_qkv(b, h, l, d, &device)?;
+            let out = sliding_window_attention(&q, &k, &v, window, 1.0 / (d as f64).sqrt())?;
+            assert_eq!(out.dims(), &[b, h, l, d], "wrong shape for L={l}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn attention_forward_full_path_matches_none_mask() -> Result<()> {
+        // Sliding with L <= window must short-circuit to the full-attention
+        // branch and produce identical output to AttnMask::None.
+        use candle_nn::{VarBuilder, VarMap};
+        let device = Device::Cpu;
+        let varmap = VarMap::new();
+        let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+        let cfg = AceStepConfig {
+            hidden_size: 32,
+            num_attention_heads: 2,
+            num_key_value_heads: 2,
+            head_dim: 16,
+            ..AceStepConfig::default()
+        };
+        let attn = AceStepAttention::new(&cfg, false, vb)?;
+
+        // L < sliding window → the Sliding branch takes the dense-attention
+        // fallback inside forward(), so both calls must agree.
+        let l = 8;
+        let x = Tensor::randn(0f32, 1.0, (1, l, cfg.hidden_size), &device)?;
+        let out_full = attn.forward(&x, None, AttnMask::None, None, None)?;
+        let out_slide =
+            attn.forward(&x, None, AttnMask::Sliding { window: 64 }, None, None)?;
+
+        let diff = max_abs_diff(&out_full, &out_slide)?;
+        assert!(diff < 1e-5, "full vs sliding (L<window) diff: {diff}");
+        Ok(())
     }
 }

--- a/candle-transformers/src/models/ace_step/dit.rs
+++ b/candle-transformers/src/models/ace_step/dit.rs
@@ -357,7 +357,9 @@ impl AceStepAttention {
         } else {
             // Self-attention or cross-attention without cache.
             let kv_input = if self.is_cross_attention {
-                encoder_hidden_states.expect("cross-attention requires encoder_hidden_states")
+                encoder_hidden_states.ok_or_else(|| {
+                    candle::Error::Msg("cross-attention requires encoder_hidden_states".into())
+                })?
             } else {
                 x
             };

--- a/candle-transformers/src/models/ace_step/lm.rs
+++ b/candle-transformers/src/models/ace_step/lm.rs
@@ -539,19 +539,15 @@ impl LmPipeline {
         let mut generated_cot_tokens: Vec<u32> = Vec::new();
 
         // Process prompt token-by-token to build KV cache incrementally
-        // (avoids large attention matrix issues on Metal)
-        let mut next_token = 0u32;
+        // (avoids large attention matrix issues on Metal).
+        // We don't sample here — just run forward passes to populate the cache.
+        // The first generated token is always forced to <think>.
         for (pos, &token) in prompt_tokens.iter().enumerate() {
             let input = Tensor::new(&[token], &self.device)?.unsqueeze(0)?;
-            let logits = self.model.forward(&input, pos)?;
-            let logits = Self::sanitize_logits(logits)?;
-            next_token = logits_processor.sample(&logits)?;
+            let _logits = self.model.forward(&input, pos)?;
         }
 
-        // Force <think> as first generated token
-        if next_token != self.token_ids.think_start {
-            next_token = self.token_ids.think_start;
-        }
+        let mut next_token = self.token_ids.think_start;
         all_tokens.push(next_token);
         generated_cot_tokens.push(next_token);
         field_forcer.activate();
@@ -715,22 +711,8 @@ impl LmPipeline {
 
     /// Squeeze model output to 1D, pull to CPU as F32, and sanitize NaN/Inf.
     ///
-    /// Metal can produce NaN/Inf for large-vocab matmuls. We pull to CPU,
-    /// replace bad values with -inf (zero probability after softmax), and
-    /// return a clean F32 tensor on CPU for sampling.
-    fn sanitize_logits(logits: Tensor) -> Result<Tensor> {
-        let logits = logits.squeeze(0)?.squeeze(0)?;
-        let n = logits.dim(0)?;
-        let mut data = logits.to_dtype(candle::DType::F32)?.to_vec1::<f32>()?;
-        for v in data.iter_mut() {
-            if !v.is_finite() {
-                *v = f32::NEG_INFINITY;
-            }
-        }
-        Tensor::from_vec(data, n, &candle::Device::Cpu)
-    }
-
-    /// Like `sanitize_logits` but also applies a constraint function to the
+    /// Squeeze model output to 1D, pull to CPU as F32, sanitize NaN/Inf,
+    /// and apply an optional constraint function to the
     /// logit values before creating the tensor. This ensures constraints
     /// operate on logits (before softmax), not probabilities.
     fn sanitize_and_constrain(

--- a/candle-transformers/src/models/ace_step/lm.rs
+++ b/candle-transformers/src/models/ace_step/lm.rs
@@ -1,0 +1,1035 @@
+//! Language Model pipeline for ACE-Step audio code generation.
+//!
+//! Implements two-phase autoregressive generation using a fine-tuned Qwen3 model:
+//! 1. **CoT phase**: generates chain-of-thought metadata (BPM, duration, etc.)
+//!    inside `<think>...</think>` tags
+//! 2. **Codes phase**: generates audio code tokens `<|audio_code_N|>` constrained
+//!    to valid codebook entries, with duration-based EOS control
+//!
+//! The generated audio codes are converted to latents via
+//! `ResidualFSQ::get_output_from_indices → AudioTokenDetokenizer` and fed to the
+//! DiT as `precomputed_lm_hints_25hz`.
+//!
+//! Reference: `acestep/llm_inference.py`, `acestep/constrained_logits_processor.py`
+
+use std::collections::BTreeMap;
+
+use crate::generation::{LogitsProcessor, Sampling};
+use crate::models::qwen3;
+use candle::{Device, Result, Tensor};
+
+/// Default system instruction for the LM.
+pub const DEFAULT_LM_INSTRUCTION: &str =
+    "Generate audio semantic tokens based on the given conditions:";
+
+/// Number of audio codes generated per second of audio (5 Hz).
+pub const CODES_PER_SECOND: f64 = 5.0;
+
+/// Maximum valid audio code value (codebook size = 64000).
+pub const MAX_AUDIO_CODE: u32 = 63999;
+
+/// Generation parameters for the LM pipeline.
+pub struct LmConfig {
+    pub temperature: f64,
+    pub top_p: Option<f64>,
+    pub top_k: Option<usize>,
+    /// Maximum tokens for CoT (metadata) generation.
+    pub max_cot_tokens: usize,
+    /// Maximum tokens for audio code generation.
+    pub max_code_tokens: usize,
+    pub repetition_penalty: f64,
+    pub seed: u64,
+}
+
+impl Default for LmConfig {
+    fn default() -> Self {
+        Self {
+            temperature: 0.85,
+            top_p: None,
+            top_k: None,
+            max_cot_tokens: 512,
+            max_code_tokens: 3072,
+            repetition_penalty: 1.0,
+            seed: 42,
+        }
+    }
+}
+
+/// Result of LM generation.
+pub struct LmOutput {
+    /// Parsed metadata from CoT (bpm, caption, duration, genres, keyscale, language, timesignature).
+    pub metadata: BTreeMap<String, String>,
+    /// Raw audio code values in `[0, 63999]`.
+    pub audio_codes: Vec<i64>,
+    /// Full generated text (CoT + codes) for debugging.
+    pub raw_text: String,
+}
+
+/// Token IDs discovered from the tokenizer at runtime.
+pub struct TokenIds {
+    pub eos: u32,
+    pub think_start: u32,
+    pub think_end: u32,
+    pub audio_code_start: u32,
+    pub audio_code_end: u32,
+}
+
+impl TokenIds {
+    /// Discover special token IDs by encoding known strings.
+    ///
+    /// `encode_fn` should encode a string without special tokens and return
+    /// the token IDs. It must produce exactly one token for each special string.
+    pub fn discover(encode_fn: impl Fn(&str) -> Result<Vec<u32>>) -> Result<Self> {
+        let get_single = |s: &str| -> Result<u32> {
+            let ids = encode_fn(s)?;
+            if ids.len() != 1 {
+                candle::bail!("expected single token for {s:?}, got {ids:?}");
+            }
+            Ok(ids[0])
+        };
+
+        let eos = get_single("<|im_end|>")?;
+        let think_start = get_single("<think>")?;
+        let think_end = get_single("</think>")?;
+        let audio_code_start = get_single("<|audio_code_0|>")?;
+        let audio_code_end = audio_code_start + MAX_AUDIO_CODE;
+
+        Ok(Self {
+            eos,
+            think_start,
+            think_end,
+            audio_code_start,
+            audio_code_end,
+        })
+    }
+}
+
+/// Maximum tokens for the caption value before forcing transition.
+/// Python's FSM allows up to 512 tokens.
+const MAX_CAPTION_TOKENS: usize = 512;
+
+/// Maximum tokens for free-text numeric fields.
+const MAX_NUMERIC_TOKENS: usize = 16;
+
+/// Field types with their constraint strategies.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FieldKind {
+    /// Digits only. Transition on argmax=`\n` or max tokens.
+    Numeric,
+    /// Free text. Block `\n`, transition on argmax=`\n` or max tokens.
+    Caption,
+    /// Pick the best match from a pre-tokenized set of valid values,
+    /// then force the entire value + `\n` (greedy selection).
+    Enumerated,
+}
+
+/// One metadata field: its forced prefix and value constraint.
+struct FieldSpec {
+    /// Field name prefix to force (e.g. `"bpm: "`). Tokenized at init.
+    prefix_tokens: Vec<u32>,
+    kind: FieldKind,
+    /// Pre-tokenized valid values (only for `Enumerated`).
+    /// Each entry: complete token sequence for `" value\n"` (space + value + newline).
+    valid_values: Vec<Vec<u32>>,
+}
+
+/// Valid language codes (matches Python `VALID_LANGUAGES`).
+const VALID_LANGUAGES: &[&str] = &[
+    "ar", "az", "bg", "bn", "ca", "cs", "da", "de", "el", "en", "es", "fa", "fi", "fr", "he", "hi",
+    "hr", "ht", "hu", "id", "is", "it", "ja", "ko", "la", "lt", "ms", "ne", "nl", "no", "pa", "pl",
+    "pt", "ro", "ru", "sa", "sk", "sr", "sv", "sw", "ta", "te", "th", "tl", "tr", "uk", "ur", "vi",
+    "yue", "zh",
+];
+
+/// Valid time signatures.
+const VALID_TIMESIGS: &[&str] = &["2", "3", "4", "6"];
+
+/// Valid keyscale values (7 notes x 5 accidentals x 2 modes = 70).
+fn valid_keyscales() -> Vec<String> {
+    let notes = ["A", "B", "C", "D", "E", "F", "G"];
+    let accidentals = ["", "#", "b"];
+    let modes = ["major", "minor"];
+    let mut values = Vec::with_capacity(notes.len() * accidentals.len() * modes.len());
+    for note in &notes {
+        for acc in &accidentals {
+            for mode in &modes {
+                values.push(format!("{note}{acc} {mode}"));
+            }
+        }
+    }
+    values
+}
+
+/// CoT field-order constraint for metadata generation.
+///
+/// Matches Python's `MetadataConstrainedLogitsProcessor` field order:
+/// `bpm → caption → duration → keyscale → language → timesignature`.
+///
+/// For each field:
+/// 1. **Force** the field-name prefix token-by-token
+/// 2. **Constrain** the value according to the field kind:
+///    - `Numeric` (bpm, duration): allow only digit tokens; transition on argmax=`\n`
+///    - `Caption`: allow all tokens except `\n`; transition on argmax=`\n` or 512 tokens
+///    - `Enumerated` (keyscale, language, timesig): pick the best-scoring valid value
+///      from logits and force it entirely (greedy selection, matching Python's approach)
+struct CotFieldForcer {
+    fields: Vec<FieldSpec>,
+    /// Index of the current field (0..fields.len()).
+    field_idx: usize,
+    /// Queue of tokens to force.
+    force_queue: Vec<u32>,
+    newline_token: u32,
+    /// Token IDs for ASCII digits 0-9.
+    digit_tokens: Vec<u32>,
+    active: bool,
+    done: bool,
+    value_token_count: usize,
+}
+
+impl CotFieldForcer {
+    fn new(encode_fn: &dyn Fn(&str) -> Result<Vec<u32>>) -> Result<Self> {
+        let newline_tokens = encode_fn("\n")?;
+        let newline_token = *newline_tokens.last().ok_or_else(|| {
+            candle::Error::Msg("newline encodes to empty token sequence".to_string())
+        })?;
+
+        // Discover digit token IDs + space (for leading space after ":")
+        let mut digit_tokens: Vec<u32> = (0..=9u32)
+            .filter_map(|d| {
+                let ids = encode_fn(&d.to_string()).ok()?;
+                ids.last().copied()
+            })
+            .collect();
+        if let Ok(sp) = encode_fn(" ") {
+            if let Some(&t) = sp.last() {
+                digit_tokens.push(t);
+            }
+        }
+
+        // Pre-tokenize valid values for enumerated fields.
+        // Tokenize as " value\n" to capture the space-after-colon + newline.
+        let tokenize_values = |values: &[&str]| -> Result<Vec<Vec<u32>>> {
+            let mut result = Vec::with_capacity(values.len());
+            for &v in values {
+                let tokens = encode_fn(&format!(" {v}\n"))?;
+                if !tokens.is_empty() {
+                    result.push(tokens);
+                }
+            }
+            Ok(result)
+        };
+        let keyscale_strings = valid_keyscales();
+        let keyscale_strs: Vec<&str> = keyscale_strings.iter().map(|s| s.as_str()).collect();
+
+        let fields = vec![
+            FieldSpec {
+                prefix_tokens: encode_fn("bpm:")?,
+                kind: FieldKind::Numeric,
+                valid_values: vec![],
+            },
+            FieldSpec {
+                prefix_tokens: encode_fn("caption:")?,
+                kind: FieldKind::Caption,
+                valid_values: vec![],
+            },
+            FieldSpec {
+                prefix_tokens: encode_fn("duration:")?,
+                kind: FieldKind::Numeric,
+                valid_values: vec![],
+            },
+            FieldSpec {
+                prefix_tokens: encode_fn("keyscale:")?,
+                kind: FieldKind::Enumerated,
+                valid_values: tokenize_values(&keyscale_strs)?,
+            },
+            FieldSpec {
+                prefix_tokens: encode_fn("language:")?,
+                kind: FieldKind::Enumerated,
+                valid_values: tokenize_values(VALID_LANGUAGES)?,
+            },
+            FieldSpec {
+                prefix_tokens: encode_fn("timesignature:")?,
+                kind: FieldKind::Enumerated,
+                valid_values: tokenize_values(VALID_TIMESIGS)?,
+            },
+        ];
+
+        Ok(Self {
+            fields,
+            field_idx: 0,
+            force_queue: Vec::new(),
+            newline_token,
+            digit_tokens,
+            active: false,
+            done: false,
+            value_token_count: 0,
+        })
+    }
+
+    /// Call after `<think>` has been emitted.
+    fn activate(&mut self) {
+        self.active = true;
+        self.seed_next_field_prefix();
+    }
+
+    /// Load `\n{field_name}:` tokens into the force queue.
+    fn seed_next_field_prefix(&mut self) {
+        if self.field_idx < self.fields.len() {
+            self.force_queue.clear();
+            self.force_queue.push(self.newline_token);
+            self.force_queue
+                .extend_from_slice(&self.fields[self.field_idx].prefix_tokens);
+            self.value_token_count = 0;
+        } else {
+            // All fields done — inject final newline, then let LM emit </think>.
+            self.force_queue.clear();
+            self.force_queue.push(self.newline_token);
+            self.done = true;
+        }
+    }
+
+    /// Returns the next forced token, or `None` for free generation.
+    fn next_forced_token(&mut self) -> Option<u32> {
+        if !self.active || self.force_queue.is_empty() {
+            return None;
+        }
+        Some(self.force_queue.remove(0))
+    }
+
+    /// Apply per-field value constraints to logits.
+    ///
+    /// For `Enumerated` fields, picks the best valid value from logits and
+    /// queues the entire value for forcing (returns `true` always).
+    ///
+    /// For `Numeric` and `Caption` fields, masks invalid tokens and returns
+    /// `true` when the LM wants to transition (argmax = `\n` or limit hit).
+    fn constrain_value_logits(&mut self, logits: &mut [f32]) -> bool {
+        if !self.active || self.done || !self.force_queue.is_empty() {
+            return false;
+        }
+
+        let field = &self.fields[self.field_idx];
+        match field.kind {
+            FieldKind::Enumerated => {
+                // Greedy selection: pick the valid value whose first token
+                // has the highest logit, then force the entire value + next
+                // field prefix in one go.
+                //
+                // Valid values are pre-tokenized as " value\n", so the newline
+                // is included. After the value we append the next field prefix.
+                let best = field
+                    .valid_values
+                    .iter()
+                    .filter(|v| !v.is_empty())
+                    .max_by(|a, b| {
+                        let sa = logits
+                            .get(a[0] as usize)
+                            .copied()
+                            .unwrap_or(f32::NEG_INFINITY);
+                        let sb = logits
+                            .get(b[0] as usize)
+                            .copied()
+                            .unwrap_or(f32::NEG_INFINITY);
+                        sa.partial_cmp(&sb).unwrap_or(std::cmp::Ordering::Equal)
+                    })
+                    .cloned();
+
+                self.field_idx += 1;
+
+                // Build force_queue: value tokens + next field prefix (or final \n)
+                self.force_queue.clear();
+                if let Some(value_tokens) = best {
+                    // value_tokens = " value\n" — already includes newline
+                    self.force_queue.extend_from_slice(&value_tokens);
+                }
+                // Append next field prefix (or final newline if all fields done)
+                if self.field_idx < self.fields.len() {
+                    // Don't push extra newline — value_tokens already ends with \n
+                    self.force_queue
+                        .extend_from_slice(&self.fields[self.field_idx].prefix_tokens);
+                    self.value_token_count = 0;
+                } else {
+                    // All fields done — the value's trailing \n is enough
+                    self.done = true;
+                }
+                true
+            }
+            FieldKind::Numeric => {
+                self.value_token_count += 1;
+                let argmax = Self::argmax(logits);
+                if argmax == self.newline_token || self.value_token_count >= MAX_NUMERIC_TOKENS {
+                    self.field_idx += 1;
+                    self.seed_next_field_prefix();
+                    true
+                } else {
+                    // Allow only digits + space (for leading space after colon)
+                    Self::whitelist(logits, &self.digit_tokens, self.newline_token);
+                    false
+                }
+            }
+            FieldKind::Caption => {
+                self.value_token_count += 1;
+                let argmax = Self::argmax(logits);
+                if argmax == self.newline_token || self.value_token_count >= MAX_CAPTION_TOKENS {
+                    self.field_idx += 1;
+                    self.seed_next_field_prefix();
+                    true
+                } else {
+                    // Block newline only
+                    if (self.newline_token as usize) < logits.len() {
+                        logits[self.newline_token as usize] = f32::NEG_INFINITY;
+                    }
+                    false
+                }
+            }
+        }
+    }
+
+    fn argmax(logits: &[f32]) -> u32 {
+        logits
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(i, _)| i as u32)
+            .unwrap_or(0)
+    }
+
+    /// Keep only `allowed` tokens + space in logits, set everything else to -inf.
+    fn whitelist(logits: &mut [f32], allowed: &[u32], _newline: u32) {
+        // Build a quick bitset for allowed tokens
+        let mut allowed_set = vec![false; logits.len()];
+        for &t in allowed {
+            if (t as usize) < logits.len() {
+                allowed_set[t as usize] = true;
+            }
+        }
+        // Also allow space (U+0020 = token for " ")
+        // Space is often merged with the next token, but allowing the standalone
+        // space token handles the leading space after ": ".
+        for i in 0..logits.len() {
+            if !allowed_set[i] {
+                logits[i] = f32::NEG_INFINITY;
+            }
+        }
+    }
+}
+
+/// Constrained decoding for audio code generation.
+///
+/// During the codes phase, only audio code tokens and EOS are allowed.
+/// Duration is enforced by blocking EOS until the target number of codes
+/// is reached, then forcing EOS.
+struct AudioCodeConstraint {
+    audio_code_start: u32,
+    audio_code_end: u32,
+    eos_token_id: u32,
+    target_codes: usize,
+    codes_count: usize,
+}
+
+impl AudioCodeConstraint {
+    fn new(token_ids: &TokenIds, target_codes: usize) -> Self {
+        Self {
+            audio_code_start: token_ids.audio_code_start,
+            audio_code_end: token_ids.audio_code_end,
+            eos_token_id: token_ids.eos,
+            target_codes,
+            codes_count: 0,
+        }
+    }
+
+    /// Apply constraints to logits. Called via `LogitsProcessor::sample_f`.
+    fn apply(&self, logits: &mut [f32]) {
+        // Only allow audio code tokens + EOS (after target is reached)
+        for (i, v) in logits.iter_mut().enumerate() {
+            let i = i as u32;
+            let is_audio_code = i >= self.audio_code_start && i <= self.audio_code_end;
+            let is_eos = i == self.eos_token_id;
+            if is_audio_code {
+                // Always allow audio codes
+            } else if is_eos && self.codes_count >= self.target_codes {
+                // Allow EOS only after target reached — model decides when to stop
+            } else {
+                *v = f32::NEG_INFINITY;
+            }
+        }
+    }
+
+    /// Record that an audio code token was generated.
+    fn record_token(&mut self, token_id: u32) {
+        if token_id >= self.audio_code_start && token_id <= self.audio_code_end {
+            self.codes_count += 1;
+        }
+    }
+}
+
+/// LM pipeline wrapping a Qwen3 causal LM for audio code generation.
+pub struct LmPipeline {
+    model: qwen3::ModelForCausalLM,
+    token_ids: TokenIds,
+    device: Device,
+}
+
+impl LmPipeline {
+    /// Create from a pre-loaded model and discovered token IDs.
+    pub fn new(model: qwen3::ModelForCausalLM, token_ids: TokenIds, device: Device) -> Self {
+        Self {
+            model,
+            token_ids,
+            device,
+        }
+    }
+
+    /// Format the chat prompt for the LM.
+    ///
+    /// Returns the formatted string. The caller must tokenize it.
+    ///
+    /// Format: `<|im_start|>system\n{system}<|im_end|>\n<|im_start|>user\n{user}<|im_end|>\n<|im_start|>assistant\n`
+    pub fn format_prompt(caption: &str, lyrics: &str) -> String {
+        let system = format!("# Instruction\n{DEFAULT_LM_INSTRUCTION}\n\n");
+        let lyrics_section = if lyrics.is_empty() {
+            "[Instrumental]".to_string()
+        } else {
+            lyrics.to_string()
+        };
+        let user = format!("# Caption\n{caption}\n\n# Lyric\n{lyrics_section}\n");
+        format!(
+            "<|im_start|>system\n{system}<|im_end|>\n<|im_start|>user\n{user}<|im_end|>\n<|im_start|>assistant\n"
+        )
+    }
+
+    /// Format the codes-phase prompt: original prompt + CoT output + newline.
+    pub fn format_codes_prompt(caption: &str, lyrics: &str, cot_text: &str) -> String {
+        let system = format!("# Instruction\n{DEFAULT_LM_INSTRUCTION}\n\n");
+        let lyrics_section = if lyrics.is_empty() {
+            "[Instrumental]".to_string()
+        } else {
+            lyrics.to_string()
+        };
+        let user = format!("# Caption\n{caption}\n\n# Lyric\n{lyrics_section}\n");
+        format!(
+            "<|im_start|>system\n{system}<|im_end|>\n<|im_start|>user\n{user}<|im_end|>\n<|im_start|>assistant\n{cot_text}\n"
+        )
+    }
+
+    /// Run two-phase generation: CoT (metadata) + audio codes.
+    ///
+    /// `prompt_tokens`: tokenized CoT prompt (from `format_prompt`)
+    /// `decode_fn`: converts a single token ID to its string representation
+    /// `encode_fn`: tokenizes a string without special tokens
+    pub fn generate(
+        &mut self,
+        prompt_tokens: &[u32],
+        target_duration_secs: f64,
+        config: &LmConfig,
+        decode_fn: &dyn Fn(u32) -> Result<String>,
+        encode_fn: &dyn Fn(&str) -> Result<Vec<u32>>,
+    ) -> Result<LmOutput> {
+        let target_codes = (target_duration_secs * CODES_PER_SECOND).ceil() as usize;
+        // Allow LM to generate up to 2x target (it decides when to stop),
+        // but cap at max_code_tokens to avoid runaway generation
+        let max_codes = config.max_code_tokens.min(target_codes * 2 + 50);
+
+        // ---- Phase 1: CoT generation with field-order constraints ----
+        self.model.clear_kv_cache();
+        let mut logits_processor = self.make_logits_processor(config);
+        let mut field_forcer = CotFieldForcer::new(encode_fn)?;
+
+        let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
+        let mut generated_cot_tokens: Vec<u32> = Vec::new();
+
+        // Process prompt token-by-token to build KV cache incrementally
+        // (avoids large attention matrix issues on Metal)
+        let mut next_token = 0u32;
+        for (pos, &token) in prompt_tokens.iter().enumerate() {
+            let input = Tensor::new(&[token], &self.device)?.unsqueeze(0)?;
+            let logits = self.model.forward(&input, pos)?;
+            let logits = Self::sanitize_logits(logits)?;
+            next_token = logits_processor.sample(&logits)?;
+        }
+
+        // Force <think> as first generated token
+        if next_token != self.token_ids.think_start {
+            next_token = self.token_ids.think_start;
+        }
+        all_tokens.push(next_token);
+        generated_cot_tokens.push(next_token);
+        field_forcer.activate();
+
+        // Generate until </think> or max tokens.
+        //
+        // The field forcer alternates between two modes:
+        // 1. **Forced**: inject pre-tokenized field prefixes (e.g. "\nbpm:")
+        //    and enumerated values (keyscale, language, timesig)
+        // 2. **Free**: LM generates the field value with per-field constraints:
+        //    - Numeric (bpm, duration): only digit tokens allowed
+        //    - Caption: all tokens except `\n`
+        //    - Enumerated: greedy pick from pre-tokenized valid values
+        //    Transition when argmax=`\n` or token limit reached.
+        for _ in 1..config.max_cot_tokens {
+            // Always feed the previous token to advance KV cache
+            let input = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
+            let logits = self.model.forward(&input, all_tokens.len() - 1)?;
+
+            if let Some(forced) = field_forcer.next_forced_token() {
+                // Forced mode: discard logits, use the predetermined token
+                next_token = forced;
+            } else {
+                // Free mode: apply sanitize + field constraint, then sample
+                let logits = Self::sanitize_and_constrain(logits, |l| {
+                    field_forcer.constrain_value_logits(l);
+                })?;
+
+                // If constrain_value_logits triggered a transition, a forced
+                // token is now available — use it instead of sampling.
+                if let Some(forced) = field_forcer.next_forced_token() {
+                    next_token = forced;
+                } else {
+                    next_token = logits_processor.sample(&logits)?;
+                }
+            }
+
+            all_tokens.push(next_token);
+            generated_cot_tokens.push(next_token);
+
+            if next_token == self.token_ids.think_end {
+                break;
+            }
+        }
+
+        // Decode CoT text and parse metadata
+        let cot_text = self.decode_tokens(&generated_cot_tokens, decode_fn)?;
+        let metadata = Self::parse_metadata(&cot_text);
+
+        // ---- Phase 2: Audio codes generation ----
+        // Re-feed all tokens (prompt + CoT + newline) to build fresh KV cache
+        self.model.clear_kv_cache();
+
+        let newline_tokens = encode_fn("\n")?;
+        let mut full_tokens = all_tokens.clone();
+        full_tokens.extend_from_slice(&newline_tokens);
+        let prompt_len = full_tokens.len();
+
+        let mut constraint = AudioCodeConstraint::new(&self.token_ids, target_codes);
+        let mut logits_processor = self.make_logits_processor(config);
+
+        // Process all-but-last to build KV cache, then last token to get logits
+        for (pos, &token) in full_tokens[..prompt_len - 1].iter().enumerate() {
+            let input = Tensor::new(&[token], &self.device)?.unsqueeze(0)?;
+            let _ = self.model.forward(&input, pos)?;
+        }
+        let last_input = Tensor::new(&[full_tokens[prompt_len - 1]], &self.device)?.unsqueeze(0)?;
+        let logits = self.model.forward(&last_input, prompt_len - 1)?;
+        let logits = Self::sanitize_and_constrain(logits, |l| constraint.apply(l))?;
+
+        let mut next_token = logits_processor.sample(&logits)?;
+        constraint.record_token(next_token);
+
+        let mut code_tokens: Vec<u32> = vec![next_token];
+        let mut pos = prompt_len;
+
+        for _ in 1..max_codes {
+            if next_token == self.token_ids.eos {
+                break;
+            }
+
+            let input = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
+            let logits = self.model.forward(&input, pos)?;
+            let logits = Self::sanitize_and_constrain(logits, |l| constraint.apply(l))?;
+
+            next_token = logits_processor.sample(&logits)?;
+            constraint.record_token(next_token);
+            code_tokens.push(next_token);
+            pos += 1;
+        }
+
+        // Extract audio code values from token IDs
+        let audio_codes: Vec<i64> = code_tokens
+            .iter()
+            .filter(|&&t| {
+                t >= self.token_ids.audio_code_start && t <= self.token_ids.audio_code_end
+            })
+            .map(|&t| (t - self.token_ids.audio_code_start) as i64)
+            .collect();
+
+        let codes_text = self.decode_tokens(&code_tokens, decode_fn)?;
+
+        Ok(LmOutput {
+            metadata,
+            audio_codes,
+            raw_text: format!("{cot_text}\n{codes_text}"),
+        })
+    }
+
+    /// Parse metadata from CoT text between `<think>` and `</think>`.
+    pub fn parse_metadata(text: &str) -> BTreeMap<String, String> {
+        let mut metadata = BTreeMap::new();
+
+        // Extract content between <think> and </think>
+        let inner = if let Some(start) = text.find("<think>") {
+            let after_tag = &text[start + 7..];
+            if let Some(end) = after_tag.find("</think>") {
+                &after_tag[..end]
+            } else {
+                after_tag
+            }
+        } else {
+            text
+        };
+
+        let mut current_key: Option<String> = None;
+        let mut current_value_lines: Vec<String> = Vec::new();
+
+        let save_field =
+            |key: &Option<String>, lines: &[String], map: &mut BTreeMap<String, String>| {
+                if let Some(k) = key {
+                    let value = lines.join("\n").trim().to_string();
+                    if !value.is_empty() {
+                        map.insert(k.clone(), value);
+                    }
+                }
+            };
+
+        for line in inner.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('<') {
+                continue;
+            }
+
+            // New field: non-indented line with ':'
+            if !line.starts_with(' ') && !line.starts_with('\t') && line.contains(':') {
+                save_field(&current_key, &current_value_lines, &mut metadata);
+                if let Some((k, v)) = line.split_once(':') {
+                    current_key = Some(k.trim().to_lowercase());
+                    current_value_lines = vec![v.to_string()];
+                }
+            } else if current_key.is_some() {
+                // Continuation line
+                current_value_lines.push(line.to_string());
+            }
+        }
+        save_field(&current_key, &current_value_lines, &mut metadata);
+
+        metadata
+    }
+
+    /// Squeeze model output to 1D, pull to CPU as F32, and sanitize NaN/Inf.
+    ///
+    /// Metal can produce NaN/Inf for large-vocab matmuls. We pull to CPU,
+    /// replace bad values with -inf (zero probability after softmax), and
+    /// return a clean F32 tensor on CPU for sampling.
+    fn sanitize_logits(logits: Tensor) -> Result<Tensor> {
+        let logits = logits.squeeze(0)?.squeeze(0)?;
+        let n = logits.dim(0)?;
+        let mut data = logits.to_dtype(candle::DType::F32)?.to_vec1::<f32>()?;
+        for v in data.iter_mut() {
+            if !v.is_finite() {
+                *v = f32::NEG_INFINITY;
+            }
+        }
+        Tensor::from_vec(data, n, &candle::Device::Cpu)
+    }
+
+    /// Like `sanitize_logits` but also applies a constraint function to the
+    /// logit values before creating the tensor. This ensures constraints
+    /// operate on logits (before softmax), not probabilities.
+    fn sanitize_and_constrain(
+        logits: Tensor,
+        constrain: impl FnOnce(&mut [f32]),
+    ) -> Result<Tensor> {
+        let logits = logits.squeeze(0)?.squeeze(0)?;
+        let n = logits.dim(0)?;
+        let mut data = logits.to_dtype(candle::DType::F32)?.to_vec1::<f32>()?;
+        for v in data.iter_mut() {
+            if !v.is_finite() {
+                *v = f32::NEG_INFINITY;
+            }
+        }
+        constrain(&mut data);
+        Tensor::from_vec(data, n, &candle::Device::Cpu)
+    }
+
+    fn make_logits_processor(&self, config: &LmConfig) -> LogitsProcessor {
+        let sampling = if config.temperature <= 0.0 {
+            Sampling::ArgMax
+        } else {
+            match (config.top_k, config.top_p) {
+                (Some(k), Some(p)) => Sampling::TopKThenTopP {
+                    k,
+                    p,
+                    temperature: config.temperature,
+                },
+                (Some(k), None) => Sampling::TopK {
+                    k,
+                    temperature: config.temperature,
+                },
+                (None, Some(p)) => Sampling::TopP {
+                    p,
+                    temperature: config.temperature,
+                },
+                (None, None) => Sampling::All {
+                    temperature: config.temperature,
+                },
+            }
+        };
+        LogitsProcessor::from_sampling(config.seed, sampling)
+    }
+
+    fn decode_tokens(
+        &self,
+        tokens: &[u32],
+        decode_fn: &dyn Fn(u32) -> Result<String>,
+    ) -> Result<String> {
+        let mut text = String::new();
+        for &t in tokens {
+            text.push_str(&decode_fn(t)?);
+        }
+        Ok(text)
+    }
+}
+
+/// Parse audio code values from a text string containing `<|audio_code_N|>` tokens.
+///
+/// Returns code values in `[0, 63999]`, clamped to valid range.
+pub fn parse_audio_codes_from_text(text: &str) -> Vec<i64> {
+    let mut codes = Vec::new();
+    let mut remaining = text;
+    while let Some(start) = remaining.find("<|audio_code_") {
+        let after_prefix = &remaining[start + 13..]; // skip "<|audio_code_"
+        if let Some(end) = after_prefix.find("|>") {
+            let num_str = &after_prefix[..end];
+            if let Ok(val) = num_str.parse::<i64>() {
+                codes.push(val.clamp(0, MAX_AUDIO_CODE as i64));
+            }
+            remaining = &after_prefix[end + 2..];
+        } else {
+            break;
+        }
+    }
+    codes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_metadata() {
+        let text = "<think>\nbpm: 120\ncaption: A calm piano melody\nduration: 30\ngenres: Classical\nkeyscale: C major\nlanguage: en\ntimesignature: 4\n</think>";
+        let meta = LmPipeline::parse_metadata(text);
+        assert_eq!(meta.get("bpm").unwrap().trim(), "120");
+        assert_eq!(meta.get("caption").unwrap().trim(), "A calm piano melody");
+        assert_eq!(meta.get("duration").unwrap().trim(), "30");
+        assert_eq!(meta.get("keyscale").unwrap().trim(), "C major");
+        assert_eq!(meta.get("language").unwrap().trim(), "en");
+        assert_eq!(meta.get("timesignature").unwrap().trim(), "4");
+    }
+
+    #[test]
+    fn test_parse_metadata_multiline_caption() {
+        let text = "<think>\nbpm: 90\ncaption: A long description\n  that spans multiple lines\nduration: 60\n</think>";
+        let meta = LmPipeline::parse_metadata(text);
+        assert!(meta.get("caption").unwrap().contains("multiple lines"));
+        assert_eq!(meta.get("bpm").unwrap().trim(), "90");
+        assert_eq!(meta.get("duration").unwrap().trim(), "60");
+    }
+
+    #[test]
+    fn test_parse_audio_codes_from_text() {
+        let text = "<|audio_code_100|><|audio_code_200|><|audio_code_63999|>";
+        let codes = parse_audio_codes_from_text(text);
+        assert_eq!(codes, vec![100, 200, 63999]);
+    }
+
+    #[test]
+    fn test_parse_audio_codes_clamp() {
+        let text = "<|audio_code_99999|><|audio_code_0|>";
+        let codes = parse_audio_codes_from_text(text);
+        assert_eq!(codes, vec![63999, 0]);
+    }
+
+    #[test]
+    fn test_parse_audio_codes_empty() {
+        assert!(parse_audio_codes_from_text("no codes here").is_empty());
+        assert!(parse_audio_codes_from_text("").is_empty());
+    }
+
+    #[test]
+    fn test_format_prompt() {
+        let prompt = LmPipeline::format_prompt("calm piano", "hello world");
+        assert!(prompt.contains("<|im_start|>system"));
+        assert!(prompt.contains("Generate audio semantic tokens"));
+        assert!(prompt.contains("calm piano"));
+        assert!(prompt.contains("hello world"));
+        assert!(prompt.ends_with("<|im_start|>assistant\n"));
+    }
+
+    #[test]
+    fn test_format_prompt_no_lyrics() {
+        let prompt = LmPipeline::format_prompt("calm piano", "");
+        assert!(prompt.contains("[Instrumental]"));
+    }
+
+    #[test]
+    fn test_audio_code_constraint() {
+        let token_ids = TokenIds {
+            eos: 10,
+            think_start: 20,
+            think_end: 21,
+            audio_code_start: 100,
+            audio_code_end: 199,
+        };
+        let mut constraint = AudioCodeConstraint::new(&token_ids, 3);
+
+        // Before target: only audio codes allowed
+        let mut logits = vec![1.0f32; 200];
+        constraint.apply(&mut logits);
+        assert_eq!(logits[0], f32::NEG_INFINITY); // non-audio blocked
+        assert_eq!(logits[10], f32::NEG_INFINITY); // EOS blocked
+        assert_eq!(logits[100], 1.0); // audio code allowed
+        assert_eq!(logits[150], 1.0); // audio code allowed
+
+        // Generate 3 codes
+        constraint.record_token(100);
+        constraint.record_token(101);
+        constraint.record_token(102);
+
+        // At target: EOS now allowed alongside audio codes (model decides)
+        let mut logits = vec![1.0f32; 200];
+        constraint.apply(&mut logits);
+        assert_eq!(logits[10], 1.0); // EOS allowed
+        assert_eq!(logits[100], 1.0); // audio codes still allowed
+        assert_eq!(logits[0], f32::NEG_INFINITY); // non-audio still blocked
+    }
+
+    #[test]
+    fn test_cot_field_forcer_numeric_field() -> Result<()> {
+        let encode_fn = |s: &str| -> Result<Vec<u32>> { Ok(s.bytes().map(|b| b as u32).collect()) };
+        let mut forcer = CotFieldForcer::new(&encode_fn)?;
+        let newline = b'\n' as u32;
+
+        assert!(forcer.next_forced_token().is_none());
+        forcer.activate();
+
+        // Drain forced "\nbpm:"
+        let mut forced = Vec::new();
+        while let Some(t) = forcer.next_forced_token() {
+            forced.push(t);
+        }
+        let forced_str: String = forced.iter().map(|&t| t as u8 as char).collect();
+        assert_eq!(forced_str, "\nbpm:");
+
+        // bpm is Numeric: digits should be allowed, non-digits blocked
+        let mut logits = vec![1.0f32; 256];
+        logits[b'1' as usize] = 10.0; // argmax = '1'
+        let transitioned = forcer.constrain_value_logits(&mut logits);
+        assert!(!transitioned);
+        // 'A' should be blocked (not a digit or space)
+        assert_eq!(logits[b'A' as usize], f32::NEG_INFINITY);
+        // '1' should still be allowed
+        assert!(logits[b'1' as usize] > f32::NEG_INFINITY);
+
+        // argmax = newline → transition
+        let mut logits = vec![0.0f32; 256];
+        logits[newline as usize] = 10.0;
+        assert!(forcer.constrain_value_logits(&mut logits));
+
+        // Next should be "\ncaption:" prefix
+        let mut forced = Vec::new();
+        while let Some(t) = forcer.next_forced_token() {
+            forced.push(t);
+        }
+        let forced_str: String = forced.iter().map(|&t| t as u8 as char).collect();
+        assert_eq!(forced_str, "\ncaption:");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cot_field_forcer_enumerated_field() -> Result<()> {
+        let encode_fn = |s: &str| -> Result<Vec<u32>> { Ok(s.bytes().map(|b| b as u32).collect()) };
+        let mut forcer = CotFieldForcer::new(&encode_fn)?;
+        let newline = b'\n' as u32;
+        forcer.activate();
+
+        // Skip bpm, caption, duration (Numeric/Caption fields)
+        for _ in 0..3 {
+            while forcer.next_forced_token().is_some() {} // drain prefix
+            let mut logits = vec![0.0f32; 256];
+            logits[newline as usize] = 10.0;
+            forcer.constrain_value_logits(&mut logits); // transition
+        }
+
+        // Now at keyscale (Enumerated). Drain prefix "\nkeyscale:"
+        let mut forced = Vec::new();
+        while let Some(t) = forcer.next_forced_token() {
+            forced.push(t);
+        }
+        let forced_str: String = forced.iter().map(|&t| t as u8 as char).collect();
+        assert_eq!(forced_str, "\nkeyscale:");
+
+        // Enumerated: constrain_value_logits picks the best valid value.
+        // Set logit for space+C tokens high (to bias toward "C major" or similar)
+        let mut logits = vec![0.0f32; 256];
+        logits[b' ' as usize] = 10.0; // " C major\n" starts with space
+        let transitioned = forcer.constrain_value_logits(&mut logits);
+        assert!(transitioned);
+
+        // force_queue should now contain " <value>\n" + next field prefix
+        let mut forced = Vec::new();
+        while let Some(t) = forcer.next_forced_token() {
+            forced.push(t);
+        }
+        let forced_str: String = forced.iter().map(|&t| t as u8 as char).collect();
+        // Should contain a valid keyscale value + newline + "language:" prefix
+        assert!(
+            forced_str.contains("major") || forced_str.contains("minor"),
+            "expected keyscale value, got: {forced_str:?}"
+        );
+        assert!(
+            forced_str.contains("language:"),
+            "expected next field prefix, got: {forced_str:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cot_field_forcer_completes_all_fields() -> Result<()> {
+        let encode_fn = |s: &str| -> Result<Vec<u32>> { Ok(s.bytes().map(|b| b as u32).collect()) };
+        let mut forcer = CotFieldForcer::new(&encode_fn)?;
+        let newline = b'\n' as u32;
+        forcer.activate();
+
+        // Run through all fields until done
+        let mut total_forced = Vec::new();
+        for _ in 0..2000 {
+            if forcer.done {
+                break;
+            }
+            if let Some(t) = forcer.next_forced_token() {
+                total_forced.push(t);
+            } else {
+                // Free generation — simulate argmax = newline to transition
+                let mut logits = vec![0.0f32; 256];
+                logits[newline as usize] = 10.0;
+                forcer.constrain_value_logits(&mut logits);
+            }
+        }
+
+        assert!(forcer.done, "forcer should be done after all fields");
+        let text: String = total_forced.iter().map(|&t| t as u8 as char).collect();
+        // All field names should appear in order
+        assert!(text.contains("bpm:"), "missing bpm in: {text:?}");
+        assert!(text.contains("caption:"), "missing caption in: {text:?}");
+        assert!(text.contains("duration:"), "missing duration in: {text:?}");
+        assert!(text.contains("keyscale:"), "missing keyscale in: {text:?}");
+        assert!(text.contains("language:"), "missing language in: {text:?}");
+        assert!(
+            text.contains("timesignature:"),
+            "missing timesignature in: {text:?}"
+        );
+
+        Ok(())
+    }
+}

--- a/candle-transformers/src/models/ace_step/mod.rs
+++ b/candle-transformers/src/models/ace_step/mod.rs
@@ -1,0 +1,349 @@
+//! ACE-Step 1.5 music generation model.
+//!
+//! ACE-Step is a music generation foundation model based on a diffusion transformer (DiT)
+//! architecture with text conditioning for lyrics and style prompts. Supports two
+//! inference modes:
+//!
+//! - **DiT-only**: text encoder → DiT denoising → VAE decode (base/sft models)
+//! - **LM+DiT**: Qwen3 LM generates metadata + audio codes → DiT conditioned on
+//!   codes → VAE decode (turbo models, higher quality)
+//!
+//! ## Modules
+//!
+//! - [`pipeline`] — `AceStepPipeline` high-level API (text2music, cover)
+//! - [`model`] — `AceStepConditionGenerationModel` (condition encoder + DiT + tokenizer)
+//! - [`lm`] — `LmPipeline` for Qwen3-based audio code generation
+//! - [`dit`] — `AceStepDiTModel` diffusion transformer
+//! - [`condition`] — `ConditionEncoder` (text/lyric/timbre encoding)
+//! - [`tokenizer`] — `AudioTokenizer` / `AudioTokenDetokenizer` / `ResidualFSQ`
+//! - [`sampling`] — timestep schedules, Euler ODE/SDE, APG guidance
+//! - [`vae`] — `AutoencoderOobleck` / `OobleckDecoder` for audio ↔ latent
+//!
+//! - [HuggingFace Models](https://huggingface.co/ACE-Step)
+//! - [GitHub Repository](https://github.com/ACE-Step/ACE-Step-1.5)
+
+pub mod condition;
+pub mod dit;
+pub mod lm;
+pub mod model;
+pub mod sampling;
+pub mod tokenizer;
+pub mod vae;
+
+use candle_nn::Activation;
+
+// -- AceStepConfig default value functions -----------------------------------
+
+fn default_hidden_size() -> usize {
+    2048
+}
+fn default_intermediate_size() -> usize {
+    6144
+}
+fn default_num_hidden_layers() -> usize {
+    24
+}
+fn default_num_attention_heads() -> usize {
+    16
+}
+fn default_num_key_value_heads() -> usize {
+    8
+}
+fn default_head_dim() -> usize {
+    128
+}
+fn default_hidden_act() -> Activation {
+    Activation::Silu
+}
+fn default_rms_norm_eps() -> f64 {
+    1e-6
+}
+fn default_rope_theta() -> f64 {
+    1_000_000.0
+}
+fn default_use_sliding_window() -> bool {
+    true
+}
+fn default_sliding_window() -> usize {
+    128
+}
+fn default_in_channels() -> usize {
+    192
+}
+fn default_patch_size() -> usize {
+    2
+}
+fn default_text_hidden_dim() -> usize {
+    1024
+}
+fn default_audio_acoustic_hidden_dim() -> usize {
+    64
+}
+fn default_timbre_hidden_dim() -> usize {
+    64
+}
+fn default_pool_window_size() -> usize {
+    5
+}
+fn default_vocab_size() -> usize {
+    64003
+}
+fn default_max_position_embeddings() -> usize {
+    32768
+}
+fn default_fsq_dim() -> usize {
+    2048
+}
+fn default_fsq_input_levels() -> Vec<usize> {
+    vec![8, 8, 8, 5, 5, 5]
+}
+fn default_fsq_input_num_quantizers() -> usize {
+    1
+}
+fn default_attention_bias() -> bool {
+    false
+}
+fn default_attention_dropout() -> f64 {
+    0.0
+}
+fn default_num_lyric_encoder_hidden_layers() -> usize {
+    8
+}
+fn default_num_timbre_encoder_hidden_layers() -> usize {
+    4
+}
+fn default_num_attention_pooler_hidden_layers() -> usize {
+    2
+}
+fn default_num_audio_decoder_hidden_layers() -> usize {
+    24
+}
+fn default_layer_types() -> Vec<String> {
+    (0..24)
+        .map(|i| {
+            if i % 2 == 0 {
+                "sliding_attention".to_string()
+            } else {
+                "full_attention".to_string()
+            }
+        })
+        .collect()
+}
+
+/// Main configuration for the ACE-Step 1.5 DiT-based music generation model.
+///
+/// Deserializable from HuggingFace `config.json`. Supports both the base (3.5B)
+/// and XL variants via optional encoder dimension overrides.
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+pub struct AceStepConfig {
+    // -- DiT dimensions ------------------------------------------------------
+    #[serde(default = "default_hidden_size")]
+    pub hidden_size: usize,
+    #[serde(default = "default_intermediate_size")]
+    pub intermediate_size: usize,
+    #[serde(default = "default_num_hidden_layers")]
+    pub num_hidden_layers: usize,
+    #[serde(default = "default_num_attention_heads")]
+    pub num_attention_heads: usize,
+    #[serde(default = "default_num_key_value_heads")]
+    pub num_key_value_heads: usize,
+    #[serde(default = "default_head_dim")]
+    pub head_dim: usize,
+
+    // -- Encoder dimensions (XL only, optional) ------------------------------
+    #[serde(default)]
+    pub encoder_hidden_size: Option<usize>,
+    #[serde(default)]
+    pub encoder_intermediate_size: Option<usize>,
+    #[serde(default)]
+    pub encoder_num_attention_heads: Option<usize>,
+    #[serde(default)]
+    pub encoder_num_key_value_heads: Option<usize>,
+
+    // -- Common parameters ---------------------------------------------------
+    #[serde(default = "default_hidden_act")]
+    pub hidden_act: Activation,
+    #[serde(default = "default_rms_norm_eps")]
+    pub rms_norm_eps: f64,
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f64,
+    #[serde(default = "default_use_sliding_window")]
+    pub use_sliding_window: bool,
+    #[serde(default = "default_sliding_window")]
+    pub sliding_window: usize,
+    #[serde(default = "default_in_channels")]
+    pub in_channels: usize,
+    #[serde(default = "default_patch_size")]
+    pub patch_size: usize,
+    #[serde(default = "default_text_hidden_dim")]
+    pub text_hidden_dim: usize,
+    #[serde(default = "default_audio_acoustic_hidden_dim")]
+    pub audio_acoustic_hidden_dim: usize,
+    #[serde(default = "default_timbre_hidden_dim")]
+    pub timbre_hidden_dim: usize,
+    #[serde(default = "default_pool_window_size")]
+    pub pool_window_size: usize,
+    #[serde(default = "default_vocab_size")]
+    pub vocab_size: usize,
+    #[serde(default = "default_max_position_embeddings")]
+    pub max_position_embeddings: usize,
+    #[serde(default = "default_fsq_dim")]
+    pub fsq_dim: usize,
+    #[serde(default = "default_fsq_input_levels")]
+    pub fsq_input_levels: Vec<usize>,
+    #[serde(default = "default_fsq_input_num_quantizers")]
+    pub fsq_input_num_quantizers: usize,
+    #[serde(default = "default_attention_bias")]
+    pub attention_bias: bool,
+    #[serde(default = "default_attention_dropout")]
+    pub attention_dropout: f64,
+
+    // -- Sub-model layer counts ----------------------------------------------
+    #[serde(default = "default_num_lyric_encoder_hidden_layers")]
+    pub num_lyric_encoder_hidden_layers: usize,
+    #[serde(default = "default_num_timbre_encoder_hidden_layers")]
+    pub num_timbre_encoder_hidden_layers: usize,
+    #[serde(default = "default_num_attention_pooler_hidden_layers")]
+    pub num_attention_pooler_hidden_layers: usize,
+    #[serde(default = "default_num_audio_decoder_hidden_layers")]
+    pub num_audio_decoder_hidden_layers: usize,
+
+    // -- Layer type schedule -------------------------------------------------
+    #[serde(default = "default_layer_types")]
+    pub layer_types: Vec<String>,
+
+    // -- Turbo flag ----------------------------------------------------------
+    #[serde(default)]
+    pub is_turbo: bool,
+}
+
+impl AceStepConfig {
+    /// Returns the encoder hidden size, falling back to the main `hidden_size`.
+    pub fn encoder_hidden_size(&self) -> usize {
+        self.encoder_hidden_size.unwrap_or(self.hidden_size)
+    }
+
+    /// Returns the encoder intermediate size, falling back to the main `intermediate_size`.
+    pub fn encoder_intermediate_size(&self) -> usize {
+        self.encoder_intermediate_size
+            .unwrap_or(self.intermediate_size)
+    }
+
+    /// Returns the encoder attention head count, falling back to `num_attention_heads`.
+    pub fn encoder_num_attention_heads(&self) -> usize {
+        self.encoder_num_attention_heads
+            .unwrap_or(self.num_attention_heads)
+    }
+
+    /// Returns the encoder key-value head count, falling back to `num_key_value_heads`.
+    pub fn encoder_num_key_value_heads(&self) -> usize {
+        self.encoder_num_key_value_heads
+            .unwrap_or(self.num_key_value_heads)
+    }
+}
+
+impl Default for AceStepConfig {
+    fn default() -> Self {
+        Self {
+            hidden_size: 2048,
+            intermediate_size: 6144,
+            num_hidden_layers: 24,
+            num_attention_heads: 16,
+            num_key_value_heads: 8,
+            head_dim: 128,
+            encoder_hidden_size: None,
+            encoder_intermediate_size: None,
+            encoder_num_attention_heads: None,
+            encoder_num_key_value_heads: None,
+            hidden_act: Activation::Silu,
+            rms_norm_eps: 1e-6,
+            rope_theta: 1_000_000.0,
+            use_sliding_window: true,
+            sliding_window: 128,
+            in_channels: 192,
+            patch_size: 2,
+            text_hidden_dim: 1024,
+            audio_acoustic_hidden_dim: 64,
+            timbre_hidden_dim: 64,
+            pool_window_size: 5,
+            vocab_size: 64003,
+            max_position_embeddings: 32768,
+            fsq_dim: 2048,
+            fsq_input_levels: vec![8, 8, 8, 5, 5, 5],
+            fsq_input_num_quantizers: 1,
+            attention_bias: false,
+            attention_dropout: 0.0,
+            num_lyric_encoder_hidden_layers: 8,
+            num_timbre_encoder_hidden_layers: 4,
+            num_attention_pooler_hidden_layers: 2,
+            num_audio_decoder_hidden_layers: 24,
+            layer_types: default_layer_types(),
+            is_turbo: false,
+        }
+    }
+}
+
+// -- VaeConfig default value functions ---------------------------------------
+
+fn default_vae_encoder_hidden_size() -> usize {
+    128
+}
+fn default_vae_decoder_channels() -> usize {
+    128
+}
+fn default_vae_decoder_input_channels() -> usize {
+    64
+}
+fn default_vae_audio_channels() -> usize {
+    2
+}
+fn default_vae_downsampling_ratios() -> Vec<usize> {
+    vec![2, 4, 4, 6, 10]
+}
+fn default_vae_channel_multiples() -> Vec<usize> {
+    vec![1, 2, 4, 8, 16]
+}
+fn default_vae_sampling_rate() -> usize {
+    48000
+}
+
+/// Configuration for the ACE-Step VAE (variational autoencoder) that converts
+/// between waveform audio and the latent space consumed by the DiT.
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+pub struct VaeConfig {
+    #[serde(default = "default_vae_encoder_hidden_size")]
+    pub encoder_hidden_size: usize,
+    #[serde(default = "default_vae_decoder_channels")]
+    pub decoder_channels: usize,
+    #[serde(default = "default_vae_decoder_input_channels")]
+    pub decoder_input_channels: usize,
+    #[serde(default = "default_vae_audio_channels")]
+    pub audio_channels: usize,
+    #[serde(default = "default_vae_downsampling_ratios")]
+    pub downsampling_ratios: Vec<usize>,
+    #[serde(default = "default_vae_channel_multiples")]
+    pub channel_multiples: Vec<usize>,
+    #[serde(default = "default_vae_sampling_rate")]
+    pub sampling_rate: usize,
+}
+
+impl VaeConfig {
+    /// Computes the total hop length as the product of all downsampling ratios.
+    pub fn hop_length(&self) -> usize {
+        self.downsampling_ratios.iter().product()
+    }
+}
+
+impl Default for VaeConfig {
+    fn default() -> Self {
+        Self {
+            encoder_hidden_size: 128,
+            decoder_channels: 128,
+            decoder_input_channels: 64,
+            audio_channels: 2,
+            downsampling_ratios: vec![2, 4, 4, 6, 10],
+            channel_multiples: vec![1, 2, 4, 8, 16],
+            sampling_rate: 48000,
+        }
+    }
+}

--- a/candle-transformers/src/models/ace_step/model.rs
+++ b/candle-transformers/src/models/ace_step/model.rs
@@ -211,7 +211,7 @@ impl AceStepConditionGenerationModel {
         // Skip entirely when is_covers is all-false (text2music) — no tokenize/detokenize needed.
         let latent_len = inputs.src_latents.dim(1)?;
 
-        let any_covers = inputs.is_covers.sum_all()?.to_scalar::<u8>()? > 0;
+        let any_covers = inputs.is_covers.gt(0u8)?.sum_all()?.to_scalar::<i64>()? > 0;
 
         let src_latents = if any_covers {
             let lm_hints_25hz = if let Some(precomputed) = inputs.precomputed_lm_hints_25hz {

--- a/candle-transformers/src/models/ace_step/model.rs
+++ b/candle-transformers/src/models/ace_step/model.rs
@@ -1,0 +1,449 @@
+//! Top-level ACE-Step conditional generation model.
+//!
+//! Mirrors the subset of Python's `AceStepConditionGenerationModel` needed for
+//! **single-sample DiT-only Text2Music** with base/sft models. Owns the
+//! condition encoder, DiT decoder, audio tokenizer/detokenizer, and
+//! null-condition embedding. Provides `prepare_condition` and
+//! `generate_latents` as the primary API, operating in latent space.
+//!
+//! ## Current scope vs Python
+//!
+//! Implemented:
+//! - Text2Music with base/sft (continuous schedule + APG guidance)
+//! - Text2Music with turbo (discrete schedule, no CFG)
+//! - Real tokenizer masks, encoder_attention_mask propagation
+//! - Cover mode (`is_covers`, tokenize/detokenize round-trip in prepare_condition)
+//! - `precomputed_lm_hints_25Hz` / `audio_codes` (LM-generated audio codes)
+//! - Audio cover strength blending (switch condition mid-loop with KV cache reset)
+//! - Custom timestep schedules for turbo models (mapped to VALID_TIMESTEPS)
+//!
+//! Not yet implemented (Python `generate_audio` features):
+//! - Batched inference (batch > 1)
+//! - LoRA support
+
+use candle::{DType, Device, Result, Tensor};
+use candle_nn::VarBuilder;
+
+use super::condition::ConditionEncoder;
+use super::dit::AceStepDiTModel;
+use super::sampling;
+use super::tokenizer::{AudioTokenDetokenizer, AudioTokenizer};
+use super::AceStepConfig;
+
+/// Inputs for the condition encoder.
+pub struct ConditionInputs<'a> {
+    /// Text encoder hidden states `(B, T_text, text_hidden_dim)`.
+    pub text_hidden_states: &'a Tensor,
+    /// Text attention mask `(B, T_text)`.
+    pub text_attention_mask: &'a Tensor,
+    /// Lyric token embeddings `(B, T_lyric, text_hidden_dim)`.
+    pub lyric_hidden_states: &'a Tensor,
+    /// Lyric attention mask `(B, T_lyric)`.
+    pub lyric_attention_mask: &'a Tensor,
+    /// Packed reference audio features `(N, T_audio, timbre_hidden_dim)`.
+    pub refer_audio_packed: &'a Tensor,
+    /// 1D order mask mapping segments to batch indices `(N,)`.
+    pub refer_audio_order_mask: &'a Tensor,
+    /// Source latents `(B, T, acoustic_dim)` — silence for text2music.
+    pub src_latents: &'a Tensor,
+    /// Chunk masks `(B, T, acoustic_dim)` — ones for full generation.
+    pub chunk_masks: &'a Tensor,
+    /// Silence latent for tokenizer padding `(1, T_max, acoustic_dim)`.
+    pub silence_latent: &'a Tensor,
+    /// Boolean tensor `(B,)` — true for cover mode items.
+    pub is_covers: &'a Tensor,
+    /// Precomputed LM hints at 25Hz `(B, T, acoustic_dim)`. Skips tokenize/detokenize.
+    pub precomputed_lm_hints_25hz: Option<&'a Tensor>,
+    /// Audio codes from LM `(B, N, 1)`. Skips tokenize, uses quantizer → detokenize.
+    pub audio_codes: Option<&'a Tensor>,
+    /// Text hidden states for the non-cover condition (used when `audio_cover_strength < 1.0`).
+    pub non_cover_text_hidden_states: Option<&'a Tensor>,
+    /// Attention mask for non-cover text.
+    pub non_cover_text_attention_mask: Option<&'a Tensor>,
+}
+
+/// Prepared conditioning for the DiT decoder.
+pub struct PreparedCondition {
+    pub encoder_hidden_states: Tensor,
+    pub encoder_attention_mask: Tensor,
+    pub context_latents: Tensor,
+}
+
+/// Options for latent generation.
+pub struct GenerateOptions {
+    pub seed: Option<u64>,
+    pub num_steps: usize,
+    pub guidance_scale: f64,
+    pub shift: f64,
+    pub is_turbo: bool,
+    /// ODE (deterministic) or SDE (stochastic) sampling.
+    pub infer_method: sampling::InferMethod,
+    /// Timestep range in which CFG/APG guidance is applied.
+    /// Outside this range, only the conditional prediction is used.
+    /// Default: `(0.0, 1.0)` — apply guidance at all timesteps.
+    pub cfg_interval: (f64, f64),
+    /// Custom timestep schedule for turbo models (1–20 values).
+    /// Each value is mapped to the nearest valid timestep. When `None`,
+    /// the shift-based schedule is used.
+    pub timesteps: Option<Vec<f64>>,
+    /// Fraction of denoising steps that use the cover condition (0.0–1.0).
+    /// At `cover_steps = round(num_steps * audio_cover_strength)` the loop
+    /// switches to the non-cover condition and clears the KV cache.
+    /// Default: `1.0` (no blending — cover condition used for all steps).
+    pub audio_cover_strength: f64,
+}
+
+impl Default for GenerateOptions {
+    fn default() -> Self {
+        Self {
+            seed: None,
+            num_steps: 50,
+            guidance_scale: 5.0,
+            shift: 1.0,
+            is_turbo: false,
+            infer_method: sampling::InferMethod::Ode,
+            cfg_interval: (0.0, 1.0),
+            timesteps: None,
+            audio_cover_strength: 1.0,
+        }
+    }
+}
+
+/// Top-level ACE-Step model that owns all sub-modules and provides
+/// `prepare_condition` + `generate_latents` as the main API.
+pub struct AceStepConditionGenerationModel {
+    config: AceStepConfig,
+    encoder: ConditionEncoder,
+    decoder: AceStepDiTModel,
+    pub tokenizer: AudioTokenizer,
+    pub detokenizer: AudioTokenDetokenizer,
+    null_condition_emb: Tensor,
+}
+
+impl AceStepConditionGenerationModel {
+    /// Load all sub-modules from a single safetensors checkpoint.
+    pub fn new(config: &AceStepConfig, vb: VarBuilder) -> Result<Self> {
+        let encoder = ConditionEncoder::new(config, vb.pp("encoder"))?;
+        let decoder = AceStepDiTModel::new(config, vb.pp("decoder"))?;
+        let tokenizer = AudioTokenizer::new(config, vb.pp("tokenizer"))?;
+        let detokenizer = AudioTokenDetokenizer::new(config, vb.pp("detokenizer"))?;
+        // XL models use encoder_hidden_size for null_condition_emb (it operates
+        // in encoder space, not decoder space).
+        let null_condition_emb =
+            vb.get((1, 1, config.encoder_hidden_size()), "null_condition_emb")?;
+
+        Ok(Self {
+            config: config.clone(),
+            encoder,
+            decoder,
+            tokenizer,
+            detokenizer,
+            null_condition_emb,
+        })
+    }
+
+    /// Tokenize audio latents: pad to `pool_window_size` multiple, reshape, quantize.
+    ///
+    /// Returns `(quantized, indices, downsampled_mask)`.
+    fn tokenize(
+        &self,
+        hidden_states: &Tensor,
+        silence_latent: &Tensor,
+        attention_mask: &Tensor,
+    ) -> Result<(Tensor, Tensor, Tensor)> {
+        let (b, t, d) = hidden_states.dims3()?;
+        let pws = self.tokenizer.pool_window_size();
+
+        // Pad to multiple of pool_window_size using silence_latent
+        let (hidden_states, attention_mask) = if t % pws != 0 {
+            let pad_len = pws - (t % pws);
+            let pad = silence_latent
+                .narrow(1, 0, pad_len)?
+                .broadcast_as((b, pad_len, d))?
+                .contiguous()?;
+            let hs = Tensor::cat(&[hidden_states, &pad], 1)?;
+            let mask_pad = Tensor::zeros(
+                (b, pad_len),
+                attention_mask.dtype(),
+                attention_mask.device(),
+            )?;
+            let am = Tensor::cat(&[attention_mask, &mask_pad], 1)?;
+            (hs, am)
+        } else {
+            (hidden_states.clone(), attention_mask.clone())
+        };
+
+        let t_padded = hidden_states.dim(1)?;
+        let num_patches = t_padded / pws;
+
+        // Reshape: (B, T, D) -> (B, T/pws, pws, D)
+        let reshaped = hidden_states.reshape((b, num_patches, pws, d))?;
+
+        // Downsample attention_mask: reshape (B, T) -> (B, T/pws, pws) then max
+        let mask_reshaped = attention_mask.reshape((b, num_patches, pws))?;
+        let downsampled_mask = mask_reshaped.max(2)?;
+
+        let (quantized, indices) = self.tokenizer.forward(&reshaped)?;
+        Ok((quantized, indices, downsampled_mask))
+    }
+
+    /// Detokenize quantized representations back to acoustic space.
+    fn detokenize(&self, quantized: &Tensor) -> Result<Tensor> {
+        self.detokenizer.forward(quantized)
+    }
+
+    /// Prepare conditioning: encode text/lyrics/timbre into packed encoder
+    /// hidden states, and build context latents from src_latents + chunk_masks.
+    ///
+    /// When cover mode is active (`is_covers > 0`), source latents are replaced
+    /// with tokenized-then-detokenized LM hints.
+    pub fn prepare_condition(&self, inputs: &ConditionInputs) -> Result<PreparedCondition> {
+        let (encoder_hidden_states, encoder_attention_mask) = self.encoder.forward(
+            inputs.text_hidden_states,
+            inputs.text_attention_mask,
+            inputs.lyric_hidden_states,
+            inputs.lyric_attention_mask,
+            inputs.refer_audio_packed,
+            inputs.refer_audio_order_mask,
+        )?;
+
+        // Cover mode: compute LM hints and replace src_latents where is_covers > 0.
+        // Skip entirely when is_covers is all-false (text2music) — no tokenize/detokenize needed.
+        let latent_len = inputs.src_latents.dim(1)?;
+
+        let any_covers = inputs.is_covers.sum_all()?.to_scalar::<u8>()? > 0;
+
+        let src_latents = if any_covers {
+            let lm_hints_25hz = if let Some(precomputed) = inputs.precomputed_lm_hints_25hz {
+                precomputed.narrow(1, 0, latent_len)?
+            } else if let Some(audio_codes) = inputs.audio_codes {
+                let quantized = self.tokenizer.get_output_from_indices(audio_codes)?;
+                let detokenized = self.detokenize(&quantized)?;
+                let det_len = detokenized.dim(1)?;
+                if det_len >= latent_len {
+                    detokenized.narrow(1, 0, latent_len)?
+                } else {
+                    let pad = inputs.silence_latent.narrow(1, 0, latent_len - det_len)?;
+                    Tensor::cat(&[&detokenized, &pad], 1)?
+                }
+            } else {
+                let b = inputs.src_latents.dim(0)?;
+                let attention_mask = Tensor::ones(
+                    (b, latent_len),
+                    inputs.src_latents.dtype(),
+                    inputs.src_latents.device(),
+                )?;
+                let (quantized, _indices, _mask) =
+                    self.tokenize(inputs.src_latents, inputs.silence_latent, &attention_mask)?;
+                let detokenized = self.detokenize(&quantized)?;
+                detokenized.narrow(1, 0, latent_len)?
+            };
+
+            let is_covers_3d = inputs
+                .is_covers
+                .gt(0u8)?
+                .unsqueeze(1)?
+                .unsqueeze(2)?
+                .broadcast_as(inputs.src_latents.shape())?;
+            is_covers_3d.where_cond(&lm_hints_25hz, inputs.src_latents)?
+        } else {
+            inputs.src_latents.clone()
+        };
+
+        // Context = [src_latents, chunk_masks] along feature dim
+        let context_latents = Tensor::cat(&[&src_latents, inputs.chunk_masks], candle::D::Minus1)?;
+
+        Ok(PreparedCondition {
+            encoder_hidden_states,
+            encoder_attention_mask,
+            context_latents,
+        })
+    }
+
+    /// Clear cross-attention KV caches. Call between generations with different
+    /// encoder states (different prompts).
+    pub fn clear_kv_cache(&mut self) {
+        self.decoder.clear_kv_cache();
+    }
+
+    /// Generate audio latents from prepared conditions.
+    ///
+    /// Returns the denoised latent `(B, T, acoustic_dim)` ready for VAE decode.
+    /// Automatically caches cross-attention K/V on the first denoising step and
+    /// reuses them for subsequent steps (encoder states are constant).
+    ///
+    /// When `non_cover_condition` is provided and `opts.audio_cover_strength < 1.0`,
+    /// the loop switches from cover to non-cover condition partway through and
+    /// clears the KV cache at the transition.
+    pub fn generate_latents(
+        &mut self,
+        condition: &PreparedCondition,
+        non_cover_condition: Option<&PreparedCondition>,
+        opts: &GenerateOptions,
+        device: &Device,
+        dtype: DType,
+    ) -> Result<Tensor> {
+        // Clear KV cache so it gets rebuilt for this generation's encoder states.
+        self.decoder.clear_kv_cache();
+
+        let latent_frames = condition.context_latents.dim(1)?;
+        let acoustic_dim = self.config.audio_acoustic_hidden_dim;
+
+        if let Some(seed) = opts.seed {
+            device.set_seed(seed)?;
+        }
+        let noise =
+            Tensor::randn(0f32, 1f32, (1, latent_frames, acoustic_dim), device)?.to_dtype(dtype)?;
+
+        let mut xt = noise;
+
+        if opts.is_turbo {
+            // Turbo: discrete schedule, no CFG, final step = x0 prediction
+            let t_schedule = match &opts.timesteps {
+                Some(ts) => sampling::get_custom_turbo_schedule(ts)?,
+                None => sampling::get_turbo_schedule(opts.shift),
+            };
+            let num_steps = t_schedule.len();
+            let cover_steps = (num_steps as f64 * opts.audio_cover_strength).round() as usize;
+            let mut active = condition;
+
+            for step in 0..num_steps {
+                // Switch to non-cover condition at the transition point
+                if let Some(nc) = non_cover_condition {
+                    if step == cover_steps && step > 0 {
+                        active = nc;
+                        self.decoder.clear_kv_cache();
+                    }
+                }
+
+                let t_curr = t_schedule[step];
+                let t_tensor =
+                    Tensor::from_vec(vec![t_curr as f32], (1,), device)?.to_dtype(dtype)?;
+
+                let vt = self.decoder.forward(
+                    &xt,
+                    &t_tensor,
+                    &t_tensor,
+                    None,
+                    &active.encoder_hidden_states,
+                    Some(&active.encoder_attention_mask),
+                    &active.context_latents,
+                )?;
+
+                if step == num_steps - 1 {
+                    xt = sampling::get_x0_from_noise(&xt, &vt, t_curr)?;
+                } else {
+                    let t_next = t_schedule[step + 1];
+                    match opts.infer_method {
+                        sampling::InferMethod::Ode => {
+                            xt = sampling::euler_step(&xt, &vt, t_curr - t_next)?;
+                        }
+                        sampling::InferMethod::Sde => {
+                            xt = sampling::sde_step(&xt, &vt, t_curr, t_next)?;
+                        }
+                    }
+                }
+            }
+        } else {
+            // Base/SFT: continuous schedule with APG guidance
+            let schedule = sampling::get_schedule(opts.num_steps, opts.shift);
+            let mut momentum_buffer = sampling::MomentumBuffer::new(-0.75);
+            let do_cfg = opts.guidance_scale > 1.0;
+            let cover_steps = (opts.num_steps as f64 * opts.audio_cover_strength).round() as usize;
+
+            // Build doubled tensors for CFG from cover condition
+            let build_cfg_tensors =
+                |cond: &PreparedCondition, null_emb: &Tensor| -> Result<(Tensor, Tensor, Tensor)> {
+                    let null_enc = null_emb
+                        .broadcast_as(cond.encoder_hidden_states.shape())?
+                        .contiguous()?;
+                    if do_cfg {
+                        let enc = Tensor::cat(&[&cond.encoder_hidden_states, &null_enc], 0)?;
+                        let mask = Tensor::cat(
+                            &[&cond.encoder_attention_mask, &cond.encoder_attention_mask],
+                            0,
+                        )?;
+                        let ctx = Tensor::cat(&[&cond.context_latents, &cond.context_latents], 0)?;
+                        Ok((enc, mask, ctx))
+                    } else {
+                        Ok((
+                            cond.encoder_hidden_states.clone(),
+                            cond.encoder_attention_mask.clone(),
+                            cond.context_latents.clone(),
+                        ))
+                    }
+                };
+
+            let (mut enc_cond, mut enc_mask_cond, mut ctx_doubled) =
+                build_cfg_tensors(condition, &self.null_condition_emb)?;
+
+            let (cfg_start, cfg_end) = opts.cfg_interval;
+
+            for step in 0..opts.num_steps {
+                // Switch to non-cover condition at the transition point
+                if let Some(nc) = non_cover_condition {
+                    if step == cover_steps && step > 0 {
+                        self.decoder.clear_kv_cache();
+                        let rebuilt = build_cfg_tensors(nc, &self.null_condition_emb)?;
+                        enc_cond = rebuilt.0;
+                        enc_mask_cond = rebuilt.1;
+                        ctx_doubled = rebuilt.2;
+                    }
+                }
+
+                let t_curr = schedule[step];
+                let t_prev = schedule[step + 1];
+
+                let x_input = if do_cfg {
+                    Tensor::cat(&[&xt, &xt], 0)?
+                } else {
+                    xt.clone()
+                };
+                let batch_size = x_input.dim(0)?;
+                let t_tensor =
+                    Tensor::from_vec(vec![t_curr as f32; batch_size], (batch_size,), device)?
+                        .to_dtype(dtype)?;
+
+                let vt = self.decoder.forward(
+                    &x_input,
+                    &t_tensor,
+                    &t_tensor,
+                    None,
+                    &enc_cond,
+                    Some(&enc_mask_cond),
+                    &ctx_doubled,
+                )?;
+
+                let vt = if do_cfg {
+                    let v_cond = vt.narrow(0, 0, 1)?;
+                    let v_uncond = vt.narrow(0, 1, 1)?;
+                    let apply_guidance = t_curr >= cfg_start && t_curr <= cfg_end;
+                    if apply_guidance {
+                        sampling::apg_forward(
+                            &v_cond,
+                            &v_uncond,
+                            opts.guidance_scale,
+                            &mut momentum_buffer,
+                            2.5,
+                        )?
+                    } else {
+                        v_cond
+                    }
+                } else {
+                    vt
+                };
+
+                match opts.infer_method {
+                    sampling::InferMethod::Ode => {
+                        xt = sampling::euler_step(&xt, &vt, t_curr - t_prev)?;
+                    }
+                    sampling::InferMethod::Sde => {
+                        xt = sampling::sde_step(&xt, &vt, t_curr, t_prev)?;
+                    }
+                }
+            }
+        }
+
+        Ok(xt)
+    }
+}

--- a/candle-transformers/src/models/ace_step/model.rs
+++ b/candle-transformers/src/models/ace_step/model.rs
@@ -311,7 +311,15 @@ impl AceStepConditionGenerationModel {
             };
             let num_steps = t_schedule.len();
             let cover_steps = (num_steps as f64 * opts.audio_cover_strength).round() as usize;
-            let mut active = condition;
+            let mut active = if cover_steps == 0 {
+                if let Some(nc) = non_cover_condition {
+                    nc
+                } else {
+                    condition
+                }
+            } else {
+                condition
+            };
 
             for step in 0..num_steps {
                 // Switch to non-cover condition at the transition point
@@ -380,8 +388,13 @@ impl AceStepConditionGenerationModel {
                     }
                 };
 
+            let initial_condition = if cover_steps == 0 {
+                non_cover_condition.unwrap_or(condition)
+            } else {
+                condition
+            };
             let (mut enc_cond, mut enc_mask_cond, mut ctx_doubled) =
-                build_cfg_tensors(condition, &self.null_condition_emb)?;
+                build_cfg_tensors(initial_condition, &self.null_condition_emb)?;
 
             let (cfg_start, cfg_end) = opts.cfg_interval;
 

--- a/candle-transformers/src/models/ace_step/model.rs
+++ b/candle-transformers/src/models/ace_step/model.rs
@@ -211,7 +211,13 @@ impl AceStepConditionGenerationModel {
         // Skip entirely when is_covers is all-false (text2music) — no tokenize/detokenize needed.
         let latent_len = inputs.src_latents.dim(1)?;
 
-        let any_covers = inputs.is_covers.gt(0u8)?.sum_all()?.to_scalar::<i64>()? > 0;
+        let any_covers = inputs
+            .is_covers
+            .gt(0u8)?
+            .to_dtype(candle::DType::U32)?
+            .sum_all()?
+            .to_scalar::<u32>()?
+            > 0;
 
         let src_latents = if any_covers {
             let lm_hints_25hz = if let Some(precomputed) = inputs.precomputed_lm_hints_25hz {

--- a/candle-transformers/src/models/ace_step/sampling.rs
+++ b/candle-transformers/src/models/ace_step/sampling.rs
@@ -1,0 +1,328 @@
+//! Flow matching sampler for ACE-Step diffusion model.
+//!
+//! Implements the Euler ODE solver for rectified flow / flow matching,
+//! with Adaptive Prompt Guidance (APG) support.
+
+use candle::{Result, Tensor};
+
+/// All unique timesteps from shift=1,2,3 with fix_nfe=8.
+/// Turbo models were distilled on these exact values — custom timesteps are
+/// mapped to the nearest entry in this table.
+const VALID_TIMESTEPS: [f64; 20] = [
+    1.0,
+    0.9545454545454546,
+    0.9333333333333333,
+    0.9,
+    0.875,
+    0.8571428571428571,
+    0.8333333333333334,
+    0.7692307692307693,
+    0.75,
+    0.6666666666666666,
+    0.6428571428571429,
+    0.625,
+    0.5454545454545454,
+    0.5,
+    0.4,
+    0.375,
+    0.3,
+    0.25,
+    0.2222222222222222,
+    0.125,
+];
+
+/// Generate a linear timestep schedule from 1.0 to 0.0.
+///
+/// Optionally applies a time shift transformation:
+/// `t_shifted = shift * t / (1 + (shift - 1) * t)`
+pub fn get_schedule(num_steps: usize, shift: f64) -> Vec<f64> {
+    let mut schedule = Vec::with_capacity(num_steps + 1);
+    for i in 0..=num_steps {
+        let t = 1.0 - (i as f64 / num_steps as f64);
+        let t = if (shift - 1.0).abs() > 1e-6 {
+            shift * t / (1.0 + (shift - 1.0) * t)
+        } else {
+            t
+        };
+        schedule.push(t);
+    }
+    schedule
+}
+
+/// Pre-defined discrete timestep schedules for turbo models.
+/// These are the only valid schedules — turbo models were distilled on these
+/// exact timesteps and will produce poor results with continuous schedules.
+///
+/// Each schedule has `fix_nfe` steps (default 8) plus an implicit final t=0.
+pub fn get_turbo_schedule(shift: f64) -> Vec<f64> {
+    if (shift - 1.0).abs() < 0.5 {
+        // shift ≈ 1
+        vec![1.0, 0.875, 0.75, 0.625, 0.5, 0.375, 0.25, 0.125]
+    } else if (shift - 2.0).abs() < 0.5 {
+        // shift ≈ 2
+        vec![
+            1.0,
+            0.9333333333333333,
+            0.8571428571428571,
+            0.7692307692307693,
+            0.6666666666666666,
+            0.5454545454545454,
+            0.4,
+            0.2222222222222222,
+        ]
+    } else {
+        // shift ≈ 3 (default for turbo)
+        vec![
+            1.0,
+            0.9545454545454546,
+            0.9,
+            0.8333333333333334,
+            0.75,
+            0.6428571428571429,
+            0.5,
+            0.3,
+        ]
+    }
+}
+
+/// Build a custom turbo schedule from user-provided timestep values.
+///
+/// Each value is mapped to the nearest entry in `VALID_TIMESTEPS`. Trailing
+/// zeros are stripped, and the resulting schedule must have 1–20 entries.
+pub fn get_custom_turbo_schedule(timesteps: &[f64]) -> Result<Vec<f64>> {
+    let end = timesteps
+        .iter()
+        .rposition(|&t| t != 0.0)
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let timesteps = &timesteps[..end];
+    if timesteps.is_empty() || timesteps.len() > 20 {
+        candle::bail!(
+            "custom timesteps must have 1-20 non-zero values, got {}",
+            timesteps.len()
+        );
+    }
+    Ok(timesteps
+        .iter()
+        .map(|&t| {
+            *VALID_TIMESTEPS
+                .iter()
+                .min_by(|&&a, &&b| (a - t).abs().partial_cmp(&(b - t).abs()).unwrap())
+                .unwrap()
+        })
+        .collect())
+}
+
+/// Get x0 (clean sample) from noisy sample and velocity prediction.
+/// Flow matching: x_t = t * noise + (1 - t) * x_0, v = noise - x_0
+/// Therefore: x_0 = x_t - v * t
+pub fn get_x0_from_noise(xt: &Tensor, vt: &Tensor, t: f64) -> Result<Tensor> {
+    xt - (vt * t)?
+}
+
+/// Euler ODE step for flow matching.
+///
+/// Given current sample `x_t` and velocity prediction `v_t`:
+/// `x_{t-dt} = x_t - v_t * dt`
+pub fn euler_step(x: &Tensor, v: &Tensor, dt: f64) -> Result<Tensor> {
+    x - (v * dt)?
+}
+
+/// SDE step: predict clean sample, then re-add noise at the next timestep.
+///
+/// `x_0 = get_x0_from_noise(x_t, v_t, t_curr)`
+/// `x_{t_next} = (1 - t_next) * x_0 + t_next * noise`
+pub fn sde_step(xt: &Tensor, vt: &Tensor, t_curr: f64, t_next: f64) -> Result<Tensor> {
+    let x0 = get_x0_from_noise(xt, vt, t_curr)?;
+    let noise = Tensor::randn_like(&x0, 0., 1.)?;
+    let clean_part = (&x0 * (1.0 - t_next))?;
+    let noise_part = (noise * t_next)?;
+    clean_part + noise_part
+}
+
+/// Inference method for the denoising loop.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum InferMethod {
+    /// Ordinary Differential Equation — deterministic Euler integration.
+    Ode,
+    /// Stochastic Differential Equation — predicts x0 then re-noises.
+    Sde,
+}
+
+/// Momentum buffer for APG (Adaptive Prompt Guidance).
+pub struct MomentumBuffer {
+    momentum: f64,
+    running_average: Option<Tensor>,
+}
+
+impl MomentumBuffer {
+    pub fn new(momentum: f64) -> Self {
+        Self {
+            momentum,
+            running_average: None,
+        }
+    }
+
+    /// Update running average: `running_avg = update_value + momentum * running_avg`
+    pub fn update(&mut self, update_value: &Tensor) -> Result<()> {
+        let new_average = match &self.running_average {
+            Some(ra) => (ra * self.momentum)?,
+            None => Tensor::zeros_like(update_value)?,
+        };
+        self.running_average = Some((update_value + new_average)?);
+        Ok(())
+    }
+
+    pub fn get(&self) -> Option<&Tensor> {
+        self.running_average.as_ref()
+    }
+}
+
+/// Project v0 onto v1 and decompose into parallel and orthogonal components.
+///
+/// Operates along `dim` (typically dim=1 for sequence dimension).
+/// Uses F64 precision internally for numerical stability (matching Python).
+fn project(v0: &Tensor, v1: &Tensor, dim: usize) -> Result<(Tensor, Tensor)> {
+    let orig_device = v0.device().clone();
+    let orig_dtype = v0.dtype();
+
+    // Move to CPU and use F64 for numerical stability (Python does v0.double(), v1.double())
+    let v0 = v0
+        .to_device(&candle::Device::Cpu)?
+        .to_dtype(candle::DType::F64)?;
+    let v1 = v1
+        .to_device(&candle::Device::Cpu)?
+        .to_dtype(candle::DType::F64)?;
+
+    // L2 normalize v1 along dim
+    let v1_norm = v1.sqr()?.sum_keepdim(dim)?.sqrt()?;
+    let v1_normalized = v1.broadcast_div(&(v1_norm + 1e-8)?)?;
+
+    // Project: v0_parallel = (v0 · v1_hat) * v1_hat
+    let dot = (&v0 * &v1_normalized)?.sum_keepdim(dim)?;
+    let v0_parallel = dot.broadcast_mul(&v1_normalized)?;
+    let v0_orthogonal = (&v0 - &v0_parallel)?;
+
+    Ok((
+        v0_parallel.to_dtype(orig_dtype)?.to_device(&orig_device)?,
+        v0_orthogonal
+            .to_dtype(orig_dtype)?
+            .to_device(&orig_device)?,
+    ))
+}
+
+/// Adaptive Prompt Guidance (APG).
+///
+/// Decomposes the cond-uncond difference into parallel/orthogonal components
+/// relative to the conditional prediction, applies norm thresholding, and
+/// uses momentum for temporal smoothing.
+///
+/// Reference: ACE-Step's `apg_forward` in `apg_guidance.py`.
+pub fn apg_forward(
+    pred_cond: &Tensor,
+    pred_uncond: &Tensor,
+    guidance_scale: f64,
+    momentum_buffer: &mut MomentumBuffer,
+    norm_threshold: f64,
+) -> Result<Tensor> {
+    // dims=[1] in Python — operates along the sequence dimension
+    let dim = 1usize;
+    let orig_device = pred_cond.device().clone();
+    let orig_dtype = pred_cond.dtype();
+
+    // Move everything to CPU for numerical stability (Python does this for MPS)
+    let pred_cond_cpu = pred_cond.to_device(&candle::Device::Cpu)?;
+    let pred_uncond_cpu = pred_uncond.to_device(&candle::Device::Cpu)?;
+
+    let diff = (&pred_cond_cpu - &pred_uncond_cpu)?;
+
+    // Apply momentum smoothing
+    momentum_buffer.update(&diff)?;
+    let diff = momentum_buffer.get().unwrap().clone();
+
+    // Norm thresholding: clamp L2 norm along dim to prevent oversaturation
+    let diff = if norm_threshold > 0.0 {
+        let diff_norm = diff.sqr()?.sum_keepdim(dim)?.sqrt()?;
+        let ones = Tensor::ones_like(&diff_norm)?;
+        let scale = (ones * norm_threshold)?.broadcast_div(&(&diff_norm + 1e-8)?)?;
+        let scale = scale.minimum(&Tensor::ones_like(&scale)?)?;
+        diff.broadcast_mul(&scale)?
+    } else {
+        diff
+    };
+
+    // Decompose into parallel and orthogonal components
+    let (_diff_parallel, diff_orthogonal) = project(&diff, &pred_cond_cpu, dim)?;
+
+    // eta=0.0 by default: use only orthogonal component
+    let result = (pred_cond_cpu + diff_orthogonal * (guidance_scale - 1.0))?;
+    result.to_dtype(orig_dtype)?.to_device(&orig_device)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_custom_turbo_schedule_basic() -> Result<()> {
+        // Exact valid timesteps should pass through unchanged
+        let ts = vec![1.0, 0.875, 0.75, 0.5, 0.25];
+        let result = get_custom_turbo_schedule(&ts)?;
+        assert_eq!(result, ts);
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_custom_turbo_schedule_nearest_mapping() -> Result<()> {
+        // Values should be mapped to nearest valid timestep
+        let ts = vec![0.99, 0.51, 0.13];
+        let result = get_custom_turbo_schedule(&ts)?;
+        assert_eq!(result, vec![1.0, 0.5, 0.125]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_custom_turbo_schedule_strips_trailing_zeros() -> Result<()> {
+        let ts = vec![1.0, 0.5, 0.0, 0.0];
+        let result = get_custom_turbo_schedule(&ts)?;
+        assert_eq!(result.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_custom_turbo_schedule_empty_after_strip() {
+        let ts = vec![0.0, 0.0];
+        assert!(get_custom_turbo_schedule(&ts).is_err());
+    }
+
+    #[test]
+    fn test_get_custom_turbo_schedule_too_long() {
+        let ts = vec![1.0; 21];
+        assert!(get_custom_turbo_schedule(&ts).is_err());
+    }
+
+    #[test]
+    fn test_get_custom_turbo_schedule_single() -> Result<()> {
+        let ts = vec![0.87];
+        let result = get_custom_turbo_schedule(&ts)?;
+        assert_eq!(result, vec![0.875]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_turbo_schedule_shift1_matches_custom() -> Result<()> {
+        // The shift=1 hardcoded schedule should match custom input of same values
+        let hardcoded = get_turbo_schedule(1.0);
+        let custom = get_custom_turbo_schedule(&hardcoded)?;
+        assert_eq!(hardcoded, custom);
+        Ok(())
+    }
+
+    #[test]
+    fn test_turbo_schedule_shift3_matches_custom() -> Result<()> {
+        let hardcoded = get_turbo_schedule(3.0);
+        let custom = get_custom_turbo_schedule(&hardcoded)?;
+        assert_eq!(hardcoded, custom);
+        Ok(())
+    }
+}

--- a/candle-transformers/src/models/ace_step/sampling.rs
+++ b/candle-transformers/src/models/ace_step/sampling.rs
@@ -102,12 +102,22 @@ pub fn get_custom_turbo_schedule(timesteps: &[f64]) -> Result<Vec<f64>> {
             timesteps.len()
         );
     }
+    for &t in timesteps {
+        if !t.is_finite() {
+            candle::bail!("custom timesteps contain non-finite value: {t}");
+        }
+    }
     Ok(timesteps
         .iter()
         .map(|&t| {
             *VALID_TIMESTEPS
                 .iter()
-                .min_by(|&&a, &&b| (a - t).abs().partial_cmp(&(b - t).abs()).unwrap())
+                .min_by(|&&a, &&b| {
+                    (a - t)
+                        .abs()
+                        .partial_cmp(&(b - t).abs())
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                })
                 .unwrap()
         })
         .collect())
@@ -182,17 +192,19 @@ impl MomentumBuffer {
 ///
 /// Operates along `dim` (typically dim=1 for sequence dimension).
 /// Uses F64 precision internally for numerical stability (matching Python).
+/// On Metal, computation is moved to CPU to avoid MPS numeric issues.
 fn project(v0: &Tensor, v1: &Tensor, dim: usize) -> Result<(Tensor, Tensor)> {
     let orig_device = v0.device().clone();
     let orig_dtype = v0.dtype();
 
-    // Move to CPU and use F64 for numerical stability (Python does v0.double(), v1.double())
-    let v0 = v0
-        .to_device(&candle::Device::Cpu)?
-        .to_dtype(candle::DType::F64)?;
-    let v1 = v1
-        .to_device(&candle::Device::Cpu)?
-        .to_dtype(candle::DType::F64)?;
+    // Use CPU for Metal (MPS numeric issues); stay on device for CUDA.
+    let compute_device = if orig_device.is_metal() {
+        candle::Device::Cpu
+    } else {
+        orig_device.clone()
+    };
+    let v0 = v0.to_device(&compute_device)?.to_dtype(candle::DType::F64)?;
+    let v1 = v1.to_device(&compute_device)?.to_dtype(candle::DType::F64)?;
 
     // L2 normalize v1 along dim
     let v1_norm = v1.sqr()?.sum_keepdim(dim)?.sqrt()?;
@@ -230,9 +242,15 @@ pub fn apg_forward(
     let orig_device = pred_cond.device().clone();
     let orig_dtype = pred_cond.dtype();
 
-    // Move everything to CPU for numerical stability (Python does this for MPS)
-    let pred_cond_cpu = pred_cond.to_device(&candle::Device::Cpu)?;
-    let pred_uncond_cpu = pred_uncond.to_device(&candle::Device::Cpu)?;
+    // On Metal, move to CPU for numerical stability (Python does this for MPS).
+    // On CUDA/CPU, stay on the original device to avoid transfer overhead.
+    let compute_device = if orig_device.is_metal() {
+        candle::Device::Cpu
+    } else {
+        orig_device.clone()
+    };
+    let pred_cond_cpu = pred_cond.to_device(&compute_device)?;
+    let pred_uncond_cpu = pred_uncond.to_device(&compute_device)?;
 
     let diff = (&pred_cond_cpu - &pred_uncond_cpu)?;
 

--- a/candle-transformers/src/models/ace_step/sampling.rs
+++ b/candle-transformers/src/models/ace_step/sampling.rs
@@ -36,6 +36,9 @@ const VALID_TIMESTEPS: [f64; 20] = [
 /// Optionally applies a time shift transformation:
 /// `t_shifted = shift * t / (1 + (shift - 1) * t)`
 pub fn get_schedule(num_steps: usize, shift: f64) -> Vec<f64> {
+    if num_steps == 0 {
+        return vec![0.0];
+    }
     let mut schedule = Vec::with_capacity(num_steps + 1);
     for i in 0..=num_steps {
         let t = 1.0 - (i as f64 / num_steps as f64);
@@ -203,8 +206,12 @@ fn project(v0: &Tensor, v1: &Tensor, dim: usize) -> Result<(Tensor, Tensor)> {
     } else {
         orig_device.clone()
     };
-    let v0 = v0.to_device(&compute_device)?.to_dtype(candle::DType::F64)?;
-    let v1 = v1.to_device(&compute_device)?.to_dtype(candle::DType::F64)?;
+    let v0 = v0
+        .to_device(&compute_device)?
+        .to_dtype(candle::DType::F64)?;
+    let v1 = v1
+        .to_device(&compute_device)?
+        .to_dtype(candle::DType::F64)?;
 
     // L2 normalize v1 along dim
     let v1_norm = v1.sqr()?.sum_keepdim(dim)?.sqrt()?;

--- a/candle-transformers/src/models/ace_step/tokenizer.rs
+++ b/candle-transformers/src/models/ace_step/tokenizer.rs
@@ -1,0 +1,656 @@
+//! Audio tokenizer and detokenizer for ACE-Step.
+//!
+//! Implements Finite Scalar Quantization (FSQ) based audio tokenization.
+//! These components are used in the cover/audio-code pipeline (LM + DiT hybrid
+//! mode) but are **not exercised** by the Text2Music path.
+//!
+//! **Validation status** (against Python `vector_quantize_pytorch.ResidualFSQ`):
+//! - `AudioTokenDetokenizer`: bit-exact (diff_max < 0.00001)
+//! - `ResidualFSQ` (quantizer): FSQ bound/round matches; small rounding
+//!   boundary differences (diff_max ~0.018) are expected for discrete
+//!   quantization due to float precision at level boundaries.
+//! - `AttentionPooler` / `AudioTokenizer`: structurally correct, minor
+//!   float precision differences propagate through FSQ rounding.
+
+use crate::models::with_tracing::{linear, linear_no_bias, Linear, RmsNorm};
+use crate::utils::repeat_kv;
+use candle::{DType, Module, Result, Tensor, D};
+use candle_nn::{Activation, VarBuilder};
+use std::sync::Arc;
+
+use super::dit::RotaryEmbedding;
+use super::AceStepConfig;
+
+// ---------------------------------------------------------------------------
+// Encoder MLP (same SiLU-gated pattern as Qwen3MLP)
+// ---------------------------------------------------------------------------
+#[derive(Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
+struct MLP {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+    act_fn: Activation,
+}
+
+impl MLP {
+    fn new(
+        hidden_size: usize,
+        intermediate_size: usize,
+        act: Activation,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        Ok(Self {
+            gate_proj: linear_no_bias(hidden_size, intermediate_size, vb.pp("gate_proj"))?,
+            up_proj: linear_no_bias(hidden_size, intermediate_size, vb.pp("up_proj"))?,
+            down_proj: linear_no_bias(intermediate_size, hidden_size, vb.pp("down_proj"))?,
+            act_fn: act,
+        })
+    }
+}
+
+impl Module for MLP {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let lhs = x.apply(&self.gate_proj)?.apply(&self.act_fn)?;
+        let rhs = x.apply(&self.up_proj)?;
+        (lhs * rhs)?.apply(&self.down_proj)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encoder Attention (bidirectional, GQA, with RoPE)
+// ---------------------------------------------------------------------------
+#[derive(Debug, Clone)]
+struct TokenizerAttention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    o_proj: Linear,
+    q_norm: RmsNorm,
+    k_norm: RmsNorm,
+    num_heads: usize,
+    num_kv_heads: usize,
+    num_kv_groups: usize,
+    head_dim: usize,
+    hidden_size: usize,
+}
+
+impl TokenizerAttention {
+    fn new(cfg: &AceStepConfig, vb: VarBuilder) -> Result<Self> {
+        let enc_hs = cfg.encoder_hidden_size();
+        let num_heads = cfg.encoder_num_attention_heads();
+        let num_kv_heads = cfg.encoder_num_key_value_heads();
+        let head_dim = cfg.head_dim;
+        let hidden_size = num_heads * head_dim;
+
+        Ok(Self {
+            q_proj: linear_no_bias(enc_hs, num_heads * head_dim, vb.pp("q_proj"))?,
+            k_proj: linear_no_bias(enc_hs, num_kv_heads * head_dim, vb.pp("k_proj"))?,
+            v_proj: linear_no_bias(enc_hs, num_kv_heads * head_dim, vb.pp("v_proj"))?,
+            o_proj: linear_no_bias(num_heads * head_dim, enc_hs, vb.pp("o_proj"))?,
+            q_norm: RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?,
+            k_norm: RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?,
+            num_heads,
+            num_kv_heads,
+            num_kv_groups: num_heads / num_kv_heads,
+            head_dim,
+            hidden_size,
+        })
+    }
+
+    fn forward(
+        &self,
+        x: &Tensor,
+        attn_mask: Option<&Tensor>,
+        rotary: &RotaryEmbedding,
+    ) -> Result<Tensor> {
+        let (b, l, _) = x.dims3()?;
+
+        let q = self.q_proj.forward(x)?;
+        let k = self.k_proj.forward(x)?;
+        let v = self.v_proj.forward(x)?;
+
+        let q = q
+            .reshape((b, l, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let k = k
+            .reshape((b, l, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let v = v
+            .reshape((b, l, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        // Per-head RMSNorm
+        let q = self.q_norm.forward(&q.flatten(0, 1)?)?.reshape(q.shape())?;
+        let k = self.k_norm.forward(&k.flatten(0, 1)?)?.reshape(k.shape())?;
+
+        // RoPE
+        let (q, k) = rotary.apply(&q, &k, 0)?;
+
+        // GQA
+        let k = repeat_kv(k, self.num_kv_groups)?.contiguous()?;
+        let v = repeat_kv(v, self.num_kv_groups)?.contiguous()?;
+
+        // Attention
+        let scale = 1.0 / (self.head_dim as f64).sqrt();
+        let mut scores = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
+        if let Some(m) = attn_mask {
+            scores = scores.broadcast_add(m)?;
+        }
+        let probs = candle_nn::ops::softmax_last_dim(&scores)?;
+        let ctx = probs.matmul(&v)?;
+
+        ctx.transpose(1, 2)?
+            .reshape((b, l, self.hidden_size))?
+            .apply(&self.o_proj)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encoder Layer
+// ---------------------------------------------------------------------------
+#[derive(Debug, Clone)]
+struct EncoderLayer {
+    self_attn: TokenizerAttention,
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+    mlp: MLP,
+}
+
+impl EncoderLayer {
+    fn new(cfg: &AceStepConfig, _layer_idx: usize, vb: VarBuilder) -> Result<Self> {
+        let enc_hs = cfg.encoder_hidden_size();
+        Ok(Self {
+            self_attn: TokenizerAttention::new(cfg, vb.pp("self_attn"))?,
+            input_layernorm: RmsNorm::new(enc_hs, cfg.rms_norm_eps, vb.pp("input_layernorm"))?,
+            post_attention_layernorm: RmsNorm::new(
+                enc_hs,
+                cfg.rms_norm_eps,
+                vb.pp("post_attention_layernorm"),
+            )?,
+            mlp: MLP::new(
+                enc_hs,
+                cfg.encoder_intermediate_size(),
+                cfg.hidden_act,
+                vb.pp("mlp"),
+            )?,
+        })
+    }
+
+    fn forward(
+        &self,
+        x: &Tensor,
+        attn_mask: Option<&Tensor>,
+        rotary: &RotaryEmbedding,
+    ) -> Result<Tensor> {
+        let residual = x.clone();
+        let h = self.input_layernorm.forward(x)?;
+        let h = self.self_attn.forward(&h, attn_mask, rotary)?;
+        let x = (residual + h)?;
+
+        let residual = x.clone();
+        let h = self.post_attention_layernorm.forward(&x)?;
+        let h = h.apply(&self.mlp)?;
+        residual + h
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AttentionPooler - CLS-token based attention pooling
+// ---------------------------------------------------------------------------
+#[derive(Debug, Clone)]
+pub struct AttentionPooler {
+    embed_tokens: Linear,
+    layers: Vec<EncoderLayer>,
+    norm: RmsNorm,
+    special_token: Tensor,
+    rotary_emb: Arc<RotaryEmbedding>,
+}
+
+impl AttentionPooler {
+    pub fn new(cfg: &AceStepConfig, vb: VarBuilder) -> Result<Self> {
+        let enc_hs = cfg.encoder_hidden_size();
+        let mut layers = Vec::with_capacity(cfg.num_attention_pooler_hidden_layers);
+        let vb_l = vb.pp("layers");
+        for i in 0..cfg.num_attention_pooler_hidden_layers {
+            layers.push(EncoderLayer::new(cfg, i, vb_l.pp(i))?);
+        }
+        let rotary_emb = Arc::new(RotaryEmbedding::new(vb.dtype(), cfg, vb.device())?);
+        Ok(Self {
+            embed_tokens: linear(enc_hs, enc_hs, vb.pp("embed_tokens"))?,
+            layers,
+            norm: RmsNorm::new(enc_hs, cfg.rms_norm_eps, vb.pp("norm"))?,
+            special_token: vb.get((1, 1, enc_hs), "special_token")?,
+            rotary_emb,
+        })
+    }
+
+    /// Pool patches into sequence-level representations.
+    /// Input: (B, T, pool_window_size, D) → Output: (B, T, D)
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let (b, t, p, _d) = x.dims4()?;
+        let x = x.apply(&self.embed_tokens)?;
+
+        // Prepend CLS token to each patch group
+        let cls = self
+            .special_token
+            .broadcast_as((b * t, 1, x.dim(D::Minus1)?))?;
+        let x = x.reshape((b * t, p, ()))?;
+        let x = Tensor::cat(&[&cls, &x], 1)?;
+
+        let mut hidden = x;
+        for layer in &self.layers {
+            hidden = layer.forward(&hidden, None, &self.rotary_emb)?;
+        }
+        let hidden = self.norm.forward(&hidden)?;
+
+        // Extract CLS output (position 0)
+        hidden.narrow(1, 0, 1)?.squeeze(1)?.reshape((b, t, ()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ResidualFSQ - Finite Scalar Quantization
+// ---------------------------------------------------------------------------
+
+/// Residual Finite Scalar Quantization.
+///
+/// Matches `vector_quantize_pytorch.ResidualFSQ` with a single top-level
+/// `project_in` (dim → codebook_dim) and `project_out` (codebook_dim → dim).
+/// Each FSQ layer independently quantizes each codebook dimension to its
+/// corresponding number of levels using `tanh` bounding and rounding.
+#[derive(Debug, Clone)]
+pub struct ResidualFSQ {
+    project_in: Linear,
+    project_out: Linear,
+    /// Precomputed: (levels - 1) * (1 + eps) / 2 for each codebook dim
+    half_l: Vec<f32>,
+    /// Precomputed: levels // 2
+    half_width: Vec<f32>,
+    /// Precomputed: 0.5 for even levels, 0.0 for odd
+    offset: Vec<f32>,
+    /// Precomputed: atanh(offset / half_l) shift
+    shift: Vec<f32>,
+    /// Precomputed basis for index calculation: [1, L0, L0*L1, ...]
+    basis: Vec<i64>,
+    /// Quantization levels per codebook dimension (e.g. [8, 8, 8, 5, 5, 5]).
+    levels: Vec<usize>,
+    /// Model working dtype (inferred from VarBuilder at construction time).
+    model_dtype: DType,
+}
+
+impl ResidualFSQ {
+    pub fn new(cfg: &AceStepConfig, vb: VarBuilder) -> Result<Self> {
+        let model_dtype = vb.dtype();
+        let dim = cfg.fsq_dim;
+        let levels = &cfg.fsq_input_levels;
+        let codebook_dim = levels.len();
+
+        // Single project_in/project_out at the ResidualFSQ level
+        let project_in = linear(dim, codebook_dim, vb.pp("project_in"))?;
+        let project_out = linear(codebook_dim, dim, vb.pp("project_out"))?;
+
+        let eps = 1e-3f32;
+        let half_l: Vec<f32> = levels
+            .iter()
+            .map(|&l| (l as f32 - 1.0) * (1.0 + eps) / 2.0)
+            .collect();
+        let half_width: Vec<f32> = levels.iter().map(|&l| (l / 2) as f32).collect();
+        let offset: Vec<f32> = levels
+            .iter()
+            .map(|&l| if l % 2 == 0 { 0.5 } else { 0.0 })
+            .collect();
+        let shift: Vec<f32> = half_l
+            .iter()
+            .zip(&offset)
+            .map(|(&hl, &o)| (o / hl).atanh())
+            .collect();
+
+        let mut basis = vec![1i64];
+        for i in 0..levels.len() - 1 {
+            basis.push(basis[i] * levels[i] as i64);
+        }
+
+        Ok(Self {
+            project_in,
+            project_out,
+            half_l,
+            half_width,
+            offset,
+            shift,
+            basis,
+            levels: levels.to_vec(),
+            model_dtype,
+        })
+    }
+
+    /// FSQ bound + round: `round(tanh(z + shift) * half_l - offset) / half_width`
+    fn fsq_quantize(&self, z: &Tensor) -> Result<Tensor> {
+        let dev = z.device();
+        let half_l = Tensor::new(&self.half_l[..], dev)?
+            .unsqueeze(0)?
+            .unsqueeze(0)?;
+        let offset = Tensor::new(&self.offset[..], dev)?
+            .unsqueeze(0)?
+            .unsqueeze(0)?;
+        let shift = Tensor::new(&self.shift[..], dev)?
+            .unsqueeze(0)?
+            .unsqueeze(0)?;
+        let half_width = Tensor::new(&self.half_width[..], dev)?
+            .unsqueeze(0)?
+            .unsqueeze(0)?;
+
+        // bound: tanh(z + shift) * half_l - offset, then round, then / half_width
+        let bounded = z
+            .broadcast_add(&shift)?
+            .tanh()?
+            .broadcast_mul(&half_l)?
+            .broadcast_sub(&offset)?;
+        let rounded = bounded.round()?;
+        rounded.broadcast_div(&half_width)
+    }
+
+    /// Quantize continuous representations into discrete tokens.
+    /// Input: `(B, N, dim)`. Returns `(quantized_out, indices)` where
+    /// `quantized_out` has the same shape as input and `indices` is `(B, N, num_quantizers)`.
+    pub fn forward(&self, x: &Tensor) -> Result<(Tensor, Tensor)> {
+        // project_in: (B, N, dim) -> (B, N, codebook_dim)
+        let projected = x.apply(&self.project_in)?;
+
+        // FSQ quantize
+        let codes = self.fsq_quantize(&projected)?; // (B, N, codebook_dim)
+
+        // Compute indices from codes: scale_and_shift then dot with basis
+        let dev = x.device();
+        let half_width = Tensor::new(&self.half_width[..], dev)?
+            .unsqueeze(0)?
+            .unsqueeze(0)?;
+        let offset = Tensor::new(&self.offset[..], dev)?
+            .unsqueeze(0)?
+            .unsqueeze(0)?;
+        let basis = Tensor::new(&self.basis[..], dev)?
+            .unsqueeze(0)?
+            .unsqueeze(0)?;
+        // scale_and_shift: codes * half_width + offset
+        let shifted = codes.broadcast_mul(&half_width)?.broadcast_add(&offset)?;
+        let indices = shifted
+            .to_dtype(DType::F32)?
+            .broadcast_mul(&basis.to_dtype(DType::F32)?)?
+            .sum(2)?
+            .round()?
+            .to_dtype(DType::I64)?
+            .unsqueeze(2)?; // (B, N, 1)
+
+        // project_out: (B, N, codebook_dim) -> (B, N, dim)
+        let quantized_out = codes.apply(&self.project_out)?;
+
+        Ok((quantized_out, indices))
+    }
+
+    /// Reconstruct from quantized codes (not indices).
+    /// Input: `(B, N, codebook_dim)` → Output: `(B, N, dim)`.
+    pub fn get_output_from_codes(&self, codes: &Tensor) -> Result<Tensor> {
+        codes.apply(&self.project_out)
+    }
+
+    /// Reconstruct from packed indices.
+    /// Input: `(B, N, 1)` → Output: `(B, N, dim)`.
+    ///
+    /// Inverse of the forward path: decompose flat index into per-level values
+    /// via basis, then invert scale_and_shift, then `project_out`.
+    pub fn get_output_from_indices(&self, indices: &Tensor) -> Result<Tensor> {
+        let dev = indices.device();
+        let indices = indices.squeeze(D::Minus1)?.to_dtype(DType::F32)?;
+        let codebook_dim = self.levels.len();
+
+        // Decompose: level_val[i] = floor(index / basis[i]) % levels[i]
+        // F32 has enough precision for indices up to 64000 (max codebook size).
+        let mut code_dims = Vec::with_capacity(codebook_dim);
+        for i in 0..codebook_dim {
+            let b = self.basis[i] as f32;
+            let l = self.levels[i] as f32;
+            let dim_val = indices.affine(1.0 / b as f64, 0.0)?.floor()?;
+            // modulo: dim_val - floor(dim_val / l) * l
+            let dim_val = (&dim_val
+                - dim_val
+                    .affine(1.0 / l as f64, 0.0)?
+                    .floor()?
+                    .affine(l as f64, 0.0)?)?;
+            code_dims.push(dim_val);
+        }
+        let shifted = Tensor::stack(&code_dims, D::Minus1)?;
+
+        // Inverse scale_and_shift (Python convention):
+        // forward: shifted = codes * half_width + half_width  →  shifted ∈ [0, levels-1]
+        // inverse: codes = (shifted - half_width) / half_width
+        let hw = Tensor::new(&self.half_width[..], dev)?
+            .unsqueeze(0)?
+            .unsqueeze(0)?;
+        let codes = shifted.broadcast_sub(&hw)?.broadcast_div(&hw)?;
+
+        codes.to_dtype(self.model_dtype)?.apply(&self.project_out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::Device;
+
+    /// Build a minimal ResidualFSQ with identity projections for testing.
+    fn test_fsq() -> Result<ResidualFSQ> {
+        let dev = &Device::Cpu;
+        let levels = vec![8, 8, 8, 5, 5, 5];
+        let codebook_dim = levels.len();
+
+        // Identity-like project_in/project_out (codebook_dim x codebook_dim)
+        let eye = Tensor::eye(codebook_dim, DType::F32, dev)?;
+        let zeros = Tensor::zeros(codebook_dim, DType::F32, dev)?;
+
+        let eps = 1e-3f32;
+        let half_l: Vec<f32> = levels
+            .iter()
+            .map(|&l| (l as f32 - 1.0) * (1.0 + eps) / 2.0)
+            .collect();
+        let half_width: Vec<f32> = levels.iter().map(|&l| (l / 2) as f32).collect();
+        let offset: Vec<f32> = levels
+            .iter()
+            .map(|&l| if l % 2 == 0 { 0.5 } else { 0.0 })
+            .collect();
+        let shift: Vec<f32> = half_l
+            .iter()
+            .zip(&offset)
+            .map(|(&hl, &o)| (o / hl).atanh())
+            .collect();
+        let mut basis = vec![1i64];
+        for i in 0..levels.len() - 1 {
+            basis.push(basis[i] * levels[i] as i64);
+        }
+
+        Ok(ResidualFSQ {
+            project_in: Linear::from_weights(eye.clone(), Some(zeros.clone())),
+            project_out: Linear::from_weights(eye, Some(zeros)),
+            half_l,
+            half_width,
+            offset,
+            shift,
+            basis,
+            levels,
+            model_dtype: DType::F32,
+        })
+    }
+
+    #[test]
+    fn test_get_output_from_indices_roundtrip() -> Result<()> {
+        // Test that manually-packed Python-convention indices correctly
+        // reconstruct codes via get_output_from_indices.
+        let fsq = test_fsq()?;
+        let dev = &Device::Cpu;
+        // levels = [8,8,8,5,5,5], half_width = [4,4,4,2,2,2]
+        // basis = [1, 8, 64, 512, 2560, 12800]
+        //
+        // Choose codes: [0.25, -0.5, 0.75, 0.5, -1.0, 0.0]
+        // Python scale_and_shift: shifted = codes * half_width + half_width
+        //   = [0.25*4+4, -0.5*4+4, 0.75*4+4, 0.5*2+2, -1.0*2+2, 0.0*2+2]
+        //   = [5, 2, 7, 3, 0, 2]
+        // index = 5*1 + 2*8 + 7*64 + 3*512 + 0*2560 + 2*12800
+        //       = 5 + 16 + 448 + 1536 + 0 + 25600 = 27605
+        let expected_codes: Vec<f32> = vec![0.25, -0.5, 0.75, 0.5, -1.0, 0.0];
+        let index: i64 = 27605;
+
+        let indices = Tensor::new(&[[index]], dev)?.unsqueeze(2)?; // (1, 1, 1)
+        let reconstructed = fsq.get_output_from_indices(&indices)?;
+        let vals = reconstructed.squeeze(0)?.squeeze(0)?.to_vec1::<f32>()?;
+
+        for (i, (&got, &want)) in vals.iter().zip(expected_codes.iter()).enumerate() {
+            assert!((got - want).abs() < 1e-5, "dim {i}: got={got}, want={want}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_output_from_indices_known_values() -> Result<()> {
+        let fsq = test_fsq()?;
+        let dev = &Device::Cpu;
+
+        // Index 0 should decompose to level_vals = [0, 0, 0, 0, 0, 0]
+        // Python convention: codes = (level_vals - half_width) / half_width
+        // For levels [8,8,8,5,5,5]: half_width=[4,4,4,2,2,2]
+        // codes = [(0-4)/4, (0-4)/4, (0-4)/4, (0-2)/2, (0-2)/2, (0-2)/2]
+        //       = [-1, -1, -1, -1, -1, -1]
+        let indices = Tensor::new(&[[0i64]], dev)?.unsqueeze(2)?; // (1, 1, 1)
+        let result = fsq.get_output_from_indices(&indices)?;
+        let vals = result.squeeze(0)?.squeeze(0)?.to_vec1::<f32>()?;
+        assert!((vals[0] - (-1.0)).abs() < 1e-5, "val[0]={}", vals[0]);
+        assert!((vals[3] - (-1.0)).abs() < 1e-5, "val[3]={}", vals[3]);
+
+        // Index that corresponds to center: half_width values for each level
+        // level_vals = [4, 4, 4, 2, 2, 2]
+        // packed index = 4*1 + 4*8 + 4*64 + 2*512 + 2*2560 + 2*12800
+        //             = 4 + 32 + 256 + 1024 + 5120 + 25600 = 32036
+        // codes = [0, 0, 0, 0, 0, 0]
+        let indices = Tensor::new(&[[32036i64]], dev)?.unsqueeze(2)?;
+        let result = fsq.get_output_from_indices(&indices)?;
+        let vals = result.squeeze(0)?.squeeze(0)?.to_vec1::<f32>()?;
+        for (i, &v) in vals.iter().enumerate() {
+            assert!(v.abs() < 1e-5, "center val[{i}]={v}, expected 0");
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AudioTokenizer
+// ---------------------------------------------------------------------------
+#[derive(Debug, Clone)]
+pub struct AudioTokenizer {
+    audio_acoustic_proj: Linear,
+    attention_pooler: AttentionPooler,
+    quantizer: ResidualFSQ,
+    pool_window_size: usize,
+}
+
+impl AudioTokenizer {
+    pub fn new(cfg: &AceStepConfig, vb: VarBuilder) -> Result<Self> {
+        let enc_hs = cfg.encoder_hidden_size();
+        Ok(Self {
+            audio_acoustic_proj: linear(
+                cfg.audio_acoustic_hidden_dim,
+                enc_hs,
+                vb.pp("audio_acoustic_proj"),
+            )?,
+            attention_pooler: AttentionPooler::new(cfg, vb.pp("attention_pooler"))?,
+            quantizer: ResidualFSQ::new(cfg, vb.pp("quantizer"))?,
+            pool_window_size: cfg.pool_window_size,
+        })
+    }
+
+    pub fn pool_window_size(&self) -> usize {
+        self.pool_window_size
+    }
+
+    /// Reconstruct from packed indices via the quantizer.
+    /// Input: `(B, N, 1)` → Output: `(B, N, dim)`.
+    pub fn get_output_from_indices(&self, indices: &Tensor) -> Result<Tensor> {
+        self.quantizer.get_output_from_indices(indices)
+    }
+
+    /// Tokenize audio features into quantized tokens.
+    /// Input: (B, T_patches, pool_window_size, acoustic_dim)
+    /// Output: (quantized, indices)
+    pub fn forward(&self, x: &Tensor) -> Result<(Tensor, Tensor)> {
+        let x = x.apply(&self.audio_acoustic_proj)?;
+        let pooled = self.attention_pooler.forward(&x)?;
+        self.quantizer.forward(&pooled)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AudioTokenDetokenizer
+// ---------------------------------------------------------------------------
+#[derive(Debug, Clone)]
+pub struct AudioTokenDetokenizer {
+    embed_tokens: Linear,
+    layers: Vec<EncoderLayer>,
+    norm: RmsNorm,
+    proj_out: Linear,
+    special_tokens: Tensor,
+    pool_window_size: usize,
+    rotary_emb: Arc<RotaryEmbedding>,
+}
+
+impl AudioTokenDetokenizer {
+    pub fn new(cfg: &AceStepConfig, vb: VarBuilder) -> Result<Self> {
+        let enc_hs = cfg.encoder_hidden_size();
+        let num_layers = cfg.num_attention_pooler_hidden_layers;
+
+        let mut layers = Vec::with_capacity(num_layers);
+        let vb_l = vb.pp("layers");
+        for i in 0..num_layers {
+            layers.push(EncoderLayer::new(cfg, i, vb_l.pp(i))?);
+        }
+        let rotary_emb = Arc::new(RotaryEmbedding::new(vb.dtype(), cfg, vb.device())?);
+
+        Ok(Self {
+            embed_tokens: linear(enc_hs, enc_hs, vb.pp("embed_tokens"))?,
+            layers,
+            norm: RmsNorm::new(enc_hs, cfg.rms_norm_eps, vb.pp("norm"))?,
+            proj_out: linear(enc_hs, cfg.audio_acoustic_hidden_dim, vb.pp("proj_out"))?,
+            special_tokens: vb.get((1, cfg.pool_window_size, enc_hs), "special_tokens")?,
+            pool_window_size: cfg.pool_window_size,
+            rotary_emb,
+        })
+    }
+
+    /// Detokenize quantized tokens back to continuous acoustic representations.
+    /// Input: (B, T, D) → Output: (B, T * pool_window_size, acoustic_dim)
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let (b, t, _d) = x.dims3()?;
+        let x = x.apply(&self.embed_tokens)?;
+
+        // Expand each token into pool_window_size patches
+        let x = x
+            .unsqueeze(2)?
+            .broadcast_as((b, t, self.pool_window_size, x.dim(D::Minus1)?))?;
+        let special = self.special_tokens.broadcast_as((
+            b,
+            t,
+            self.pool_window_size,
+            self.special_tokens.dim(D::Minus1)?,
+        ))?;
+        let x = (x.contiguous()? + special.contiguous()?)?;
+
+        // Reshape for processing: (B*T, pool_window_size, hidden)
+        let x = x.reshape((b * t, self.pool_window_size, ()))?;
+
+        let mut hidden = x;
+        for layer in &self.layers {
+            hidden = layer.forward(&hidden, None, &self.rotary_emb)?;
+        }
+        let hidden = self.norm.forward(&hidden)?;
+        let hidden = hidden.apply(&self.proj_out)?;
+
+        // Reshape back: (B*T, P, acoustic_dim) → (B, T*P, acoustic_dim)
+        hidden.reshape((b, t * self.pool_window_size, ()))
+    }
+}

--- a/candle-transformers/src/models/ace_step/vae.rs
+++ b/candle-transformers/src/models/ace_step/vae.rs
@@ -1,0 +1,502 @@
+//! AutoencoderOobleck VAE for the ACE-Step music generation model.
+//!
+//! This module implements the Oobleck audio VAE that encodes 48kHz stereo audio
+//! into a compact latent representation and decodes it back. The architecture
+//! uses Snake1d activations, weight-normalized convolutions, and a progressive
+//! channel structure with strided up/downsampling.
+//!
+//! The encoder compresses (B, 2, T_audio) to (B, 128, T_latent) which is then
+//! split into mean and log-variance (each 64 channels) for the diagonal Gaussian.
+//! The decoder reconstructs (B, 64, T_latent) back to (B, 2, T_audio) where
+//! T_audio is approximately T_latent * 1920 (the product of downsampling ratios).
+//!
+//! Reference: diffusers `AutoencoderOobleck`
+
+use candle::{Module, Result, Tensor, D};
+use candle_nn::{Conv1d, Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, VarBuilder};
+
+use super::VaeConfig;
+use crate::models::encodec;
+
+// ---------------------------------------------------------------------------
+// Snake1d activation
+// ---------------------------------------------------------------------------
+
+/// Learnable Snake activation with alpha and beta parameters stored in log-scale.
+///
+/// Computes: `x + (exp(beta) + 1e-9).recip() * sin(exp(alpha) * x)^2`
+///
+/// Both `alpha` and `beta` have shape `(1, channels, 1)` and are exponentiated
+/// before use to ensure positivity.
+#[derive(Debug, Clone)]
+pub struct Snake1d {
+    alpha: Tensor,
+    beta: Tensor,
+}
+
+impl Snake1d {
+    pub fn new(channels: usize, vb: VarBuilder) -> Result<Self> {
+        let alpha = vb.get((1, channels, 1), "alpha")?;
+        let beta = vb.get((1, channels, 1), "beta")?;
+        Ok(Self { alpha, beta })
+    }
+}
+
+impl Module for Snake1d {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let alpha = self.alpha.exp()?;
+        let beta = self.beta.exp()?;
+        let sin = alpha.broadcast_mul(xs)?.sin()?;
+        let sin_sq = (&sin * &sin)?;
+        xs + ((&beta + 1e-9)?.recip()?.broadcast_mul(&sin_sq)?)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OobleckResidualUnit
+// ---------------------------------------------------------------------------
+
+/// Residual unit with dilated convolutions and Snake1d activations.
+///
+/// Structure: `snake1 -> conv1(k=7, dilation=d) -> snake2 -> conv2(k=1) + skip`
+///
+/// All convolutions use weight normalization. The skip connection trims the
+/// input if the output is shorter due to dilation-induced size differences.
+#[derive(Debug, Clone)]
+pub struct OobleckResidualUnit {
+    snake1: Snake1d,
+    conv1: Conv1d,
+    snake2: Snake1d,
+    conv2: Conv1d,
+}
+
+impl OobleckResidualUnit {
+    pub fn new(dim: usize, dilation: usize, vb: VarBuilder) -> Result<Self> {
+        let pad = ((7 - 1) * dilation) / 2;
+        let snake1 = Snake1d::new(dim, vb.pp("snake1"))?;
+        let cfg1 = Conv1dConfig {
+            dilation,
+            padding: pad,
+            ..Default::default()
+        };
+        let conv1 = encodec::conv1d_weight_norm(dim, dim, 7, cfg1, vb.pp("conv1"))?;
+        let snake2 = Snake1d::new(dim, vb.pp("snake2"))?;
+        let conv2 = encodec::conv1d_weight_norm(dim, dim, 1, Default::default(), vb.pp("conv2"))?;
+        Ok(Self {
+            snake1,
+            conv1,
+            snake2,
+            conv2,
+        })
+    }
+}
+
+impl Module for OobleckResidualUnit {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let ys = xs
+            .apply(&self.snake1)?
+            .apply(&self.conv1)?
+            .apply(&self.snake2)?
+            .apply(&self.conv2)?;
+        let xs_len = xs.dim(D::Minus1)?;
+        let ys_len = ys.dim(D::Minus1)?;
+        let pad = (xs_len - ys_len) / 2;
+        if pad > 0 {
+            &ys + xs.narrow(D::Minus1, pad, ys_len)?
+        } else {
+            ys + xs
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OobleckEncoderBlock
+// ---------------------------------------------------------------------------
+
+/// Encoder block: 3 residual units (dilations 1, 3, 9) followed by Snake1d
+/// activation and a strided downsampling convolution.
+#[derive(Debug, Clone)]
+pub struct OobleckEncoderBlock {
+    res_unit1: OobleckResidualUnit,
+    res_unit2: OobleckResidualUnit,
+    res_unit3: OobleckResidualUnit,
+    snake1: Snake1d,
+    conv1: Conv1d,
+}
+
+impl OobleckEncoderBlock {
+    pub fn new(input_dim: usize, output_dim: usize, stride: usize, vb: VarBuilder) -> Result<Self> {
+        let res_unit1 = OobleckResidualUnit::new(input_dim, 1, vb.pp("res_unit1"))?;
+        let res_unit2 = OobleckResidualUnit::new(input_dim, 3, vb.pp("res_unit2"))?;
+        let res_unit3 = OobleckResidualUnit::new(input_dim, 9, vb.pp("res_unit3"))?;
+        let snake1 = Snake1d::new(input_dim, vb.pp("snake1"))?;
+        let cfg = Conv1dConfig {
+            stride,
+            padding: stride.div_ceil(2),
+            ..Default::default()
+        };
+        let conv1 =
+            encodec::conv1d_weight_norm(input_dim, output_dim, 2 * stride, cfg, vb.pp("conv1"))?;
+        Ok(Self {
+            res_unit1,
+            res_unit2,
+            res_unit3,
+            snake1,
+            conv1,
+        })
+    }
+}
+
+impl Module for OobleckEncoderBlock {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        xs.apply(&self.res_unit1)?
+            .apply(&self.res_unit2)?
+            .apply(&self.res_unit3)?
+            .apply(&self.snake1)?
+            .apply(&self.conv1)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OobleckDecoderBlock
+// ---------------------------------------------------------------------------
+
+/// Decoder block: Snake1d activation and transposed convolution for upsampling,
+/// followed by 3 residual units (dilations 1, 3, 9).
+#[derive(Debug, Clone)]
+pub struct OobleckDecoderBlock {
+    snake1: Snake1d,
+    conv_t1: ConvTranspose1d,
+    res_unit1: OobleckResidualUnit,
+    res_unit2: OobleckResidualUnit,
+    res_unit3: OobleckResidualUnit,
+}
+
+impl OobleckDecoderBlock {
+    pub fn new(input_dim: usize, output_dim: usize, stride: usize, vb: VarBuilder) -> Result<Self> {
+        let snake1 = Snake1d::new(input_dim, vb.pp("snake1"))?;
+        let cfg = ConvTranspose1dConfig {
+            stride,
+            padding: stride.div_ceil(2),
+            ..Default::default()
+        };
+        let conv_t1 = encodec::conv_transpose1d_weight_norm(
+            input_dim,
+            output_dim,
+            2 * stride,
+            true,
+            cfg,
+            vb.pp("conv_t1"),
+        )?;
+        let res_unit1 = OobleckResidualUnit::new(output_dim, 1, vb.pp("res_unit1"))?;
+        let res_unit2 = OobleckResidualUnit::new(output_dim, 3, vb.pp("res_unit2"))?;
+        let res_unit3 = OobleckResidualUnit::new(output_dim, 9, vb.pp("res_unit3"))?;
+        Ok(Self {
+            snake1,
+            conv_t1,
+            res_unit1,
+            res_unit2,
+            res_unit3,
+        })
+    }
+}
+
+impl Module for OobleckDecoderBlock {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        xs.apply(&self.snake1)?
+            .apply(&self.conv_t1)?
+            .apply(&self.res_unit1)?
+            .apply(&self.res_unit2)?
+            .apply(&self.res_unit3)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OobleckEncoder
+// ---------------------------------------------------------------------------
+
+/// Oobleck encoder that compresses stereo audio to a latent representation.
+///
+/// Channel progression (default config):
+/// `2 -> 128 -> 128 -> 256 -> 512 -> 1024 -> 2048 -> 128`
+#[derive(Debug, Clone)]
+pub struct OobleckEncoder {
+    conv1: Conv1d,
+    blocks: Vec<OobleckEncoderBlock>,
+    snake1: Snake1d,
+    conv2: Conv1d,
+}
+
+impl OobleckEncoder {
+    pub fn new(config: &VaeConfig, vb: VarBuilder) -> Result<Self> {
+        let enc_hs = config.encoder_hidden_size;
+
+        // Prepend 1 to channel_multiples: [1, 1, 2, 4, 8, 16]
+        let mut multiples = vec![1usize];
+        multiples.extend_from_slice(&config.channel_multiples);
+
+        let cfg1 = Conv1dConfig {
+            padding: 3,
+            ..Default::default()
+        };
+        let conv1 =
+            encodec::conv1d_weight_norm(config.audio_channels, enc_hs, 7, cfg1, vb.pp("conv1"))?;
+
+        let mut blocks = Vec::with_capacity(config.downsampling_ratios.len());
+        for (i, &stride) in config.downsampling_ratios.iter().enumerate() {
+            let in_channels = enc_hs * multiples[i];
+            let out_channels = enc_hs * multiples[i + 1];
+            let block =
+                OobleckEncoderBlock::new(in_channels, out_channels, stride, vb.pp("block").pp(i))?;
+            blocks.push(block);
+        }
+
+        let final_channels = enc_hs * multiples[multiples.len() - 1];
+        let snake1 = Snake1d::new(final_channels, vb.pp("snake1"))?;
+
+        let cfg2 = Conv1dConfig {
+            padding: 1,
+            ..Default::default()
+        };
+        let conv2 = encodec::conv1d_weight_norm(final_channels, enc_hs, 3, cfg2, vb.pp("conv2"))?;
+
+        Ok(Self {
+            conv1,
+            blocks,
+            snake1,
+            conv2,
+        })
+    }
+}
+
+impl Module for OobleckEncoder {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let mut xs = xs.apply(&self.conv1)?;
+        for block in &self.blocks {
+            xs = xs.apply(block)?;
+        }
+        xs.apply(&self.snake1)?.apply(&self.conv2)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OobleckDecoder
+// ---------------------------------------------------------------------------
+
+/// Oobleck decoder that reconstructs stereo audio from a latent representation.
+///
+/// Channel progression (default config):
+/// `64 -> 2048 -> 1024 -> 512 -> 256 -> 128 -> 2`
+#[derive(Debug, Clone)]
+pub struct OobleckDecoder {
+    conv1: Conv1d,
+    blocks: Vec<OobleckDecoderBlock>,
+    snake1: Snake1d,
+    conv2: Conv1d,
+}
+
+impl OobleckDecoder {
+    pub fn new(config: &VaeConfig, vb: VarBuilder) -> Result<Self> {
+        let dec_ch = config.decoder_channels;
+
+        // Prepend 1 to channel_multiples: [1, 1, 2, 4, 8, 16]
+        let mut multiples = vec![1usize];
+        multiples.extend_from_slice(&config.channel_multiples);
+        let n = multiples.len(); // 6
+
+        // Upsampling ratios are reversed downsampling: [10, 6, 4, 4, 2]
+        let upsampling_ratios: Vec<usize> =
+            config.downsampling_ratios.iter().copied().rev().collect();
+
+        let cfg1 = Conv1dConfig {
+            padding: 3,
+            ..Default::default()
+        };
+        // conv1: decoder_input_channels -> dec_ch * mult[-1] (e.g. 64 -> 2048)
+        let first_channels = dec_ch * multiples[n - 1];
+        let conv1 = encodec::conv1d_weight_norm(
+            config.decoder_input_channels,
+            first_channels,
+            7,
+            cfg1,
+            vb.pp("conv1"),
+        )?;
+
+        let mut blocks = Vec::with_capacity(upsampling_ratios.len());
+        for (i, &stride) in upsampling_ratios.iter().enumerate() {
+            // Channels go from mult[N-1-i] to mult[N-2-i]
+            let in_channels = dec_ch * multiples[n - 1 - i];
+            let out_channels = dec_ch * multiples[n - 2 - i];
+            let block =
+                OobleckDecoderBlock::new(in_channels, out_channels, stride, vb.pp("block").pp(i))?;
+            blocks.push(block);
+        }
+
+        let snake1 = Snake1d::new(dec_ch, vb.pp("snake1"))?;
+
+        let cfg2 = Conv1dConfig {
+            padding: 3,
+            ..Default::default()
+        };
+        // Final conv: dec_ch -> audio_channels, NO bias
+        let conv2 = encodec::conv1d_weight_norm_no_bias(
+            dec_ch,
+            config.audio_channels,
+            7,
+            cfg2,
+            vb.pp("conv2"),
+        )?;
+
+        Ok(Self {
+            conv1,
+            blocks,
+            snake1,
+            conv2,
+        })
+    }
+}
+
+impl Module for OobleckDecoder {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let mut xs = xs.apply(&self.conv1)?;
+        for block in &self.blocks {
+            xs = xs.apply(block)?;
+        }
+        xs.apply(&self.snake1)?.apply(&self.conv2)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AutoencoderOobleck
+// ---------------------------------------------------------------------------
+
+/// AutoencoderOobleck: full VAE combining encoder and decoder for audio.
+///
+/// Encodes stereo 48kHz audio `(B, 2, T)` to latent `(B, 64, T/1920)` and
+/// decodes back. Uses a diagonal Gaussian latent distribution with
+/// reparameterization sampling.
+#[derive(Debug, Clone)]
+pub struct AutoencoderOobleck {
+    encoder: OobleckEncoder,
+    decoder: OobleckDecoder,
+    config: VaeConfig,
+}
+
+impl AutoencoderOobleck {
+    pub fn new(config: &VaeConfig, vb: VarBuilder) -> Result<Self> {
+        let encoder = OobleckEncoder::new(config, vb.pp("encoder"))?;
+        let decoder = OobleckDecoder::new(config, vb.pp("decoder"))?;
+        Ok(Self {
+            encoder,
+            decoder,
+            config: config.clone(),
+        })
+    }
+
+    /// Encode audio to a latent sample using the diagonal Gaussian.
+    ///
+    /// The encoder output `(B, encoder_hidden_size, T_latent)` is split along
+    /// the channel dimension into mean and log-variance (each with
+    /// `decoder_input_channels` channels), then sampled via reparameterization:
+    /// `z = mean + exp(0.5 * logvar) * noise`.
+    pub fn encode(&self, xs: &Tensor) -> Result<Tensor> {
+        let h = self.encoder.forward(xs)?;
+        let latent_dim = self.config.decoder_input_channels;
+        let mean = h.narrow(1, 0, latent_dim)?;
+        let logvar = h.narrow(1, latent_dim, latent_dim)?;
+        let std = (logvar * 0.5)?.exp()?;
+        let noise = std.randn_like(0., 1.)?;
+        &mean + std.mul(&noise)?
+    }
+
+    /// Encode audio to the latent mean (no sampling noise).
+    ///
+    /// For deterministic encoding (e.g. when exact reconstruction matters),
+    /// this returns only the mean of the diagonal Gaussian, without
+    /// reparameterization noise.
+    pub fn encode_mean(&self, xs: &Tensor) -> Result<Tensor> {
+        let h = self.encoder.forward(xs)?;
+        let latent_dim = self.config.decoder_input_channels;
+        h.narrow(1, 0, latent_dim)
+    }
+
+    /// Decode a latent representation back to audio waveform.
+    ///
+    /// Input shape: `(B, decoder_input_channels, T_latent)`
+    /// Output shape: `(B, audio_channels, T_audio)`
+    pub fn decode(&self, z: &Tensor) -> Result<Tensor> {
+        self.decoder.forward(z)
+    }
+
+    /// Tiled encoding for long audio that may not fit in GPU memory.
+    ///
+    /// Splits the audio into overlapping chunks, encodes each independently,
+    /// trims the overlap regions, and concatenates. Uses the overlap-discard
+    /// strategy to avoid boundary artifacts.
+    ///
+    /// - `chunk_samples`: audio samples per chunk (default: 48000 * 30 = 30s)
+    /// - `overlap_samples`: overlap in audio samples (default: 48000 * 2 = 2s)
+    ///
+    /// Input: `(B, channels, T_audio)`, output: `(B, latent_dim, T_latent)`
+    pub fn tiled_encode(
+        &self,
+        xs: &Tensor,
+        chunk_samples: Option<usize>,
+        overlap_samples: Option<usize>,
+    ) -> Result<Tensor> {
+        let chunk_size = chunk_samples.unwrap_or(48000 * 30);
+        let overlap = overlap_samples.unwrap_or(48000 * 2);
+        let total_samples = xs.dim(2)?;
+
+        // Short audio: encode directly
+        if total_samples <= chunk_size {
+            return self.encode(xs);
+        }
+
+        let stride = chunk_size - 2 * overlap;
+        if stride == 0 {
+            candle::bail!(
+                "tiled_encode: chunk_size ({chunk_size}) must be > 2 * overlap ({overlap})"
+            );
+        }
+        let num_steps = total_samples.div_ceil(stride);
+        let mut downsample_factor: Option<f64> = None;
+        let mut latent_chunks = Vec::with_capacity(num_steps);
+
+        for i in 0..num_steps {
+            let core_start = i * stride;
+            let core_end = (core_start + stride).min(total_samples);
+
+            // Window with overlap
+            let win_start = core_start.saturating_sub(overlap);
+            let win_end = (core_end + overlap).min(total_samples);
+
+            let audio_chunk = xs.narrow(2, win_start, win_end - win_start)?;
+            let latent_chunk = self.encode(&audio_chunk)?;
+
+            // Determine downsample factor from first chunk
+            let df = downsample_factor.get_or_insert_with(|| {
+                audio_chunk.dim(2).unwrap() as f64 / latent_chunk.dim(2).unwrap() as f64
+            });
+
+            // Trim overlap in latent space
+            let added_start = core_start - win_start;
+            let trim_start = (added_start as f64 / *df).round() as usize;
+
+            let added_end = win_end - core_end;
+            let trim_end = (added_end as f64 / *df).round() as usize;
+
+            let latent_len = latent_chunk.dim(2)?;
+            let end_idx = if trim_end > 0 {
+                latent_len - trim_end
+            } else {
+                latent_len
+            };
+            let core_len = end_idx - trim_start;
+            let latent_core = latent_chunk.narrow(2, trim_start, core_len)?;
+            latent_chunks.push(latent_core);
+        }
+
+        Tensor::cat(&latent_chunks.iter().collect::<Vec<_>>(), 2)
+    }
+}

--- a/candle-transformers/src/models/ace_step/vae.rs
+++ b/candle-transformers/src/models/ace_step/vae.rs
@@ -480,16 +480,21 @@ impl AutoencoderOobleck {
             let latent_chunk = self.encode(&audio_chunk)?;
 
             // Determine downsample factor from first chunk
-            let df = downsample_factor.get_or_insert_with(|| {
-                audio_chunk.dim(2).unwrap() as f64 / latent_chunk.dim(2).unwrap() as f64
-            });
+            let df = match downsample_factor {
+                Some(df) => df,
+                None => {
+                    let df = audio_chunk.dim(2)? as f64 / latent_chunk.dim(2)? as f64;
+                    downsample_factor = Some(df);
+                    df
+                }
+            };
 
             // Trim overlap in latent space
             let added_start = core_start - win_start;
-            let trim_start = (added_start as f64 / *df).round() as usize;
+            let trim_start = (added_start as f64 / df).round() as usize;
 
             let added_end = win_end - core_end;
-            let trim_end = (added_end as f64 / *df).round() as usize;
+            let trim_end = (added_end as f64 / df).round() as usize;
 
             let latent_len = latent_chunk.dim(2)?;
             let end_idx = if trim_end > 0 {

--- a/candle-transformers/src/models/ace_step/vae.rs
+++ b/candle-transformers/src/models/ace_step/vae.rs
@@ -100,11 +100,16 @@ impl Module for OobleckResidualUnit {
             .apply(&self.conv2)?;
         let xs_len = xs.dim(D::Minus1)?;
         let ys_len = ys.dim(D::Minus1)?;
-        let pad = (xs_len - ys_len) / 2;
-        if pad > 0 {
-            &ys + xs.narrow(D::Minus1, pad, ys_len)?
+        if xs_len >= ys_len {
+            let pad = (xs_len - ys_len) / 2;
+            if pad > 0 {
+                &ys + xs.narrow(D::Minus1, pad, ys_len)?
+            } else {
+                ys + xs
+            }
         } else {
-            ys + xs
+            let pad = (ys_len - xs_len) / 2;
+            &ys.narrow(D::Minus1, pad, xs_len)? + xs
         }
     }
 }
@@ -453,12 +458,12 @@ impl AutoencoderOobleck {
             return self.encode(xs);
         }
 
-        let stride = chunk_size - 2 * overlap;
-        if stride == 0 {
+        if chunk_size <= 2 * overlap {
             candle::bail!(
                 "tiled_encode: chunk_size ({chunk_size}) must be > 2 * overlap ({overlap})"
             );
         }
+        let stride = chunk_size - 2 * overlap;
         let num_steps = total_samples.div_ceil(stride);
         let mut downsample_factor: Option<f64> = None;
         let mut latent_chunks = Vec::with_capacity(num_steps);

--- a/candle-transformers/src/models/ace_step/vae.rs
+++ b/candle-transformers/src/models/ace_step/vae.rs
@@ -359,6 +359,95 @@ impl OobleckDecoder {
             conv2,
         })
     }
+
+    /// Tiled decoding for long latents that may not fit in memory.
+    ///
+    /// Splits the latent along the time axis into overlapping chunks, decodes
+    /// each chunk independently via `forward`, trims the overlap regions in
+    /// audio space, and concatenates the cores. The decoder is fully
+    /// convolutional with local padding, so cores away from chunk boundaries
+    /// are numerically identical to a single full-length decode (up to the
+    /// decoder's finite receptive field, absorbed by the overlap).
+    ///
+    /// For short latents (`T_latent <= chunk_latent_frames`) this falls back
+    /// to a plain `forward` call.
+    ///
+    /// - `chunk_latent_frames`: latent frames per chunk (default 128 ≈ 5.1s of
+    ///   audio at 48 kHz with a 1920× upsample ratio).
+    /// - `overlap_latent_frames`: overlap on each side in latent frames
+    ///   (default 16). Must satisfy `chunk > 2 * overlap`.
+    ///
+    /// Input: `(B, decoder_input_channels, T_latent)`.
+    /// Output: `(B, audio_channels, T_latent * upsample_ratio)`.
+    pub fn tiled_decode(
+        &self,
+        z: &Tensor,
+        chunk_latent_frames: Option<usize>,
+        overlap_latent_frames: Option<usize>,
+    ) -> Result<Tensor> {
+        let chunk_size = chunk_latent_frames.unwrap_or(128);
+        let overlap = overlap_latent_frames.unwrap_or(16);
+        let total_frames = z.dim(2)?;
+
+        if total_frames <= chunk_size {
+            return self.forward(z);
+        }
+
+        if chunk_size <= 2 * overlap {
+            candle::bail!(
+                "tiled_decode: chunk_latent_frames ({chunk_size}) must be > 2 * overlap_latent_frames ({overlap})"
+            );
+        }
+
+        let stride = chunk_size - 2 * overlap;
+        let num_steps = total_frames.div_ceil(stride);
+        let mut upsample_factor: Option<usize> = None;
+        let mut audio_chunks = Vec::with_capacity(num_steps);
+
+        for i in 0..num_steps {
+            let core_start = i * stride;
+            let core_end = (core_start + stride).min(total_frames);
+            if core_start >= core_end {
+                break;
+            }
+
+            // Expand the window with overlap on both sides, clipped at the edges.
+            let win_start = core_start.saturating_sub(overlap);
+            let win_end = (core_end + overlap).min(total_frames);
+
+            let latent_chunk = z.narrow(2, win_start, win_end - win_start)?;
+            let audio_chunk = self.forward(&latent_chunk)?;
+
+            // Determine the upsample factor from the first chunk. The decoder
+            // is strided-conv-transpose only, so audio_len is an integer
+            // multiple of latent_len.
+            let up = match upsample_factor {
+                Some(up) => up,
+                None => {
+                    let audio_len = audio_chunk.dim(2)?;
+                    let latent_len = latent_chunk.dim(2)?;
+                    if latent_len == 0 || audio_len % latent_len != 0 {
+                        candle::bail!(
+                            "tiled_decode: audio length {audio_len} is not a multiple of latent length {latent_len}"
+                        );
+                    }
+                    let up = audio_len / latent_len;
+                    upsample_factor = Some(up);
+                    up
+                }
+            };
+
+            // Trim the overlap in audio space to recover only the core.
+            let trim_start = (core_start - win_start) * up;
+            let trim_end = (win_end - core_end) * up;
+            let audio_len = audio_chunk.dim(2)?;
+            let core_len = audio_len - trim_start - trim_end;
+            let audio_core = audio_chunk.narrow(2, trim_start, core_len)?;
+            audio_chunks.push(audio_core);
+        }
+
+        Tensor::cat(&audio_chunks.iter().collect::<Vec<_>>(), 2)
+    }
 }
 
 impl Module for OobleckDecoder {
@@ -431,6 +520,17 @@ impl AutoencoderOobleck {
     /// Output shape: `(B, audio_channels, T_audio)`
     pub fn decode(&self, z: &Tensor) -> Result<Tensor> {
         self.decoder.forward(z)
+    }
+
+    /// Tiled decoding for long latents; see [`OobleckDecoder::tiled_decode`].
+    pub fn tiled_decode(
+        &self,
+        z: &Tensor,
+        chunk_latent_frames: Option<usize>,
+        overlap_latent_frames: Option<usize>,
+    ) -> Result<Tensor> {
+        self.decoder
+            .tiled_decode(z, chunk_latent_frames, overlap_latent_frames)
     }
 
     /// Tiled encoding for long audio that may not fit in GPU memory.
@@ -508,5 +608,109 @@ impl AutoencoderOobleck {
         }
 
         Tensor::cat(&latent_chunks.iter().collect::<Vec<_>>(), 2)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::{DType, Device};
+    use candle_nn::{VarBuilder, VarMap};
+
+    /// Build a small OobleckDecoder with random weights on CPU. The
+    /// architecture is identical to the production decoder; we just shrink the
+    /// channel count so the test runs quickly.
+    fn tiny_decoder() -> Result<(OobleckDecoder, Device)> {
+        let device = Device::Cpu;
+        let varmap = VarMap::new();
+        let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+        let config = VaeConfig {
+            decoder_channels: 8,
+            decoder_input_channels: 4,
+            audio_channels: 2,
+            // Keep the real upsampling structure to exercise all 5 blocks.
+            downsampling_ratios: vec![2, 4, 4, 6, 10],
+            channel_multiples: vec![1, 1, 1, 1, 1],
+            ..VaeConfig::default()
+        };
+        let decoder = OobleckDecoder::new(&config, vb)?;
+        Ok((decoder, device))
+    }
+
+    /// Elementwise compare two tensors tolerant to matching NaN/Inf values.
+    /// The decoder has random weights with no normalization, so activations
+    /// can explode past fp32 range — but `forward` and `tiled_decode` do the
+    /// same computation on the same slice, so whatever NaN/Inf pattern
+    /// `forward` produces, `tiled_decode` must produce in the same places.
+    fn tensors_agree(a: &Tensor, b: &Tensor, atol: f32) -> Result<bool> {
+        let a = a.flatten_all()?.to_vec1::<f32>()?;
+        let b = b.flatten_all()?.to_vec1::<f32>()?;
+        assert_eq!(a.len(), b.len(), "shape mismatch");
+        for (x, y) in a.iter().zip(b.iter()) {
+            let ok = match (x.is_nan(), y.is_nan()) {
+                (true, true) => true,
+                (false, false) => {
+                    if x.is_infinite() || y.is_infinite() {
+                        x == y
+                    } else {
+                        let scale = x.abs().max(y.abs()).max(1.0);
+                        (x - y).abs() <= atol * scale
+                    }
+                }
+                _ => false,
+            };
+            if !ok {
+                eprintln!("mismatch: forward={x} tiled={y}");
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    #[test]
+    fn tiled_decode_short_input_delegates_to_forward() -> Result<()> {
+        let (decoder, device) = tiny_decoder()?;
+        // total < chunk → tiled_decode must short-circuit to forward.
+        let z = Tensor::randn(0f32, 1.0, (1, 4, 64), &device)?;
+
+        let y_direct = decoder.forward(&z)?;
+        let y_tiled = decoder.tiled_decode(&z, Some(128), Some(16))?;
+
+        assert_eq!(y_tiled.dims(), y_direct.dims());
+        assert!(tensors_agree(&y_direct, &y_tiled, 1e-5)?);
+        Ok(())
+    }
+
+    #[test]
+    fn tiled_decode_matches_forward_across_chunks() -> Result<()> {
+        let (decoder, device) = tiny_decoder()?;
+        // Force multiple chunk boundaries.
+        let t_latent = 300;
+        let z = Tensor::randn(0f32, 1.0, (1, 4, t_latent), &device)?;
+
+        let y_direct = decoder.forward(&z)?;
+        let y_tiled = decoder.tiled_decode(&z, Some(64), Some(16))?;
+
+        assert_eq!(
+            y_tiled.dims(),
+            y_direct.dims(),
+            "tiled output shape must equal full-forward shape"
+        );
+        // Receptive field fits inside the 16-frame overlap, so cores should
+        // match within fp32 rounding slack. Values can be extreme due to
+        // random untrained weights; compare relative.
+        assert!(tensors_agree(&y_direct, &y_tiled, 1e-3)?);
+        Ok(())
+    }
+
+    #[test]
+    fn tiled_decode_rejects_bad_overlap() -> Result<()> {
+        let (decoder, device) = tiny_decoder()?;
+        let z = Tensor::randn(0f32, 1.0, (1, 4, 200), &device)?;
+
+        // chunk <= 2 * overlap must fail.
+        let err = decoder.tiled_decode(&z, Some(32), Some(16));
+        assert!(err.is_err(), "expected tiled_decode to reject chunk<=2*overlap");
+        Ok(())
     }
 }

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -8,12 +8,13 @@
 //!  - Text to image models: [`stable_diffusion`] and [`wuerstchen`], ...
 //!  - Audio models: [`whisper`], [`encodec`], [`metavoice`], [`parler_tts`], ...
 //!  - Computer vision models: [`dinov2`], [`convmixer`], [`efficientnet`], ...
-//!  
+//!
 //! Some of the models also have quantized variants, e.g.  [`quantized_blip`], [`quantized_llama`] and  [`quantized_qwen2`].
 //!
 //! The implementations aim to be readable while maintaining good performance. For more information
 //! on each model see the model's module docs in the links below.
 
+pub mod ace_step;
 pub mod based;
 pub mod beit;
 pub mod bert;

--- a/candle-transformers/src/models/qwen3.rs
+++ b/candle-transformers/src/models/qwen3.rs
@@ -308,7 +308,7 @@ impl Model {
         })
     }
 
-    fn clear_kv_cache(&mut self) {
+    pub fn clear_kv_cache(&mut self) {
         for l in &mut self.layers {
             l.clear_kv_cache();
         }
@@ -355,6 +355,12 @@ impl Model {
             h = layer.forward(&h, causal.as_ref(), offset)?;
         }
         self.norm.forward(&h)
+    }
+
+    /// Embed token IDs without running through transformer layers.
+    /// Returns raw token embeddings of shape `(B, L, hidden_size)`.
+    pub fn embed_tokens(&self, input: &Tensor) -> Result<Tensor> {
+        self.embed_tokens.forward(input)
     }
 }
 


### PR DESCRIPTION
## Summary

- Add ACE-Step 1.5 music generation model (DiT + VAE + LM pipeline) to `candle-transformers`
- Add full CLI example with text-to-music, cover, repaint, and LM+DiT modes
- Support all model variants: base/sft/turbo (2B) and XL (4B), LM 0.6B/1.7B/4B

Closes #3390

## Model components (`candle-transformers/src/models/ace_step/`)

| Module | Description |
|--------|-------------|
| `dit.rs` | Diffusion transformer — sliding/full attention, cross-attention KV caching, AdaLN-Zero |
| `condition.rs` | Condition encoder — text/lyric/timbre encoding, pack_sequences, XL CLS token |
| `vae.rs` | AutoencoderOobleck — encoder (with tiled encoding) and decoder |
| `tokenizer.rs` | ResidualFSQ quantizer, AttentionPooler, AudioTokenizer/Detokenizer |
| `lm.rs` | Qwen3-based LM pipeline — two-phase generation (CoT metadata + audio codes), constrained decoding with per-field constraints (greedy enumerated for keyscale/language/timesig, digit-only for bpm/duration) |
| `model.rs` | Top-level model — prepare_condition, generate_latents (base + turbo paths) |
| `sampling.rs` | Euler ODE/SDE, APG guidance, turbo discrete schedules, custom timestep support |
| `mod.rs` | AceStepConfig, VaeConfig with serde deserialization |

## Example (`candle-examples/examples/ace-step/`)

| Feature | Details |
|---------|---------|
| Text-to-music | `--prompt "jazz piano" --duration 30` |
| LM+DiT pipeline | `--infer-type lm-dit --lm-model ACE-Step/acestep-5Hz-lm-0.6B` — LM generates metadata + audio codes, metadata fed back to DiT text encoder |
| Cover mode | `--reference-audio song.wav` with optional `--timbre-audio voice.wav` for separate timbre source |
| Repaint mode | `--repaint-audio source.wav --repaint-start 3 --repaint-end 7` |
| Lyrics | `--lyrics "text"` or `--lyrics file.txt` (auto-detects file path) |
| XL support | Sharded weight loading via `model.safetensors.index.json`, separate encoder/decoder dims |
| Post-processing | BS1770 loudness normalization (-14 LUFS), peak clamp, 50ms fade-out |
| Memory management | LM auto-unloaded after code generation to free GPU memory for DiT |
| Advanced options | `--audio-cover-strength`, `--cfg-interval-start/end`, `--infer-method ode/sde` |

## Verified components

| Component | Verification |
|-----------|-------------|
| ConditionEncoder | Bit-exact vs Python (max diff=0.000001) |
| AceStepDiTModel | Bit-exact vs Python (max diff=0.000022) |
| AutoencoderOobleck | Bit-exact vs Python (max diff=0.000004) |
| AudioTokenDetokenizer | Bit-exact vs Python (max diff=0.000004) |
| ResidualFSQ | Round-trip verified (unit tests) |
| APG sampler | Bit-exact vs Python (max diff=0.000001) |
| LM pipeline | E2E verified — valid codes + metadata |

## Other changes

- `candle-examples/src/wav.rs`: add `read_pcm_from_wav` and `write_pcm_as_wav_stereo` for WAV I/O without symphonia dependency
- `candle-examples/src/audio.rs`: add `pcm_decode_all_channels` and `resample` for multi-channel audio loading
- `candle-transformers/src/models/qwen3.rs`: add `embed_tokens()` accessor and `ModelForCausalLM` wrapper for causal LM inference

## Test plan

- [x] `cargo test -p candle-transformers --lib ace_step` — 21 tests pass (sampling, LM parsing, constrained decoding, field forcer)
- [x] `cargo clippy --example ace-step` — zero warnings
- [x] DiT-only generation with base/sft models (2B) — verified output quality
- [x] LM+DiT generation with turbo models (2B) — verified metadata + audio codes
- [x] XL model loading and generation (4B, sharded weights)
- [x] Cover mode with reference audio
- [x] Repaint mode with selective re-generation