### PR TITLE
metal: add BQ=8 tile variants for sdpa full kernel (q_seq ∈ [2, 8])

### DIFF
--- a/candle-metal-kernels/src/kernels/sdpa.rs
+++ b/candle-metal-kernels/src/kernels/sdpa.rs
@@ -94,7 +94,17 @@ pub fn call_sdpa_full(
         (8, 8, 1, 1)
     } else {
         let bk = if bd < 128 { 32 } else { 16 };
-        (32, bk, 4, 1)
+        // For short Q sequences (speculative-decoding verify batches, short
+        // prefills), use BQ=8 to avoid padding Q to 32 and wasting up to
+        // 75% of query threads. The BQ=8 kernels are instantiated alongside
+        // the BQ=32 ones in `scaled_dot_product_attention.metal` for every
+        // supported head_dim.
+        let ql = q_shape[2];
+        if ql <= 8 {
+            (8, bk, 1, 1)
+        } else {
+            (32, bk, 4, 1)
+        }
     };
 
     let b = q_shape[0];

--- a/candle-metal-kernels/src/metal_src/scaled_dot_product_attention.metal
+++ b/candle-metal-kernels/src/metal_src/scaled_dot_product_attention.metal
@@ -2319,7 +2319,17 @@ template <
     instantiate_attn(iname, itype, 32, 32,  80, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  72, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  64, 4, 1, mname, mtype) \
-    instantiate_attn(iname, itype, 32, 32,  32, 4, 1, mname, mtype)
+    instantiate_attn(iname, itype, 32, 32,  32, 4, 1, mname, mtype) \
+    /* BQ=8 variants for speculative-decoding verify batches where Q seq */\
+    /* sits in [2, 8]. Padding to BQ=32 wastes ~75% of query work; BQ=8 */\
+    /* keeps padding under 1/8 at the cost of more threadgroups on grid.y.*/\
+    instantiate_attn(iname, itype,  8, 16, 256, 1, 1, mname, mtype) \
+    instantiate_attn(iname, itype,  8, 16, 128, 1, 1, mname, mtype) \
+    instantiate_attn(iname, itype,  8, 32,  96, 1, 1, mname, mtype) \
+    instantiate_attn(iname, itype,  8, 32,  80, 1, 1, mname, mtype) \
+    instantiate_attn(iname, itype,  8, 32,  72, 1, 1, mname, mtype) \
+    instantiate_attn(iname, itype,  8, 32,  64, 1, 1, mname, mtype) \
+    instantiate_attn(iname, itype,  8, 32,  32, 1, 1, mname, mtype)
 
 #define instantiate_attn_mask_helper(iname, itype) \
     instantiate_attn_shapes_helper(iname, itype, iname, itype) \


### PR DESCRIPTION
## Summary

The full-attention kernel historically used `BQ=32` for every `head_dim` except 512. Speculative-decoding verify batches hand it `q_seq` in the `[2, 8]` range, so ~75% of the Q threads in each block sat idle (padding) and the overall launch was much slower than necessary. There was nothing wrong with the kernel template — it's parametric in `BQ` and already works with `BQ=8` — just no instantiation for standard head_dims.

## Changes

- Add `BQ=8 / WM=1 / WN=1` instantiations alongside the `BQ=32` set for every `head_dim` the full kernel supports (32, 64, 72, 80, 96, 128, 256), both with and without the bool mask.
- Update the Rust dispatcher to pick the `BQ=8` kernel whenever `q_seq ≤ 8`; longer sequences still route to `BQ=32` (no regression on prefill).

## Relationship to #3479

#3479 (sdpa vector routing fix) is the correctness-first piece that routes `q_seq > 1` through the full kernel at all. This PR is the perf follow-up — it's only *reachable* after #3479 lands, but mechanically touches disjoint files (`candle-metal-kernels/...` here vs `candle-nn/...` in #3479), so the two can be reviewed and merged independently in either order.

## Test plan

- [x] All 7 sdpa tests green.
- [x] Adds no new public API.