### PR TITLE
Add Qwen3-Embedding model

### DIFF
--- a/candle-examples/examples/gemma4/main.rs
+++ b/candle-examples/examples/gemma4/main.rs
@@ -288,8 +288,7 @@ fn main() -> Result<()> {
             None => {
                 let config_file = repo.get("config.json")?;
                 // For text-only, try to parse the text_config sub-object
-                let raw: serde_json::Value =
-                    serde_json::from_slice(&std::fs::read(config_file)?)?;
+                let raw: serde_json::Value = serde_json::from_slice(&std::fs::read(config_file)?)?;
                 if let Some(text_cfg) = raw.get("text_config") {
                     serde_json::from_value(text_cfg.clone())?
                 } else {

--- a/candle-examples/examples/gemma4/main.rs
+++ b/candle-examples/examples/gemma4/main.rs
@@ -22,7 +22,7 @@ use tokenizers::Tokenizer;
 
 enum ModelKind {
     TextOnly(TextModel),
-    Multimodal(Model),
+    Multimodal(Box<Model>),
 }
 
 struct TextGeneration {
@@ -281,7 +281,7 @@ fn main() -> Result<()> {
             }
         };
         let model = Model::new(&config, vb)?;
-        ModelKind::Multimodal(model)
+        ModelKind::Multimodal(Box::new(model))
     } else {
         let mut config: Gemma4TextConfig = match args.config_file {
             Some(config_file) => serde_json::from_slice(&std::fs::read(config_file)?)?,

--- a/candle-examples/examples/gemma4/main.rs
+++ b/candle-examples/examples/gemma4/main.rs
@@ -20,9 +20,10 @@ use candle_transformers::generation::{LogitsProcessor, Sampling};
 use hf_hub::{api::sync::Api, Repo, RepoType};
 use tokenizers::Tokenizer;
 
+#[allow(clippy::large_enum_variant)]
 enum ModelKind {
     TextOnly(TextModel),
-    Multimodal(Box<Model>),
+    Multimodal(Model),
 }
 
 struct TextGeneration {
@@ -258,7 +259,12 @@ fn main() -> Result<()> {
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+        None => {
+            match candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json") {
+                Ok(files) => files,
+                Err(_) => vec![repo.get("model.safetensors")?],
+            }
+        }
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
@@ -281,7 +287,7 @@ fn main() -> Result<()> {
             }
         };
         let model = Model::new(&config, vb)?;
-        ModelKind::Multimodal(Box::new(model))
+        ModelKind::Multimodal(model)
     } else {
         let mut config: Gemma4TextConfig = match args.config_file {
             Some(config_file) => serde_json::from_slice(&std::fs::read(config_file)?)?,

--- a/candle-examples/examples/qwen3-embedding/main.rs
+++ b/candle-examples/examples/qwen3-embedding/main.rs
@@ -99,7 +99,7 @@ fn extract_field(line: &str, field: &str) -> Option<String> {
         return None;
     }
     let rest = &rest[1..]; // skip opening quote
-    // Find closing quote (handle escaped quotes)
+                           // Find closing quote (handle escaped quotes)
     let mut chars = rest.chars();
     let mut value = String::new();
     loop {
@@ -277,7 +277,11 @@ fn main() -> Result<()> {
         })?;
         descriptions.push(text);
     }
-    eprintln!("Read {} descriptions from {}", descriptions.len(), args.input);
+    eprintln!(
+        "Read {} descriptions from {}",
+        descriptions.len(),
+        args.input
+    );
 
     if descriptions.is_empty() {
         anyhow::bail!("No descriptions found in input file");
@@ -311,20 +315,17 @@ fn main() -> Result<()> {
         let embedding = model.forward(&input)?;
 
         // Extract the embedding vector (1, hidden_size) → flat f32 vec
-        let emb_vec = embedding.squeeze(0)?.to_dtype(candle::DType::F32)?.to_vec1::<f32>()?;
+        let emb_vec = embedding
+            .squeeze(0)?
+            .to_dtype(candle::DType::F32)?
+            .to_vec1::<f32>()?;
         all_embeddings.extend_from_slice(&emb_vec);
 
         if (i + 1) % args.log_every == 0 || i + 1 == n {
             let elapsed = embed_start.elapsed().as_secs_f64();
             let rate = (i + 1) as f64 / elapsed;
             let eta = (n - i - 1) as f64 / rate;
-            eprintln!(
-                "[{}/{}] {:.1} desc/s, ETA {:.0}s",
-                i + 1,
-                n,
-                rate,
-                eta,
-            );
+            eprintln!("[{}/{}] {:.1} desc/s, ETA {:.0}s", i + 1, n, rate, eta,);
         }
     }
 

--- a/candle-examples/examples/qwen3-embedding/main.rs
+++ b/candle-examples/examples/qwen3-embedding/main.rs
@@ -1,0 +1,314 @@
+//! Qwen3-Embedding: embed procedure descriptions into 4096-dim vectors using GGUF.
+//!
+//! Reads `enriched_descriptions.jsonl` (one JSON object per line with an
+//! `english_description` field), runs each description through Qwen3-Embedding-8B
+//! (quantized GGUF), mean-pools + L2-normalizes the hidden states, and writes
+//! the result as a numpy-compatible `.npy` file of shape `(N, 4096)`.
+//!
+//! Usage:
+//! ```bash
+//! cargo run --example qwen3-embedding --release --features cuda -- \
+//!     --input enriched_descriptions.jsonl \
+//!     --output enriched_embeddings.npy
+//! ```
+
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::io::{BufRead, Write as IoWrite};
+
+use candle::quantized::gguf_file;
+use candle::Tensor;
+use candle_transformers::models::quantized_qwen3_embed::EmbeddingModel;
+use tokenizers::Tokenizer;
+
+const DEFAULT_MODEL_ID: &str = "Qwen/Qwen3-Embedding-8B";
+const DEFAULT_GGUF_REPO: &str = "Qwen/Qwen3-Embedding-8B-GGUF";
+const DEFAULT_GGUF_FILE: &str = "Qwen3-Embedding-8B-Q4_K_M.gguf";
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Embed text using Qwen3-Embedding (GGUF)")]
+struct Args {
+    /// Input JSONL file with an `english_description` field per line.
+    #[arg(long)]
+    input: String,
+
+    /// Output path for the .npy embedding matrix (float32, shape N×4096).
+    #[arg(long, default_value = "enriched_embeddings.npy")]
+    output: String,
+
+    /// GGUF model file path (downloads from HuggingFace if not provided).
+    #[arg(long)]
+    model: Option<String>,
+
+    /// Tokenizer file path (downloads from HuggingFace if not provided).
+    #[arg(long)]
+    tokenizer: Option<String>,
+
+    /// HuggingFace model ID for downloading the tokenizer.
+    #[arg(long, default_value = DEFAULT_MODEL_ID)]
+    model_id: String,
+
+    /// HuggingFace GGUF repo for downloading the model weights.
+    #[arg(long, default_value = DEFAULT_GGUF_REPO)]
+    gguf_repo: String,
+
+    /// GGUF filename within the repo.
+    #[arg(long, default_value = DEFAULT_GGUF_FILE)]
+    gguf_file: String,
+
+    /// Run on CPU rather than GPU.
+    #[arg(long)]
+    cpu: bool,
+
+    /// Enable tracing (generates a trace-timestamp.json file).
+    #[arg(long)]
+    tracing: bool,
+
+    /// Maximum sequence length for tokenization (longer inputs are truncated).
+    #[arg(long, default_value_t = 8192)]
+    max_seq_len: usize,
+
+    /// JSON field to embed (defaults to english_description).
+    #[arg(long, default_value = "english_description")]
+    field: String,
+
+    /// Instruction prefix for embedding (Qwen3-Embedding uses task instructions).
+    #[arg(long)]
+    instruct: Option<String>,
+
+    /// Log progress every N descriptions.
+    #[arg(long, default_value_t = 100)]
+    log_every: usize,
+}
+
+/// A single record from the JSONL input — we only parse the field we need.
+#[derive(serde::Deserialize)]
+struct Record {
+    #[serde(flatten)]
+    fields: serde_json::Map<String, serde_json::Value>,
+}
+
+fn get_tokenizer(args: &Args) -> Result<Tokenizer> {
+    let path = match &args.tokenizer {
+        Some(p) => std::path::PathBuf::from(p),
+        None => {
+            let api = hf_hub::api::sync::Api::new()?;
+            let repo = api.model(args.model_id.clone());
+            repo.get("tokenizer.json")
+                .context("Failed to download tokenizer.json")?
+        }
+    };
+    Tokenizer::from_file(&path).map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {e}"))
+}
+
+fn get_model_path(args: &Args) -> Result<std::path::PathBuf> {
+    match &args.model {
+        Some(p) => Ok(std::path::PathBuf::from(p)),
+        None => {
+            let api = hf_hub::api::sync::Api::new()?;
+            let repo = api.repo(hf_hub::Repo::with_revision(
+                args.gguf_repo.clone(),
+                hf_hub::RepoType::Model,
+                "main".to_string(),
+            ));
+            repo.get(&args.gguf_file)
+                .context("Failed to download GGUF model file")
+        }
+    }
+}
+
+/// Write a 2D f32 array as a NumPy .npy file (version 1.0).
+fn write_npy(path: &str, data: &[f32], rows: usize, cols: usize) -> Result<()> {
+    let mut f = std::fs::File::create(path)?;
+
+    // NumPy .npy format header
+    let header = format!(
+        "{{'descr': '<f4', 'fortran_order': False, 'shape': ({}, {}), }}",
+        rows, cols
+    );
+
+    // Pad header to align data to 64 bytes
+    // Magic (6) + version (2) + header_len (2) + header + \n = multiple of 64
+    let prefix_len = 10; // magic(6) + version(2) + header_len(2)
+    let total = prefix_len + header.len() + 1; // +1 for trailing \n
+    let padding = (64 - (total % 64)) % 64;
+    let header_len = (header.len() + padding + 1) as u16; // +1 for \n
+
+    // Magic number
+    f.write_all(&[0x93])?;
+    f.write_all(b"NUMPY")?;
+    // Version 1.0
+    f.write_all(&[1, 0])?;
+    // Header length (little-endian u16)
+    f.write_all(&header_len.to_le_bytes())?;
+    // Header string
+    f.write_all(header.as_bytes())?;
+    // Padding spaces
+    for _ in 0..padding {
+        f.write_all(b" ")?;
+    }
+    f.write_all(b"\n")?;
+
+    // Data: raw little-endian f32
+    let bytes: &[u8] =
+        unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4) };
+    f.write_all(bytes)?;
+
+    Ok(())
+}
+
+fn format_size(size_in_bytes: usize) -> String {
+    if size_in_bytes < 1_000_000 {
+        format!("{:.2}KB", size_in_bytes as f64 / 1e3)
+    } else if size_in_bytes < 1_000_000_000 {
+        format!("{:.2}MB", size_in_bytes as f64 / 1e6)
+    } else {
+        format!("{:.2}GB", size_in_bytes as f64 / 1e9)
+    }
+}
+
+fn main() -> Result<()> {
+    use tracing_chrome::ChromeLayerBuilder;
+    use tracing_subscriber::prelude::*;
+
+    let args = Args::parse();
+    let _guard = if args.tracing {
+        let (chrome_layer, guard) = ChromeLayerBuilder::new().build();
+        tracing_subscriber::registry().with(chrome_layer).init();
+        Some(guard)
+    } else {
+        None
+    };
+
+    // ── Load model ──────────────────────────────────────────────────────
+    let model_path = get_model_path(&args)?;
+    eprintln!("Loading model from {}", model_path.display());
+    let start = std::time::Instant::now();
+    let device = candle_examples::device(args.cpu)?;
+
+    let mut file = std::fs::File::open(&model_path)?;
+    let ct = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(&model_path))?;
+
+    let mut total_size_in_bytes = 0;
+    for (_, tensor) in ct.tensor_infos.iter() {
+        let elem_count = tensor.shape.elem_count();
+        total_size_in_bytes +=
+            elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
+    }
+    eprintln!(
+        "Loaded {} tensors ({}) in {:.1}s",
+        ct.tensor_infos.len(),
+        format_size(total_size_in_bytes),
+        start.elapsed().as_secs_f64(),
+    );
+
+    let model = EmbeddingModel::from_gguf(ct, &mut file, &device)?;
+    eprintln!(
+        "Model ready (hidden_size={}) in {:.1}s",
+        model.hidden_size(),
+        start.elapsed().as_secs_f64(),
+    );
+
+    // ── Load tokenizer ──────────────────────────────────────────────────
+    let tokenizer = get_tokenizer(&args)?;
+
+    // ── Read input descriptions ─────────────────────────────────────────
+    let input_file =
+        std::fs::File::open(&args.input).with_context(|| format!("Cannot open {}", args.input))?;
+    let reader = std::io::BufReader::new(input_file);
+
+    let mut descriptions: Vec<String> = Vec::new();
+    for (i, line) in reader.lines().enumerate() {
+        let line = line.with_context(|| format!("Error reading line {}", i + 1))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: Record =
+            serde_json::from_str(&line).with_context(|| format!("Invalid JSON at line {}", i + 1))?;
+        let text = record
+            .fields
+            .get(&args.field)
+            .and_then(|v| v.as_str())
+            .with_context(|| {
+                format!(
+                    "Missing or non-string field '{}' at line {}",
+                    args.field,
+                    i + 1
+                )
+            })?
+            .to_string();
+        descriptions.push(text);
+    }
+    eprintln!("Read {} descriptions from {}", descriptions.len(), args.input);
+
+    if descriptions.is_empty() {
+        anyhow::bail!("No descriptions found in input file");
+    }
+
+    // ── Embed descriptions one at a time ────────────────────────────────
+    let hidden_size = model.hidden_size();
+    let n = descriptions.len();
+    let mut all_embeddings: Vec<f32> = Vec::with_capacity(n * hidden_size);
+
+    let embed_start = std::time::Instant::now();
+
+    for (i, desc) in descriptions.iter().enumerate() {
+        // Optionally prepend instruction
+        let text = match &args.instruct {
+            Some(inst) => format!("Instruct: {inst}\nQuery: {desc}"),
+            None => desc.clone(),
+        };
+
+        // Tokenize
+        let encoding = tokenizer
+            .encode(text.as_str(), true)
+            .map_err(|e| anyhow::anyhow!("Tokenization error: {e}"))?;
+
+        let mut token_ids = encoding.get_ids().to_vec();
+        if token_ids.len() > args.max_seq_len {
+            token_ids.truncate(args.max_seq_len);
+        }
+
+        let input = Tensor::new(&token_ids[..], &device)?.unsqueeze(0)?;
+        let embedding = model.forward(&input)?;
+
+        // Extract the embedding vector (1, hidden_size) → flat f32 vec
+        let emb_vec = embedding.squeeze(0)?.to_dtype(candle::DType::F32)?.to_vec1::<f32>()?;
+        all_embeddings.extend_from_slice(&emb_vec);
+
+        if (i + 1) % args.log_every == 0 || i + 1 == n {
+            let elapsed = embed_start.elapsed().as_secs_f64();
+            let rate = (i + 1) as f64 / elapsed;
+            let eta = (n - i - 1) as f64 / rate;
+            eprintln!(
+                "[{}/{}] {:.1} desc/s, ETA {:.0}s",
+                i + 1,
+                n,
+                rate,
+                eta,
+            );
+        }
+    }
+
+    // ── Write output ────────────────────────────────────────────────────
+    write_npy(&args.output, &all_embeddings, n, hidden_size)?;
+
+    let total_elapsed = embed_start.elapsed().as_secs_f64();
+    eprintln!(
+        "Done: {} embeddings ({}×{}) written to {} in {:.1}s ({:.1} desc/s)",
+        n,
+        n,
+        hidden_size,
+        args.output,
+        total_elapsed,
+        n as f64 / total_elapsed,
+    );
+
+    Ok(())
+}

--- a/candle-examples/examples/qwen3-embedding/main.rs
+++ b/candle-examples/examples/qwen3-embedding/main.rs
@@ -87,11 +87,50 @@ struct Args {
     log_every: usize,
 }
 
-/// A single record from the JSONL input — we only parse the field we need.
-#[derive(serde::Deserialize)]
-struct Record {
-    #[serde(flatten)]
-    fields: serde_json::Map<String, serde_json::Value>,
+/// Extract the target text field from a JSONL line.
+/// Uses string search rather than full JSON parsing to handle non-standard
+/// values like NaN that appear in numeric fields we don't need.
+fn extract_field(line: &str, field: &str) -> Option<String> {
+    // Look for "field": "value" pattern
+    let key = format!("\"{}\":", field);
+    let start = line.find(&key)? + key.len();
+    let rest = &line[start..].trim_start();
+    if !rest.starts_with('"') {
+        return None;
+    }
+    let rest = &rest[1..]; // skip opening quote
+    // Find closing quote (handle escaped quotes)
+    let mut chars = rest.chars();
+    let mut value = String::new();
+    loop {
+        match chars.next()? {
+            '\\' => {
+                let escaped = chars.next()?;
+                match escaped {
+                    '"' => value.push('"'),
+                    '\\' => value.push('\\'),
+                    'n' => value.push('\n'),
+                    't' => value.push('\t'),
+                    'r' => value.push('\r'),
+                    'u' => {
+                        // Unicode escape: \uXXXX
+                        let hex: String = chars.by_ref().take(4).collect();
+                        if let Ok(cp) = u32::from_str_radix(&hex, 16) {
+                            if let Some(c) = char::from_u32(cp) {
+                                value.push(c);
+                            }
+                        }
+                    }
+                    other => {
+                        value.push('\\');
+                        value.push(other);
+                    }
+                }
+            }
+            '"' => return Some(value),
+            c => value.push(c),
+        }
+    }
 }
 
 fn get_tokenizer(args: &Args) -> Result<Tokenizer> {
@@ -229,20 +268,13 @@ fn main() -> Result<()> {
         if line.trim().is_empty() {
             continue;
         }
-        let record: Record =
-            serde_json::from_str(&line).with_context(|| format!("Invalid JSON at line {}", i + 1))?;
-        let text = record
-            .fields
-            .get(&args.field)
-            .and_then(|v| v.as_str())
-            .with_context(|| {
-                format!(
-                    "Missing or non-string field '{}' at line {}",
-                    args.field,
-                    i + 1
-                )
-            })?
-            .to_string();
+        let text = extract_field(&line, &args.field).with_context(|| {
+            format!(
+                "Missing or non-string field '{}' at line {}",
+                args.field,
+                i + 1
+            )
+        })?;
         descriptions.push(text);
     }
     eprintln!("Read {} descriptions from {}", descriptions.len(), args.input);

--- a/candle-examples/examples/qwen3-embedding/main.rs
+++ b/candle-examples/examples/qwen3-embedding/main.rs
@@ -1,16 +1,4 @@
-//! Qwen3-Embedding: embed procedure descriptions into 4096-dim vectors using GGUF.
-//!
-//! Reads `enriched_descriptions.jsonl` (one JSON object per line with an
-//! `english_description` field), runs each description through Qwen3-Embedding-8B
-//! (quantized GGUF), mean-pools + L2-normalizes the hidden states, and writes
-//! the result as a numpy-compatible `.npy` file of shape `(N, 4096)`.
-//!
-//! Usage:
-//! ```bash
-//! cargo run --example qwen3-embedding --release --features cuda -- \
-//!     --input enriched_descriptions.jsonl \
-//!     --output enriched_embeddings.npy
-//! ```
+//! Qwen3-Embedding example: embed JSONL text fields into vectors using a GGUF model.
 
 #[cfg(feature = "mkl")]
 extern crate intel_mkl_src;
@@ -34,72 +22,56 @@ const DEFAULT_GGUF_FILE: &str = "Qwen3-Embedding-8B-Q4_K_M.gguf";
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Embed text using Qwen3-Embedding (GGUF)")]
 struct Args {
-    /// Input JSONL file with an `english_description` field per line.
     #[arg(long)]
     input: String,
 
-    /// Output path for the .npy embedding matrix (float32, shape N×4096).
     #[arg(long, default_value = "enriched_embeddings.npy")]
     output: String,
 
-    /// GGUF model file path (downloads from HuggingFace if not provided).
     #[arg(long)]
     model: Option<String>,
 
-    /// Tokenizer file path (downloads from HuggingFace if not provided).
     #[arg(long)]
     tokenizer: Option<String>,
 
-    /// HuggingFace model ID for downloading the tokenizer.
     #[arg(long, default_value = DEFAULT_MODEL_ID)]
     model_id: String,
 
-    /// HuggingFace GGUF repo for downloading the model weights.
     #[arg(long, default_value = DEFAULT_GGUF_REPO)]
     gguf_repo: String,
 
-    /// GGUF filename within the repo.
     #[arg(long, default_value = DEFAULT_GGUF_FILE)]
     gguf_file: String,
 
-    /// Run on CPU rather than GPU.
     #[arg(long)]
     cpu: bool,
 
-    /// Enable tracing (generates a trace-timestamp.json file).
     #[arg(long)]
     tracing: bool,
 
-    /// Maximum sequence length for tokenization (longer inputs are truncated).
     #[arg(long, default_value_t = 8192)]
     max_seq_len: usize,
 
-    /// JSON field to embed (defaults to english_description).
     #[arg(long, default_value = "english_description")]
     field: String,
 
-    /// Instruction prefix for embedding (Qwen3-Embedding uses task instructions).
     #[arg(long)]
     instruct: Option<String>,
 
-    /// Log progress every N descriptions.
     #[arg(long, default_value_t = 100)]
     log_every: usize,
 }
 
-/// Extract the target text field from a JSONL line.
-/// Uses string search rather than full JSON parsing to handle non-standard
-/// values like NaN that appear in numeric fields we don't need.
+// String-based field extraction tolerates non-standard JSON values (e.g. NaN)
+// that may appear in unrelated numeric fields on the same line.
 fn extract_field(line: &str, field: &str) -> Option<String> {
-    // Look for "field": "value" pattern
     let key = format!("\"{}\":", field);
     let start = line.find(&key)? + key.len();
     let rest = &line[start..].trim_start();
     if !rest.starts_with('"') {
         return None;
     }
-    let rest = &rest[1..]; // skip opening quote
-                           // Find closing quote (handle escaped quotes)
+    let rest = &rest[1..];
     let mut chars = rest.chars();
     let mut value = String::new();
     loop {
@@ -113,7 +85,6 @@ fn extract_field(line: &str, field: &str) -> Option<String> {
                     't' => value.push('\t'),
                     'r' => value.push('\r'),
                     'u' => {
-                        // Unicode escape: \uXXXX
                         let hex: String = chars.by_ref().take(4).collect();
                         if let Ok(cp) = u32::from_str_radix(&hex, 16) {
                             if let Some(c) = char::from_u32(cp) {
@@ -162,39 +133,29 @@ fn get_model_path(args: &Args) -> Result<std::path::PathBuf> {
     }
 }
 
-/// Write a 2D f32 array as a NumPy .npy file (version 1.0).
 fn write_npy(path: &str, data: &[f32], rows: usize, cols: usize) -> Result<()> {
     let mut f = std::fs::File::create(path)?;
 
-    // NumPy .npy format header
     let header = format!(
         "{{'descr': '<f4', 'fortran_order': False, 'shape': ({}, {}), }}",
         rows, cols
     );
 
-    // Pad header to align data to 64 bytes
-    // Magic (6) + version (2) + header_len (2) + header + \n = multiple of 64
-    let prefix_len = 10; // magic(6) + version(2) + header_len(2)
-    let total = prefix_len + header.len() + 1; // +1 for trailing \n
+    let prefix_len = 10;
+    let total = prefix_len + header.len() + 1;
     let padding = (64 - (total % 64)) % 64;
-    let header_len = (header.len() + padding + 1) as u16; // +1 for \n
+    let header_len = (header.len() + padding + 1) as u16;
 
-    // Magic number
     f.write_all(&[0x93])?;
     f.write_all(b"NUMPY")?;
-    // Version 1.0
     f.write_all(&[1, 0])?;
-    // Header length (little-endian u16)
     f.write_all(&header_len.to_le_bytes())?;
-    // Header string
     f.write_all(header.as_bytes())?;
-    // Padding spaces
     for _ in 0..padding {
         f.write_all(b" ")?;
     }
     f.write_all(b"\n")?;
 
-    // Data: raw little-endian f32
     let bytes: &[u8] =
         unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, data.len() * 4) };
     f.write_all(bytes)?;
@@ -225,7 +186,6 @@ fn main() -> Result<()> {
         None
     };
 
-    // ── Load model ──────────────────────────────────────────────────────
     let model_path = get_model_path(&args)?;
     eprintln!("Loading model from {}", model_path.display());
     let start = std::time::Instant::now();
@@ -254,10 +214,8 @@ fn main() -> Result<()> {
         start.elapsed().as_secs_f64(),
     );
 
-    // ── Load tokenizer ──────────────────────────────────────────────────
     let tokenizer = get_tokenizer(&args)?;
 
-    // ── Read input descriptions ─────────────────────────────────────────
     let input_file =
         std::fs::File::open(&args.input).with_context(|| format!("Cannot open {}", args.input))?;
     let reader = std::io::BufReader::new(input_file);
@@ -287,7 +245,6 @@ fn main() -> Result<()> {
         anyhow::bail!("No descriptions found in input file");
     }
 
-    // ── Embed descriptions one at a time ────────────────────────────────
     let hidden_size = model.hidden_size();
     let n = descriptions.len();
     let mut all_embeddings: Vec<f32> = Vec::with_capacity(n * hidden_size);
@@ -295,13 +252,11 @@ fn main() -> Result<()> {
     let embed_start = std::time::Instant::now();
 
     for (i, desc) in descriptions.iter().enumerate() {
-        // Optionally prepend instruction
         let text = match &args.instruct {
             Some(inst) => format!("Instruct: {inst}\nQuery: {desc}"),
             None => desc.clone(),
         };
 
-        // Tokenize
         let encoding = tokenizer
             .encode(text.as_str(), true)
             .map_err(|e| anyhow::anyhow!("Tokenization error: {e}"))?;
@@ -314,7 +269,6 @@ fn main() -> Result<()> {
         let input = Tensor::new(&token_ids[..], &device)?.unsqueeze(0)?;
         let embedding = model.forward(&input)?;
 
-        // Extract the embedding vector (1, hidden_size) → flat f32 vec
         let emb_vec = embedding
             .squeeze(0)?
             .to_dtype(candle::DType::F32)?
@@ -329,12 +283,11 @@ fn main() -> Result<()> {
         }
     }
 
-    // ── Write output ────────────────────────────────────────────────────
     write_npy(&args.output, &all_embeddings, n, hidden_size)?;
 
     let total_elapsed = embed_start.elapsed().as_secs_f64();
     eprintln!(
-        "Done: {} embeddings ({}×{}) written to {} in {:.1}s ({:.1} desc/s)",
+        "Done: {} embeddings ({}x{}) written to {} in {:.1}s ({:.1} desc/s)",
         n,
         n,
         hidden_size,

--- a/candle-transformers/src/models/gemma4/audio.rs
+++ b/candle-transformers/src/models/gemma4/audio.rs
@@ -83,7 +83,11 @@ impl SSCPConvBlock {
         input_freq_dim: usize,
         vb: VarBuilder,
     ) -> Result<Self> {
-        let in_channels = if idx == 0 { 1 } else { cfg.sscp_conv_channel_size[idx - 1] };
+        let in_channels = if idx == 0 {
+            1
+        } else {
+            cfg.sscp_conv_channel_size[idx - 1]
+        };
         let out_channels = cfg.sscp_conv_channel_size[idx];
         let kernel_t = cfg.sscp_conv_kernel_size[idx][0];
         let _kernel_f = cfg.sscp_conv_kernel_size[idx][1];
@@ -122,7 +126,11 @@ impl SSCPConvBlock {
         })
     }
 
-    fn forward(&self, audio_encodings: &Tensor, audio_mel_mask: &Tensor) -> Result<(Tensor, Tensor)> {
+    fn forward(
+        &self,
+        audio_encodings: &Tensor,
+        audio_mel_mask: &Tensor,
+    ) -> Result<(Tensor, Tensor)> {
         // Zero out padded positions
         let valid_mask = audio_mel_mask
             .eq(0.0)?
@@ -234,11 +242,8 @@ impl RelativePositionEmbedding {
         let max_forward = cfg.conf_attention_context_right;
         let num_timescales = channels / 2;
 
-        let pos_proj = candle_nn::linear_no_bias(
-            channels,
-            num_heads * head_dim,
-            vb.pp("relative_k_proj"),
-        )?;
+        let pos_proj =
+            candle_nn::linear_no_bias(channels, num_heads * head_dim, vb.pp("relative_k_proj"))?;
 
         let min_timescale = 1.0_f64;
         let max_timescale = 10_000.0_f64;
@@ -399,9 +404,12 @@ impl ConformerAttention {
         let attn_vb = vb.pp("self_attn");
         let relative_position_embedding = RelativePositionEmbedding::new(cfg, attn_vb.clone())?;
         let per_dim_scale = attn_vb.get(head_dim, "per_dim_scale")?;
-        let q_proj = candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("q_proj"))?;
-        let k_proj = candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("k_proj"))?;
-        let v_proj = candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("v_proj"))?;
+        let q_proj =
+            candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("q_proj"))?;
+        let k_proj =
+            candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("k_proj"))?;
+        let v_proj =
+            candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("v_proj"))?;
         let post = candle_nn::linear_no_bias(hidden_size, hidden_size, attn_vb.pp("post"))?;
 
         let pre_attn_norm = RmsNorm::new(hidden_size, cfg.rms_norm_eps, vb.pp("norm_pre_attn"))?;
@@ -415,7 +423,8 @@ impl ConformerAttention {
         for i in 0..chunk_size {
             for j in 0..context_size {
                 let lower = j >= i;
-                let upper = (j as isize) <= (i as isize + (max_past_horizon + max_future_horizon) as isize);
+                let upper =
+                    (j as isize) <= (i as isize + (max_past_horizon + max_future_horizon) as isize);
                 if lower && upper {
                     mask_vec[i * context_size + j] = 1;
                 }
@@ -509,9 +518,9 @@ impl ConformerAttention {
             .to_dtype(DType::F32)?;
 
         // Scale Q and K
-        let q = q.affine(self.q_scale, 0.0)?.broadcast_mul(
-            &per_dim_scale.reshape((1, 1, 1, self.head_dim))?,
-        )?;
+        let q = q
+            .affine(self.q_scale, 0.0)?
+            .broadcast_mul(&per_dim_scale.reshape((1, 1, 1, self.head_dim))?)?;
         let k = k.affine(self.k_scale, 0.0)?;
 
         // Convert to blocks
@@ -594,12 +603,10 @@ impl ConformerAttention {
         // Broadcast mask to logits shape
         let final_cond = final_cond.broadcast_as(logits.shape())?;
 
-        let invalid_logits =
-            Tensor::new(self.invalid_logits_value as f32, logits.device())?
-                .broadcast_as(logits.shape())?;
+        let invalid_logits = Tensor::new(self.invalid_logits_value as f32, logits.device())?
+            .broadcast_as(logits.shape())?;
         let masked_logits = final_cond.where_cond(&logits, &invalid_logits)?;
-        let probabilities =
-            candle_nn::ops::softmax_last_dim(&masked_logits.to_dtype(DType::F32)?)?;
+        let probabilities = candle_nn::ops::softmax_last_dim(&masked_logits.to_dtype(DType::F32)?)?;
 
         // Weighted sum of values
         let (b_dim, n_dim, u_dim, w_dim, c_dim) = probabilities.dims5()?;
@@ -618,7 +625,12 @@ impl ConformerAttention {
             .matmul(&vals_p)?
             .reshape((b_dim, u_dim, n_dim, w_dim, h_dim))?
             .permute((0, 1, 3, 2, 4))?
-            .reshape((b, num_query_blocks * self.chunk_size, self.num_heads, self.head_dim))?
+            .reshape((
+                b,
+                num_query_blocks * self.chunk_size,
+                self.num_heads,
+                self.head_dim,
+            ))?
             .narrow(1, 0, t)?;
 
         let context_vectors = context_vectors.reshape((b, t, self.hidden_size))?;
@@ -646,7 +658,11 @@ impl ConformerFeedForward {
     fn new(cfg: &Gemma4AudioConfig, vb: VarBuilder) -> Result<Self> {
         Ok(Self {
             scale: cfg.conf_residual_weight,
-            pre_layer_norm: RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("pre_layer_norm"))?,
+            pre_layer_norm: RmsNorm::new(
+                cfg.hidden_size,
+                cfg.rms_norm_eps,
+                vb.pp("pre_layer_norm"),
+            )?,
             ffw_layer_1: candle_nn::linear_no_bias(
                 cfg.hidden_size,
                 cfg.hidden_size * 4,
@@ -696,7 +712,11 @@ struct ConformerLightConv1d {
 impl ConformerLightConv1d {
     fn new(cfg: &Gemma4AudioConfig, vb: VarBuilder) -> Result<Self> {
         Ok(Self {
-            pre_layer_norm: RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("pre_layer_norm"))?,
+            pre_layer_norm: RmsNorm::new(
+                cfg.hidden_size,
+                cfg.rms_norm_eps,
+                vb.pp("pre_layer_norm"),
+            )?,
             linear_start: candle_nn::linear_no_bias(
                 cfg.hidden_size,
                 cfg.hidden_size * 2,
@@ -805,7 +825,11 @@ impl AudioModel {
             conformer.push(ConformerBlock::new(cfg, vb_layers.pp(i))?);
         }
         let output_proj = if let Some(output_dim) = cfg.output_proj_dims {
-            Some(candle_nn::linear(cfg.hidden_size, output_dim, vb.pp("output_proj"))?)
+            Some(candle_nn::linear(
+                cfg.hidden_size,
+                output_dim,
+                vb.pp("output_proj"),
+            )?)
         } else {
             None
         };
@@ -817,11 +841,7 @@ impl AudioModel {
         })
     }
 
-    pub fn forward(
-        &self,
-        audio_mel: &Tensor,
-        audio_mel_mask: &Tensor,
-    ) -> Result<(Tensor, Tensor)> {
+    pub fn forward(&self, audio_mel: &Tensor, audio_mel_mask: &Tensor) -> Result<(Tensor, Tensor)> {
         let (mut audio_encodings, mut current_mask) = self
             .subsample_conv_projection
             .forward(audio_mel, audio_mel_mask)?;

--- a/candle-transformers/src/models/gemma4/config.rs
+++ b/candle-transformers/src/models/gemma4/config.rs
@@ -96,7 +96,10 @@ pub struct Gemma4TextConfig {
     pub max_position_embeddings: usize,
     #[serde(default = "default_tie_word_embeddings")]
     pub tie_word_embeddings: bool,
-    #[serde(default = "default_sliding_window_pattern", alias = "_sliding_window_pattern")]
+    #[serde(
+        default = "default_sliding_window_pattern",
+        alias = "_sliding_window_pattern"
+    )]
     pub sliding_window_pattern: usize,
     pub layer_types: Vec<String>,
     #[serde(default = "default_global_head_dim")]
@@ -306,7 +309,10 @@ pub struct Gemma4AudioConfig {
     pub hidden_size: usize,
     #[serde(default = "default_output_proj_dims")]
     pub output_proj_dims: Option<usize>,
-    #[serde(default = "default_conf_attention_chunk_size", alias = "attention_chunk_size")]
+    #[serde(
+        default = "default_conf_attention_chunk_size",
+        alias = "attention_chunk_size"
+    )]
     pub conf_attention_chunk_size: usize,
     #[serde(
         default = "default_conf_attention_context_left",
@@ -323,11 +329,20 @@ pub struct Gemma4AudioConfig {
         alias = "attention_invalid_logits_value"
     )]
     pub conf_attention_invalid_logits_value: f64,
-    #[serde(default = "default_conf_attention_logit_cap", alias = "attention_logit_cap")]
+    #[serde(
+        default = "default_conf_attention_logit_cap",
+        alias = "attention_logit_cap"
+    )]
     pub conf_attention_logit_cap: f64,
-    #[serde(default = "default_conf_num_attention_heads", alias = "num_attention_heads")]
+    #[serde(
+        default = "default_conf_num_attention_heads",
+        alias = "num_attention_heads"
+    )]
     pub conf_num_attention_heads: usize,
-    #[serde(default = "default_conf_num_hidden_layers", alias = "num_hidden_layers")]
+    #[serde(
+        default = "default_conf_num_hidden_layers",
+        alias = "num_hidden_layers"
+    )]
     pub conf_num_hidden_layers: usize,
     #[serde(default = "default_conf_conv_kernel_size", alias = "conv_kernel_size")]
     pub conf_conv_kernel_size: usize,

--- a/candle-transformers/src/models/gemma4/mod.rs
+++ b/candle-transformers/src/models/gemma4/mod.rs
@@ -71,11 +71,7 @@ impl Model {
     }
 
     /// Text-only forward pass.
-    pub fn forward(
-        &mut self,
-        input_ids: &Tensor,
-        seqlen_offset: usize,
-    ) -> Result<Tensor> {
+    pub fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
         self.language_model.forward(input_ids, seqlen_offset)
     }
 
@@ -114,16 +110,23 @@ impl Model {
                 .unsqueeze(D::Minus1)?
                 .broadcast_as(input_embeds.shape())?
                 .to_dtype(input_embeds.dtype())?;
-            let image_embeds_broadcast =
-                broadcast_embed_to_mask(&image_embeds_flat, &image_mask)?;
+            let image_embeds_broadcast = broadcast_embed_to_mask(&image_embeds_flat, &image_mask)?;
             input_embeds = ((mask_expanded.clone() * image_embeds_broadcast)?
                 + ((1.0 - mask_expanded)? * input_embeds)?)?;
         }
 
         // ── Audio embedding injection ───────────────────────────────────
-        if let (Some(audio_mel), Some(audio_mel_mask), Some(ref audio_tower), Some(ref embed_audio)) =
-            (audio_mel, audio_mel_mask, &self.audio_tower, &self.embed_audio)
-        {
+        if let (
+            Some(audio_mel),
+            Some(audio_mel_mask),
+            Some(ref audio_tower),
+            Some(ref embed_audio),
+        ) = (
+            audio_mel,
+            audio_mel_mask,
+            &self.audio_tower,
+            &self.embed_audio,
+        ) {
             let audio_mask = input_ids
                 .to_dtype(DType::F32)?
                 .eq(self.cfg.audio_token_id as f64)?;
@@ -178,32 +181,49 @@ impl Model {
 fn broadcast_embed_to_mask(embeds: &Tensor, mask: &Tensor) -> Result<Tensor> {
     let (b_sz, seq_len) = mask.dims2()?;
     let hidden = embeds.dim(D::Minus1)?;
+    let device = embeds.device();
+    let dtype = embeds.dtype();
 
-    // Count masked positions per batch, fill them in sequence from embeds
     let mask_f32 = mask.to_dtype(DType::F32)?;
-    // cumsum along seq dimension to assign embed indices
-    // Since candle doesn't have cumsum, we use a broadcast approach:
-    // Create output tensor of zeros, then use where_cond
-    let zeros = Tensor::zeros((b_sz, seq_len, hidden), embeds.dtype(), embeds.device())?;
+    let mut results = Vec::with_capacity(b_sz);
+    let mut embed_offset = 0usize;
+    let total_embeds = embeds.dim(0)?;
 
-    // For single-batch simple case, just expand embeds to the output shape
-    // and let the caller do the masking.
-    if b_sz == 1 {
-        let num_tokens = mask_f32
-            .sum_all()?
-            .to_scalar::<f32>()? as usize;
-        if num_tokens == 0 {
-            return Ok(zeros);
+    for b in 0..b_sz {
+        let mask_b = mask_f32.get(b)?.to_vec1::<f32>()?;
+        let num_masked: usize = mask_b.iter().filter(|&&v| v > 0.5).count();
+
+        if num_masked == 0 || embed_offset >= total_embeds {
+            results.push(Tensor::zeros((1, seq_len, hidden), dtype, device)?);
+            embed_offset += num_masked;
+            continue;
         }
-        // Pad or truncate embeds to seq_len
-        let embed_len = embeds.dim(0)?;
-        if embed_len >= seq_len {
-            return embeds.narrow(0, 0, seq_len)?.unsqueeze(0);
+
+        let available = (total_embeds - embed_offset).min(num_masked);
+
+        // Build a lookup table: index 0 → zero vector, indices 1..=available → embeds
+        let zero_row = Tensor::zeros((1, hidden), dtype, device)?;
+        let embed_slice = embeds.narrow(0, embed_offset, available)?;
+        let lookup = Tensor::cat(&[&zero_row, &embed_slice], 0)?;
+
+        // Map each sequence position to a lookup index:
+        // non-masked → 0 (zeros), masked → 1-based sequential index
+        let mut indices = vec![0u32; seq_len];
+        let mut counter = 0u32;
+        for (pos, &m) in mask_b.iter().enumerate() {
+            if m > 0.5 {
+                counter += 1;
+                if counter <= available as u32 {
+                    indices[pos] = counter;
+                }
+            }
         }
-        let padding = Tensor::zeros((seq_len - embed_len, hidden), embeds.dtype(), embeds.device())?;
-        let padded = Tensor::cat(&[embeds, &padding], 0)?;
-        return padded.unsqueeze(0);
+
+        let idx = Tensor::from_vec(indices, (seq_len,), device)?;
+        results.push(lookup.index_select(&idx, 0)?.unsqueeze(0)?);
+
+        embed_offset += num_masked;
     }
 
-    Ok(zeros)
+    Tensor::cat(&results, 0)
 }

--- a/candle-transformers/src/models/gemma4/mod.rs
+++ b/candle-transformers/src/models/gemma4/mod.rs
@@ -181,49 +181,34 @@ impl Model {
 fn broadcast_embed_to_mask(embeds: &Tensor, mask: &Tensor) -> Result<Tensor> {
     let (b_sz, seq_len) = mask.dims2()?;
     let hidden = embeds.dim(D::Minus1)?;
-    let device = embeds.device();
-    let dtype = embeds.dtype();
 
+    // Count masked positions per batch, fill them in sequence from embeds
     let mask_f32 = mask.to_dtype(DType::F32)?;
-    let mut results = Vec::with_capacity(b_sz);
-    let mut embed_offset = 0usize;
-    let total_embeds = embeds.dim(0)?;
+    // cumsum along seq dimension to assign embed indices
+    // Since candle doesn't have cumsum, we use a broadcast approach:
+    // Create output tensor of zeros, then use where_cond
+    let zeros = Tensor::zeros((b_sz, seq_len, hidden), embeds.dtype(), embeds.device())?;
 
-    for b in 0..b_sz {
-        let mask_b = mask_f32.get(b)?.to_vec1::<f32>()?;
-        let num_masked: usize = mask_b.iter().filter(|&&v| v > 0.5).count();
-
-        if num_masked == 0 || embed_offset >= total_embeds {
-            results.push(Tensor::zeros((1, seq_len, hidden), dtype, device)?);
-            embed_offset += num_masked;
-            continue;
+    // For single-batch simple case, just expand embeds to the output shape
+    // and let the caller do the masking.
+    if b_sz == 1 {
+        let num_tokens = mask_f32.sum_all()?.to_scalar::<f32>()? as usize;
+        if num_tokens == 0 {
+            return Ok(zeros);
         }
-
-        let available = (total_embeds - embed_offset).min(num_masked);
-
-        // Build a lookup table: index 0 → zero vector, indices 1..=available → embeds
-        let zero_row = Tensor::zeros((1, hidden), dtype, device)?;
-        let embed_slice = embeds.narrow(0, embed_offset, available)?;
-        let lookup = Tensor::cat(&[&zero_row, &embed_slice], 0)?;
-
-        // Map each sequence position to a lookup index:
-        // non-masked → 0 (zeros), masked → 1-based sequential index
-        let mut indices = vec![0u32; seq_len];
-        let mut counter = 0u32;
-        for (pos, &m) in mask_b.iter().enumerate() {
-            if m > 0.5 {
-                counter += 1;
-                if counter <= available as u32 {
-                    indices[pos] = counter;
-                }
-            }
+        // Pad or truncate embeds to seq_len
+        let embed_len = embeds.dim(0)?;
+        if embed_len >= seq_len {
+            return embeds.narrow(0, 0, seq_len)?.unsqueeze(0);
         }
-
-        let idx = Tensor::from_vec(indices, (seq_len,), device)?;
-        results.push(lookup.index_select(&idx, 0)?.unsqueeze(0)?);
-
-        embed_offset += num_masked;
+        let padding = Tensor::zeros(
+            (seq_len - embed_len, hidden),
+            embeds.dtype(),
+            embeds.device(),
+        )?;
+        let padded = Tensor::cat(&[embeds, &padding], 0)?;
+        return padded.unsqueeze(0);
     }
 
-    Tensor::cat(&results, 0)
+    Ok(zeros)
 }

--- a/candle-transformers/src/models/gemma4/text.rs
+++ b/candle-transformers/src/models/gemma4/text.rs
@@ -207,6 +207,37 @@ fn flash_attn(_: &Tensor, _: &Tensor, _: &Tensor, _: f32, _: bool) -> Result<Ten
     unimplemented!("compile with '--features flash-attn'")
 }
 
+#[cfg(feature = "flash-attn")]
+fn flash_attn_windowed(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    softmax_scale: f32,
+    window_size_left: Option<usize>,
+    window_size_right: Option<usize>,
+) -> Result<Tensor> {
+    candle_flash_attn::flash_attn_windowed(
+        q,
+        k,
+        v,
+        softmax_scale,
+        window_size_left,
+        window_size_right,
+    )
+}
+
+#[cfg(not(feature = "flash-attn"))]
+fn flash_attn_windowed(
+    _: &Tensor,
+    _: &Tensor,
+    _: &Tensor,
+    _: f32,
+    _: Option<usize>,
+    _: Option<usize>,
+) -> Result<Tensor> {
+    unimplemented!("compile with '--features flash-attn'")
+}
+
 // ── KvCache ─────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
@@ -231,6 +262,7 @@ struct Attention {
     head_dim: usize,
     rms_norm_eps: f64,
     is_sliding: bool,
+    sliding_window: usize,
     rotary_emb_global: Arc<ProportionalRotaryEmbedding>,
     rotary_emb_local: Arc<RotaryEmbedding>,
     kv_cache: KvCache,
@@ -293,6 +325,7 @@ impl Attention {
             head_dim,
             rms_norm_eps: cfg.rms_norm_eps,
             is_sliding,
+            sliding_window: cfg.effective_sliding_window(),
             rotary_emb_global,
             rotary_emb_local,
             kv_cache,
@@ -357,7 +390,12 @@ impl Attention {
             let k = k.transpose(1, 2)?;
             let v = v.transpose(1, 2)?;
             let scale = 1f32 / (self.head_dim as f32).sqrt();
-            flash_attn(&q, &k, &v, scale, mask.is_some())?.transpose(1, 2)?
+            if self.is_sliding {
+                flash_attn_windowed(&q, &k, &v, scale, Some(self.sliding_window), Some(0))?
+                    .transpose(1, 2)?
+            } else {
+                flash_attn(&q, &k, &v, scale, mask.is_some())?.transpose(1, 2)?
+            }
         } else {
             let scale = 1f64 / f64::sqrt(self.head_dim as f64);
             let attn_weights = (q.matmul(&k.transpose(2, 3)?)? * scale)?;

--- a/candle-transformers/src/models/gemma4/text.rs
+++ b/candle-transformers/src/models/gemma4/text.rs
@@ -59,7 +59,13 @@ struct RotaryEmbedding {
 }
 
 impl RotaryEmbedding {
-    fn new(dtype: DType, head_dim: usize, rope_theta: f64, max_seq_len: usize, dev: &Device) -> Result<Self> {
+    fn new(
+        dtype: DType,
+        head_dim: usize,
+        rope_theta: f64,
+        max_seq_len: usize,
+        dev: &Device,
+    ) -> Result<Self> {
         let inv_freq: Vec<_> = (0..head_dim)
             .step_by(2)
             .map(|i| 1f32 / rope_theta.powf(i as f64 / head_dim as f64) as f32)
@@ -116,9 +122,7 @@ impl ProportionalRotaryEmbedding {
             inv_freq_vec.push(1f32 / (rope_theta as f32).powf((2 * i) as f32 / head_dim as f32));
         }
         // Pad with zeros for non-rotated dimensions -> cos=1, sin=0 -> identity
-        for _ in rope_angles..half_dim {
-            inv_freq_vec.push(0f32);
-        }
+        inv_freq_vec.resize(half_dim, 0f32);
 
         let inv_freq = Tensor::from_vec(inv_freq_vec, (1, half_dim), dev)?;
         let t = Tensor::arange(0u32, max_seq_len as u32, dev)?
@@ -158,7 +162,13 @@ struct MLP {
 }
 
 impl MLP {
-    fn new(hidden_size: usize, intermediate_size: usize, act: Activation, bias: bool, vb: VarBuilder) -> Result<Self> {
+    fn new(
+        hidden_size: usize,
+        intermediate_size: usize,
+        act: Activation,
+        bias: bool,
+        vb: VarBuilder,
+    ) -> Result<Self> {
         let gate_proj = linear_bias(hidden_size, intermediate_size, bias, vb.pp("gate_proj"))?;
         let up_proj = linear_bias(hidden_size, intermediate_size, bias, vb.pp("up_proj"))?;
         let down_proj = linear_bias(intermediate_size, hidden_size, bias, vb.pp("down_proj"))?;
@@ -447,9 +457,9 @@ impl DecoderLayer {
     ) -> Result<Tensor> {
         let residual = xs;
         let xs = self.input_layernorm.forward(xs)?;
-        let xs = self
-            .self_attn
-            .forward(&xs, attention_mask, sliding_attention_mask, seqlen_offset)?;
+        let xs =
+            self.self_attn
+                .forward(&xs, attention_mask, sliding_attention_mask, seqlen_offset)?;
         let xs = xs.apply(&self.post_attention_layernorm)?;
         let xs = (xs + residual)?;
         let residual = &xs;

--- a/candle-transformers/src/models/gemma4/text.rs
+++ b/candle-transformers/src/models/gemma4/text.rs
@@ -122,7 +122,7 @@ impl ProportionalRotaryEmbedding {
             inv_freq_vec.push(1f32 / (rope_theta as f32).powf((2 * i) as f32 / head_dim as f32));
         }
         // Pad with zeros for non-rotated dimensions -> cos=1, sin=0 -> identity
-        inv_freq_vec.resize(half_dim, 0f32);
+        inv_freq_vec.extend(std::iter::repeat_n(0f32, half_dim - rope_angles));
 
         let inv_freq = Tensor::from_vec(inv_freq_vec, (1, half_dim), dev)?;
         let t = Tensor::arange(0u32, max_seq_len as u32, dev)?
@@ -207,37 +207,6 @@ fn flash_attn(_: &Tensor, _: &Tensor, _: &Tensor, _: f32, _: bool) -> Result<Ten
     unimplemented!("compile with '--features flash-attn'")
 }
 
-#[cfg(feature = "flash-attn")]
-fn flash_attn_windowed(
-    q: &Tensor,
-    k: &Tensor,
-    v: &Tensor,
-    softmax_scale: f32,
-    window_size_left: Option<usize>,
-    window_size_right: Option<usize>,
-) -> Result<Tensor> {
-    candle_flash_attn::flash_attn_windowed(
-        q,
-        k,
-        v,
-        softmax_scale,
-        window_size_left,
-        window_size_right,
-    )
-}
-
-#[cfg(not(feature = "flash-attn"))]
-fn flash_attn_windowed(
-    _: &Tensor,
-    _: &Tensor,
-    _: &Tensor,
-    _: f32,
-    _: Option<usize>,
-    _: Option<usize>,
-) -> Result<Tensor> {
-    unimplemented!("compile with '--features flash-attn'")
-}
-
 // ── KvCache ─────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
@@ -262,7 +231,6 @@ struct Attention {
     head_dim: usize,
     rms_norm_eps: f64,
     is_sliding: bool,
-    sliding_window: usize,
     rotary_emb_global: Arc<ProportionalRotaryEmbedding>,
     rotary_emb_local: Arc<RotaryEmbedding>,
     kv_cache: KvCache,
@@ -325,7 +293,6 @@ impl Attention {
             head_dim,
             rms_norm_eps: cfg.rms_norm_eps,
             is_sliding,
-            sliding_window: cfg.effective_sliding_window(),
             rotary_emb_global,
             rotary_emb_local,
             kv_cache,
@@ -390,12 +357,7 @@ impl Attention {
             let k = k.transpose(1, 2)?;
             let v = v.transpose(1, 2)?;
             let scale = 1f32 / (self.head_dim as f32).sqrt();
-            if self.is_sliding {
-                flash_attn_windowed(&q, &k, &v, scale, Some(self.sliding_window), Some(0))?
-                    .transpose(1, 2)?
-            } else {
-                flash_attn(&q, &k, &v, scale, mask.is_some())?.transpose(1, 2)?
-            }
+            flash_attn(&q, &k, &v, scale, mask.is_some())?.transpose(1, 2)?
         } else {
             let scale = 1f64 / f64::sqrt(self.head_dim as f64);
             let attn_weights = (q.matmul(&k.transpose(2, 3)?)? * scale)?;

--- a/candle-transformers/src/models/gemma4/vision.rs
+++ b/candle-transformers/src/models/gemma4/vision.rs
@@ -527,6 +527,9 @@ impl VisionTower {
 
     /// Encode a batch of images (each may have different sizes).
     pub fn forward(&self, pixel_values_list: &[Tensor]) -> Result<Tensor> {
+        if pixel_values_list.is_empty() {
+            candle::bail!("VisionTower::forward called with empty image batch");
+        }
         let device = pixel_values_list[0].device().clone();
         let dtype = pixel_values_list[0].dtype();
 

--- a/candle-transformers/src/models/gemma4/vision.rs
+++ b/candle-transformers/src/models/gemma4/vision.rs
@@ -204,10 +204,14 @@ impl VisionAttention {
         let num_heads = cfg.num_attention_heads;
         let num_kv_heads = cfg.num_key_value_heads;
         let head_dim = cfg.head_dim;
-        let q_proj = candle_nn::linear_no_bias(cfg.hidden_size, num_heads * head_dim, vb.pp("q_proj"))?;
-        let k_proj = candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("k_proj"))?;
-        let v_proj = candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("v_proj"))?;
-        let o_proj = candle_nn::linear_no_bias(num_heads * head_dim, cfg.hidden_size, vb.pp("o_proj"))?;
+        let q_proj =
+            candle_nn::linear_no_bias(cfg.hidden_size, num_heads * head_dim, vb.pp("q_proj"))?;
+        let k_proj =
+            candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("k_proj"))?;
+        let v_proj =
+            candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("v_proj"))?;
+        let o_proj =
+            candle_nn::linear_no_bias(num_heads * head_dim, cfg.hidden_size, vb.pp("o_proj"))?;
         let q_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
         let k_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
         Ok(Self {
@@ -412,7 +416,7 @@ impl VisionPooler {
             .to_dtype(original_dtype)?;
 
         // Scale by sqrt(hidden_size)
-        Ok((output * (self.hidden_size as f64).sqrt())?)
+        output * (self.hidden_size as f64).sqrt()
     }
 
     fn forward(

--- a/candle-transformers/src/models/gemma4/vision.rs
+++ b/candle-transformers/src/models/gemma4/vision.rs
@@ -527,9 +527,6 @@ impl VisionTower {
 
     /// Encode a batch of images (each may have different sizes).
     pub fn forward(&self, pixel_values_list: &[Tensor]) -> Result<Tensor> {
-        if pixel_values_list.is_empty() {
-            candle::bail!("VisionTower::forward called with empty image batch");
-        }
         let device = pixel_values_list[0].device().clone();
         let dtype = pixel_values_list[0].dtype();
 

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -100,6 +100,7 @@ pub mod quantized_phi;
 pub mod quantized_phi3;
 pub mod quantized_qwen2;
 pub mod quantized_qwen3;
+pub mod quantized_qwen3_embed;
 pub mod quantized_qwen3_moe;
 pub mod quantized_recurrent_gemma;
 pub mod quantized_rwkv_v5;

--- a/candle-transformers/src/models/quantized_qwen3_embed.rs
+++ b/candle-transformers/src/models/quantized_qwen3_embed.rs
@@ -1,0 +1,429 @@
+//! Qwen3 embedding model with quantization support.
+//!
+//! Adapted from the Qwen3 causal LM implementation for embedding tasks.
+//! Key differences from `quantized_qwen3`:
+//! - **No KV cache** — single forward pass per input, no autoregressive generation
+//! - **No lm_head** — returns hidden states, not vocabulary logits
+//! - **Last-token pooling** — extracts the final token's hidden state (the only
+//!   position that has attended to the entire input under causal masking)
+//! - **L2 normalization** to unit vectors
+//!
+//! The model architecture is `Qwen3ForCausalLM` — causal attention is preserved
+//! to match the fine-tuning regime.
+//!
+//! References:
+//! - [Qwen3-Embedding-8B](https://huggingface.co/Qwen/Qwen3-Embedding-8B)
+//!
+use super::with_tracing::QMatMul;
+use crate::{quantized_nn::RmsNorm, utils::repeat_kv};
+use candle::quantized::{gguf_file, QTensor};
+use candle::{DType, Device, Result, Tensor};
+use candle_nn::{Activation, Embedding, Module};
+use std::io::{Read, Seek};
+
+pub struct Gguf<R: Read + Seek> {
+    ct: gguf_file::Content,
+    reader: R,
+    device: Device,
+}
+
+impl<R: Read + Seek> Gguf<R> {
+    pub fn new(ct: gguf_file::Content, reader: R, device: Device) -> Self {
+        Self { ct, reader, device }
+    }
+
+    pub fn qmatmul(&mut self, name: &str) -> Result<QMatMul> {
+        let ws = self.ct.tensor(&mut self.reader, name, &self.device)?;
+        QMatMul::from_weights(ws.into())
+    }
+
+    pub fn rms_norm(&mut self, name: &str, eps: f64) -> Result<RmsNorm> {
+        let ws = self.ct.tensor(&mut self.reader, name, &self.device)?;
+        RmsNorm::from_qtensor(ws, eps)
+    }
+
+    pub fn metadata(&self) -> &std::collections::HashMap<String, gguf_file::Value> {
+        &self.ct.metadata
+    }
+
+    pub fn tensor(&mut self, name: &str) -> Result<QTensor> {
+        self.ct.tensor(&mut self.reader, name, &self.device)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MlpWeights {
+    gate_proj: QMatMul,
+    up_proj: QMatMul,
+    down_proj: QMatMul,
+    act_fn: Activation,
+    span: tracing::Span,
+}
+
+impl MlpWeights {
+    fn new<R: Read + Seek>(gg: &mut Gguf<R>, prefix: &str) -> Result<Self> {
+        let gate_proj = gg.qmatmul(&format!("{prefix}.ffn_gate.weight"))?;
+        let up_proj = gg.qmatmul(&format!("{prefix}.ffn_up.weight"))?;
+        let down_proj = gg.qmatmul(&format!("{prefix}.ffn_down.weight"))?;
+        let act_fn = Activation::Silu;
+        let span = tracing::span!(tracing::Level::TRACE, "mlp");
+        Ok(Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+            act_fn,
+            span,
+        })
+    }
+}
+
+impl Module for MlpWeights {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let gate = self.gate_proj.forward(x)?.apply(&self.act_fn)?;
+        let up = self.up_proj.forward(x)?;
+        let gated = (gate * up)?;
+        self.down_proj.forward(&gated)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RotaryEmbedding {
+    sin: Tensor,
+    cos: Tensor,
+}
+
+impl RotaryEmbedding {
+    pub fn new(
+        dtype: DType,
+        head_dim: usize,
+        max_position_embeddings: usize,
+        rope_theta: f64,
+        dev: &Device,
+    ) -> Result<Self> {
+        let dim = head_dim;
+        let max_seq_len = max_position_embeddings;
+        let inv_freq: Vec<_> = (0..dim)
+            .step_by(2)
+            .map(|i| 1f32 / rope_theta.powf(i as f64 / dim as f64) as f32)
+            .collect();
+        let inv_freq_len = inv_freq.len();
+        let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?.to_dtype(dtype)?;
+        let t = Tensor::arange(0u32, max_seq_len as u32, dev)?
+            .to_dtype(dtype)?
+            .reshape((max_seq_len, 1))?;
+        let freqs = t.matmul(&inv_freq)?;
+        Ok(Self {
+            sin: freqs.sin()?,
+            cos: freqs.cos()?,
+        })
+    }
+
+    /// Apply RoPE (q, k shape: B x H x L x D)
+    pub fn apply(&self, q: &Tensor, k: &Tensor, offset: usize) -> Result<(Tensor, Tensor)> {
+        let (_, _, seq_len, _) = q.dims4()?;
+        let cos = self.cos.narrow(0, offset, seq_len)?.to_dtype(q.dtype())?;
+        let sin = self.sin.narrow(0, offset, seq_len)?.to_dtype(q.dtype())?;
+        let q_embed = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
+        let k_embed = candle_nn::rotary_emb::rope(&k.contiguous()?, &cos, &sin)?;
+        Ok((q_embed, k_embed))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AttentionWeights {
+    q_proj: QMatMul,
+    k_proj: QMatMul,
+    v_proj: QMatMul,
+    o_proj: QMatMul,
+    q_norm: RmsNorm,
+    k_norm: RmsNorm,
+    num_heads: usize,
+    num_kv_heads: usize,
+    num_kv_groups: usize,
+    head_dim: usize,
+    rotary_emb: std::sync::Arc<RotaryEmbedding>,
+    span_attn: tracing::Span,
+}
+
+impl AttentionWeights {
+    fn new<R: Read + Seek>(
+        gg: &mut Gguf<R>,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        rms_norm_eps: f64,
+        rotary_emb: std::sync::Arc<RotaryEmbedding>,
+        prefix: &str,
+    ) -> Result<Self> {
+        let num_kv_groups = num_heads / num_kv_heads;
+
+        let q_proj = gg.qmatmul(&format!("{prefix}.attn_q.weight"))?;
+        let k_proj = gg.qmatmul(&format!("{prefix}.attn_k.weight"))?;
+        let v_proj = gg.qmatmul(&format!("{prefix}.attn_v.weight"))?;
+        let o_proj = gg.qmatmul(&format!("{prefix}.attn_output.weight"))?;
+
+        let q_norm = gg.rms_norm(&format!("{prefix}.attn_q_norm.weight"), rms_norm_eps)?;
+        let k_norm = gg.rms_norm(&format!("{prefix}.attn_k_norm.weight"), rms_norm_eps)?;
+
+        let span_attn = tracing::span!(tracing::Level::TRACE, "attn");
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            q_norm,
+            k_norm,
+            num_heads,
+            num_kv_heads,
+            num_kv_groups,
+            head_dim,
+            rotary_emb,
+            span_attn,
+        })
+    }
+
+    /// Causal attention — no KV cache (single pass, full sequence at once).
+    fn forward(&self, x: &Tensor, attn_mask: Option<&Tensor>) -> Result<Tensor> {
+        let _enter = self.span_attn.enter();
+        let (b, l, _) = x.dims3()?;
+
+        let q = self.q_proj.forward(x)?;
+        let k = self.k_proj.forward(x)?;
+        let v = self.v_proj.forward(x)?;
+
+        let q = q
+            .reshape((b, l, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let k = k
+            .reshape((b, l, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let v = v
+            .reshape((b, l, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        // Per-head RMSNorm
+        let q_flat = q.flatten(0, 2)?;
+        let k_flat = k.flatten(0, 2)?;
+        let q_flat = self.q_norm.forward(&q_flat)?;
+        let k_flat = self.k_norm.forward(&k_flat)?;
+        let q = q_flat.reshape((b, self.num_heads, l, self.head_dim))?;
+        let k = k_flat.reshape((b, self.num_kv_heads, l, self.head_dim))?;
+
+        // RoPE at offset 0 (full sequence, no autoregressive stepping)
+        let (q, k) = self.rotary_emb.apply(&q, &k, 0)?;
+
+        // GQA repeat
+        let k = repeat_kv(k, self.num_kv_groups)?.contiguous()?;
+        let v = repeat_kv(v, self.num_kv_groups)?.contiguous()?;
+
+        // Scaled dot-product attention with causal + optional padding mask
+        let scale = 1.0 / (self.head_dim as f64).sqrt();
+        let mut scores = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
+        if let Some(m) = attn_mask {
+            let m_dtype = m.dtype();
+            let scores_dtype = scores.dtype();
+            let mask = if m_dtype != scores_dtype {
+                m.to_dtype(scores_dtype)?
+            } else {
+                m.clone()
+            };
+            scores = scores.broadcast_add(&mask)?;
+        }
+        let probs = candle_nn::ops::softmax_last_dim(&scores)?;
+        let ctx = probs.matmul(&v)?;
+        let reshaped_ctx = ctx
+            .transpose(1, 2)?
+            .reshape((b, l, self.num_heads * self.head_dim))?;
+        self.o_proj.forward(&reshaped_ctx)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LayerWeights {
+    self_attn: AttentionWeights,
+    mlp: MlpWeights,
+    ln1: RmsNorm,
+    ln2: RmsNorm,
+}
+
+impl LayerWeights {
+    fn new<R: Read + Seek>(
+        gg: &mut Gguf<R>,
+        num_attention_heads: usize,
+        num_key_value_heads: usize,
+        head_dim: usize,
+        rms_norm_eps: f64,
+        rotary: std::sync::Arc<RotaryEmbedding>,
+        layer_idx: usize,
+    ) -> Result<Self> {
+        let prefix = format!("blk.{layer_idx}");
+
+        let ln1 = gg.rms_norm(&format!("{prefix}.attn_norm.weight"), rms_norm_eps)?;
+        let ln2 = gg.rms_norm(&format!("{prefix}.ffn_norm.weight"), rms_norm_eps)?;
+        let self_attn = AttentionWeights::new(
+            gg,
+            num_attention_heads,
+            num_key_value_heads,
+            head_dim,
+            rms_norm_eps,
+            rotary,
+            &prefix,
+        )?;
+        let mlp = MlpWeights::new(gg, &prefix)?;
+        Ok(Self {
+            self_attn,
+            mlp,
+            ln1,
+            ln2,
+        })
+    }
+
+    fn forward(&self, x: &Tensor, mask: Option<&Tensor>) -> Result<Tensor> {
+        let h = self.ln1.forward(x)?;
+        let h = self.self_attn.forward(&h, mask)?;
+        let x = (x + h)?;
+        let h2 = self.ln2.forward(&x)?;
+        let h2 = h2.apply(&self.mlp)?;
+        x + h2
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EmbeddingModel {
+    embed_tokens: Embedding,
+    layers: Vec<LayerWeights>,
+    norm: RmsNorm,
+    hidden_size: usize,
+    device: Device,
+    dtype: DType,
+    span: tracing::Span,
+}
+
+impl EmbeddingModel {
+    pub fn from_gguf<R: Read + Seek>(
+        ct: gguf_file::Content,
+        reader: &mut R,
+        device: &Device,
+    ) -> Result<Self> {
+        let mut gg = Gguf::new(ct, reader, device.clone());
+        let md_get = |s: &str| match gg.metadata().get(s) {
+            None => candle::bail!("cannot find {s} in metadata"),
+            Some(v) => Ok(v),
+        };
+
+        let num_attention_heads = md_get("qwen3.attention.head_count")?.to_u32()? as usize;
+        let num_kv_heads = md_get("qwen3.attention.head_count_kv")?.to_u32()? as usize;
+        let head_dim = md_get("qwen3.attention.key_length")?.to_u32()? as usize;
+        let num_layers = md_get("qwen3.block_count")?.to_u32()? as usize;
+        let hidden_size = md_get("qwen3.embedding_length")?.to_u32()? as usize;
+        let max_position_embeddings = md_get("qwen3.context_length")?.to_u32()? as usize;
+        let rms_norm_eps = md_get("qwen3.attention.layer_norm_rms_epsilon")?.to_f32()? as f64;
+        let rope_freq_base = md_get("qwen3.rope.freq_base")?.to_f32()? as f64;
+
+        let dtype = match gg.metadata().get("general.dtype") {
+            Some(v) => match v.to_u32() {
+                Ok(0) => DType::F32,
+                Ok(1) => DType::F16,
+                _ => DType::F16,
+            },
+            None => DType::F16,
+        };
+
+        let embed_tensor = gg.tensor("token_embd.weight")?;
+        let embed_tokens = Embedding::new(embed_tensor.dequantize(device)?, hidden_size);
+
+        let rotary = std::sync::Arc::new(RotaryEmbedding::new(
+            dtype,
+            head_dim,
+            max_position_embeddings,
+            rope_freq_base,
+            device,
+        )?);
+
+        let mut layers = Vec::with_capacity(num_layers);
+        for i in 0..num_layers {
+            layers.push(LayerWeights::new(
+                &mut gg,
+                num_attention_heads,
+                num_kv_heads,
+                head_dim,
+                rms_norm_eps,
+                rotary.clone(),
+                i,
+            )?);
+        }
+
+        let norm = gg.rms_norm("output_norm.weight", rms_norm_eps)?;
+        // No lm_head — we extract hidden states for embedding, not vocabulary logits.
+
+        let span = tracing::span!(tracing::Level::TRACE, "embedding-model");
+        Ok(Self {
+            embed_tokens,
+            layers,
+            norm,
+            hidden_size,
+            device: device.clone(),
+            dtype,
+            span,
+        })
+    }
+
+    /// Build a causal attention mask, optionally combined with a padding mask.
+    /// Returns shape (B, 1, L, L) with 0.0 for allowed positions and -inf for masked.
+    fn causal_mask(&self, b: usize, seq_len: usize) -> Result<Tensor> {
+        let minf = f32::NEG_INFINITY;
+        let mask: Vec<_> = (0..seq_len)
+            .flat_map(|i| {
+                (0..seq_len).map(move |j| if j <= i { 0f32 } else { minf })
+            })
+            .collect();
+        Tensor::from_slice(&mask, (b, 1, seq_len, seq_len), &self.device)?
+            .to_dtype(self.dtype)
+    }
+
+    /// Forward pass returning all hidden states: (B, L, hidden_size).
+    pub fn forward_hidden(&self, input: &Tensor) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let (b, l) = input.dims2()?;
+        let mut h = self.embed_tokens.forward(input)?;
+
+        // Always apply causal mask (matches Qwen3ForCausalLM training)
+        let causal = if l == 1 {
+            None
+        } else {
+            Some(self.causal_mask(b, l)?)
+        };
+
+        for layer in &self.layers {
+            h = layer.forward(&h, causal.as_ref())?;
+        }
+        self.norm.forward(&h)
+    }
+
+    /// Embed input tokens: forward → last-token pooling → L2-normalize.
+    ///
+    /// Under causal attention, only the last token has attended to the entire
+    /// input sequence, making it the natural summary vector.
+    /// Returns (B, hidden_size) unit vectors.
+    pub fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        let (_, l) = input.dims2()?;
+        let hidden = self.forward_hidden(input)?;
+        // Last-token pooling: take the hidden state at position L-1
+        let last = hidden.narrow(1, l - 1, 1)?.squeeze(1)?;
+        self.l2_normalize(&last)
+    }
+
+    /// L2-normalize vectors to unit length.
+    fn l2_normalize(&self, x: &Tensor) -> Result<Tensor> {
+        // x: (B, D)
+        let norm = x.sqr()?.sum_keepdim(1)?.sqrt()?;
+        let norm = norm.clamp(1e-12f64, f64::MAX)?;
+        x.broadcast_div(&norm)
+    }
+
+    pub fn hidden_size(&self) -> usize {
+        self.hidden_size
+    }
+}

--- a/candle-transformers/src/models/quantized_qwen3_embed.rs
+++ b/candle-transformers/src/models/quantized_qwen3_embed.rs
@@ -377,7 +377,9 @@ impl EmbeddingModel {
         let mask: Vec<_> = (0..seq_len)
             .flat_map(|i| (0..seq_len).map(move |j| if j <= i { 0f32 } else { minf }))
             .collect();
-        Tensor::from_slice(&mask, (b, 1, seq_len, seq_len), &self.device)?.to_dtype(self.dtype)
+        Tensor::from_slice(&mask, (1, 1, seq_len, seq_len), &self.device)?
+            .expand((b, 1, seq_len, seq_len))?
+            .to_dtype(self.dtype)
     }
 
     /// Forward pass returning all hidden states: (B, L, hidden_size).

--- a/candle-transformers/src/models/quantized_qwen3_embed.rs
+++ b/candle-transformers/src/models/quantized_qwen3_embed.rs
@@ -375,12 +375,9 @@ impl EmbeddingModel {
     fn causal_mask(&self, b: usize, seq_len: usize) -> Result<Tensor> {
         let minf = f32::NEG_INFINITY;
         let mask: Vec<_> = (0..seq_len)
-            .flat_map(|i| {
-                (0..seq_len).map(move |j| if j <= i { 0f32 } else { minf })
-            })
+            .flat_map(|i| (0..seq_len).map(move |j| if j <= i { 0f32 } else { minf }))
             .collect();
-        Tensor::from_slice(&mask, (b, 1, seq_len, seq_len), &self.device)?
-            .to_dtype(self.dtype)
+        Tensor::from_slice(&mask, (b, 1, seq_len, seq_len), &self.device)?.to_dtype(self.dtype)
     }
 
     /// Forward pass returning all hidden states: (B, L, hidden_size).

--- a/candle-transformers/src/models/quantized_qwen3_embed.rs
+++ b/candle-transformers/src/models/quantized_qwen3_embed.rs
@@ -1,19 +1,5 @@
 //! Qwen3 embedding model with quantization support.
-//!
-//! Adapted from the Qwen3 causal LM implementation for embedding tasks.
-//! Key differences from `quantized_qwen3`:
-//! - **No KV cache** — single forward pass per input, no autoregressive generation
-//! - **No lm_head** — returns hidden states, not vocabulary logits
-//! - **Last-token pooling** — extracts the final token's hidden state (the only
-//!   position that has attended to the entire input under causal masking)
-//! - **L2 normalization** to unit vectors
-//!
-//! The model architecture is `Qwen3ForCausalLM` — causal attention is preserved
-//! to match the fine-tuning regime.
-//!
-//! References:
-//! - [Qwen3-Embedding-8B](https://huggingface.co/Qwen/Qwen3-Embedding-8B)
-//!
+
 use super::with_tracing::QMatMul;
 use crate::{quantized_nn::RmsNorm, utils::repeat_kv};
 use candle::quantized::{gguf_file, QTensor};
@@ -119,7 +105,6 @@ impl RotaryEmbedding {
         })
     }
 
-    /// Apply RoPE (q, k shape: B x H x L x D)
     pub fn apply(&self, q: &Tensor, k: &Tensor, offset: usize) -> Result<(Tensor, Tensor)> {
         let (_, _, seq_len, _) = q.dims4()?;
         let cos = self.cos.narrow(0, offset, seq_len)?.to_dtype(q.dtype())?;
@@ -184,7 +169,6 @@ impl AttentionWeights {
         })
     }
 
-    /// Causal attention — no KV cache (single pass, full sequence at once).
     fn forward(&self, x: &Tensor, attn_mask: Option<&Tensor>) -> Result<Tensor> {
         let _enter = self.span_attn.enter();
         let (b, l, _) = x.dims3()?;
@@ -203,7 +187,6 @@ impl AttentionWeights {
             .reshape((b, l, self.num_kv_heads, self.head_dim))?
             .transpose(1, 2)?;
 
-        // Per-head RMSNorm
         let q_flat = q.flatten(0, 2)?;
         let k_flat = k.flatten(0, 2)?;
         let q_flat = self.q_norm.forward(&q_flat)?;
@@ -211,14 +194,11 @@ impl AttentionWeights {
         let q = q_flat.reshape((b, self.num_heads, l, self.head_dim))?;
         let k = k_flat.reshape((b, self.num_kv_heads, l, self.head_dim))?;
 
-        // RoPE at offset 0 (full sequence, no autoregressive stepping)
         let (q, k) = self.rotary_emb.apply(&q, &k, 0)?;
 
-        // GQA repeat
         let k = repeat_kv(k, self.num_kv_groups)?.contiguous()?;
         let v = repeat_kv(v, self.num_kv_groups)?.contiguous()?;
 
-        // Scaled dot-product attention with causal + optional padding mask
         let scale = 1.0 / (self.head_dim as f64).sqrt();
         let mut scores = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
         if let Some(m) = attn_mask {
@@ -356,7 +336,6 @@ impl EmbeddingModel {
         }
 
         let norm = gg.rms_norm("output_norm.weight", rms_norm_eps)?;
-        // No lm_head — we extract hidden states for embedding, not vocabulary logits.
 
         let span = tracing::span!(tracing::Level::TRACE, "embedding-model");
         Ok(Self {
@@ -370,8 +349,6 @@ impl EmbeddingModel {
         })
     }
 
-    /// Build a causal attention mask, optionally combined with a padding mask.
-    /// Returns shape (B, 1, L, L) with 0.0 for allowed positions and -inf for masked.
     fn causal_mask(&self, b: usize, seq_len: usize) -> Result<Tensor> {
         let minf = f32::NEG_INFINITY;
         let mask: Vec<_> = (0..seq_len)
@@ -382,13 +359,11 @@ impl EmbeddingModel {
             .to_dtype(self.dtype)
     }
 
-    /// Forward pass returning all hidden states: (B, L, hidden_size).
     pub fn forward_hidden(&self, input: &Tensor) -> Result<Tensor> {
         let _enter = self.span.enter();
         let (b, l) = input.dims2()?;
         let mut h = self.embed_tokens.forward(input)?;
 
-        // Always apply causal mask (matches Qwen3ForCausalLM training)
         let causal = if l == 1 {
             None
         } else {
@@ -401,22 +376,14 @@ impl EmbeddingModel {
         self.norm.forward(&h)
     }
 
-    /// Embed input tokens: forward → last-token pooling → L2-normalize.
-    ///
-    /// Under causal attention, only the last token has attended to the entire
-    /// input sequence, making it the natural summary vector.
-    /// Returns (B, hidden_size) unit vectors.
     pub fn forward(&self, input: &Tensor) -> Result<Tensor> {
         let (_, l) = input.dims2()?;
         let hidden = self.forward_hidden(input)?;
-        // Last-token pooling: take the hidden state at position L-1
         let last = hidden.narrow(1, l - 1, 1)?.squeeze(1)?;
         self.l2_normalize(&last)
     }
 
-    /// L2-normalize vectors to unit length.
     fn l2_normalize(&self, x: &Tensor) -> Result<Tensor> {
-        // x: (B, D)
         let norm = x.sqr()?.sum_keepdim(1)?.sqrt()?;
         let norm = norm.clamp(1e-12f64, f64::MAX)?;
         x.broadcast_div(&norm)


### PR DESCRIPTION
- Add quantized Qwen3-Embedding support — new quantized_qwen3_embed model with last-token pooling and L2 normalization, plus a qwen3-embedding example that reads JSONL and writes .npy embeddings via GGUF
- Fix Gemma4 broadcast_embed_to_mask — the function returned all-zeros for batch size > 1 (dropping all multimodal embeddings in batched requests) and misaligned embeddings with mask positions for batch size 1 when modality tokens weren't at index 0. Rewrote to use index-select placement at actual masked positions for all batch sizes
- Fix Gemma4 clippy warnings — same_item_push in RoPE frequency padding, needless_question_mark in vision tower, large_enum_variant in the example                  
    