### PR TITLE
metal-kernels: enumerate GPUs via MTLCopyAllDevices, not MTLCreateSystemDefaultDevice

### DIFF
--- a/candle-metal-kernels/src/metal/device.rs
+++ b/candle-metal-kernels/src/metal/device.rs
@@ -3,7 +3,9 @@ use crate::{
 };
 use objc2::{rc::Retained, runtime::AnyObject, runtime::ProtocolObject};
 use objc2_foundation::NSString;
-use objc2_metal::{MTLCompileOptions, MTLCreateSystemDefaultDevice, MTLDevice};
+use objc2_metal::{
+    MTLCompileOptions, MTLCopyAllDevices, MTLCreateSystemDefaultDevice, MTLDevice,
+};
 use std::{ffi::c_void, ptr};
 
 /// Metal device type classification based on Apple Silicon architecture.
@@ -48,14 +50,52 @@ impl Device {
     }
 
     pub fn all() -> Vec<Self> {
-        MTLCreateSystemDefaultDevice()
-            .into_iter()
+        // Use MTLCopyAllDevices — the real enumeration API. The singular
+        // MTLCreateSystemDefaultDevice() can return nil on some macOS
+        // configurations (reproduced on an M3 Pro running macOS 14.5) even
+        // though a GPU is attached, which would leave `all()` empty and
+        // panic any downstream `.swap_remove(0)`. MTLCopyAllDevices
+        // reliably returns the attached devices.
+        //
+        // objc2-metal's MTLCopyAllDevices is available on every Apple
+        // target: on macOS / Mac Catalyst it calls the native symbol, on
+        // iOS / tvOS / visionOS it is polyfilled as a 0- or 1-element
+        // NSArray around MTLCreateSystemDefaultDevice. No cfg gate needed.
+        //
+        // On multi-GPU Macs MTLCopyAllDevices does not guarantee that the
+        // system-default device sits at index 0. Reorder so it does, to
+        // preserve the long-standing expectation that
+        // `candle-core::MetalDevice::new(0)` gives callers the default
+        // device on dGPU+iGPU or eGPU setups.
+        let mut devices: Vec<Device> = MTLCopyAllDevices()
+            .iter()
             .map(|raw| Device { raw })
-            .collect()
+            .collect();
+        if devices.len() > 1 {
+            if let Some(default) = MTLCreateSystemDefaultDevice() {
+                let default_id = default.registryID();
+                if let Some(pos) = devices
+                    .iter()
+                    .position(|d| d.registry_id() == default_id)
+                {
+                    if pos != 0 {
+                        devices.swap(0, pos);
+                    }
+                }
+            }
+        }
+        devices
     }
 
     pub fn system_default() -> Option<Self> {
-        MTLCreateSystemDefaultDevice().map(|raw| Device { raw })
+        // Mirror the fallback used in `all()`: if MTLCreateSystemDefaultDevice
+        // returns nil on a machine where MTLCopyAllDevices reports a GPU,
+        // fall through to the first enumerated device so callers of
+        // `system_default()` see the same GPU as `all()` and don't
+        // spuriously .unwrap() to a panic.
+        MTLCreateSystemDefaultDevice()
+            .map(|raw| Device { raw })
+            .or_else(|| Device::all().into_iter().next())
     }
 
     pub fn new_buffer(


### PR DESCRIPTION
## Summary

- `Device::all()` in `candle-metal-kernels` wraps `MTLCreateSystemDefaultDevice()` (the *singular* default-device API) in a `Vec`. On some macOS configurations — reproduced on an M3 Pro running macOS 14.5 — that call returns `nil` even though a GPU is present and `MTLCopyAllDevices()` correctly returns it. Downstream `candle-core::metal_backend::MetalDevice::new` then hits `.swap_remove(0)` on an empty Vec and the whole binary panics with `swap_remove index (is 0) should be < len (is 0)`.
- Switch `Device::all()` to `MTLCopyAllDevices()` — the real enumeration API. `objc2-metal`'s wrapper is available on every Apple target (native on macOS / Mac Catalyst; polyfilled via `MTLCreateSystemDefaultDevice` on iOS / tvOS / visionOS), so no `#[cfg]` gating is needed.
- **Preserve existing `new_metal(0)` semantics on multi-GPU Macs.** `MTLCopyAllDevices` doesn't promise the system-default device sits at index 0, so after enumeration reorder the Vec so the device whose `registryID` matches `MTLCreateSystemDefaultDevice` comes first. No-op on single-GPU machines.
- **Also fix `system_default()`** for consistency: fall through to the first enumerated device if the singular API returns `nil`. Without this, the many `system_default().unwrap()` call sites in tests / examples / benchmarks still panic in the exact scenario this patch claims to fix (including `candle-metal-kernels/src/tests.rs`, `examples/metal_benchmarks.rs`).

## Repro on the affected M3 Pro

```rust
use objc2_metal::{MTLCreateSystemDefaultDevice, MTLCopyAllDevices, MTLDevice};
fn main() {
    // Before this PR:
    println!("MTLCreateSystemDefaultDevice: {:?}",
        MTLCreateSystemDefaultDevice().map(|d| d.name().to_string()));
    // -> None
    // After this PR:
    for d in MTLCopyAllDevices().iter() { println!("MTLCopyAllDevices entry: {}", d.name()); }
    // -> Apple M3 Pro
}
```

Before: any `candle-core` Metal backend user aborts at startup. After: Metal initialises normally, `new_metal(0)` still returns the system-default GPU.

## Test plan

- [x] Builds on aarch64 macOS (\`cargo build --release -p candle-metal-kernels\`).
- [x] Fixes a real-world panic in a downstream binary (\`dropbox/witchcraft\`'s \`pickbrain\`) on M3 Pro.
- [ ] Not manually tested: iOS / tvOS / visionOS targets. The code path for those is unchanged — \`objc2-metal::MTLCopyAllDevices\` polyfills to \`MTLCreateSystemDefaultDevice\` on those platforms, matching the previous behaviour.

## Notes

Happy to split the \`system_default()\` fix into a follow-up if preferred, but the two functions are inconsistent without it and upstream reviewers of my downstream patch flagged the inconsistency as a bug. Bundling keeps \`all()\` and \`system_default()\` returning data for the same set of devices.

Generated with [Claude Code](https://claude.com/claude-code)