### PR TITLE
Fix uninitialized workspace in fast_mmvq path

### DIFF
--- a/candle-core/src/quantized/fast_mmvq.rs
+++ b/candle-core/src/quantized/fast_mmvq.rs
@@ -62,17 +62,24 @@ fn workspace_ensure(
     let map = WORKSPACE.get_or_init(|| Mutex::new(HashMap::new()));
     let device_key = dev.id();
     let mut guard = map.lock().unwrap();
+    // alloc_zeros (not unsafe alloc): the quantize_q8_1 kernel writes only
+    // the k-sized portion of each row, but MATRIX_ROW_PADDING extends the
+    // row stride beyond that. The mmvq kernels read every block including
+    // the padded tail, so uninitialized bytes feed into the dot product and
+    // produce incorrect output (top-1 tends to be unchanged but ranks 2+
+    // and logit values drift). Same family as the fix in
+    // https://github.com/huggingface/candle/pull/3428 for mul_mat_vec_via_q8_1.
     let slot = match guard.entry(device_key) {
         std::collections::hash_map::Entry::Occupied(entry) => {
             let slot = entry.into_mut();
             if slot.cap < bytes {
-                slot.slice = unsafe { dev.alloc::<u8>(bytes)? };
+                slot.slice = dev.alloc_zeros::<u8>(bytes)?;
                 slot.cap = bytes;
             }
             slot
         }
         std::collections::hash_map::Entry::Vacant(entry) => {
-            let slice = unsafe { dev.alloc::<u8>(bytes)? };
+            let slice = dev.alloc_zeros::<u8>(bytes)?;
             entry.insert(WorkspaceSlot { slice, cap: bytes })
         }
     };


### PR DESCRIPTION
## Summary

The per-device Q8_1 scratch workspace added in #3463 is allocated via `unsafe dev.alloc::<u8>(bytes)`, leaving the bytes uninitialized. The `launch_mmvq_gguf_quantize_q8_1_*` kernels fill the k-sized portion of each row, but `MATRIX_ROW_PADDING` extends the row stride past that, and the mmvq reader consumes every block including the padded tail. Stale bytes in the tail feed into the dot product — top-1 is typically correct but ranks 2+ drift and logit magnitudes change from the pre-#3463 path.

Same family as the fix in #3428 for `mul_mat_vec_via_q8_1` / `mul_mat_via_q8_1` / `load_quantized`.

Switching the two alloc sites in \`workspace_ensure\` from \`dev.alloc::<u8>\` to \`dev.alloc_zeros::<u8>\` zero-fills the padded tail once per workspace growth and produces stable, expected logits.

## Repro

Gemma 4 26B-A4B-it Q4_K_M GGUF on RTX 3060 Ti + CUDA 13.2, decode 60 tokens with \`--temperature 0\`.

Pre-fix (current main): \`FIRST_TOKEN_LOGITS\` top value drifts and top-N ranks 2+ differ from the pre-#3463 \`mul_mat_vec_via_q8_1\` path. Drift is reproducible within a run and changes across runs only when the workspace grows.

Post-fix: logits align with the pre-#3463 path, and are stable across runs.

## Test plan

- [x] Build with \`--features cuda\` on CUDA 13.2
- [x] Run Gemma 4 Q4_K_M decode, verify top-10 logits are stable and match the non-fast_mmvq fallback within expected numerical tolerance
- [ ] Cross-check on another model size / quant type if reviewer wants