### PR TITLE
Add QTensor::cat and fuse quantized Qwen3 SwiGLU gate/up projection

### DIFF
--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -658,6 +658,104 @@ impl QTensor {
         self.storage.data()
     }
 
+    /// Concatenate quantized tensors along `dim` without dequantizing them.
+    pub fn cat(qtensors: &[&Self], dim: usize) -> Result<Self> {
+        let Some(first) = qtensors.first() else {
+            crate::bail!("cannot concatenate an empty list of quantized tensors")
+        };
+        if first.rank() == 0 {
+            crate::bail!("cannot concatenate scalar quantized tensors")
+        }
+        if dim >= first.rank() {
+            crate::bail!(
+                "dimension {} out of range for quantized tensor with rank {}",
+                dim,
+                first.rank()
+            )
+        }
+
+        let dtype = first.dtype();
+        let device = first.device();
+        let dims = first.shape().dims();
+        let block_size = dtype.block_size();
+        let type_size = dtype.type_size();
+        let prefix_elems = dims[..dim].iter().product::<usize>().max(1);
+
+        let mut out_dims = dims.to_vec();
+        out_dims[dim] = 0;
+        let mut chunks = Vec::with_capacity(qtensors.len());
+        let mut total_bytes = 0usize;
+
+        for qtensor in qtensors {
+            if qtensor.dtype() != dtype {
+                crate::bail!(
+                    "cannot concatenate quantized tensors with different dtypes: {:?} vs {:?}",
+                    dtype,
+                    qtensor.dtype()
+                )
+            }
+            if qtensor.device().location() != device.location() {
+                crate::bail!(
+                    "cannot concatenate quantized tensors on different devices: {:?} vs {:?}",
+                    device.location(),
+                    qtensor.device().location()
+                )
+            }
+            if qtensor.rank() != first.rank() {
+                crate::bail!(
+                    "cannot concatenate quantized tensors with different ranks: {} vs {}",
+                    first.rank(),
+                    qtensor.rank()
+                )
+            }
+            for (axis, (&lhs_dim, &rhs_dim)) in dims.iter().zip(qtensor.shape().dims()).enumerate()
+            {
+                if axis != dim && lhs_dim != rhs_dim {
+                    crate::bail!(
+                        "cannot concatenate quantized tensors with mismatched shapes {:?} and {:?} on dim {}",
+                        first.shape(),
+                        qtensor.shape(),
+                        dim
+                    )
+                }
+            }
+
+            let suffix_elems = qtensor.shape().dims()[dim..].iter().product::<usize>();
+            if !suffix_elems.is_multiple_of(block_size) {
+                crate::bail!(
+                    "quantized tensor suffix from dim {} must be divisible by block size {}: {:?}",
+                    dim,
+                    block_size,
+                    qtensor.shape()
+                )
+            }
+            let chunk_bytes = suffix_elems / block_size * type_size;
+            let data = qtensor.data()?;
+            if data.len() != prefix_elems * chunk_bytes {
+                crate::bail!(
+                    "unexpected quantized storage size for {:?}: got {}, expected {}",
+                    qtensor.shape(),
+                    data.len(),
+                    prefix_elems * chunk_bytes
+                )
+            }
+            total_bytes += data.len();
+            out_dims[dim] += qtensor.shape().dims()[dim];
+            chunks.push((data, chunk_bytes));
+        }
+
+        let mut data = Vec::with_capacity(total_bytes);
+        for prefix_idx in 0..prefix_elems {
+            for (chunk, chunk_bytes) in &chunks {
+                let start = prefix_idx * *chunk_bytes;
+                let end = start + *chunk_bytes;
+                data.extend_from_slice(&chunk[start..end]);
+            }
+        }
+
+        ggml_file::qtensor_from_ggml(dtype, &data, out_dims, &device)
+    }
+
     pub fn indexed_moe_forward(&self, x: &Tensor, ids: &Tensor) -> Result<Tensor> {
         match &self.storage {
             QStorage::Cuda(s) => match (&*x.storage(), &*ids.storage()) {

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -261,6 +261,75 @@ test_device!(quantized_matmul, qmm_cpu, qmm_cuda, qmm_metal);
 test_device!(quantized_matmul_neg, qmm_n_cpu, qmm_n_cuda, qmm_n_metal);
 test_device!(qmm_batch, qmm_b_cpu, qmm_b_cuda, qmm_b_metal);
 
+fn qtensor_cat_dim0(device: &Device) -> Result<()> {
+    let lhs = Tensor::from_vec(
+        (0..2 * 256).map(|i| (i as f32 - 200.) / 50.).collect(),
+        (2, 256),
+        device,
+    )?;
+    let rhs = Tensor::from_vec(
+        (0..3 * 256).map(|i| (i as f32 - 300.) / 75.).collect(),
+        (3, 256),
+        device,
+    )?;
+
+    let lhs_q = quantized::QTensor::quantize(&lhs, GgmlDType::Q4K)?;
+    let rhs_q = quantized::QTensor::quantize(&rhs, GgmlDType::Q4K)?;
+    let cat_q = quantized::QTensor::cat(&[&lhs_q, &rhs_q], 0)?;
+    assert_eq!(cat_q.shape().dims(), [5, 256]);
+
+    let mut expected_bytes = lhs_q.data()?.into_owned();
+    expected_bytes.extend_from_slice(rhs_q.data()?.as_ref());
+    assert_eq!(cat_q.data()?.as_ref(), expected_bytes.as_slice());
+
+    let expected = Tensor::cat(&[&lhs_q.dequantize(device)?, &rhs_q.dequantize(device)?], 0)?;
+    let got = cat_q.dequantize(device)?;
+    let diff = (&got - &expected)?.abs()?.sum_all()?.to_scalar::<f32>()?;
+    assert_eq!(diff, 0.0);
+    Ok(())
+}
+
+fn qtensor_cat_dim1(device: &Device) -> Result<()> {
+    let lhs = Tensor::from_vec(
+        (0..2 * 2 * 256)
+            .map(|i| ((i % 137) as f32 - 68.) / 29.)
+            .collect(),
+        (2, 2, 256),
+        device,
+    )?;
+    let rhs = Tensor::from_vec(
+        (0..2 * 256)
+            .map(|i| ((i % 113) as f32 - 56.) / 23.)
+            .collect(),
+        (2, 1, 256),
+        device,
+    )?;
+
+    let lhs_q = quantized::QTensor::quantize(&lhs, GgmlDType::Q4K)?;
+    let rhs_q = quantized::QTensor::quantize(&rhs, GgmlDType::Q4K)?;
+    let cat_q = quantized::QTensor::cat(&[&lhs_q, &rhs_q], 1)?;
+    assert_eq!(cat_q.shape().dims(), [2, 3, 256]);
+
+    let expected = Tensor::cat(&[&lhs_q.dequantize(device)?, &rhs_q.dequantize(device)?], 1)?;
+    let got = cat_q.dequantize(device)?;
+    let diff = (&got - &expected)?.abs()?.sum_all()?.to_scalar::<f32>()?;
+    assert_eq!(diff, 0.0);
+    Ok(())
+}
+
+test_device!(
+    qtensor_cat_dim0,
+    qtensor_cat_dim0_cpu,
+    qtensor_cat_dim0_cuda,
+    qtensor_cat_dim0_metal
+);
+test_device!(
+    qtensor_cat_dim1,
+    qtensor_cat_dim1_cpu,
+    qtensor_cat_dim1_cuda,
+    qtensor_cat_dim1_metal
+);
+
 fn quantize_q4_0(device: &Device) -> Result<()> {
     let src = (0..32 * 4).map(|v| v as f32).collect::<Vec<_>>();
 

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -9,7 +9,7 @@
 use super::with_tracing::QMatMul;
 use crate::{quantized_nn::RmsNorm, utils::repeat_kv};
 use candle::quantized::{gguf_file, QTensor};
-use candle::{DType, Device, Result, Storage, Tensor};
+use candle::{DType, Device, Result, Storage, Tensor, D};
 use candle_nn::attention::cpu_flash::causal::causal_decode_f32_interleaved;
 use candle_nn::attention::{flash_attn, AttnMask};
 use candle_nn::kv_cache::{ConcatKvCache, InterleavedKvCache, RawInterleavedKvCache};
@@ -49,24 +49,42 @@ impl<R: Read + Seek> Gguf<R> {
 
 #[derive(Debug, Clone)]
 struct MlpWeights {
-    gate_proj: QMatMul,
-    up_proj: QMatMul,
+    gate_up_proj: QMatMul,
     down_proj: QMatMul,
+    intermediate_size: usize,
     act_fn: Activation,
     span: tracing::Span,
 }
 
 impl MlpWeights {
     fn new<R: Read + Seek>(gg: &mut Gguf<R>, prefix: &str) -> Result<Self> {
-        let gate_proj = gg.qmatmul(&format!("{prefix}.ffn_gate.weight"))?;
-        let up_proj = gg.qmatmul(&format!("{prefix}.ffn_up.weight"))?;
+        let gate_proj = gg.tensor(&format!("{prefix}.ffn_gate.weight"))?;
+        let up_proj = gg.tensor(&format!("{prefix}.ffn_up.weight"))?;
+        let gate_dims = gate_proj.shape().dims();
+        let up_dims = up_proj.shape().dims();
+        if gate_dims.len() != 2 || up_dims.len() != 2 {
+            candle::bail!(
+                "expected 2D SwiGLU weights, got gate {:?} and up {:?}",
+                gate_proj.shape(),
+                up_proj.shape()
+            )
+        }
+        if gate_dims[0] != up_dims[0] {
+            candle::bail!(
+                "expected equal gate/up projection sizes, got {} and {}",
+                gate_dims[0],
+                up_dims[0]
+            )
+        }
+        let intermediate_size = gate_dims[0];
+        let gate_up_proj = QMatMul::from_weights(QTensor::cat(&[&gate_proj, &up_proj], 0)?.into())?;
         let down_proj = gg.qmatmul(&format!("{prefix}.ffn_down.weight"))?;
         let act_fn = Activation::Silu;
         let span = tracing::span!(tracing::Level::TRACE, "mlp");
         Ok(Self {
-            gate_proj,
-            up_proj,
+            gate_up_proj,
             down_proj,
+            intermediate_size,
             act_fn,
             span,
         })
@@ -76,8 +94,11 @@ impl MlpWeights {
 impl Module for MlpWeights {
     fn forward(&self, x: &Tensor) -> Result<Tensor> {
         let _enter = self.span.enter();
-        let gate = self.gate_proj.forward(x)?.apply(&self.act_fn)?;
-        let up = self.up_proj.forward(x)?;
+        let gate_up = self.gate_up_proj.forward(x)?;
+        let gate = gate_up
+            .narrow(D::Minus1, 0, self.intermediate_size)?
+            .apply(&self.act_fn)?;
+        let up = gate_up.narrow(D::Minus1, self.intermediate_size, self.intermediate_size)?;
         let gated = (gate * up)?;
         self.down_proj.forward(&gated)
     }
@@ -586,5 +607,68 @@ impl ModelWeights {
         for layer in &mut self.layers {
             layer.clear_kv_cache();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candle::quantized::{GgmlDType, QMatMul, QTensor};
+    use candle::{Device, Module, Result, Tensor, D};
+
+    #[test]
+    fn fused_gate_up_qmatmul_matches_split_path() -> Result<()> {
+        let device = Device::Cpu;
+        let hidden_size = 256;
+        let intermediate_size = 512;
+        let batch_size = 3;
+
+        let xs = Tensor::from_vec(
+            (0..batch_size * hidden_size)
+                .map(|i| (i as f32 - 128.) / 128.)
+                .collect(),
+            (batch_size, hidden_size),
+            &device,
+        )?;
+
+        let gate_weight = Tensor::from_vec(
+            (0..intermediate_size * hidden_size)
+                .map(|i| ((i % 97) as f32 - 48.) / 32.)
+                .collect(),
+            (intermediate_size, hidden_size),
+            &device,
+        )?;
+        let up_weight = Tensor::from_vec(
+            (0..intermediate_size * hidden_size)
+                .map(|i| ((i % 89) as f32 - 44.) / 28.)
+                .collect(),
+            (intermediate_size, hidden_size),
+            &device,
+        )?;
+
+        let gate_q = QTensor::quantize(&gate_weight, GgmlDType::Q4K)?;
+        let up_q = QTensor::quantize(&up_weight, GgmlDType::Q4K)?;
+        let fused_q = QTensor::cat(&[&gate_q, &up_q], 0)?;
+        assert_eq!(fused_q.shape().dims(), [intermediate_size * 2, hidden_size]);
+        let gate_bytes = gate_q.data()?;
+        let up_bytes = up_q.data()?;
+        let fused_bytes = fused_q.data()?;
+        assert_eq!(&fused_bytes[..gate_bytes.len()], gate_bytes.as_ref());
+        assert_eq!(&fused_bytes[gate_bytes.len()..], up_bytes.as_ref());
+
+        let gate = QMatMul::from_qtensor(gate_q)?.forward(&xs)?;
+        let up = QMatMul::from_qtensor(up_q)?.forward(&xs)?;
+        let fused = QMatMul::from_qtensor(fused_q)?.forward(&xs)?;
+        let fused_gate = fused.narrow(D::Minus1, 0, intermediate_size)?;
+        let fused_up = fused.narrow(D::Minus1, intermediate_size, intermediate_size)?;
+
+        let gate_diff = (&gate - &fused_gate)?
+            .abs()?
+            .sum_all()?
+            .to_scalar::<f32>()?;
+        let up_diff = (&up - &fused_up)?.abs()?.sum_all()?.to_scalar::<f32>()?;
+        assert_eq!(gate_diff, 0.0);
+        assert_eq!(up_diff, 0.0);
+
+        Ok(())
     }
 }

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -77,7 +77,7 @@ impl MlpWeights {
             )
         }
         let intermediate_size = gate_dims[0];
-        let gate_up_proj = QMatMul::from_weights(QTensor::cat(&[&gate_proj, &up_proj], 0)?.into())?;
+        let gate_up_proj = QMatMul::from_qtensor(QTensor::cat(&[&gate_proj, &up_proj], 0)?)?;
         let down_proj = gg.qmatmul(&format!("{prefix}.ffn_down.weight"))?;
         let act_fn = Activation::Silu;
         let span = tracing::span!(tracing::Level::TRACE, "mlp");

--- a/candle-transformers/src/models/with_tracing.rs
+++ b/candle-transformers/src/models/with_tracing.rs
@@ -122,6 +122,12 @@ impl QMatMul {
         let span = tracing::span!(tracing::Level::TRACE, "qmatmul");
         Ok(Self { inner, span })
     }
+
+    pub fn from_qtensor(ws: candle::quantized::QTensor) -> Result<Self> {
+        let inner = candle::quantized::QMatMul::from_qtensor(ws)?;
+        let span = tracing::span!(tracing::Level::TRACE, "qmatmul");
+        Ok(Self { inner, span })
+    }
 }
 
 impl Module for QMatMul {


### PR DESCRIPTION
## Summary
- add `QTensor::cat` for raw block-aligned concatenation of quantized tensors
- use `QTensor::cat` in `quantized_qwen3` to fuse SwiGLU gate/up projections into a single `QMatMul`
- add regression tests for quantized concat and fused-vs-split matmul equivalence

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --tests --examples --benches -- -D warnings`
- `cargo test -p candle-core --test quantized_tests qtensor_cat_dim`
- `cargo test -p candle-transformers fused_gate_up_qmatmul_matches_split_path`
- `cargo test --workspace -q`