### PR TITLE
fix clippy lints surfaced by Rust 1.95

### DIFF
--- a/candle-core/src/npy.rs
+++ b/candle-core/src/npy.rs
@@ -117,11 +117,9 @@ impl Header {
             match c {
                 '(' => cnt_parenthesis += 1,
                 ')' => cnt_parenthesis -= 1,
-                ',' => {
-                    if cnt_parenthesis == 0 {
-                        parts.push(header[start_index..index].to_owned());
-                        start_index = index + 1;
-                    }
+                ',' if cnt_parenthesis == 0 => {
+                    parts.push(header[start_index..index].to_owned());
+                    start_index = index + 1;
                 }
                 _ => {}
             }

--- a/candle-examples/examples/quantized-lfm2/main.rs
+++ b/candle-examples/examples/quantized-lfm2/main.rs
@@ -285,7 +285,7 @@ fn main() -> Result<()> {
         next_token
     };
 
-    let mut index_pos = tokens.len();
+    let index_pos_start = tokens.len();
     let prompt_dt = start_prompt_processing.elapsed();
 
     all_tokens.push(next_token);
@@ -297,7 +297,7 @@ fn main() -> Result<()> {
     let eos_token = guess_eos_id(tos.tokenizer());
     let mut sampled = 0;
     let start_post_prompt = std::time::Instant::now();
-    for _ in 0..to_sample {
+    for (index_pos, _) in (index_pos_start..).zip(0..to_sample) {
         if let Some(max_ctx) = context_length {
             if index_pos + 1 > max_ctx {
                 println!("\n\ncontext window of {max_ctx} reached, stopping generation");
@@ -319,7 +319,6 @@ fn main() -> Result<()> {
             )?
         };
         next_token = logits_processor.sample(&logits)?;
-        index_pos += 1;
         all_tokens.push(next_token);
         if let Some(t) = tos.next_token(next_token)? {
             print!("{t}");

--- a/candle-transformers/src/models/fastvit.rs
+++ b/candle-transformers/src/models/fastvit.rs
@@ -197,11 +197,7 @@ fn mobileone_block(
     use_act: bool,
     vb: VarBuilder,
 ) -> Result<Func<'static>> {
-    let groups = if group_size == 0 {
-        1
-    } else {
-        in_channels / group_size
-    };
+    let groups = in_channels.checked_div(group_size).unwrap_or(1);
 
     let padding = kernel / 2;
     let conv2d_cfg = Conv2dConfig {

--- a/candle-transformers/src/models/paddleocr_vl/mod.rs
+++ b/candle-transformers/src/models/paddleocr_vl/mod.rs
@@ -534,11 +534,11 @@ impl PaddleOCRVLModel {
             return Ok(generated_tokens);
         }
 
-        let mut seqlen_offset = current_ids.dim(1)?;
+        let seqlen_offset_start = current_ids.dim(1)?;
         current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
         // Subsequent forward passes (text only, using KV cache)
-        for _ in 1..max_new_tokens {
+        for (seqlen_offset, _) in (seqlen_offset_start..).zip(1..max_new_tokens) {
             let logits = self.forward(&current_ids, None, None, seqlen_offset)?;
             let next_token = logits
                 .argmax(D::Minus1)?
@@ -551,7 +551,6 @@ impl PaddleOCRVLModel {
                 break;
             }
 
-            seqlen_offset += 1;
             current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
         }
 
@@ -595,12 +594,12 @@ impl PaddleOCRVLModel {
             return Ok(generated_tokens);
         }
 
-        let mut seqlen_offset = current_ids.dim(1)?;
+        let seqlen_offset_start = current_ids.dim(1)?;
         current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
         // Subsequent forward passes (text only, using KV cache)
         // Uses same incremental decoding as single-image generation
-        for _ in 1..max_new_tokens {
+        for (seqlen_offset, _) in (seqlen_offset_start..).zip(1..max_new_tokens) {
             let logits = self.forward(&current_ids, None, None, seqlen_offset)?;
             let next_token = logits
                 .argmax(D::Minus1)?
@@ -613,7 +612,6 @@ impl PaddleOCRVLModel {
                 break;
             }
 
-            seqlen_offset += 1;
             current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
         }
 
@@ -661,11 +659,11 @@ impl PaddleOCRVLModel {
             return Ok(generated_tokens);
         }
 
-        let mut seqlen_offset = current_ids.dim(1)?;
+        let seqlen_offset_start = current_ids.dim(1)?;
         current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
         // Subsequent forward passes (text only, using KV cache)
-        for _ in 1..max_new_tokens {
+        for (seqlen_offset, _) in (seqlen_offset_start..).zip(1..max_new_tokens) {
             let logits = self.forward(&current_ids, None, None, seqlen_offset)?;
             let next_token = logits
                 .argmax(D::Minus1)?
@@ -678,7 +676,6 @@ impl PaddleOCRVLModel {
                 break;
             }
 
-            seqlen_offset += 1;
             current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
         }
 
@@ -867,11 +864,11 @@ impl PaddleOCRVLModel {
             return Ok(generated_tokens);
         }
 
-        let mut seqlen_offset = current_ids.dim(1)?;
+        let seqlen_offset_start = current_ids.dim(1)?;
         current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
         // Subsequent forward passes (text only, using KV cache)
-        for _ in 1..max_new_tokens {
+        for (seqlen_offset, _) in (seqlen_offset_start..).zip(1..max_new_tokens) {
             let logits = self.forward(&current_ids, None, None, seqlen_offset)?;
             let logits = apply_repetition_penalty(&logits, &generated_tokens, repetition_penalty)?;
             let next_token = logits
@@ -885,7 +882,6 @@ impl PaddleOCRVLModel {
                 break;
             }
 
-            seqlen_offset += 1;
             current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
         }
 
@@ -1044,10 +1040,10 @@ impl PaddleOCRVLModel {
         }
 
         // Generation steps
-        let mut seqlen_offset = input_ids.dim(1)?;
+        let seqlen_offset_start = input_ids.dim(1)?;
         let mut current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
-        for step in 1..max_steps {
+        for (seqlen_offset, step) in (seqlen_offset_start..).zip(1..max_steps) {
             // Compute position for M-RoPE
             let pos = seqlen_offset as i64 + self.mrope_position_delta;
             let (batch_size, seq_len, _) = {
@@ -1100,7 +1096,6 @@ impl PaddleOCRVLModel {
                 break;
             }
 
-            seqlen_offset += 1;
             current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
         }
 

--- a/candle-transformers/src/models/stella_en_v5.rs
+++ b/candle-transformers/src/models/stella_en_v5.rs
@@ -288,11 +288,7 @@ impl Attention {
         let hidden_sz = cfg.hidden_size;
         let num_heads = cfg.num_attention_heads;
         let num_kv_heads = cfg.num_key_value_heads;
-        let num_kv_groups = if num_kv_heads > 0 {
-            num_heads / num_kv_heads
-        } else {
-            0
-        };
+        let num_kv_groups = num_heads.checked_div(num_kv_heads).unwrap_or(0);
         let head_dim = hidden_sz / num_heads;
 
         let (qkv_proj, o_proj) = match cfg.variant {


### PR DESCRIPTION
## Summary

Stable rustc 1.95.0 ships four new clippy lints that fire on pre-existing code in the workspace and block the CI clippy job (`cargo clippy --workspace --tests --examples --benches -- -D warnings`). This PR fixes each one in-place; no functional changes.

## Changes

| File | Lint | Fix |
|------|------|-----|
| `candle-core/src/npy.rs` | `collapsible_match` | Rewrite `',' => { if cnt == 0 { ... } }` as match guard `',' if cnt == 0 => { ... }` |
| `candle-transformers/src/models/fastvit.rs` | `manual_checked_division` | `in_channels.checked_div(group_size).unwrap_or(1)` |
| `candle-transformers/src/models/stella_en_v5.rs` | `manual_checked_division` | `num_heads.checked_div(num_kv_heads).unwrap_or(0)` |
| `candle-transformers/src/models/paddleocr_vl/mod.rs` (×5) | `explicit_counter_loop` | `for (seqlen_offset, _) in (start..).zip(1..N)` — loop-var pattern, manual `+= 1` dropped |
| `candle-examples/examples/quantized-lfm2/main.rs` | `explicit_counter_loop` | Same zip pattern with `index_pos` |

### Correctness notes

- **`manual_checked_division`**: semantically identical for `usize` by construction — `checked_div(d)` returns `None` iff `d == 0`, matching the original `if d == 0 { default }` branch exactly.
- **`explicit_counter_loop`**: mechanical transform. The `RangeFrom::next()` on `(start..)` yields `start, start+1, start+2, ...` via the iterator's internal `+= 1`, so each loop iteration observes the same `offset` values as before. `break` exits at the same point. `seqlen_offset` remains a CPU `usize` — no device-side changes.

### Validation

Automated tests don't exercise these code paths, so correctness of the counter-loop refactors was verified by running the example binaries before and after the refactor with fixed seeds / inputs:

- **quantized-lfm2**: `--which lfm2-350m-q4_k_m --prompt "The quick brown fox" --sample-len 40 --temperature 0 --seed 42` — 39 tokens generated, byte-identical output.
- **paddleocr-vl**: `--image test_ocr.png --task ocr --max-length 128` (single-image path, hits the first of the five loops) — 97 tokens, byte-identical OCR output.

The other four paddleocr_vl loops (multi-image-combined, multi-image-separate, with repetition penalty, export-mode step loop) use the identical mechanical transform, so the same correctness argument applies.

## Test plan

- [x] `cargo clippy --workspace --tests --examples --benches -- -D warnings` passes locally (exit 0).
- [x] `cargo fmt --all -- --check` passes.
- [x] Example-binary validation as above.

## Why this matters

Unblocks the clippy job on main and on any open PR (currently #3477, #3478, #3479, #3480 are all failing CI on exactly this lint set).