### PR TITLE
Fix clippy warnings for Rust 1.95.

### DIFF
--- a/candle-core/src/npy.rs
+++ b/candle-core/src/npy.rs
@@ -117,11 +117,9 @@ impl Header {
             match c {
                 '(' => cnt_parenthesis += 1,
                 ')' => cnt_parenthesis -= 1,
-                ',' => {
-                    if cnt_parenthesis == 0 {
-                        parts.push(header[start_index..index].to_owned());
-                        start_index = index + 1;
-                    }
+                ',' if cnt_parenthesis == 0 => {
+                    parts.push(header[start_index..index].to_owned());
+                    start_index = index + 1;
                 }
                 _ => {}
             }

--- a/candle-examples/examples/quantized-lfm2/main.rs
+++ b/candle-examples/examples/quantized-lfm2/main.rs
@@ -285,7 +285,6 @@ fn main() -> Result<()> {
         next_token
     };
 
-    let mut index_pos = tokens.len();
     let prompt_dt = start_prompt_processing.elapsed();
 
     all_tokens.push(next_token);
@@ -297,7 +296,7 @@ fn main() -> Result<()> {
     let eos_token = guess_eos_id(tos.tokenizer());
     let mut sampled = 0;
     let start_post_prompt = std::time::Instant::now();
-    for _ in 0..to_sample {
+    for (index_pos, _) in (tokens.len()..).zip(0..to_sample) {
         if let Some(max_ctx) = context_length {
             if index_pos + 1 > max_ctx {
                 println!("\n\ncontext window of {max_ctx} reached, stopping generation");
@@ -319,7 +318,6 @@ fn main() -> Result<()> {
             )?
         };
         next_token = logits_processor.sample(&logits)?;
-        index_pos += 1;
         all_tokens.push(next_token);
         if let Some(t) = tos.next_token(next_token)? {
             print!("{t}");

--- a/candle-transformers/src/models/fastvit.rs
+++ b/candle-transformers/src/models/fastvit.rs
@@ -197,11 +197,7 @@ fn mobileone_block(
     use_act: bool,
     vb: VarBuilder,
 ) -> Result<Func<'static>> {
-    let groups = if group_size == 0 {
-        1
-    } else {
-        in_channels / group_size
-    };
+    let groups = in_channels.checked_div(group_size).unwrap_or(1);
 
     let padding = kernel / 2;
     let conv2d_cfg = Conv2dConfig {

--- a/candle-transformers/src/models/paddleocr_vl/mod.rs
+++ b/candle-transformers/src/models/paddleocr_vl/mod.rs
@@ -534,11 +534,11 @@ impl PaddleOCRVLModel {
             return Ok(generated_tokens);
         }
 
-        let mut seqlen_offset = current_ids.dim(1)?;
+        let initial_offset = current_ids.dim(1)?;
         current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
         // Subsequent forward passes (text only, using KV cache)
-        for _ in 1..max_new_tokens {
+        for (seqlen_offset, _) in (initial_offset..).zip(1..max_new_tokens) {
             let logits = self.forward(&current_ids, None, None, seqlen_offset)?;
             let next_token = logits
                 .argmax(D::Minus1)?
@@ -551,7 +551,6 @@ impl PaddleOCRVLModel {
                 break;
             }
 
-            seqlen_offset += 1;
             current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
         }
 
@@ -595,12 +594,12 @@ impl PaddleOCRVLModel {
             return Ok(generated_tokens);
         }
 
-        let mut seqlen_offset = current_ids.dim(1)?;
+        let initial_offset = current_ids.dim(1)?;
         current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
         // Subsequent forward passes (text only, using KV cache)
         // Uses same incremental decoding as single-image generation
-        for _ in 1..max_new_tokens {
+        for (seqlen_offset, _) in (initial_offset..).zip(1..max_new_tokens) {
             let logits = self.forward(&current_ids, None, None, seqlen_offset)?;
             let next_token = logits
                 .argmax(D::Minus1)?
@@ -613,7 +612,6 @@ impl PaddleOCRVLModel {
                 break;
             }
 
-            seqlen_offset += 1;
             current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
         }
 
@@ -661,11 +659,11 @@ impl PaddleOCRVLModel {
             return Ok(generated_tokens);
         }
 
-        let mut seqlen_offset = current_ids.dim(1)?;
+        let initial_offset = current_ids.dim(1)?;
         current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
         // Subsequent forward passes (text only, using KV cache)
-        for _ in 1..max_new_tokens {
+        for (seqlen_offset, _) in (initial_offset..).zip(1..max_new_tokens) {
             let logits = self.forward(&current_ids, None, None, seqlen_offset)?;
             let next_token = logits
                 .argmax(D::Minus1)?
@@ -678,7 +676,6 @@ impl PaddleOCRVLModel {
                 break;
             }
 
-            seqlen_offset += 1;
             current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
         }
 
@@ -867,11 +864,11 @@ impl PaddleOCRVLModel {
             return Ok(generated_tokens);
         }
 
-        let mut seqlen_offset = current_ids.dim(1)?;
+        let initial_offset = current_ids.dim(1)?;
         current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
         // Subsequent forward passes (text only, using KV cache)
-        for _ in 1..max_new_tokens {
+        for (seqlen_offset, _) in (initial_offset..).zip(1..max_new_tokens) {
             let logits = self.forward(&current_ids, None, None, seqlen_offset)?;
             let logits = apply_repetition_penalty(&logits, &generated_tokens, repetition_penalty)?;
             let next_token = logits
@@ -885,7 +882,6 @@ impl PaddleOCRVLModel {
                 break;
             }
 
-            seqlen_offset += 1;
             current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
         }
 
@@ -1044,10 +1040,9 @@ impl PaddleOCRVLModel {
         }
 
         // Generation steps
-        let mut seqlen_offset = input_ids.dim(1)?;
         let mut current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
 
-        for step in 1..max_steps {
+        for (seqlen_offset, step) in (input_ids.dim(1)?..).zip(1..max_steps) {
             // Compute position for M-RoPE
             let pos = seqlen_offset as i64 + self.mrope_position_delta;
             let (batch_size, seq_len, _) = {
@@ -1100,7 +1095,6 @@ impl PaddleOCRVLModel {
                 break;
             }
 
-            seqlen_offset += 1;
             current_ids = Tensor::new(&[next_token], &self.device)?.unsqueeze(0)?;
         }
 

--- a/candle-transformers/src/models/stella_en_v5.rs
+++ b/candle-transformers/src/models/stella_en_v5.rs
@@ -288,11 +288,7 @@ impl Attention {
         let hidden_sz = cfg.hidden_size;
         let num_heads = cfg.num_attention_heads;
         let num_kv_heads = cfg.num_key_value_heads;
-        let num_kv_groups = if num_kv_heads > 0 {
-            num_heads / num_kv_heads
-        } else {
-            0
-        };
+        let num_kv_groups = num_heads.checked_div(num_kv_heads).unwrap_or(0);
         let head_dim = hidden_sz / num_heads;
 
         let (qkv_proj, o_proj) = match cfg.variant {


### PR DESCRIPTION
## Summary

Fixes clippy warnings introduced by Rust 1.95 (released 2026-04-14). Restores `cargo clippy --workspace --tests --examples --benches -- -D warnings` to a clean state, which is currently the CI clippy command in `.github/workflows/rust-ci.yml`.

The `-D warnings` CI job aborts at the first failing crate (`candle-core`), which was hiding 8 additional warnings in `candle-transformers` and `candle-examples`. All 9 sites are addressed here.

## Lints fixed

### `clippy::collapsible_match` (1 site)
- `candle-core/src/npy.rs:121`: inner `if` inside a match arm folded into a match guard. Behavior is identical because the original `',' => { if cnt_parenthesis == 0 { ... } }` already fell through to the following iteration when the guard was false.

### `clippy::manual_checked_ops` (2 sites)
- `candle-transformers/src/models/fastvit.rs:200`: `if group_size == 0 { 1 } else { in_channels / group_size }` becomes `in_channels.checked_div(group_size).unwrap_or(1)`.
- `candle-transformers/src/models/stella_en_v5.rs:291`: `if num_kv_heads > 0 { num_heads / num_kv_heads } else { 0 }` becomes `num_heads.checked_div(num_kv_heads).unwrap_or(0)`. Note the fallback is `0`, not `1`, matching the original else branch.

### `clippy::explicit_counter_loop` (6 sites)
- `candle-transformers/src/models/paddleocr_vl/mod.rs:541, 603, 668, 874, 1050`
- `candle-examples/examples/quantized-lfm2/main.rs:300`

Manual `seqlen_offset += 1` and `index_pos += 1` counters replaced with `(start..).zip(range)` iteration.

### Note on paddleocr_vl: deviating from clippy's suggestion

Clippy suggests `for (seqlen_offset, _) in (current_ids.dim(1)?..).zip(1..max_new_tokens)` at the loop site. For four of the five paddleocr_vl sites (lines 541, 603, 668, 874), this suggestion is semantically incorrect because `current_ids` is reassigned on the line immediately before the loop:

```rust
let mut seqlen_offset = current_ids.dim(1)?;            // captures prompt length
current_ids = Tensor::new(&[next_token], ...)?.unsqueeze(0)?;  // reassigns to 1-token tensor
for _ in 1..max_new_tokens { ... }
```

Applying clippy's inline suggestion would evaluate `current_ids.dim(1)?` after the reassignment, producing `1` instead of the prompt length. To preserve semantics, these four sites bind the original dim before the reassignment:

```rust
let initial_offset = current_ids.dim(1)?;
current_ids = Tensor::new(&[next_token], ...)?.unsqueeze(0)?;
for (seqlen_offset, _) in (initial_offset..).zip(1..max_new_tokens) { ... }
```

The fifth site (line 1050) uses `input_ids` for the range, which is not reassigned before the loop, so clippy's suggestion is applied verbatim.

## Environment

- OS: Ubuntu 22.04 on WSL2, x86_64
- `rustc 1.95.0 (59807616e 2026-04-14)`
- `clippy 0.1.95 (59807616e1 2026-04-14)`

## Verification

Locally on the environment above, all of the following pass cleanly:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --tests --examples --benches -- -D warnings`
- `cargo test --workspace`

## Test plan

- [x] Clippy clean under CI command (`-D warnings`, workspace, tests, examples, benches)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace` passes (no regressions)
- [ ] Runtime inference through the modified paddleocr_vl generation loops and the quantized-lfm2 example was not exercised (neither has coverage in the existing test suite, and running them requires downloading model weights). The refactor preserves iteration count and per-iteration counter values by construction, but a runtime sanity check from a reviewer with access to the models would be welcome.
- [ ] Only tested on Linux x86_64. CI covers Ubuntu, Windows, macOS, and Ubuntu ARM; the changes are pure Rust with no platform-specific code, so all should pass, but I have not verified cross-platform locally.