### PR TITLE
Handle Flash Attn V2 SMEM conditions better

### DIFF
--- a/candle-examples/examples/gemma4/main.rs
+++ b/candle-examples/examples/gemma4/main.rs
@@ -288,8 +288,7 @@ fn main() -> Result<()> {
             None => {
                 let config_file = repo.get("config.json")?;
                 // For text-only, try to parse the text_config sub-object
-                let raw: serde_json::Value =
-                    serde_json::from_slice(&std::fs::read(config_file)?)?;
+                let raw: serde_json::Value = serde_json::from_slice(&std::fs::read(config_file)?)?;
                 if let Some(text_cfg) = raw.get("text_config") {
                     serde_json::from_value(text_cfg.clone())?
                 } else {

--- a/candle-flash-attn/kernels/flash_fwd_launch_template.h
+++ b/candle-flash-attn/kernels/flash_fwd_launch_template.h
@@ -376,8 +376,10 @@ void run_mha_fwd_hdim512(Flash_fwd_params &params, cudaStream_t stream) {
     DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
         // For A100 (164KB max smem), use 64 x 32 with 4 warps (128KB smem).
         // For sm86/sm89 (100KB max smem), use 32 x 32 with 4 warps (96KB smem).
-        if (max_smem_per_block >= 2 * Headdim * (64 + 2 * 32)) {  // 128 KB
-            run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 32, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+        // kBlockN must be >= kBlockKSmem (64) for correct V transposed shared memory access.
+        // With kBlockM=64, kBlockN=64: smem = 2 * 512 * (64 + 128) = 192 KB
+        if (max_smem_per_block >= 2 * Headdim * (64 + 2 * 64)) {  // 192 KB
+            run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
         } else {
             run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 32, 32, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
         }

--- a/candle-flash-attn/kernels/flash_fwd_launch_template.h
+++ b/candle-flash-attn/kernels/flash_fwd_launch_template.h
@@ -374,14 +374,22 @@ void run_mha_fwd_hdim512(Flash_fwd_params &params, cudaStream_t stream) {
       C10_CUDA_CHECK(status_);
     }
     DROPOUT_SWITCH(params.p_dropout < 1.f, Is_dropout, [&] {
-        // For A100 (164KB max smem), use 64 x 32 with 4 warps (128KB smem).
-        // For sm86/sm89 (100KB max smem), use 32 x 32 with 4 warps (96KB smem).
-        // kBlockN must be >= kBlockKSmem (64) for correct V transposed shared memory access.
-        // With kBlockM=64, kBlockN=64: smem = 2 * 512 * (64 + 128) = 192 KB
-        if (max_smem_per_block >= 2 * Headdim * (64 + 2 * 64)) {  // 192 KB
+        // kBlockN must be >= kBlockKSmem (64) for correct V transposed shared
+        // memory access with hdim512.
+        // Tier 1: >= 192 KB (H100, Blackwell) -> 64x64
+        // Tier 2: >= 160 KB (A100)            -> 32x64
+        // Tier 3: <  160 KB (sm86/89)         -> cannot run correctly, caller must check supports_head_dim() and use eager attention.
+        if (max_smem_per_block >= 2 * Headdim * (64 + 2 * 64)) {
             run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 64, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+        } else if (max_smem_per_block >= 2 * Headdim * (32 + 2 * 64)) {
+            run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 32, 64, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
         } else {
-            run_flash_fwd<Flash_fwd_kernel_traits<Headdim, 32, 32, 4, false, false, T>, Is_dropout, Is_causal>(params, stream);
+            // Insufficient smem for any correct hdim512 kernel config.
+            // Caller must check supports_head_dim() and use eager attention.
+            fprintf(stderr, "FATAL: flash attention hdim512 requires >= 160 KB shared memory, "
+                    "but this GPU only has %d bytes. Use supports_head_dim() to check "
+                    "and fall back to eager attention.\n", max_smem_per_block);
+            abort();
         }
     });
 }

--- a/candle-flash-attn/src/lib.rs
+++ b/candle-flash-attn/src/lib.rs
@@ -22,7 +22,7 @@ pub fn supports_head_dim(device: &candle::CudaDevice, head_dim: usize) -> bool {
     let max_smem = device
         .cuda_stream()
         .context()
-        .device_attribute(
+        .attribute(
             candle::cuda_backend::cudarc::driver::sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
         )
         .unwrap_or(0) as usize;

--- a/candle-flash-attn/src/lib.rs
+++ b/candle-flash-attn/src/lib.rs
@@ -5,6 +5,30 @@ use candle::cuda_backend::cudarc::driver::DevicePtr;
 use candle::{CpuStorage, DType, Layout, Result, Shape, Tensor};
 use half::{bf16, f16};
 
+/// Returns whether flash attention can correctly handle the given `head_dim` on `device`.
+///
+/// - For head_dim <= 256, flash-attn v2 works on all CUDA GPUs.
+/// - For head_dim > 256, the kernel requires `kBlockN >= 64` which needs more shared memory than some GPUs have. This function checks the GPU's max shared memory and returns false
+///
+/// Callers should fall back to eager attention when this returns false.
+pub fn supports_head_dim(device: &candle::CudaDevice, head_dim: usize) -> bool {
+    if head_dim <= 256 {
+        return true;
+    }
+    // For head_dim > 256: kBlockKSmem = 64 (since head_dim % 64 == 0), so kBlockN >= 64.
+    // Minimum config: kBlockM=32, kBlockN=64.
+    // smem = 2 * head_dim * (kBlockM + 2 * kBlockN) bytes
+    let min_smem = 2 * head_dim * (32 + 2 * 64); // smallest valid config
+    let max_smem = device
+        .cuda_stream()
+        .context()
+        .device_attribute(
+            candle::cuda_backend::cudarc::driver::sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
+        )
+        .unwrap_or(0) as usize;
+    max_smem >= min_smem
+}
+
 pub struct FlashAttn {
     pub softmax_scale: f32,
     pub alibi_slopes: Option<Tensor>,

--- a/candle-transformers/src/models/gemma4/audio.rs
+++ b/candle-transformers/src/models/gemma4/audio.rs
@@ -83,7 +83,11 @@ impl SSCPConvBlock {
         input_freq_dim: usize,
         vb: VarBuilder,
     ) -> Result<Self> {
-        let in_channels = if idx == 0 { 1 } else { cfg.sscp_conv_channel_size[idx - 1] };
+        let in_channels = if idx == 0 {
+            1
+        } else {
+            cfg.sscp_conv_channel_size[idx - 1]
+        };
         let out_channels = cfg.sscp_conv_channel_size[idx];
         let kernel_t = cfg.sscp_conv_kernel_size[idx][0];
         let _kernel_f = cfg.sscp_conv_kernel_size[idx][1];
@@ -122,7 +126,11 @@ impl SSCPConvBlock {
         })
     }
 
-    fn forward(&self, audio_encodings: &Tensor, audio_mel_mask: &Tensor) -> Result<(Tensor, Tensor)> {
+    fn forward(
+        &self,
+        audio_encodings: &Tensor,
+        audio_mel_mask: &Tensor,
+    ) -> Result<(Tensor, Tensor)> {
         // Zero out padded positions
         let valid_mask = audio_mel_mask
             .eq(0.0)?
@@ -234,11 +242,8 @@ impl RelativePositionEmbedding {
         let max_forward = cfg.conf_attention_context_right;
         let num_timescales = channels / 2;
 
-        let pos_proj = candle_nn::linear_no_bias(
-            channels,
-            num_heads * head_dim,
-            vb.pp("relative_k_proj"),
-        )?;
+        let pos_proj =
+            candle_nn::linear_no_bias(channels, num_heads * head_dim, vb.pp("relative_k_proj"))?;
 
         let min_timescale = 1.0_f64;
         let max_timescale = 10_000.0_f64;
@@ -399,9 +404,12 @@ impl ConformerAttention {
         let attn_vb = vb.pp("self_attn");
         let relative_position_embedding = RelativePositionEmbedding::new(cfg, attn_vb.clone())?;
         let per_dim_scale = attn_vb.get(head_dim, "per_dim_scale")?;
-        let q_proj = candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("q_proj"))?;
-        let k_proj = candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("k_proj"))?;
-        let v_proj = candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("v_proj"))?;
+        let q_proj =
+            candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("q_proj"))?;
+        let k_proj =
+            candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("k_proj"))?;
+        let v_proj =
+            candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("v_proj"))?;
         let post = candle_nn::linear_no_bias(hidden_size, hidden_size, attn_vb.pp("post"))?;
 
         let pre_attn_norm = RmsNorm::new(hidden_size, cfg.rms_norm_eps, vb.pp("norm_pre_attn"))?;
@@ -415,7 +423,8 @@ impl ConformerAttention {
         for i in 0..chunk_size {
             for j in 0..context_size {
                 let lower = j >= i;
-                let upper = (j as isize) <= (i as isize + (max_past_horizon + max_future_horizon) as isize);
+                let upper =
+                    (j as isize) <= (i as isize + (max_past_horizon + max_future_horizon) as isize);
                 if lower && upper {
                     mask_vec[i * context_size + j] = 1;
                 }
@@ -509,9 +518,9 @@ impl ConformerAttention {
             .to_dtype(DType::F32)?;
 
         // Scale Q and K
-        let q = q.affine(self.q_scale, 0.0)?.broadcast_mul(
-            &per_dim_scale.reshape((1, 1, 1, self.head_dim))?,
-        )?;
+        let q = q
+            .affine(self.q_scale, 0.0)?
+            .broadcast_mul(&per_dim_scale.reshape((1, 1, 1, self.head_dim))?)?;
         let k = k.affine(self.k_scale, 0.0)?;
 
         // Convert to blocks
@@ -594,12 +603,10 @@ impl ConformerAttention {
         // Broadcast mask to logits shape
         let final_cond = final_cond.broadcast_as(logits.shape())?;
 
-        let invalid_logits =
-            Tensor::new(self.invalid_logits_value as f32, logits.device())?
-                .broadcast_as(logits.shape())?;
+        let invalid_logits = Tensor::new(self.invalid_logits_value as f32, logits.device())?
+            .broadcast_as(logits.shape())?;
         let masked_logits = final_cond.where_cond(&logits, &invalid_logits)?;
-        let probabilities =
-            candle_nn::ops::softmax_last_dim(&masked_logits.to_dtype(DType::F32)?)?;
+        let probabilities = candle_nn::ops::softmax_last_dim(&masked_logits.to_dtype(DType::F32)?)?;
 
         // Weighted sum of values
         let (b_dim, n_dim, u_dim, w_dim, c_dim) = probabilities.dims5()?;
@@ -618,7 +625,12 @@ impl ConformerAttention {
             .matmul(&vals_p)?
             .reshape((b_dim, u_dim, n_dim, w_dim, h_dim))?
             .permute((0, 1, 3, 2, 4))?
-            .reshape((b, num_query_blocks * self.chunk_size, self.num_heads, self.head_dim))?
+            .reshape((
+                b,
+                num_query_blocks * self.chunk_size,
+                self.num_heads,
+                self.head_dim,
+            ))?
             .narrow(1, 0, t)?;
 
         let context_vectors = context_vectors.reshape((b, t, self.hidden_size))?;
@@ -646,7 +658,11 @@ impl ConformerFeedForward {
     fn new(cfg: &Gemma4AudioConfig, vb: VarBuilder) -> Result<Self> {
         Ok(Self {
             scale: cfg.conf_residual_weight,
-            pre_layer_norm: RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("pre_layer_norm"))?,
+            pre_layer_norm: RmsNorm::new(
+                cfg.hidden_size,
+                cfg.rms_norm_eps,
+                vb.pp("pre_layer_norm"),
+            )?,
             ffw_layer_1: candle_nn::linear_no_bias(
                 cfg.hidden_size,
                 cfg.hidden_size * 4,
@@ -696,7 +712,11 @@ struct ConformerLightConv1d {
 impl ConformerLightConv1d {
     fn new(cfg: &Gemma4AudioConfig, vb: VarBuilder) -> Result<Self> {
         Ok(Self {
-            pre_layer_norm: RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("pre_layer_norm"))?,
+            pre_layer_norm: RmsNorm::new(
+                cfg.hidden_size,
+                cfg.rms_norm_eps,
+                vb.pp("pre_layer_norm"),
+            )?,
             linear_start: candle_nn::linear_no_bias(
                 cfg.hidden_size,
                 cfg.hidden_size * 2,
@@ -805,7 +825,11 @@ impl AudioModel {
             conformer.push(ConformerBlock::new(cfg, vb_layers.pp(i))?);
         }
         let output_proj = if let Some(output_dim) = cfg.output_proj_dims {
-            Some(candle_nn::linear(cfg.hidden_size, output_dim, vb.pp("output_proj"))?)
+            Some(candle_nn::linear(
+                cfg.hidden_size,
+                output_dim,
+                vb.pp("output_proj"),
+            )?)
         } else {
             None
         };
@@ -817,11 +841,7 @@ impl AudioModel {
         })
     }
 
-    pub fn forward(
-        &self,
-        audio_mel: &Tensor,
-        audio_mel_mask: &Tensor,
-    ) -> Result<(Tensor, Tensor)> {
+    pub fn forward(&self, audio_mel: &Tensor, audio_mel_mask: &Tensor) -> Result<(Tensor, Tensor)> {
         let (mut audio_encodings, mut current_mask) = self
             .subsample_conv_projection
             .forward(audio_mel, audio_mel_mask)?;

--- a/candle-transformers/src/models/gemma4/config.rs
+++ b/candle-transformers/src/models/gemma4/config.rs
@@ -96,7 +96,10 @@ pub struct Gemma4TextConfig {
     pub max_position_embeddings: usize,
     #[serde(default = "default_tie_word_embeddings")]
     pub tie_word_embeddings: bool,
-    #[serde(default = "default_sliding_window_pattern", alias = "_sliding_window_pattern")]
+    #[serde(
+        default = "default_sliding_window_pattern",
+        alias = "_sliding_window_pattern"
+    )]
     pub sliding_window_pattern: usize,
     pub layer_types: Vec<String>,
     #[serde(default = "default_global_head_dim")]
@@ -306,7 +309,10 @@ pub struct Gemma4AudioConfig {
     pub hidden_size: usize,
     #[serde(default = "default_output_proj_dims")]
     pub output_proj_dims: Option<usize>,
-    #[serde(default = "default_conf_attention_chunk_size", alias = "attention_chunk_size")]
+    #[serde(
+        default = "default_conf_attention_chunk_size",
+        alias = "attention_chunk_size"
+    )]
     pub conf_attention_chunk_size: usize,
     #[serde(
         default = "default_conf_attention_context_left",
@@ -323,11 +329,20 @@ pub struct Gemma4AudioConfig {
         alias = "attention_invalid_logits_value"
     )]
     pub conf_attention_invalid_logits_value: f64,
-    #[serde(default = "default_conf_attention_logit_cap", alias = "attention_logit_cap")]
+    #[serde(
+        default = "default_conf_attention_logit_cap",
+        alias = "attention_logit_cap"
+    )]
     pub conf_attention_logit_cap: f64,
-    #[serde(default = "default_conf_num_attention_heads", alias = "num_attention_heads")]
+    #[serde(
+        default = "default_conf_num_attention_heads",
+        alias = "num_attention_heads"
+    )]
     pub conf_num_attention_heads: usize,
-    #[serde(default = "default_conf_num_hidden_layers", alias = "num_hidden_layers")]
+    #[serde(
+        default = "default_conf_num_hidden_layers",
+        alias = "num_hidden_layers"
+    )]
     pub conf_num_hidden_layers: usize,
     #[serde(default = "default_conf_conv_kernel_size", alias = "conv_kernel_size")]
     pub conf_conv_kernel_size: usize,

--- a/candle-transformers/src/models/gemma4/mod.rs
+++ b/candle-transformers/src/models/gemma4/mod.rs
@@ -71,11 +71,7 @@ impl Model {
     }
 
     /// Text-only forward pass.
-    pub fn forward(
-        &mut self,
-        input_ids: &Tensor,
-        seqlen_offset: usize,
-    ) -> Result<Tensor> {
+    pub fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
         self.language_model.forward(input_ids, seqlen_offset)
     }
 
@@ -114,16 +110,23 @@ impl Model {
                 .unsqueeze(D::Minus1)?
                 .broadcast_as(input_embeds.shape())?
                 .to_dtype(input_embeds.dtype())?;
-            let image_embeds_broadcast =
-                broadcast_embed_to_mask(&image_embeds_flat, &image_mask)?;
+            let image_embeds_broadcast = broadcast_embed_to_mask(&image_embeds_flat, &image_mask)?;
             input_embeds = ((mask_expanded.clone() * image_embeds_broadcast)?
                 + ((1.0 - mask_expanded)? * input_embeds)?)?;
         }
 
         // ── Audio embedding injection ───────────────────────────────────
-        if let (Some(audio_mel), Some(audio_mel_mask), Some(ref audio_tower), Some(ref embed_audio)) =
-            (audio_mel, audio_mel_mask, &self.audio_tower, &self.embed_audio)
-        {
+        if let (
+            Some(audio_mel),
+            Some(audio_mel_mask),
+            Some(ref audio_tower),
+            Some(ref embed_audio),
+        ) = (
+            audio_mel,
+            audio_mel_mask,
+            &self.audio_tower,
+            &self.embed_audio,
+        ) {
             let audio_mask = input_ids
                 .to_dtype(DType::F32)?
                 .eq(self.cfg.audio_token_id as f64)?;
@@ -189,9 +192,7 @@ fn broadcast_embed_to_mask(embeds: &Tensor, mask: &Tensor) -> Result<Tensor> {
     // For single-batch simple case, just expand embeds to the output shape
     // and let the caller do the masking.
     if b_sz == 1 {
-        let num_tokens = mask_f32
-            .sum_all()?
-            .to_scalar::<f32>()? as usize;
+        let num_tokens = mask_f32.sum_all()?.to_scalar::<f32>()? as usize;
         if num_tokens == 0 {
             return Ok(zeros);
         }
@@ -200,7 +201,11 @@ fn broadcast_embed_to_mask(embeds: &Tensor, mask: &Tensor) -> Result<Tensor> {
         if embed_len >= seq_len {
             return embeds.narrow(0, 0, seq_len)?.unsqueeze(0);
         }
-        let padding = Tensor::zeros((seq_len - embed_len, hidden), embeds.dtype(), embeds.device())?;
+        let padding = Tensor::zeros(
+            (seq_len - embed_len, hidden),
+            embeds.dtype(),
+            embeds.device(),
+        )?;
         let padded = Tensor::cat(&[embeds, &padding], 0)?;
         return padded.unsqueeze(0);
     }

--- a/candle-transformers/src/models/gemma4/text.rs
+++ b/candle-transformers/src/models/gemma4/text.rs
@@ -59,7 +59,13 @@ struct RotaryEmbedding {
 }
 
 impl RotaryEmbedding {
-    fn new(dtype: DType, head_dim: usize, rope_theta: f64, max_seq_len: usize, dev: &Device) -> Result<Self> {
+    fn new(
+        dtype: DType,
+        head_dim: usize,
+        rope_theta: f64,
+        max_seq_len: usize,
+        dev: &Device,
+    ) -> Result<Self> {
         let inv_freq: Vec<_> = (0..head_dim)
             .step_by(2)
             .map(|i| 1f32 / rope_theta.powf(i as f64 / head_dim as f64) as f32)
@@ -158,7 +164,13 @@ struct MLP {
 }
 
 impl MLP {
-    fn new(hidden_size: usize, intermediate_size: usize, act: Activation, bias: bool, vb: VarBuilder) -> Result<Self> {
+    fn new(
+        hidden_size: usize,
+        intermediate_size: usize,
+        act: Activation,
+        bias: bool,
+        vb: VarBuilder,
+    ) -> Result<Self> {
         let gate_proj = linear_bias(hidden_size, intermediate_size, bias, vb.pp("gate_proj"))?;
         let up_proj = linear_bias(hidden_size, intermediate_size, bias, vb.pp("up_proj"))?;
         let down_proj = linear_bias(intermediate_size, hidden_size, bias, vb.pp("down_proj"))?;
@@ -447,9 +459,9 @@ impl DecoderLayer {
     ) -> Result<Tensor> {
         let residual = xs;
         let xs = self.input_layernorm.forward(xs)?;
-        let xs = self
-            .self_attn
-            .forward(&xs, attention_mask, sliding_attention_mask, seqlen_offset)?;
+        let xs =
+            self.self_attn
+                .forward(&xs, attention_mask, sliding_attention_mask, seqlen_offset)?;
         let xs = xs.apply(&self.post_attention_layernorm)?;
         let xs = (xs + residual)?;
         let residual = &xs;

--- a/candle-transformers/src/models/gemma4/vision.rs
+++ b/candle-transformers/src/models/gemma4/vision.rs
@@ -204,10 +204,14 @@ impl VisionAttention {
         let num_heads = cfg.num_attention_heads;
         let num_kv_heads = cfg.num_key_value_heads;
         let head_dim = cfg.head_dim;
-        let q_proj = candle_nn::linear_no_bias(cfg.hidden_size, num_heads * head_dim, vb.pp("q_proj"))?;
-        let k_proj = candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("k_proj"))?;
-        let v_proj = candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("v_proj"))?;
-        let o_proj = candle_nn::linear_no_bias(num_heads * head_dim, cfg.hidden_size, vb.pp("o_proj"))?;
+        let q_proj =
+            candle_nn::linear_no_bias(cfg.hidden_size, num_heads * head_dim, vb.pp("q_proj"))?;
+        let k_proj =
+            candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("k_proj"))?;
+        let v_proj =
+            candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("v_proj"))?;
+        let o_proj =
+            candle_nn::linear_no_bias(num_heads * head_dim, cfg.hidden_size, vb.pp("o_proj"))?;
         let q_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
         let k_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
         Ok(Self {


### PR DESCRIPTION
For head_dim > 256, the kernel requires `kBlockN >= 64` which needs more shared memory than some GPUs have. This PR adds handling for the following "tiers" and a function to dynamically check compatability.

- Tier 1: >= 192 KB (H100, Blackwell) => 64x64 tile size
- Tier 2: >= 160 KB (A100) => 32x64 tile size
- Tier 3: < 160 KB (sm86/89) => cannot run correctly, caller must check supports_head_dim() and use eager attention.