### PR TITLE
Add fast CUDA MMVQ GGUF kernels

### DIFF
--- a/candle-core/src/quantized/cuda.rs
+++ b/candle-core/src/quantized/cuda.rs
@@ -19,7 +19,7 @@ pub struct QCudaStorage {
     device: CudaDevice,
 }
 
-static FORCE_DMMV: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+pub(crate) static FORCE_DMMV: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 pub fn set_force_dmmv(f: bool) {
     FORCE_DMMV.store(f, std::sync::atomic::Ordering::Relaxed)
@@ -720,6 +720,12 @@ impl QCudaStorage {
         storage: &CudaStorage,
         layout: &crate::Layout,
     ) -> Result<(CudaStorage, crate::Shape)> {
+        // Try the fast MMVQ path first (supports BF16/F32, batch 1-8, all quant types, reuses per-device workspace).
+        if let Some(result) = super::fast_mmvq::try_fwd(self, self_shape, storage, layout)? {
+            return Ok(result);
+        }
+
+        // Fallback: existing PTX-based paths.
         let max_bm = if FORCE_DMMV.load(std::sync::atomic::Ordering::Relaxed) {
             1
         } else {

--- a/candle-core/src/quantized/cuda.rs
+++ b/candle-core/src/quantized/cuda.rs
@@ -720,9 +720,11 @@ impl QCudaStorage {
         storage: &CudaStorage,
         layout: &crate::Layout,
     ) -> Result<(CudaStorage, crate::Shape)> {
-        // Try the fast MMVQ path first (supports BF16/F32, batch 1-8, all quant types, reuses per-device workspace).
-        if let Some(result) = super::fast_mmvq::try_fwd(self, self_shape, storage, layout)? {
-            return Ok(result);
+        // Try the fast MMVQ path first (supports BF16//F16/F32, batch 1-8, all quant types, reuses per-device workspace).
+        if !FORCE_DMMV.load(std::sync::atomic::Ordering::Relaxed) {
+            if let Some(result) = super::fast_mmvq::try_fwd(self, self_shape, storage, layout)? {
+                return Ok(result);
+            }
         }
 
         // Fallback: existing PTX-based paths.

--- a/candle-core/src/quantized/cuda.rs
+++ b/candle-core/src/quantized/cuda.rs
@@ -19,7 +19,8 @@ pub struct QCudaStorage {
     device: CudaDevice,
 }
 
-pub(crate) static FORCE_DMMV: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+pub(crate) static FORCE_DMMV: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
 
 pub fn set_force_dmmv(f: bool) {
     FORCE_DMMV.store(f, std::sync::atomic::Ordering::Relaxed)
@@ -727,7 +728,7 @@ impl QCudaStorage {
             }
         }
 
-        // Fallback: existing PTX-based paths.
+        // Fallback
         let max_bm = if FORCE_DMMV.load(std::sync::atomic::Ordering::Relaxed) {
             1
         } else {

--- a/candle-core/src/quantized/fast_mmvq.rs
+++ b/candle-core/src/quantized/fast_mmvq.rs
@@ -1,0 +1,279 @@
+//! CUDA fast path for GGUF matmul with BF16/F32 activations.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use super::cuda::{QCudaStorage, MATRIX_ROW_PADDING};
+use super::GgmlDType;
+use crate::cuda_backend::DeviceId;
+use crate::{backend::BackendStorage, CudaDevice, CudaStorage, DType, Result, Shape};
+
+use cudarc::driver::{CudaSlice, DevicePtr};
+
+const Q8_1_BLOCK_SIZE: usize = 32;
+const Q8_1_TYPE_SIZE: usize = 36; // 2 halves (4 bytes) + QK8_1 int8 = 4 + 32 = 36
+
+#[inline]
+fn pad(p: usize, q: usize) -> usize {
+    p.div_ceil(q) * q
+}
+
+/// Quant types supported by the fast MMVQ kernels.
+fn supports(dtype: GgmlDType) -> bool {
+    matches!(
+        dtype,
+        GgmlDType::Q4_0
+            | GgmlDType::Q4_1
+            | GgmlDType::Q5_0
+            | GgmlDType::Q5_1
+            | GgmlDType::Q8_0
+            | GgmlDType::Q2K
+            | GgmlDType::Q3K
+            | GgmlDType::Q4K
+            | GgmlDType::Q5K
+            | GgmlDType::Q6K
+    )
+}
+
+const MMVQ_MAX_BATCH: usize = 8;
+
+// ---------------------------------------------------------------------------
+// Per-device Q8_1 scratch workspace (grows-only, reused across calls).
+// ---------------------------------------------------------------------------
+
+struct WorkspaceSlot {
+    slice: CudaSlice<u8>,
+    cap: usize,
+}
+
+static WORKSPACE: OnceLock<Mutex<HashMap<DeviceId, WorkspaceSlot>>> = OnceLock::new();
+
+/// Returns a device pointer to the scratch workspace, growing it if needed.
+/// The returned `MutexGuard` must be held alive until the kernels using
+/// this pointer have been launched (all launches are on the device's
+/// default stream, so they are serialised).
+fn workspace_ensure(
+    dev: &CudaDevice,
+    bytes: usize,
+) -> Result<(
+    u64,
+    std::sync::MutexGuard<'static, HashMap<DeviceId, WorkspaceSlot>>,
+)> {
+    let map = WORKSPACE.get_or_init(|| Mutex::new(HashMap::new()));
+    let device_key = dev.id();
+    let mut guard = map.lock().unwrap();
+    let slot = match guard.get_mut(&device_key) {
+        Some(slot) => slot,
+        None => {
+            let slice = unsafe { dev.alloc::<u8>(bytes.max(1))? };
+            guard.insert(
+                device_key,
+                WorkspaceSlot {
+                    slice,
+                    cap: bytes.max(1),
+                },
+            );
+            guard.get_mut(&device_key).unwrap()
+        }
+    };
+    if slot.cap < bytes {
+        slot.slice = unsafe { dev.alloc::<u8>(bytes)? };
+        slot.cap = bytes;
+    }
+    let ptr = slot.slice.device_ptr(slot.slice.stream()).0;
+    Ok((ptr, guard))
+}
+
+// ---------------------------------------------------------------------------
+// Launcher dispatch by weight dtype and output dtype.
+// ---------------------------------------------------------------------------
+
+type PlainLauncher = unsafe extern "C" fn(
+    vx: *const std::ffi::c_void,
+    vy: *const std::ffi::c_void,
+    dst: *mut std::ffi::c_void,
+    ncols_x: i32,
+    nrows_x: i32,
+    stride_col_y: i32,
+    stride_col_dst: i32,
+    b_size: i32,
+    stream: *mut std::ffi::c_void,
+);
+
+fn plain_launcher_bf16(dtype: GgmlDType) -> Option<PlainLauncher> {
+    use candle_kernels::ffi;
+    let f: PlainLauncher = match dtype {
+        GgmlDType::Q4_0 => ffi::launch_mmvq_gguf_q4_0_bf16_plain,
+        GgmlDType::Q4_1 => ffi::launch_mmvq_gguf_q4_1_bf16_plain,
+        GgmlDType::Q5_0 => ffi::launch_mmvq_gguf_q5_0_bf16_plain,
+        GgmlDType::Q5_1 => ffi::launch_mmvq_gguf_q5_1_bf16_plain,
+        GgmlDType::Q8_0 => ffi::launch_mmvq_gguf_q8_0_bf16_plain,
+        GgmlDType::Q2K => ffi::launch_mmvq_gguf_q2_k_bf16_plain,
+        GgmlDType::Q3K => ffi::launch_mmvq_gguf_q3_k_bf16_plain,
+        GgmlDType::Q4K => ffi::launch_mmvq_gguf_q4_k_bf16_plain,
+        GgmlDType::Q5K => ffi::launch_mmvq_gguf_q5_k_bf16_plain,
+        GgmlDType::Q6K => ffi::launch_mmvq_gguf_q6_k_bf16_plain,
+        _ => return None,
+    };
+    Some(f)
+}
+
+fn plain_launcher_f32(dtype: GgmlDType) -> Option<PlainLauncher> {
+    use candle_kernels::ffi;
+    let f: PlainLauncher = match dtype {
+        GgmlDType::Q4_0 => ffi::launch_mmvq_gguf_q4_0_f32_plain,
+        GgmlDType::Q4_1 => ffi::launch_mmvq_gguf_q4_1_f32_plain,
+        GgmlDType::Q5_0 => ffi::launch_mmvq_gguf_q5_0_f32_plain,
+        GgmlDType::Q5_1 => ffi::launch_mmvq_gguf_q5_1_f32_plain,
+        GgmlDType::Q8_0 => ffi::launch_mmvq_gguf_q8_0_f32_plain,
+        GgmlDType::Q2K => ffi::launch_mmvq_gguf_q2_k_f32_plain,
+        GgmlDType::Q3K => ffi::launch_mmvq_gguf_q3_k_f32_plain,
+        GgmlDType::Q4K => ffi::launch_mmvq_gguf_q4_k_f32_plain,
+        GgmlDType::Q5K => ffi::launch_mmvq_gguf_q5_k_f32_plain,
+        GgmlDType::Q6K => ffi::launch_mmvq_gguf_q6_k_f32_plain,
+        _ => return None,
+    };
+    Some(f)
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Try the fast MMVQ path. Returns `Ok(None)` when the fast path is not applicable:
+/// - unsupported quant dtype
+/// - batch too large
+/// - non-BF16/F32 input,
+/// - FORCE_DMMV is set
+pub fn try_fwd(
+    qstorage: &QCudaStorage,
+    self_shape: &Shape,
+    rhs: &CudaStorage,
+    rhs_l: &crate::Layout,
+) -> Result<Option<(CudaStorage, Shape)>> {
+    use candle_kernels::ffi;
+
+    // Gate checks.
+    if super::cuda::FORCE_DMMV.load(std::sync::atomic::Ordering::Relaxed) {
+        return Ok(None);
+    }
+    let w_dtype = qstorage.dtype();
+    if !supports(w_dtype) {
+        return Ok(None);
+    }
+    let input_dtype = rhs.dtype();
+    if !matches!(input_dtype, DType::BF16 | DType::F32) {
+        return Ok(None);
+    }
+
+    let (nrows, ncols) = self_shape.dims2()?;
+
+    let (b_size, k) = match rhs_l.shape().dims() {
+        [b, m, k] => (b * m, *k),
+        [b, k] => (*b, *k),
+        _ => return Ok(None),
+    };
+    if ncols != k {
+        return Ok(None);
+    }
+    if b_size == 0 || b_size > MMVQ_MAX_BATCH {
+        return Ok(None);
+    }
+
+    let (o1, o2) = match rhs_l.contiguous_offsets() {
+        Some(offsets) => offsets,
+        None => return Ok(None),
+    };
+
+    let dev = qstorage.device();
+    let stream_ptr = dev.cuda_stream().cu_stream() as *mut std::ffi::c_void;
+
+    let k_padded = pad(k, MATRIX_ROW_PADDING);
+    let num_blocks_per_row = k_padded / Q8_1_BLOCK_SIZE;
+    let dst_row_bytes = num_blocks_per_row * Q8_1_TYPE_SIZE;
+    let scratch_bytes = b_size * dst_row_bytes;
+
+    let (scratch_ptr, _workspace_guard) = workspace_ensure(dev, scratch_bytes)?;
+    let scratch_ptr = scratch_ptr as *mut std::ffi::c_void;
+    let stride_col_y = (k_padded / Q8_1_BLOCK_SIZE) as i32;
+    let stride_col_dst = nrows as i32;
+    let weight_ptr = qstorage.device_ptr()? as *const std::ffi::c_void;
+
+    let mut out_shape = rhs_l.shape().dims().to_vec();
+    out_shape.pop();
+    out_shape.push(nrows);
+
+    let stream = dev.cuda_stream();
+
+    match input_dtype {
+        DType::BF16 => {
+            let rhs_slice = rhs.as_cuda_slice::<half::bf16>()?;
+            let rhs_slice = rhs_slice.slice(o1..o2);
+            let out = unsafe { dev.alloc::<half::bf16>(nrows * b_size)? };
+
+            let rhs_ptr = rhs_slice.device_ptr(&stream).0 as *const std::ffi::c_void;
+            let out_ptr = out.device_ptr(&stream).0 as *mut std::ffi::c_void;
+
+            unsafe {
+                ffi::launch_mmvq_gguf_quantize_q8_1_bf16(
+                    rhs_ptr,
+                    scratch_ptr,
+                    k as i32,
+                    k_padded as i32,
+                    b_size as i32,
+                    stream_ptr,
+                );
+                let launcher = plain_launcher_bf16(w_dtype).unwrap();
+                launcher(
+                    weight_ptr,
+                    scratch_ptr as *const std::ffi::c_void,
+                    out_ptr,
+                    k as i32,
+                    nrows as i32,
+                    stride_col_y,
+                    stride_col_dst,
+                    b_size as i32,
+                    stream_ptr,
+                );
+            }
+
+            let out_storage = CudaStorage::wrap_cuda_slice(out, dev.clone());
+            Ok(Some((out_storage, out_shape.into())))
+        }
+        DType::F32 => {
+            let rhs_slice = rhs.as_cuda_slice::<f32>()?;
+            let rhs_slice = rhs_slice.slice(o1..o2);
+            let out = unsafe { dev.alloc::<f32>(nrows * b_size)? };
+
+            let rhs_ptr = rhs_slice.device_ptr(&stream).0 as *const std::ffi::c_void;
+            let out_ptr = out.device_ptr(&stream).0 as *mut std::ffi::c_void;
+
+            unsafe {
+                ffi::launch_mmvq_gguf_quantize_q8_1_f32(
+                    rhs_ptr,
+                    scratch_ptr,
+                    k as i32,
+                    k_padded as i32,
+                    b_size as i32,
+                    stream_ptr,
+                );
+                let launcher = plain_launcher_f32(w_dtype).unwrap();
+                launcher(
+                    weight_ptr,
+                    scratch_ptr as *const std::ffi::c_void,
+                    out_ptr,
+                    k as i32,
+                    nrows as i32,
+                    stride_col_y,
+                    stride_col_dst,
+                    b_size as i32,
+                    stream_ptr,
+                );
+            }
+
+            let out_storage = CudaStorage::wrap_cuda_slice(out, dev.clone());
+            Ok(Some((out_storage, out_shape.into())))
+        }
+        _ => Ok(None),
+    }
+}

--- a/candle-core/src/quantized/fast_mmvq.rs
+++ b/candle-core/src/quantized/fast_mmvq.rs
@@ -73,10 +73,7 @@ fn workspace_ensure(
         }
         std::collections::hash_map::Entry::Vacant(entry) => {
             let slice = unsafe { dev.alloc::<u8>(bytes)? };
-            entry.insert(WorkspaceSlot {
-                slice,
-                cap: bytes,
-            })
+            entry.insert(WorkspaceSlot { slice, cap: bytes })
         }
     };
     let ptr = slot.slice.device_ptr(slot.slice.stream()).0;

--- a/candle-core/src/quantized/fast_mmvq.rs
+++ b/candle-core/src/quantized/fast_mmvq.rs
@@ -118,6 +118,24 @@ fn plain_launcher_bf16(dtype: GgmlDType) -> Option<PlainLauncher> {
     Some(f)
 }
 
+fn plain_launcher_f16(dtype: GgmlDType) -> Option<PlainLauncher> {
+    use candle_kernels::ffi;
+    let f: PlainLauncher = match dtype {
+        GgmlDType::Q4_0 => ffi::launch_mmvq_gguf_q4_0_f16_plain,
+        GgmlDType::Q4_1 => ffi::launch_mmvq_gguf_q4_1_f16_plain,
+        GgmlDType::Q5_0 => ffi::launch_mmvq_gguf_q5_0_f16_plain,
+        GgmlDType::Q5_1 => ffi::launch_mmvq_gguf_q5_1_f16_plain,
+        GgmlDType::Q8_0 => ffi::launch_mmvq_gguf_q8_0_f16_plain,
+        GgmlDType::Q2K => ffi::launch_mmvq_gguf_q2_k_f16_plain,
+        GgmlDType::Q3K => ffi::launch_mmvq_gguf_q3_k_f16_plain,
+        GgmlDType::Q4K => ffi::launch_mmvq_gguf_q4_k_f16_plain,
+        GgmlDType::Q5K => ffi::launch_mmvq_gguf_q5_k_f16_plain,
+        GgmlDType::Q6K => ffi::launch_mmvq_gguf_q6_k_f16_plain,
+        _ => return None,
+    };
+    Some(f)
+}
+
 fn plain_launcher_f32(dtype: GgmlDType) -> Option<PlainLauncher> {
     use candle_kernels::ffi;
     let f: PlainLauncher = match dtype {
@@ -162,7 +180,7 @@ pub fn try_fwd(
         return Ok(None);
     }
     let input_dtype = rhs.dtype();
-    if !matches!(input_dtype, DType::BF16 | DType::F32) {
+    if !matches!(input_dtype, DType::BF16 | DType::F16 | DType::F32) {
         return Ok(None);
     }
 
@@ -224,6 +242,40 @@ pub fn try_fwd(
                     stream_ptr,
                 );
                 let launcher = plain_launcher_bf16(w_dtype).unwrap();
+                launcher(
+                    weight_ptr,
+                    scratch_ptr as *const std::ffi::c_void,
+                    out_ptr,
+                    k as i32,
+                    nrows as i32,
+                    stride_col_y,
+                    stride_col_dst,
+                    b_size as i32,
+                    stream_ptr,
+                );
+            }
+
+            let out_storage = CudaStorage::wrap_cuda_slice(out, dev.clone());
+            Ok(Some((out_storage, out_shape.into())))
+        }
+        DType::F16 => {
+            let rhs_slice = rhs.as_cuda_slice::<half::f16>()?;
+            let rhs_slice = rhs_slice.slice(o1..o2);
+            let out = unsafe { dev.alloc::<half::f16>(nrows * b_size)? };
+
+            let rhs_ptr = rhs_slice.device_ptr(&stream).0 as *const std::ffi::c_void;
+            let out_ptr = out.device_ptr(&stream).0 as *mut std::ffi::c_void;
+
+            unsafe {
+                ffi::launch_mmvq_gguf_quantize_q8_1_f16(
+                    rhs_ptr,
+                    scratch_ptr,
+                    k as i32,
+                    k_padded as i32,
+                    b_size as i32,
+                    stream_ptr,
+                );
+                let launcher = plain_launcher_f16(w_dtype).unwrap();
                 launcher(
                     weight_ptr,
                     scratch_ptr as *const std::ffi::c_void,

--- a/candle-core/src/quantized/fast_mmvq.rs
+++ b/candle-core/src/quantized/fast_mmvq.rs
@@ -62,24 +62,23 @@ fn workspace_ensure(
     let map = WORKSPACE.get_or_init(|| Mutex::new(HashMap::new()));
     let device_key = dev.id();
     let mut guard = map.lock().unwrap();
-    let slot = match guard.get_mut(&device_key) {
-        Some(slot) => slot,
-        None => {
-            let slice = unsafe { dev.alloc::<u8>(bytes.max(1))? };
-            guard.insert(
-                device_key,
-                WorkspaceSlot {
-                    slice,
-                    cap: bytes.max(1),
-                },
-            );
-            guard.get_mut(&device_key).unwrap()
+    let slot = match guard.entry(device_key) {
+        std::collections::hash_map::Entry::Occupied(entry) => {
+            let slot = entry.into_mut();
+            if slot.cap < bytes {
+                slot.slice = unsafe { dev.alloc::<u8>(bytes)? };
+                slot.cap = bytes;
+            }
+            slot
+        }
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            let slice = unsafe { dev.alloc::<u8>(bytes)? };
+            entry.insert(WorkspaceSlot {
+                slice,
+                cap: bytes,
+            })
         }
     };
-    if slot.cap < bytes {
-        slot.slice = unsafe { dev.alloc::<u8>(bytes)? };
-        slot.cap = bytes;
-    }
     let ptr = slot.slice.device_ptr(slot.slice.stream()).0;
     Ok((ptr, guard))
 }
@@ -161,8 +160,7 @@ fn plain_launcher_f32(dtype: GgmlDType) -> Option<PlainLauncher> {
 /// Try the fast MMVQ path. Returns `Ok(None)` when the fast path is not applicable:
 /// - unsupported quant dtype
 /// - batch too large
-/// - non-BF16/F32 input,
-/// - FORCE_DMMV is set
+/// - non-BF16/F32 input
 pub fn try_fwd(
     qstorage: &QCudaStorage,
     self_shape: &Shape,
@@ -172,9 +170,6 @@ pub fn try_fwd(
     use candle_kernels::ffi;
 
     // Gate checks.
-    if super::cuda::FORCE_DMMV.load(std::sync::atomic::Ordering::Relaxed) {
-        return Ok(None);
-    }
     let w_dtype = qstorage.dtype();
     if !supports(w_dtype) {
         return Ok(None);

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -22,6 +22,8 @@ mod metal {
 }
 #[cfg(feature = "cuda")]
 pub mod cuda;
+#[cfg(feature = "cuda")]
+pub mod fast_mmvq;
 #[cfg(not(feature = "cuda"))]
 mod cuda {
     pub use super::dummy_cuda::*;

--- a/candle-examples/examples/gemma4/main.rs
+++ b/candle-examples/examples/gemma4/main.rs
@@ -293,8 +293,7 @@ fn main() -> Result<()> {
             None => {
                 let config_file = repo.get("config.json")?;
                 // For text-only, try to parse the text_config sub-object
-                let raw: serde_json::Value =
-                    serde_json::from_slice(&std::fs::read(config_file)?)?;
+                let raw: serde_json::Value = serde_json::from_slice(&std::fs::read(config_file)?)?;
                 if let Some(text_cfg) = raw.get("text_config") {
                     serde_json::from_value(text_cfg.clone())?
                 } else {

--- a/candle-kernels/build.rs
+++ b/candle-kernels/build.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
     let ptx_path = out_dir.join("ptx.rs");
     let bindings = KernelBuilder::new()
         .source_dir("src") // Scan src/ for .cu files
-        .exclude(&["moe_*.cu"]) // Exclude moe kernels for ptx build
+        .exclude(&["moe_*.cu", "mmvq_gguf.cu"]) // Exclude statically compiled kernels from ptx build
         .arg("--expt-relaxed-constexpr")
         .arg("-std=c++17")
         .arg("-O3")
@@ -26,6 +26,7 @@ fn main() -> Result<()> {
             "src/moe/moe_gguf.cu",
             "src/moe/moe_wmma.cu",
             "src/moe/moe_wmma_gguf.cu",
+            "src/mmvq_gguf.cu",
         ])
         .arg("--expt-relaxed-constexpr")
         .arg("-std=c++17")

--- a/candle-kernels/src/ffi.rs
+++ b/candle-kernels/src/ffi.rs
@@ -1,5 +1,6 @@
 use core::ffi::c_void;
 #[allow(dead_code)]
+#[allow(improper_ctypes)]
 extern "C" {
     // for unquntized models
     pub fn moe_gemm_wmma(
@@ -52,5 +53,125 @@ extern "C" {
         input_dtype: i32, // 0=f16, 1=bf16 (for inputs)
         gguf_dtype: i32,  //Q8_0: 0, Q4K: 1, Q2K: 2, Q3k: 3,  Q5K: 4, Q6K: 5  (for weights)
         stream: i64,
+    );
+
+    // ============== Dense GGUF MMVQ launchers (from mmvq_gguf.cu) ==============
+
+    // BF16 output launchers
+    pub fn launch_mmvq_gguf_q4_0_bf16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q4_1_bf16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q5_0_bf16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q5_1_bf16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q8_0_bf16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q2_k_bf16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q3_k_bf16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q4_k_bf16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q5_k_bf16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q6_k_bf16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+
+    // F32 output launchers
+    pub fn launch_mmvq_gguf_q4_0_f32_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q4_1_f32_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q5_0_f32_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q5_1_f32_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q8_0_f32_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q2_k_f32_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q3_k_f32_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q4_k_f32_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q5_k_f32_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q6_k_f32_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+
+    // Quantize launchers (activation → Q8_1)
+    pub fn launch_mmvq_gguf_quantize_q8_1_bf16(
+        x: *const c_void, vy: *mut c_void,
+        kx: i32, kx_padded: i32, num_rows: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_quantize_q8_1_f16(
+        x: *const c_void, vy: *mut c_void,
+        kx: i32, kx_padded: i32, num_rows: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_quantize_q8_1_f32(
+        x: *const c_void, vy: *mut c_void,
+        kx: i32, kx_padded: i32, num_rows: i32, stream: *mut c_void,
     );
 }

--- a/candle-kernels/src/ffi.rs
+++ b/candle-kernels/src/ffi.rs
@@ -161,6 +161,57 @@ extern "C" {
         b_size: i32, stream: *mut c_void,
     );
 
+    pub fn launch_mmvq_gguf_q4_0_f16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q4_1_f16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q5_0_f16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q5_1_f16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q8_0_f16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q2_k_f16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q3_k_f16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q4_k_f16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q5_k_f16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+    pub fn launch_mmvq_gguf_q6_k_f16_plain(
+        vx: *const c_void, vy: *const c_void, dst: *mut c_void,
+        ncols_x: i32, nrows_x: i32, stride_col_y: i32, stride_col_dst: i32,
+        b_size: i32, stream: *mut c_void,
+    );
+
     // Quantize launchers (activation → Q8_1)
     pub fn launch_mmvq_gguf_quantize_q8_1_bf16(
         x: *const c_void, vy: *mut c_void,

--- a/candle-kernels/src/mmvq_gguf.cu
+++ b/candle-kernels/src/mmvq_gguf.cu
@@ -734,7 +734,7 @@ static __device__ void mmvq_core_impl(
                             stride_col_y, stride_col_dst);                     \
   }
 
-// -- plain entries for all 10 supported quant types, batch sizes 1..8, bf16 + f32 --
+// -- plain entries for all 10 supported quant types, batch sizes 1..8, bf16 + f16 + f32 --
 #define MMVQ_PLAIN_BATCH_SET(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot) \
   MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, bf16,     \
                     __nv_bfloat16, 1)                                          \
@@ -752,6 +752,22 @@ static __device__ void mmvq_core_impl(
                     __nv_bfloat16, 7)                                          \
   MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, bf16,     \
                     __nv_bfloat16, 8)                                          \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f16,      \
+                    half, 1)                                                   \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f16,      \
+                    half, 2)                                                   \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f16,      \
+                    half, 3)                                                   \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f16,      \
+                    half, 4)                                                   \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f16,      \
+                    half, 5)                                                   \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f16,      \
+                    half, 6)                                                   \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f16,      \
+                    half, 7)                                                   \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f16,      \
+                    half, 8)                                                   \
   MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f32,      \
                     float, 1)                                                  \
   MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f32,      \
@@ -966,6 +982,17 @@ MMVQ_LAUNCHER_PLAIN(q3_k, bf16, __nv_bfloat16)
 MMVQ_LAUNCHER_PLAIN(q4_k, bf16, __nv_bfloat16)
 MMVQ_LAUNCHER_PLAIN(q5_k, bf16, __nv_bfloat16)
 MMVQ_LAUNCHER_PLAIN(q6_k, bf16, __nv_bfloat16)
+
+MMVQ_LAUNCHER_PLAIN(q4_0, f16, half)
+MMVQ_LAUNCHER_PLAIN(q4_1, f16, half)
+MMVQ_LAUNCHER_PLAIN(q5_0, f16, half)
+MMVQ_LAUNCHER_PLAIN(q5_1, f16, half)
+MMVQ_LAUNCHER_PLAIN(q8_0, f16, half)
+MMVQ_LAUNCHER_PLAIN(q2_k, f16, half)
+MMVQ_LAUNCHER_PLAIN(q3_k, f16, half)
+MMVQ_LAUNCHER_PLAIN(q4_k, f16, half)
+MMVQ_LAUNCHER_PLAIN(q5_k, f16, half)
+MMVQ_LAUNCHER_PLAIN(q6_k, f16, half)
 
 MMVQ_LAUNCHER_PLAIN(q4_0, f32, float)
 MMVQ_LAUNCHER_PLAIN(q4_1, f32, float)

--- a/candle-kernels/src/mmvq_gguf.cu
+++ b/candle-kernels/src/mmvq_gguf.cu
@@ -916,7 +916,9 @@ mmvq_gguf_quantize_q8_1_f32(const float *__restrict__ x,
   extern "C" void launch_mmvq_gguf_##tag##_##dst_tag##_plain(                  \
       const void *vx, const void *vy, void *dst, int ncols_x, int nrows_x,    \
       int stride_col_y, int stride_col_dst, int b_size, void *stream) {        \
-    const unsigned int nblocks = (unsigned int)nrows_x;                        \
+    const unsigned int rows_per_block = (b_size <= 1) ? 1 : 2;                 \
+    const unsigned int nblocks =                                               \
+        (unsigned int)((nrows_x + rows_per_block - 1) / rows_per_block);      \
     unsigned int nwarps;                                                       \
     if (b_size <= 4) {                                                         \
       nwarps = 4;                                                              \

--- a/candle-kernels/src/mmvq_gguf.cu
+++ b/candle-kernels/src/mmvq_gguf.cu
@@ -1,0 +1,1020 @@
+// GGUF matvec kernels with Q8_1-quantized activations.
+// Adapted from llama.cpp's CUDA mmvq path for the GGUF types used here.
+
+#include "cuda_bf16.h"
+#include "cuda_fp16.h"
+#include <stdint.h>
+
+// Constants, types, and helpers shared with the indexed MoE kernels.
+
+#define WARP_SIZE 32
+#define CUDA_QUANTIZE_BLOCK_SIZE 256
+#define K_QUANTS_PER_ITERATION 2
+#define QK_K 256
+#define K_SCALE_SIZE 12
+
+// Matches candle's MATRIX_ROW_PADDING.
+#define MATRIX_ROW_PADDING 512
+
+typedef uint16_t ggml_fp16_t;
+
+static __device__ __forceinline__ float warp_reduce_sum_f32(float x) {
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1) {
+    x += __shfl_xor_sync(0xffffffff, x, mask, WARP_SIZE);
+  }
+  return x;
+}
+
+static __device__ __forceinline__ float warp_reduce_max_f32(float x) {
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1) {
+    x = fmaxf(x, __shfl_xor_sync(0xffffffff, x, mask, WARP_SIZE));
+  }
+  return x;
+}
+
+static __device__ __forceinline__ int get_int_from_int8(const int8_t *x8,
+                                                        const int &i32) {
+  const uint16_t *x16 = (const uint16_t *)(x8 + sizeof(int) * i32);
+  int x32 = 0;
+  x32 |= x16[0] << 0;
+  x32 |= x16[1] << 16;
+  return x32;
+}
+
+static __device__ __forceinline__ int get_int_from_uint8(const uint8_t *x8,
+                                                         const int &i32) {
+  const uint16_t *x16 = (const uint16_t *)(x8 + sizeof(int) * i32);
+  int x32 = 0;
+  x32 |= x16[0] << 0;
+  x32 |= x16[1] << 16;
+  return x32;
+}
+
+static __device__ __forceinline__ int
+get_int_from_int8_aligned(const int8_t *x8, const int &i32) {
+  return *((const int *)(x8 + sizeof(int) * i32));
+}
+
+static __device__ __forceinline__ int
+get_int_from_uint8_aligned(const uint8_t *x8, const int &i32) {
+  return *((const int *)(x8 + sizeof(int) * i32));
+}
+
+#define MIN_CC_DP4A 610
+
+static __device__ __forceinline__ int ggml_cuda_dp4a(const int a, const int b,
+                                                     int c) {
+#if __CUDA_ARCH__ >= MIN_CC_DP4A
+  return __dp4a(a, b, c);
+#else
+  const int8_t *a8 = (const int8_t *)&a;
+  const int8_t *b8 = (const int8_t *)&b;
+  return c + a8[0] * b8[0] + a8[1] * b8[1] + a8[2] * b8[2] + a8[3] * b8[3];
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Block structs for each supported quantization type
+// ---------------------------------------------------------------------------
+
+#define QK8_0 32
+#define QR8_0 1
+#define QI8_0 (QK8_0 / (4 * QR8_0))
+typedef struct {
+  half d;
+  int8_t qs[QK8_0];
+} block_q8_0;
+
+#define QK8_1 32
+#define QR8_1 1
+#define QI8_1 (QK8_1 / (4 * QR8_1))
+typedef struct {
+  half2 ds;
+  int8_t qs[QK8_0];
+} block_q8_1;
+
+#define QR2_K 4
+#define QI2_K (QK_K / (4 * QR2_K))
+typedef struct {
+  uint8_t scales[QK_K / 16];
+  uint8_t qs[QK_K / 4];
+  half2 dm;
+} block_q2_K;
+
+#define QR3_K 4
+#define QI3_K (QK_K / (4 * QR3_K))
+typedef struct {
+  uint8_t hmask[QK_K / 8];
+  uint8_t qs[QK_K / 4];
+  uint8_t scales[K_SCALE_SIZE];
+  half d;
+} block_q3_K;
+
+#define QR4_K 2
+#define QI4_K (QK_K / (4 * QR4_K))
+typedef struct {
+  half2 dm;
+  uint8_t scales[3 * QK_K / 64];
+  uint8_t qs[QK_K / 2];
+} block_q4_K;
+
+#define QR5_K 2
+#define QI5_K (QK_K / (4 * QR5_K))
+typedef struct {
+  half2 dm;
+  uint8_t scales[K_SCALE_SIZE];
+  uint8_t qh[QK_K / 8];
+  uint8_t qs[QK_K / 2];
+} block_q5_K;
+
+#define QR6_K 2
+#define QI6_K (QK_K / (4 * QR6_K))
+typedef struct {
+  uint8_t ql[QK_K / 2];
+  uint8_t qh[QK_K / 4];
+  int8_t scales[QK_K / 16];
+  half d;
+} block_q6_K;
+
+#define QK4_0 32
+#define QR4_0 2
+#define QI4_0 (QK4_0 / (4 * QR4_0))
+typedef struct {
+  half d;
+  uint8_t qs[QK4_0 / 2];
+} block_q4_0;
+
+#define QK4_1 32
+#define QR4_1 2
+#define QI4_1 (QK4_1 / (4 * QR4_1))
+typedef struct {
+  half2 dm;
+  uint8_t qs[QK4_1 / 2];
+} block_q4_1;
+
+#define QK5_0 32
+#define QR5_0 2
+#define QI5_0 (QK5_0 / (4 * QR5_0))
+typedef struct {
+  half d;
+  uint8_t qh[4];
+  uint8_t qs[QK5_0 / 2];
+} block_q5_0;
+
+#define QK5_1 32
+#define QR5_1 2
+#define QI5_1 (QK5_1 / (4 * QR5_1))
+typedef struct {
+  half2 dm;
+  uint8_t qh[4];
+  uint8_t qs[QK5_1 / 2];
+} block_q5_1;
+
+// VDR = vec-dot unroll factor per type.
+#define VDR_Q4_0_Q8_1_MMVQ 2
+#define VDR_Q4_1_Q8_1_MMVQ 2
+#define VDR_Q5_0_Q8_1_MMVQ 2
+#define VDR_Q5_1_Q8_1_MMVQ 2
+#define VDR_Q8_0_Q8_1_MMVQ 2
+#define VDR_Q8_1_Q8_1_MMVQ 2
+#define VDR_Q2_K_Q8_1_MMVQ 1
+#define VDR_Q3_K_Q8_1_MMVQ 1
+#define VDR_Q4_K_Q8_1_MMVQ 2
+#define VDR_Q5_K_Q8_1_MMVQ 2
+#define VDR_Q6_K_Q8_1_MMVQ 1
+
+// ---------------------------------------------------------------------------
+// vec_dot impl helpers (per-quant-type)
+// ---------------------------------------------------------------------------
+
+template <int vdr>
+static __device__ __forceinline__ float
+vec_dot_q4_0_q8_1_impl(const int *v, const int *u, const float &d4,
+                       const half2 &ds8) {
+  int sumi = 0;
+#pragma unroll
+  for (int i = 0; i < vdr; ++i) {
+    const int vi0 = (v[i] >> 0) & 0x0F0F0F0F;
+    const int vi1 = (v[i] >> 4) & 0x0F0F0F0F;
+    sumi = ggml_cuda_dp4a(vi0, u[2 * i + 0], sumi);
+    sumi = ggml_cuda_dp4a(vi1, u[2 * i + 1], sumi);
+  }
+  const float2 ds8f = __half22float2(ds8);
+  return d4 * (sumi * ds8f.x - (8 * vdr / QI4_0) * ds8f.y);
+}
+
+template <int vdr>
+static __device__ __forceinline__ float
+vec_dot_q4_1_q8_1_impl(const int *v, const int *u, const half2 &dm4,
+                       const half2 &ds8) {
+  int sumi = 0;
+#pragma unroll
+  for (int i = 0; i < vdr; ++i) {
+    const int vi0 = (v[i] >> 0) & 0x0F0F0F0F;
+    const int vi1 = (v[i] >> 4) & 0x0F0F0F0F;
+    sumi = ggml_cuda_dp4a(vi0, u[2 * i + 0], sumi);
+    sumi = ggml_cuda_dp4a(vi1, u[2 * i + 1], sumi);
+  }
+  const float2 dm4f = __half22float2(dm4);
+  const float2 ds8f = __half22float2(ds8);
+  const float d4d8 = dm4f.x * ds8f.x;
+  const float m4s8 = dm4f.y * ds8f.y;
+  return sumi * d4d8 + m4s8 / (QI8_1 / (vdr * QR4_1));
+}
+
+template <int vdr>
+static __device__ __forceinline__ float
+vec_dot_q5_0_q8_1_impl(const int *vl, const int *vh, const int *u,
+                       const float &d5, const half2 &ds8) {
+  int sumi = 0;
+#pragma unroll
+  for (int i = 0; i < vdr; ++i) {
+    int vi0 = (vl[i] >> 0) & 0x0F0F0F0F;
+    vi0 |= (vh[i] << 4) & 0x00000010;
+    vi0 |= (vh[i] << 11) & 0x00001000;
+    vi0 |= (vh[i] << 18) & 0x00100000;
+    vi0 |= (vh[i] << 25) & 0x10000000;
+    sumi = ggml_cuda_dp4a(vi0, u[2 * i + 0], sumi);
+
+    int vi1 = (vl[i] >> 4) & 0x0F0F0F0F;
+    vi1 |= (vh[i] >> 12) & 0x00000010;
+    vi1 |= (vh[i] >> 5) & 0x00001000;
+    vi1 |= (vh[i] << 2) & 0x00100000;
+    vi1 |= (vh[i] << 9) & 0x10000000;
+    sumi = ggml_cuda_dp4a(vi1, u[2 * i + 1], sumi);
+  }
+  const float2 ds8f = __half22float2(ds8);
+  return d5 * (sumi * ds8f.x - (16 * vdr / QI5_0) * ds8f.y);
+}
+
+template <int vdr>
+static __device__ __forceinline__ float
+vec_dot_q5_1_q8_1_impl(const int *vl, const int *vh, const int *u,
+                       const half2 &dm5, const half2 &ds8) {
+  int sumi = 0;
+#pragma unroll
+  for (int i = 0; i < vdr; ++i) {
+    int vi0 = (vl[i] >> 0) & 0x0F0F0F0F;
+    vi0 |= (vh[i] << 4) & 0x00000010;
+    vi0 |= (vh[i] << 11) & 0x00001000;
+    vi0 |= (vh[i] << 18) & 0x00100000;
+    vi0 |= (vh[i] << 25) & 0x10000000;
+    sumi = ggml_cuda_dp4a(vi0, u[2 * i + 0], sumi);
+
+    int vi1 = (vl[i] >> 4) & 0x0F0F0F0F;
+    vi1 |= (vh[i] >> 12) & 0x00000010;
+    vi1 |= (vh[i] >> 5) & 0x00001000;
+    vi1 |= (vh[i] << 2) & 0x00100000;
+    vi1 |= (vh[i] << 9) & 0x10000000;
+    sumi = ggml_cuda_dp4a(vi1, u[2 * i + 1], sumi);
+  }
+  const float2 dm5f = __half22float2(dm5);
+  const float2 ds8f = __half22float2(ds8);
+  const float d5d8 = dm5f.x * ds8f.x;
+  const float m5s8 = dm5f.y * ds8f.y;
+  return sumi * d5d8 + m5s8 / (QI5_1 / vdr);
+}
+
+template <int vdr>
+static __device__ __forceinline__ float
+vec_dot_q8_0_q8_1_impl(const int *v, const int *u, const half &d8_0,
+                       const half &d8_1) {
+  int sumi = 0;
+#pragma unroll
+  for (int i = 0; i < vdr; ++i) {
+    sumi = ggml_cuda_dp4a(v[i], u[i], sumi);
+  }
+  return sumi * __half2float(d8_0) * __half2float(d8_1);
+}
+
+static __device__ __forceinline__ float
+vec_dot_q2_K_q8_1_impl_mmvq(const int &v, const int *__restrict__ u,
+                            const uint8_t *__restrict__ scales,
+                            const half2 &dm2, const float *__restrict__ d8) {
+  float sumf_d = 0.0f;
+  float sumf_m = 0.0f;
+#pragma unroll
+  for (int i = 0; i < QR2_K; ++i) {
+    const int sc = scales[2 * i];
+    const int vi = (v >> (2 * i)) & 0x03030303;
+    sumf_d += d8[i] * (ggml_cuda_dp4a(vi, u[i], 0) * (sc & 0xF));
+    int m = sc >> 4;
+    m |= m << 8;
+    m |= m << 16;
+    sumf_m += d8[i] * ggml_cuda_dp4a(m, u[i], 0);
+  }
+  const float2 dm2f = __half22float2(dm2);
+  return dm2f.x * sumf_d - dm2f.y * sumf_m;
+}
+
+static __device__ __forceinline__ float vec_dot_q3_K_q8_1_impl_mmvq(
+    const int &vl, const int &vh, const int *__restrict__ u,
+    const uint8_t *__restrict__ scales, const int &scale_offset,
+    const float &d3, const float *__restrict__ d8) {
+  float sumf = 0.0f;
+#pragma unroll
+  for (int i = 0; i < QR3_K; ++i) {
+    const int isc = scale_offset + 2 * i;
+    const int isc_low = isc % (QK_K / 32);
+    const int sc_shift_low = 4 * (isc / (QK_K / 32));
+    const int sc_low = (scales[isc_low] >> sc_shift_low) & 0xF;
+    const int isc_high = isc % (QK_K / 64);
+    const int sc_shift_high = 2 * (isc / (QK_K / 64));
+    const int sc_high = ((scales[(QK_K / 32) + isc_high] >> sc_shift_high) & 3)
+                        << 4;
+    const int sc = (sc_low | sc_high) - 32;
+    const int vil = (vl >> (2 * i)) & 0x03030303;
+    const int vih = ((vh >> i) << 2) & 0x04040404;
+    const int vi = __vsubss4(vil, vih);
+    sumf += d8[i] * (ggml_cuda_dp4a(vi, u[i], 0) * sc);
+  }
+  return d3 * sumf;
+}
+
+static __device__ __forceinline__ float vec_dot_q4_K_q8_1_impl_vmmq(
+    const int *__restrict__ v, const int *__restrict__ u,
+    const uint8_t *__restrict__ sc, const uint8_t *__restrict__ m,
+    const half2 &dm4, const float *__restrict__ d8) {
+  float sumf_d = 0.0f;
+  float sumf_m = 0.0f;
+#pragma unroll
+  for (int i = 0; i < QR4_K; ++i) {
+    const int v0i = (v[0] >> (4 * i)) & 0x0F0F0F0F;
+    const int v1i = (v[1] >> (4 * i)) & 0x0F0F0F0F;
+    const int dot1 =
+        ggml_cuda_dp4a(v1i, u[2 * i + 1], ggml_cuda_dp4a(v0i, u[2 * i + 0], 0));
+    const int dot2 = ggml_cuda_dp4a(
+        0x01010101, u[2 * i + 1], ggml_cuda_dp4a(0x01010101, u[2 * i + 0], 0));
+    sumf_d += d8[i] * (dot1 * sc[i]);
+    sumf_m += d8[i] * (dot2 * m[i]);
+  }
+  const float2 dm4f = __half22float2(dm4);
+  return dm4f.x * sumf_d - dm4f.y * sumf_m;
+}
+
+static __device__ __forceinline__ float vec_dot_q5_K_q8_1_impl_vmmq(
+    const int *__restrict__ vl, const int *__restrict__ vh,
+    const int *__restrict__ u, const uint8_t *__restrict__ sc,
+    const uint8_t *__restrict__ m, const half2 &dm5,
+    const float *__restrict__ d8) {
+  float sumf_d = 0.0f;
+  float sumf_m = 0.0f;
+#pragma unroll
+  for (int i = 0; i < QR5_K; ++i) {
+    const int vl0i = (vl[0] >> (4 * i)) & 0x0F0F0F0F;
+    const int vl1i = (vl[1] >> (4 * i)) & 0x0F0F0F0F;
+    const int vh0i = ((vh[0] >> i) << 4) & 0x10101010;
+    const int vh1i = ((vh[1] >> i) << 4) & 0x10101010;
+    const int v0i = vl0i | vh0i;
+    const int v1i = vl1i | vh1i;
+    const int dot1 =
+        ggml_cuda_dp4a(v0i, u[2 * i + 0], ggml_cuda_dp4a(v1i, u[2 * i + 1], 0));
+    const int dot2 = ggml_cuda_dp4a(
+        0x01010101, u[2 * i + 0], ggml_cuda_dp4a(0x01010101, u[2 * i + 1], 0));
+    sumf_d += d8[i] * (dot1 * sc[i]);
+    sumf_m += d8[i] * (dot2 * m[i]);
+  }
+  const float2 dm5f = __half22float2(dm5);
+  return dm5f.x * sumf_d - dm5f.y * sumf_m;
+}
+
+static __device__ __forceinline__ float
+vec_dot_q6_K_q8_1_impl_mmvq(const int &vl, const int &vh,
+                            const int *__restrict__ u,
+                            const int8_t *__restrict__ scales, const float &d,
+                            const float *__restrict__ d8) {
+  float sumf = 0.0f;
+#pragma unroll
+  for (int i = 0; i < QR6_K; ++i) {
+    const int sc = scales[4 * i];
+    const int vil = (vl >> (4 * i)) & 0x0F0F0F0F;
+    const int vih = ((vh >> (4 * i)) << 4) & 0x30303030;
+    const int vi = __vsubss4((vil | vih), 0x20202020);
+    sumf += d8[i] * (ggml_cuda_dp4a(vi, u[i], 0) * sc);
+  }
+  return d * sumf;
+}
+
+// vec_dot wrappers for each quant type.
+
+typedef float (*vec_dot_q_cuda_t)(const void *__restrict__ vbq,
+                                  const block_q8_1 *__restrict__ bq8_1,
+                                  const int &kbx, const int &iqs);
+
+static __device__ __forceinline__ float
+vec_dot_q4_0_q8_1(const void *__restrict__ vbq,
+                  const block_q8_1 *__restrict__ bq8_1, const int &kbx,
+                  const int &iqs) {
+  const block_q4_0 *bq4_0 = (const block_q4_0 *)vbq + kbx;
+  int v[VDR_Q4_0_Q8_1_MMVQ];
+  int u[2 * VDR_Q4_0_Q8_1_MMVQ];
+#pragma unroll
+  for (int i = 0; i < VDR_Q4_0_Q8_1_MMVQ; ++i) {
+    v[i] = get_int_from_uint8(bq4_0->qs, iqs + i);
+    u[2 * i + 0] = get_int_from_int8_aligned(bq8_1->qs, iqs + i);
+    u[2 * i + 1] = get_int_from_int8_aligned(bq8_1->qs, iqs + i + QI4_0);
+  }
+  return vec_dot_q4_0_q8_1_impl<VDR_Q4_0_Q8_1_MMVQ>(v, u, bq4_0->d, bq8_1->ds);
+}
+
+static __device__ __forceinline__ float
+vec_dot_q4_1_q8_1(const void *__restrict__ vbq,
+                  const block_q8_1 *__restrict__ bq8_1, const int &kbx,
+                  const int &iqs) {
+  const block_q4_1 *bq4_1 = (const block_q4_1 *)vbq + kbx;
+  int v[VDR_Q4_1_Q8_1_MMVQ];
+  int u[2 * VDR_Q4_1_Q8_1_MMVQ];
+#pragma unroll
+  for (int i = 0; i < VDR_Q4_1_Q8_1_MMVQ; ++i) {
+    v[i] = get_int_from_uint8_aligned(bq4_1->qs, iqs + i);
+    u[2 * i + 0] = get_int_from_int8_aligned(bq8_1->qs, iqs + i);
+    u[2 * i + 1] = get_int_from_int8_aligned(bq8_1->qs, iqs + i + QI4_1);
+  }
+  return vec_dot_q4_1_q8_1_impl<VDR_Q4_1_Q8_1_MMVQ>(v, u, bq4_1->dm, bq8_1->ds);
+}
+
+static __device__ __forceinline__ float
+vec_dot_q5_0_q8_1(const void *__restrict__ vbq,
+                  const block_q8_1 *__restrict__ bq8_1, const int &kbx,
+                  const int &iqs) {
+  const block_q5_0 *bq5_0 = (const block_q5_0 *)vbq + kbx;
+  int vl[VDR_Q5_0_Q8_1_MMVQ];
+  int vh[VDR_Q5_0_Q8_1_MMVQ];
+  int u[2 * VDR_Q5_0_Q8_1_MMVQ];
+#pragma unroll
+  for (int i = 0; i < VDR_Q5_0_Q8_1_MMVQ; ++i) {
+    vl[i] = get_int_from_uint8(bq5_0->qs, iqs + i);
+    vh[i] = get_int_from_uint8(bq5_0->qh, 0) >> (4 * (iqs + i));
+    u[2 * i + 0] = get_int_from_int8_aligned(bq8_1->qs, iqs + i);
+    u[2 * i + 1] = get_int_from_int8_aligned(bq8_1->qs, iqs + i + QI5_0);
+  }
+  return vec_dot_q5_0_q8_1_impl<VDR_Q5_0_Q8_1_MMVQ>(vl, vh, u, bq5_0->d,
+                                                     bq8_1->ds);
+}
+
+static __device__ __forceinline__ float
+vec_dot_q5_1_q8_1(const void *__restrict__ vbq,
+                  const block_q8_1 *__restrict__ bq8_1, const int &kbx,
+                  const int &iqs) {
+  const block_q5_1 *bq5_1 = (const block_q5_1 *)vbq + kbx;
+  int vl[VDR_Q5_1_Q8_1_MMVQ];
+  int vh[VDR_Q5_1_Q8_1_MMVQ];
+  int u[2 * VDR_Q5_1_Q8_1_MMVQ];
+#pragma unroll
+  for (int i = 0; i < VDR_Q5_1_Q8_1_MMVQ; ++i) {
+    vl[i] = get_int_from_uint8_aligned(bq5_1->qs, iqs + i);
+    vh[i] = get_int_from_uint8_aligned(bq5_1->qh, 0) >> (4 * (iqs + i));
+    u[2 * i + 0] = get_int_from_int8_aligned(bq8_1->qs, iqs + i);
+    u[2 * i + 1] = get_int_from_int8_aligned(bq8_1->qs, iqs + i + QI5_1);
+  }
+  return vec_dot_q5_1_q8_1_impl<VDR_Q5_1_Q8_1_MMVQ>(vl, vh, u, bq5_1->dm,
+                                                     bq8_1->ds);
+}
+
+static __device__ __forceinline__ float
+vec_dot_q8_0_q8_1(const void *__restrict__ vbq,
+                  const block_q8_1 *__restrict__ bq8_1, const int &kbx,
+                  const int &iqs) {
+  const block_q8_0 *bq8_0 = (const block_q8_0 *)vbq + kbx;
+  int v[VDR_Q8_0_Q8_1_MMVQ];
+  int u[VDR_Q8_0_Q8_1_MMVQ];
+#pragma unroll
+  for (int i = 0; i < VDR_Q8_0_Q8_1_MMVQ; ++i) {
+    v[i] = get_int_from_int8(bq8_0->qs, iqs + i);
+    u[i] = get_int_from_int8_aligned(bq8_1->qs, iqs + i);
+  }
+  return vec_dot_q8_0_q8_1_impl<VDR_Q8_0_Q8_1_MMVQ>(v, u, bq8_0->d,
+                                                     __low2half(bq8_1->ds));
+}
+
+static __device__ __forceinline__ float
+vec_dot_q2_K_q8_1(const void *__restrict__ vbq,
+                  const block_q8_1 *__restrict__ bq8_1, const int &kbx,
+                  const int &iqs) {
+  const block_q2_K *bq2_K = (const block_q2_K *)vbq + kbx;
+  const int bq8_offset = QR2_K * (iqs / QI8_1);
+  const int scale_offset = iqs - iqs % QI8_1 + (iqs % QI8_1) / (QI8_1 / 2);
+  const uint8_t *scales = bq2_K->scales + scale_offset;
+  const int v = get_int_from_uint8_aligned(bq2_K->qs, iqs);
+  int u[QR2_K];
+  float d8[QR2_K];
+#pragma unroll
+  for (int i = 0; i < QR2_K; ++i) {
+    u[i] = get_int_from_int8_aligned(bq8_1[bq8_offset + i].qs, iqs % QI8_1);
+    d8[i] = __low2float(bq8_1[bq8_offset + i].ds);
+  }
+  return vec_dot_q2_K_q8_1_impl_mmvq(v, u, scales, bq2_K->dm, d8);
+}
+
+static __device__ __forceinline__ float
+vec_dot_q3_K_q8_1(const void *__restrict__ vbq,
+                  const block_q8_1 *__restrict__ bq8_1, const int &kbx,
+                  const int &iqs) {
+  const block_q3_K *bq3_K = (const block_q3_K *)vbq + kbx;
+  const int bq8_offset = QR3_K * (iqs / (QI3_K / 2));
+  const int scale_offset = iqs - iqs % QI8_1 + (iqs % QI8_1) / (QI8_1 / 2);
+  const float d = bq3_K->d;
+  const int vl = get_int_from_uint8(bq3_K->qs, iqs);
+  const int vh =
+      ~get_int_from_uint8(bq3_K->hmask, iqs % (QI3_K / 2)) >> bq8_offset;
+  int u[QR3_K];
+  float d8[QR3_K];
+#pragma unroll
+  for (int i = 0; i < QR3_K; ++i) {
+    u[i] = get_int_from_int8_aligned(bq8_1[bq8_offset + i].qs, iqs % QI8_1);
+    d8[i] = __low2float(bq8_1[bq8_offset + i].ds);
+  }
+  return vec_dot_q3_K_q8_1_impl_mmvq(vl, vh, u, bq3_K->scales, scale_offset, d,
+                                      d8);
+}
+
+static __device__ __forceinline__ float
+vec_dot_q4_K_q8_1(const void *__restrict__ vbq,
+                  const block_q8_1 *__restrict__ bq8_1, const int &kbx,
+                  const int &iqs) {
+  const block_q4_K *bq4_K = (const block_q4_K *)vbq + kbx;
+  int v[2];
+  int u[2 * QR4_K];
+  float d8[QR4_K];
+  const int bq8_offset = QR4_K * ((iqs / 2) / (QI8_1 / 2));
+  const int *q4 =
+      (const int *)(bq4_K->qs + 16 * bq8_offset + 4 * ((iqs / 2) % 4));
+  v[0] = q4[0];
+  v[1] = q4[4];
+  const uint16_t *scales = (const uint16_t *)bq4_K->scales;
+  uint16_t aux[2];
+  const int j = bq8_offset / 2;
+  if (j < 2) {
+    aux[0] = scales[j + 0] & 0x3f3f;
+    aux[1] = scales[j + 2] & 0x3f3f;
+  } else {
+    aux[0] = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+    aux[1] = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j - 0] & 0xc0c0) >> 2);
+  }
+  const uint8_t *sc = (const uint8_t *)aux;
+  const uint8_t *m = sc + 2;
+  for (int i = 0; i < QR4_K; ++i) {
+    const block_q8_1 *bq8i = bq8_1 + bq8_offset + i;
+    d8[i] = __low2float(bq8i->ds);
+    const int *q8 = (const int *)bq8i->qs + ((iqs / 2) % 4);
+    u[2 * i + 0] = q8[0];
+    u[2 * i + 1] = q8[4];
+  }
+  return vec_dot_q4_K_q8_1_impl_vmmq(v, u, sc, m, bq4_K->dm, d8);
+}
+
+static __device__ __forceinline__ float
+vec_dot_q5_K_q8_1(const void *__restrict__ vbq,
+                  const block_q8_1 *__restrict__ bq8_1, const int &kbx,
+                  const int &iqs) {
+  const block_q5_K *bq5_K = (const block_q5_K *)vbq + kbx;
+  int vl[2];
+  int vh[2];
+  int u[2 * QR5_K];
+  float d8[QR5_K];
+  const int bq8_offset = QR5_K * ((iqs / 2) / (QI8_1 / 2));
+  const int *ql =
+      (const int *)(bq5_K->qs + 16 * bq8_offset + 4 * ((iqs / 2) % 4));
+  const int *qh = (const int *)(bq5_K->qh + 4 * ((iqs / 2) % 4));
+  vl[0] = ql[0];
+  vl[1] = ql[4];
+  vh[0] = qh[0] >> bq8_offset;
+  vh[1] = qh[4] >> bq8_offset;
+  const uint16_t *scales = (const uint16_t *)bq5_K->scales;
+  uint16_t aux[2];
+  const int j = bq8_offset / 2;
+  if (j < 2) {
+    aux[0] = scales[j + 0] & 0x3f3f;
+    aux[1] = scales[j + 2] & 0x3f3f;
+  } else {
+    aux[0] = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+    aux[1] = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j - 0] & 0xc0c0) >> 2);
+  }
+  const uint8_t *sc = (const uint8_t *)aux;
+  const uint8_t *m = sc + 2;
+#pragma unroll
+  for (int i = 0; i < QR5_K; ++i) {
+    const block_q8_1 *bq8i = bq8_1 + bq8_offset + i;
+    d8[i] = __low2float(bq8i->ds);
+    const int *q8 = (const int *)bq8i->qs + ((iqs / 2) % 4);
+    u[2 * i + 0] = q8[0];
+    u[2 * i + 1] = q8[4];
+  }
+  return vec_dot_q5_K_q8_1_impl_vmmq(vl, vh, u, sc, m, bq5_K->dm, d8);
+}
+
+static __device__ __forceinline__ float
+vec_dot_q6_K_q8_1(const void *__restrict__ vbq,
+                  const block_q8_1 *__restrict__ bq8_1, const int &kbx,
+                  const int &iqs) {
+  const block_q6_K *bq6_K = (const block_q6_K *)vbq + kbx;
+  const int bq8_offset =
+      2 * QR6_K * (iqs / (QI6_K / 2)) + (iqs % (QI6_K / 2)) / (QI6_K / 4);
+  const int scale_offset =
+      (QI6_K / 4) * (iqs / (QI6_K / 2)) + (iqs % (QI6_K / 2)) / (QI6_K / 8);
+  const int vh_shift = 2 * ((iqs % (QI6_K / 2)) / (QI6_K / 4));
+  const int vl = get_int_from_uint8(bq6_K->ql, iqs);
+  const int vh =
+      get_int_from_uint8(bq6_K->qh, (QI6_K / 4) * (iqs / (QI6_K / 2)) +
+                                        iqs % (QI6_K / 4)) >>
+      vh_shift;
+  const int8_t *scales = bq6_K->scales + scale_offset;
+  int u[QR6_K];
+  float d8[QR6_K];
+#pragma unroll
+  for (int i = 0; i < QR6_K; ++i) {
+    u[i] = get_int_from_int8_aligned(bq8_1[bq8_offset + 2 * i].qs, iqs % QI8_1);
+    d8[i] = __low2float(bq8_1[bq8_offset + 2 * i].ds);
+  }
+  return vec_dot_q6_K_q8_1_impl_mmvq(vl, vh, u, scales, bq6_K->d, d8);
+}
+
+// Core mat-vec-q template.
+
+static constexpr __device__ int mmvq_nwarps_for(int ncols_dst) {
+  return (ncols_dst <= 4) ? 4 : 2;
+}
+
+static constexpr __device__ int mmvq_rows_per_cuda_block_for(int ncols_dst) {
+  return (ncols_dst == 1) ? 1 : 2;
+}
+
+template <typename dst_t, int qk, int qi, typename block_q_t, int vdr,
+          vec_dot_q_cuda_t vec_dot_q_cuda, int ncols_dst>
+static __device__ void mmvq_core_impl(
+    const void *__restrict__ vx,
+    const block_q8_1 *__restrict__ y,
+    dst_t *__restrict__ dst,
+    const int ncols_x, const int nrows_x,
+    const int stride_col_y, const int stride_col_dst) {
+
+  constexpr int nwarps = mmvq_nwarps_for(ncols_dst);
+  constexpr int rows_per_cuda_block = mmvq_rows_per_cuda_block_for(ncols_dst);
+
+  const int tid = WARP_SIZE * threadIdx.y + threadIdx.x;
+  const int row0 = rows_per_cuda_block * blockIdx.x;
+  const int blocks_per_row_x = ncols_x / qk;
+  constexpr int blocks_per_iter = vdr * nwarps * WARP_SIZE / qi;
+
+  // Partial sums.
+  float tmp[ncols_dst][rows_per_cuda_block] = {{0.0f}};
+
+  for (int kbx = tid / (qi / vdr); kbx < blocks_per_row_x;
+       kbx += blocks_per_iter) {
+    const int kby = kbx * (qk / QK8_1);
+    const int kqs = vdr * (tid % (qi / vdr));
+
+#pragma unroll
+    for (int j = 0; j < ncols_dst; ++j) {
+#pragma unroll
+      for (int i = 0; i < rows_per_cuda_block; ++i) {
+        const int row = row0 + i;
+        const int weight_kbx = row * blocks_per_row_x + kbx;
+        tmp[j][i] +=
+            vec_dot_q_cuda(vx, &y[j * stride_col_y + kby], weight_kbx, kqs);
+      }
+    }
+  }
+
+  __shared__ float tmp_shared[nwarps - 1 > 0 ? nwarps - 1 : 1][ncols_dst]
+                              [rows_per_cuda_block][WARP_SIZE];
+
+  if (threadIdx.y > 0) {
+#pragma unroll
+    for (int j = 0; j < ncols_dst; ++j) {
+#pragma unroll
+      for (int i = 0; i < rows_per_cuda_block; ++i) {
+        tmp_shared[threadIdx.y - 1][j][i][threadIdx.x] = tmp[j][i];
+      }
+    }
+  }
+  __syncthreads();
+  if (threadIdx.y > 0) {
+    return;
+  }
+
+#pragma unroll
+  for (int j = 0; j < ncols_dst; ++j) {
+#pragma unroll
+    for (int i = 0; i < rows_per_cuda_block; ++i) {
+#pragma unroll
+      for (int l = 0; l < nwarps - 1; ++l) {
+        tmp[j][i] += tmp_shared[l][j][i][threadIdx.x];
+      }
+      tmp[j][i] = warp_reduce_sum_f32(tmp[j][i]);
+    }
+    if (threadIdx.x < rows_per_cuda_block &&
+        (rows_per_cuda_block == 1 ||
+         uint32_t(row0 + threadIdx.x) < (uint32_t)nrows_x)) {
+      dst[j * stride_col_dst + row0 + threadIdx.x] =
+          (dst_t)tmp[j][threadIdx.x];
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Extern-C kernel entry points
+//
+// Macro expands `MMVQ_PLAIN_ENTRY(tag, block_q_t, qk, qi, vdr, vec_dot,
+// dst_tag, dst_c_type, ncols)` into one `__global__` function for batch
+// size `ncols`. The Rust launcher switches on batch size 1..=8.
+// ---------------------------------------------------------------------------
+
+#define MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot,     \
+                          dst_tag, dst_c_type, ncols)                          \
+  extern "C" __global__ void                                                   \
+      mmvq_gguf_##tag##_##dst_tag##_plain_cuda##ncols(                         \
+          const void *__restrict__ vx, const void *__restrict__ vy,            \
+          dst_c_type *__restrict__ dst, const int ncols_x, const int nrows_x,  \
+          const int stride_col_y, const int stride_col_dst) {                  \
+    mmvq_core_impl<dst_c_type, qk_val, qi_val, block_q_t, vdr_val, vec_dot,    \
+                    ncols>(vx, (const block_q8_1 *)vy, dst, ncols_x, nrows_x,  \
+                            stride_col_y, stride_col_dst);                     \
+  }
+
+// -- plain entries for all 10 supported quant types, batch sizes 1..8, bf16 + f32 --
+#define MMVQ_PLAIN_BATCH_SET(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot) \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, bf16,     \
+                    __nv_bfloat16, 1)                                          \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, bf16,     \
+                    __nv_bfloat16, 2)                                          \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, bf16,     \
+                    __nv_bfloat16, 3)                                          \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, bf16,     \
+                    __nv_bfloat16, 4)                                          \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, bf16,     \
+                    __nv_bfloat16, 5)                                          \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, bf16,     \
+                    __nv_bfloat16, 6)                                          \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, bf16,     \
+                    __nv_bfloat16, 7)                                          \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, bf16,     \
+                    __nv_bfloat16, 8)                                          \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f32,      \
+                    float, 1)                                                  \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f32,      \
+                    float, 2)                                                  \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f32,      \
+                    float, 3)                                                  \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f32,      \
+                    float, 4)                                                  \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f32,      \
+                    float, 5)                                                  \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f32,      \
+                    float, 6)                                                  \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f32,      \
+                    float, 7)                                                  \
+  MMVQ_PLAIN_ENTRY(tag, block_q_t, qk_val, qi_val, vdr_val, vec_dot, f32,      \
+                    float, 8)
+
+MMVQ_PLAIN_BATCH_SET(q4_0, block_q4_0, QK4_0, QI4_0, VDR_Q4_0_Q8_1_MMVQ,
+                     vec_dot_q4_0_q8_1)
+MMVQ_PLAIN_BATCH_SET(q4_1, block_q4_1, QK4_1, QI4_1, VDR_Q4_1_Q8_1_MMVQ,
+                     vec_dot_q4_1_q8_1)
+MMVQ_PLAIN_BATCH_SET(q5_0, block_q5_0, QK5_0, QI5_0, VDR_Q5_0_Q8_1_MMVQ,
+                     vec_dot_q5_0_q8_1)
+MMVQ_PLAIN_BATCH_SET(q5_1, block_q5_1, QK5_1, QI5_1, VDR_Q5_1_Q8_1_MMVQ,
+                     vec_dot_q5_1_q8_1)
+MMVQ_PLAIN_BATCH_SET(q8_0, block_q8_0, QK8_0, QI8_0, VDR_Q8_0_Q8_1_MMVQ,
+                     vec_dot_q8_0_q8_1)
+MMVQ_PLAIN_BATCH_SET(q2_k, block_q2_K, QK_K, QI2_K, VDR_Q2_K_Q8_1_MMVQ,
+                     vec_dot_q2_K_q8_1)
+MMVQ_PLAIN_BATCH_SET(q3_k, block_q3_K, QK_K, QI3_K, VDR_Q3_K_Q8_1_MMVQ,
+                     vec_dot_q3_K_q8_1)
+MMVQ_PLAIN_BATCH_SET(q4_k, block_q4_K, QK_K, QI4_K, VDR_Q4_K_Q8_1_MMVQ,
+                     vec_dot_q4_K_q8_1)
+MMVQ_PLAIN_BATCH_SET(q5_k, block_q5_K, QK_K, QI5_K, VDR_Q5_K_Q8_1_MMVQ,
+                     vec_dot_q5_K_q8_1)
+MMVQ_PLAIN_BATCH_SET(q6_k, block_q6_K, QK_K, QI6_K, VDR_Q6_K_Q8_1_MMVQ,
+                     vec_dot_q6_K_q8_1)
+
+// Padding-aware BF16/F16/F32 -> Q8_1 quantize kernels.
+
+extern "C" __global__ void
+mmvq_gguf_quantize_q8_1_bf16(const __nv_bfloat16 *__restrict__ x,
+                             void *__restrict__ vy, const int kx,
+                             const int kx_padded) {
+  const int ix = blockDim.x * blockIdx.x + threadIdx.x;
+  if (ix >= kx_padded) {
+    return;
+  }
+  const int iy = blockDim.y * blockIdx.y + threadIdx.y;
+  const int i_padded = iy * kx_padded + ix;
+
+  block_q8_1 *y = (block_q8_1 *)vy;
+  const int ib = i_padded / QK8_1;
+  const int iqs = i_padded % QK8_1;
+
+  const float xi = (ix < kx) ? __bfloat162float(x[iy * kx + ix]) : 0.0f;
+  float amax = fabsf(xi);
+  float sum = xi;
+
+  amax = warp_reduce_max_f32(amax);
+  sum = warp_reduce_sum_f32(sum);
+
+  const float d = amax / 127.0f;
+  const int8_t q = (amax == 0.0f) ? 0 : (int8_t)roundf(xi / d);
+
+  y[ib].qs[iqs] = q;
+
+  if (iqs > 0) {
+    return;
+  }
+  reinterpret_cast<half &>(y[ib].ds.x) = (half)d;
+  reinterpret_cast<half &>(y[ib].ds.y) = (half)sum;
+}
+
+extern "C" __global__ void
+mmvq_gguf_quantize_q8_1_f16(const half *__restrict__ x,
+                            void *__restrict__ vy, const int kx,
+                            const int kx_padded) {
+  const int ix = blockDim.x * blockIdx.x + threadIdx.x;
+  if (ix >= kx_padded) {
+    return;
+  }
+  const int iy = blockDim.y * blockIdx.y + threadIdx.y;
+  const int i_padded = iy * kx_padded + ix;
+
+  block_q8_1 *y = (block_q8_1 *)vy;
+  const int ib = i_padded / QK8_1;
+  const int iqs = i_padded % QK8_1;
+
+  const float xi = (ix < kx) ? __half2float(x[iy * kx + ix]) : 0.0f;
+  float amax = fabsf(xi);
+  float sum = xi;
+
+  amax = warp_reduce_max_f32(amax);
+  sum = warp_reduce_sum_f32(sum);
+
+  const float d = amax / 127.0f;
+  const int8_t q = (amax == 0.0f) ? 0 : (int8_t)roundf(xi / d);
+
+  y[ib].qs[iqs] = q;
+
+  if (iqs > 0) {
+    return;
+  }
+  reinterpret_cast<half &>(y[ib].ds.x) = (half)d;
+  reinterpret_cast<half &>(y[ib].ds.y) = (half)sum;
+}
+
+extern "C" __global__ void
+mmvq_gguf_quantize_q8_1_f32(const float *__restrict__ x,
+                            void *__restrict__ vy, const int kx,
+                            const int kx_padded) {
+  const int ix = blockDim.x * blockIdx.x + threadIdx.x;
+  if (ix >= kx_padded) {
+    return;
+  }
+  const int iy = blockDim.y * blockIdx.y + threadIdx.y;
+  const int i_padded = iy * kx_padded + ix;
+
+  block_q8_1 *y = (block_q8_1 *)vy;
+  const int ib = i_padded / QK8_1;
+  const int iqs = i_padded % QK8_1;
+
+  const float xi = (ix < kx) ? x[iy * kx + ix] : 0.0f;
+  float amax = fabsf(xi);
+  float sum = xi;
+
+  amax = warp_reduce_max_f32(amax);
+  sum = warp_reduce_sum_f32(sum);
+
+  const float d = amax / 127.0f;
+  const int8_t q = (amax == 0.0f) ? 0 : (int8_t)roundf(xi / d);
+
+  y[ib].qs[iqs] = q;
+
+  if (iqs > 0) {
+    return;
+  }
+  reinterpret_cast<half &>(y[ib].ds.x) = (half)d;
+  reinterpret_cast<half &>(y[ib].ds.y) = (half)sum;
+}
+
+// Host-side launchers used by `candle-kernels/src/ffi.rs`.
+
+#define MMVQ_LAUNCHER_PLAIN(tag, dst_tag, dst_c_type)                          \
+  extern "C" void launch_mmvq_gguf_##tag##_##dst_tag##_plain(                  \
+      const void *vx, const void *vy, void *dst, int ncols_x, int nrows_x,    \
+      int stride_col_y, int stride_col_dst, int b_size, void *stream) {        \
+    const unsigned int nblocks = (unsigned int)nrows_x;                        \
+    unsigned int nwarps;                                                       \
+    if (b_size <= 4) {                                                         \
+      nwarps = 4;                                                              \
+    } else {                                                                   \
+      nwarps = 2;                                                              \
+    }                                                                          \
+    dim3 grid(nblocks, 1, 1);                                                  \
+    dim3 block(WARP_SIZE, nwarps, 1);                                          \
+    cudaStream_t s = static_cast<cudaStream_t>(stream);                        \
+    switch (b_size) {                                                          \
+    case 1:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_plain_cuda1<<<grid, block, 0, s>>>(        \
+          vx, vy, (dst_c_type *)dst, ncols_x, nrows_x, stride_col_y,          \
+          stride_col_dst);                                                     \
+      break;                                                                   \
+    case 2:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_plain_cuda2<<<grid, block, 0, s>>>(        \
+          vx, vy, (dst_c_type *)dst, ncols_x, nrows_x, stride_col_y,          \
+          stride_col_dst);                                                     \
+      break;                                                                   \
+    case 3:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_plain_cuda3<<<grid, block, 0, s>>>(        \
+          vx, vy, (dst_c_type *)dst, ncols_x, nrows_x, stride_col_y,          \
+          stride_col_dst);                                                     \
+      break;                                                                   \
+    case 4:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_plain_cuda4<<<grid, block, 0, s>>>(        \
+          vx, vy, (dst_c_type *)dst, ncols_x, nrows_x, stride_col_y,          \
+          stride_col_dst);                                                     \
+      break;                                                                   \
+    case 5:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_plain_cuda5<<<grid, block, 0, s>>>(        \
+          vx, vy, (dst_c_type *)dst, ncols_x, nrows_x, stride_col_y,          \
+          stride_col_dst);                                                     \
+      break;                                                                   \
+    case 6:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_plain_cuda6<<<grid, block, 0, s>>>(        \
+          vx, vy, (dst_c_type *)dst, ncols_x, nrows_x, stride_col_y,          \
+          stride_col_dst);                                                     \
+      break;                                                                   \
+    case 7:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_plain_cuda7<<<grid, block, 0, s>>>(        \
+          vx, vy, (dst_c_type *)dst, ncols_x, nrows_x, stride_col_y,          \
+          stride_col_dst);                                                     \
+      break;                                                                   \
+    case 8:                                                                    \
+      mmvq_gguf_##tag##_##dst_tag##_plain_cuda8<<<grid, block, 0, s>>>(        \
+          vx, vy, (dst_c_type *)dst, ncols_x, nrows_x, stride_col_y,          \
+          stride_col_dst);                                                     \
+      break;                                                                   \
+    default:                                                                   \
+      break;                                                                   \
+    }                                                                          \
+  }
+
+MMVQ_LAUNCHER_PLAIN(q4_0, bf16, __nv_bfloat16)
+MMVQ_LAUNCHER_PLAIN(q4_1, bf16, __nv_bfloat16)
+MMVQ_LAUNCHER_PLAIN(q5_0, bf16, __nv_bfloat16)
+MMVQ_LAUNCHER_PLAIN(q5_1, bf16, __nv_bfloat16)
+MMVQ_LAUNCHER_PLAIN(q8_0, bf16, __nv_bfloat16)
+MMVQ_LAUNCHER_PLAIN(q2_k, bf16, __nv_bfloat16)
+MMVQ_LAUNCHER_PLAIN(q3_k, bf16, __nv_bfloat16)
+MMVQ_LAUNCHER_PLAIN(q4_k, bf16, __nv_bfloat16)
+MMVQ_LAUNCHER_PLAIN(q5_k, bf16, __nv_bfloat16)
+MMVQ_LAUNCHER_PLAIN(q6_k, bf16, __nv_bfloat16)
+
+MMVQ_LAUNCHER_PLAIN(q4_0, f32, float)
+MMVQ_LAUNCHER_PLAIN(q4_1, f32, float)
+MMVQ_LAUNCHER_PLAIN(q5_0, f32, float)
+MMVQ_LAUNCHER_PLAIN(q5_1, f32, float)
+MMVQ_LAUNCHER_PLAIN(q8_0, f32, float)
+MMVQ_LAUNCHER_PLAIN(q2_k, f32, float)
+MMVQ_LAUNCHER_PLAIN(q3_k, f32, float)
+MMVQ_LAUNCHER_PLAIN(q4_k, f32, float)
+MMVQ_LAUNCHER_PLAIN(q5_k, f32, float)
+MMVQ_LAUNCHER_PLAIN(q6_k, f32, float)
+
+// Quantize launchers.
+
+extern "C" void launch_mmvq_gguf_quantize_q8_1_bf16(const void *x, void *vy,
+                                                    int kx, int kx_padded,
+                                                    int num_rows,
+                                                    void *stream) {
+  const int num_blocks_x =
+      (kx_padded + CUDA_QUANTIZE_BLOCK_SIZE - 1) / CUDA_QUANTIZE_BLOCK_SIZE;
+  dim3 grid(num_blocks_x, num_rows, 1);
+  dim3 block(CUDA_QUANTIZE_BLOCK_SIZE, 1, 1);
+  cudaStream_t s = static_cast<cudaStream_t>(stream);
+  mmvq_gguf_quantize_q8_1_bf16<<<grid, block, 0, s>>>(
+      (const __nv_bfloat16 *)x, vy, kx, kx_padded);
+}
+
+extern "C" void launch_mmvq_gguf_quantize_q8_1_f16(const void *x, void *vy,
+                                                   int kx, int kx_padded,
+                                                   int num_rows,
+                                                   void *stream) {
+  const int num_blocks_x =
+      (kx_padded + CUDA_QUANTIZE_BLOCK_SIZE - 1) / CUDA_QUANTIZE_BLOCK_SIZE;
+  dim3 grid(num_blocks_x, num_rows, 1);
+  dim3 block(CUDA_QUANTIZE_BLOCK_SIZE, 1, 1);
+  cudaStream_t s = static_cast<cudaStream_t>(stream);
+  mmvq_gguf_quantize_q8_1_f16<<<grid, block, 0, s>>>(
+      (const half *)x, vy, kx, kx_padded);
+}
+
+extern "C" void launch_mmvq_gguf_quantize_q8_1_f32(const void *x, void *vy,
+                                                   int kx, int kx_padded,
+                                                   int num_rows,
+                                                   void *stream) {
+  const int num_blocks_x =
+      (kx_padded + CUDA_QUANTIZE_BLOCK_SIZE - 1) / CUDA_QUANTIZE_BLOCK_SIZE;
+  dim3 grid(num_blocks_x, num_rows, 1);
+  dim3 block(CUDA_QUANTIZE_BLOCK_SIZE, 1, 1);
+  cudaStream_t s = static_cast<cudaStream_t>(stream);
+  mmvq_gguf_quantize_q8_1_f32<<<grid, block, 0, s>>>(
+      (const float *)x, vy, kx, kx_padded);
+}

--- a/candle-transformers/src/models/gemma4/audio.rs
+++ b/candle-transformers/src/models/gemma4/audio.rs
@@ -83,7 +83,11 @@ impl SSCPConvBlock {
         input_freq_dim: usize,
         vb: VarBuilder,
     ) -> Result<Self> {
-        let in_channels = if idx == 0 { 1 } else { cfg.sscp_conv_channel_size[idx - 1] };
+        let in_channels = if idx == 0 {
+            1
+        } else {
+            cfg.sscp_conv_channel_size[idx - 1]
+        };
         let out_channels = cfg.sscp_conv_channel_size[idx];
         let kernel_t = cfg.sscp_conv_kernel_size[idx][0];
         let _kernel_f = cfg.sscp_conv_kernel_size[idx][1];
@@ -122,7 +126,11 @@ impl SSCPConvBlock {
         })
     }
 
-    fn forward(&self, audio_encodings: &Tensor, audio_mel_mask: &Tensor) -> Result<(Tensor, Tensor)> {
+    fn forward(
+        &self,
+        audio_encodings: &Tensor,
+        audio_mel_mask: &Tensor,
+    ) -> Result<(Tensor, Tensor)> {
         // Zero out padded positions
         let valid_mask = audio_mel_mask
             .eq(0.0)?
@@ -234,11 +242,8 @@ impl RelativePositionEmbedding {
         let max_forward = cfg.conf_attention_context_right;
         let num_timescales = channels / 2;
 
-        let pos_proj = candle_nn::linear_no_bias(
-            channels,
-            num_heads * head_dim,
-            vb.pp("relative_k_proj"),
-        )?;
+        let pos_proj =
+            candle_nn::linear_no_bias(channels, num_heads * head_dim, vb.pp("relative_k_proj"))?;
 
         let min_timescale = 1.0_f64;
         let max_timescale = 10_000.0_f64;
@@ -399,9 +404,12 @@ impl ConformerAttention {
         let attn_vb = vb.pp("self_attn");
         let relative_position_embedding = RelativePositionEmbedding::new(cfg, attn_vb.clone())?;
         let per_dim_scale = attn_vb.get(head_dim, "per_dim_scale")?;
-        let q_proj = candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("q_proj"))?;
-        let k_proj = candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("k_proj"))?;
-        let v_proj = candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("v_proj"))?;
+        let q_proj =
+            candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("q_proj"))?;
+        let k_proj =
+            candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("k_proj"))?;
+        let v_proj =
+            candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("v_proj"))?;
         let post = candle_nn::linear_no_bias(hidden_size, hidden_size, attn_vb.pp("post"))?;
 
         let pre_attn_norm = RmsNorm::new(hidden_size, cfg.rms_norm_eps, vb.pp("norm_pre_attn"))?;
@@ -415,7 +423,8 @@ impl ConformerAttention {
         for i in 0..chunk_size {
             for j in 0..context_size {
                 let lower = j >= i;
-                let upper = (j as isize) <= (i as isize + (max_past_horizon + max_future_horizon) as isize);
+                let upper =
+                    (j as isize) <= (i as isize + (max_past_horizon + max_future_horizon) as isize);
                 if lower && upper {
                     mask_vec[i * context_size + j] = 1;
                 }
@@ -509,9 +518,9 @@ impl ConformerAttention {
             .to_dtype(DType::F32)?;
 
         // Scale Q and K
-        let q = q.affine(self.q_scale, 0.0)?.broadcast_mul(
-            &per_dim_scale.reshape((1, 1, 1, self.head_dim))?,
-        )?;
+        let q = q
+            .affine(self.q_scale, 0.0)?
+            .broadcast_mul(&per_dim_scale.reshape((1, 1, 1, self.head_dim))?)?;
         let k = k.affine(self.k_scale, 0.0)?;
 
         // Convert to blocks
@@ -594,12 +603,10 @@ impl ConformerAttention {
         // Broadcast mask to logits shape
         let final_cond = final_cond.broadcast_as(logits.shape())?;
 
-        let invalid_logits =
-            Tensor::new(self.invalid_logits_value as f32, logits.device())?
-                .broadcast_as(logits.shape())?;
+        let invalid_logits = Tensor::new(self.invalid_logits_value as f32, logits.device())?
+            .broadcast_as(logits.shape())?;
         let masked_logits = final_cond.where_cond(&logits, &invalid_logits)?;
-        let probabilities =
-            candle_nn::ops::softmax_last_dim(&masked_logits.to_dtype(DType::F32)?)?;
+        let probabilities = candle_nn::ops::softmax_last_dim(&masked_logits.to_dtype(DType::F32)?)?;
 
         // Weighted sum of values
         let (b_dim, n_dim, u_dim, w_dim, c_dim) = probabilities.dims5()?;
@@ -618,7 +625,12 @@ impl ConformerAttention {
             .matmul(&vals_p)?
             .reshape((b_dim, u_dim, n_dim, w_dim, h_dim))?
             .permute((0, 1, 3, 2, 4))?
-            .reshape((b, num_query_blocks * self.chunk_size, self.num_heads, self.head_dim))?
+            .reshape((
+                b,
+                num_query_blocks * self.chunk_size,
+                self.num_heads,
+                self.head_dim,
+            ))?
             .narrow(1, 0, t)?;
 
         let context_vectors = context_vectors.reshape((b, t, self.hidden_size))?;
@@ -646,7 +658,11 @@ impl ConformerFeedForward {
     fn new(cfg: &Gemma4AudioConfig, vb: VarBuilder) -> Result<Self> {
         Ok(Self {
             scale: cfg.conf_residual_weight,
-            pre_layer_norm: RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("pre_layer_norm"))?,
+            pre_layer_norm: RmsNorm::new(
+                cfg.hidden_size,
+                cfg.rms_norm_eps,
+                vb.pp("pre_layer_norm"),
+            )?,
             ffw_layer_1: candle_nn::linear_no_bias(
                 cfg.hidden_size,
                 cfg.hidden_size * 4,
@@ -696,7 +712,11 @@ struct ConformerLightConv1d {
 impl ConformerLightConv1d {
     fn new(cfg: &Gemma4AudioConfig, vb: VarBuilder) -> Result<Self> {
         Ok(Self {
-            pre_layer_norm: RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("pre_layer_norm"))?,
+            pre_layer_norm: RmsNorm::new(
+                cfg.hidden_size,
+                cfg.rms_norm_eps,
+                vb.pp("pre_layer_norm"),
+            )?,
             linear_start: candle_nn::linear_no_bias(
                 cfg.hidden_size,
                 cfg.hidden_size * 2,
@@ -805,7 +825,11 @@ impl AudioModel {
             conformer.push(ConformerBlock::new(cfg, vb_layers.pp(i))?);
         }
         let output_proj = if let Some(output_dim) = cfg.output_proj_dims {
-            Some(candle_nn::linear(cfg.hidden_size, output_dim, vb.pp("output_proj"))?)
+            Some(candle_nn::linear(
+                cfg.hidden_size,
+                output_dim,
+                vb.pp("output_proj"),
+            )?)
         } else {
             None
         };
@@ -817,11 +841,7 @@ impl AudioModel {
         })
     }
 
-    pub fn forward(
-        &self,
-        audio_mel: &Tensor,
-        audio_mel_mask: &Tensor,
-    ) -> Result<(Tensor, Tensor)> {
+    pub fn forward(&self, audio_mel: &Tensor, audio_mel_mask: &Tensor) -> Result<(Tensor, Tensor)> {
         let (mut audio_encodings, mut current_mask) = self
             .subsample_conv_projection
             .forward(audio_mel, audio_mel_mask)?;

--- a/candle-transformers/src/models/gemma4/config.rs
+++ b/candle-transformers/src/models/gemma4/config.rs
@@ -96,7 +96,10 @@ pub struct Gemma4TextConfig {
     pub max_position_embeddings: usize,
     #[serde(default = "default_tie_word_embeddings")]
     pub tie_word_embeddings: bool,
-    #[serde(default = "default_sliding_window_pattern", alias = "_sliding_window_pattern")]
+    #[serde(
+        default = "default_sliding_window_pattern",
+        alias = "_sliding_window_pattern"
+    )]
     pub sliding_window_pattern: usize,
     pub layer_types: Vec<String>,
     #[serde(default = "default_global_head_dim")]
@@ -306,7 +309,10 @@ pub struct Gemma4AudioConfig {
     pub hidden_size: usize,
     #[serde(default = "default_output_proj_dims")]
     pub output_proj_dims: Option<usize>,
-    #[serde(default = "default_conf_attention_chunk_size", alias = "attention_chunk_size")]
+    #[serde(
+        default = "default_conf_attention_chunk_size",
+        alias = "attention_chunk_size"
+    )]
     pub conf_attention_chunk_size: usize,
     #[serde(
         default = "default_conf_attention_context_left",
@@ -323,11 +329,20 @@ pub struct Gemma4AudioConfig {
         alias = "attention_invalid_logits_value"
     )]
     pub conf_attention_invalid_logits_value: f64,
-    #[serde(default = "default_conf_attention_logit_cap", alias = "attention_logit_cap")]
+    #[serde(
+        default = "default_conf_attention_logit_cap",
+        alias = "attention_logit_cap"
+    )]
     pub conf_attention_logit_cap: f64,
-    #[serde(default = "default_conf_num_attention_heads", alias = "num_attention_heads")]
+    #[serde(
+        default = "default_conf_num_attention_heads",
+        alias = "num_attention_heads"
+    )]
     pub conf_num_attention_heads: usize,
-    #[serde(default = "default_conf_num_hidden_layers", alias = "num_hidden_layers")]
+    #[serde(
+        default = "default_conf_num_hidden_layers",
+        alias = "num_hidden_layers"
+    )]
     pub conf_num_hidden_layers: usize,
     #[serde(default = "default_conf_conv_kernel_size", alias = "conv_kernel_size")]
     pub conf_conv_kernel_size: usize,

--- a/candle-transformers/src/models/gemma4/mod.rs
+++ b/candle-transformers/src/models/gemma4/mod.rs
@@ -71,11 +71,7 @@ impl Model {
     }
 
     /// Text-only forward pass.
-    pub fn forward(
-        &mut self,
-        input_ids: &Tensor,
-        seqlen_offset: usize,
-    ) -> Result<Tensor> {
+    pub fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
         self.language_model.forward(input_ids, seqlen_offset)
     }
 
@@ -114,16 +110,23 @@ impl Model {
                 .unsqueeze(D::Minus1)?
                 .broadcast_as(input_embeds.shape())?
                 .to_dtype(input_embeds.dtype())?;
-            let image_embeds_broadcast =
-                broadcast_embed_to_mask(&image_embeds_flat, &image_mask)?;
+            let image_embeds_broadcast = broadcast_embed_to_mask(&image_embeds_flat, &image_mask)?;
             input_embeds = ((mask_expanded.clone() * image_embeds_broadcast)?
                 + ((1.0 - mask_expanded)? * input_embeds)?)?;
         }
 
         // ── Audio embedding injection ───────────────────────────────────
-        if let (Some(audio_mel), Some(audio_mel_mask), Some(ref audio_tower), Some(ref embed_audio)) =
-            (audio_mel, audio_mel_mask, &self.audio_tower, &self.embed_audio)
-        {
+        if let (
+            Some(audio_mel),
+            Some(audio_mel_mask),
+            Some(ref audio_tower),
+            Some(ref embed_audio),
+        ) = (
+            audio_mel,
+            audio_mel_mask,
+            &self.audio_tower,
+            &self.embed_audio,
+        ) {
             let audio_mask = input_ids
                 .to_dtype(DType::F32)?
                 .eq(self.cfg.audio_token_id as f64)?;
@@ -189,9 +192,7 @@ fn broadcast_embed_to_mask(embeds: &Tensor, mask: &Tensor) -> Result<Tensor> {
     // For single-batch simple case, just expand embeds to the output shape
     // and let the caller do the masking.
     if b_sz == 1 {
-        let num_tokens = mask_f32
-            .sum_all()?
-            .to_scalar::<f32>()? as usize;
+        let num_tokens = mask_f32.sum_all()?.to_scalar::<f32>()? as usize;
         if num_tokens == 0 {
             return Ok(zeros);
         }
@@ -200,7 +201,11 @@ fn broadcast_embed_to_mask(embeds: &Tensor, mask: &Tensor) -> Result<Tensor> {
         if embed_len >= seq_len {
             return embeds.narrow(0, 0, seq_len)?.unsqueeze(0);
         }
-        let padding = Tensor::zeros((seq_len - embed_len, hidden), embeds.dtype(), embeds.device())?;
+        let padding = Tensor::zeros(
+            (seq_len - embed_len, hidden),
+            embeds.dtype(),
+            embeds.device(),
+        )?;
         let padded = Tensor::cat(&[embeds, &padding], 0)?;
         return padded.unsqueeze(0);
     }

--- a/candle-transformers/src/models/gemma4/text.rs
+++ b/candle-transformers/src/models/gemma4/text.rs
@@ -59,7 +59,13 @@ struct RotaryEmbedding {
 }
 
 impl RotaryEmbedding {
-    fn new(dtype: DType, head_dim: usize, rope_theta: f64, max_seq_len: usize, dev: &Device) -> Result<Self> {
+    fn new(
+        dtype: DType,
+        head_dim: usize,
+        rope_theta: f64,
+        max_seq_len: usize,
+        dev: &Device,
+    ) -> Result<Self> {
         let inv_freq: Vec<_> = (0..head_dim)
             .step_by(2)
             .map(|i| 1f32 / rope_theta.powf(i as f64 / head_dim as f64) as f32)
@@ -158,7 +164,13 @@ struct MLP {
 }
 
 impl MLP {
-    fn new(hidden_size: usize, intermediate_size: usize, act: Activation, bias: bool, vb: VarBuilder) -> Result<Self> {
+    fn new(
+        hidden_size: usize,
+        intermediate_size: usize,
+        act: Activation,
+        bias: bool,
+        vb: VarBuilder,
+    ) -> Result<Self> {
         let gate_proj = linear_bias(hidden_size, intermediate_size, bias, vb.pp("gate_proj"))?;
         let up_proj = linear_bias(hidden_size, intermediate_size, bias, vb.pp("up_proj"))?;
         let down_proj = linear_bias(intermediate_size, hidden_size, bias, vb.pp("down_proj"))?;
@@ -447,9 +459,9 @@ impl DecoderLayer {
     ) -> Result<Tensor> {
         let residual = xs;
         let xs = self.input_layernorm.forward(xs)?;
-        let xs = self
-            .self_attn
-            .forward(&xs, attention_mask, sliding_attention_mask, seqlen_offset)?;
+        let xs =
+            self.self_attn
+                .forward(&xs, attention_mask, sliding_attention_mask, seqlen_offset)?;
         let xs = xs.apply(&self.post_attention_layernorm)?;
         let xs = (xs + residual)?;
         let residual = &xs;

--- a/candle-transformers/src/models/gemma4/vision.rs
+++ b/candle-transformers/src/models/gemma4/vision.rs
@@ -204,10 +204,14 @@ impl VisionAttention {
         let num_heads = cfg.num_attention_heads;
         let num_kv_heads = cfg.num_key_value_heads;
         let head_dim = cfg.head_dim;
-        let q_proj = candle_nn::linear_no_bias(cfg.hidden_size, num_heads * head_dim, vb.pp("q_proj"))?;
-        let k_proj = candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("k_proj"))?;
-        let v_proj = candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("v_proj"))?;
-        let o_proj = candle_nn::linear_no_bias(num_heads * head_dim, cfg.hidden_size, vb.pp("o_proj"))?;
+        let q_proj =
+            candle_nn::linear_no_bias(cfg.hidden_size, num_heads * head_dim, vb.pp("q_proj"))?;
+        let k_proj =
+            candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("k_proj"))?;
+        let v_proj =
+            candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("v_proj"))?;
+        let o_proj =
+            candle_nn::linear_no_bias(num_heads * head_dim, cfg.hidden_size, vb.pp("o_proj"))?;
         let q_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
         let k_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
         Ok(Self {


### PR DESCRIPTION
Adds `mmvq_gguf.cu` and surrounding infra enabling a fast-path for GGUF decode on CUDA.

Specifically, it adds:    
- Native BF16 input/output support (no F32 round-trip!)                                                                                                                             
- On-the-fly activation quantization to `Q8_1` with dedicated `BF16`/`F16`/`F32` quantize kernels                                                                                                            
- Per-device `Q8_1` scratch workspace that is lazily allocated and reused across calls                                                                                                                 
- Batch sizes 1 to 8 with compile-time specialized kernel variants per batch size                                                                                                                       
- Automatic fast-path dispatch, falls back to existing PTX-based path for unsupported types or larger batches.