### PR TITLE
feat: Gemma4 IT with Shared KV layers, expanded MLP, configurable RoPE

### DIFF
--- a/candle-examples/examples/gemma4/main.rs
+++ b/candle-examples/examples/gemma4/main.rs
@@ -20,10 +20,34 @@ use candle_transformers::generation::{LogitsProcessor, Sampling};
 use hf_hub::{api::sync::Api, Repo, RepoType};
 use tokenizers::Tokenizer;
 
-#[allow(clippy::large_enum_variant)]
 enum ModelKind {
     TextOnly(TextModel),
     Multimodal(Model),
+}
+
+fn is_gemma4_instruct_model(model_id: &str) -> bool {
+    model_id.to_ascii_lowercase().ends_with("-it")
+}
+
+fn format_prompt(
+    prompt: &str,
+    model_id: &str,
+    multimodal: bool,
+    disable_chat_template: bool,
+    system_prompt: Option<&str>,
+) -> String {
+    if multimodal || disable_chat_template || !is_gemma4_instruct_model(model_id) {
+        return prompt.to_string();
+    }
+
+    let user_turn = format!("<|turn>user\n{}<turn|>\n<|turn>model\n", prompt.trim());
+    match system_prompt
+        .map(str::trim)
+        .filter(|prompt| !prompt.is_empty())
+    {
+        Some(system_prompt) => format!("<|turn>system\n{system_prompt}<turn|>\n{user_turn}"),
+        None => user_turn,
+    }
 }
 
 struct TextGeneration {
@@ -91,10 +115,17 @@ impl TextGeneration {
         std::io::stdout().flush()?;
 
         let mut generated_tokens = 0usize;
-        let eos_token = match self.tokenizer.get_token("</s>") {
-            Some(token) => token,
-            None => anyhow::bail!("cannot find the </s> token"),
-        };
+        let mut stop_tokens = Vec::new();
+        for token in ["<eos>", "<turn|>", "</s>"] {
+            if let Some(token_id) = self.tokenizer.get_token(token) {
+                if !stop_tokens.contains(&token_id) {
+                    stop_tokens.push(token_id);
+                }
+            }
+        }
+        if stop_tokens.is_empty() {
+            anyhow::bail!("cannot find any Gemma4 stop token (<eos>, <turn|>, </s>)");
+        }
         let start_gen = std::time::Instant::now();
         for index in 0..sample_len {
             let context_size = if index > 0 { 1 } else { tokens.len() };
@@ -120,7 +151,7 @@ impl TextGeneration {
             let next_token = self.logits_processor.sample(&logits)?;
             tokens.push(next_token);
             generated_tokens += 1;
-            if next_token == eos_token {
+            if stop_tokens.contains(&next_token) {
                 break;
             }
             if let Some(t) = self.tokenizer.next_token(next_token)? {
@@ -158,6 +189,10 @@ struct Args {
     #[arg(long)]
     prompt: String,
 
+    /// Optional system message when using Gemma4 instruction-tuned models.
+    #[arg(long)]
+    system_prompt: Option<String>,
+
     /// The temperature used to generate samples.
     #[arg(long)]
     temperature: Option<f64>,
@@ -173,6 +208,10 @@ struct Args {
     /// The seed to use when generating random samples.
     #[arg(long, default_value_t = 299792458)]
     seed: u64,
+
+    /// Disable the built-in Gemma4 chat formatting for `-it` models.
+    #[arg(long)]
+    raw_prompt: bool,
 
     /// The length of the sample to generate (in tokens).
     #[arg(long, short = 'n', default_value_t = 10000)]
@@ -245,8 +284,9 @@ fn main() -> Result<()> {
         .model_id
         .clone()
         .unwrap_or_else(|| "google/gemma-4-E4B-it".to_string());
+    let is_instruct_model = is_gemma4_instruct_model(&model_id);
     let repo = api.repo(Repo::with_revision(
-        model_id,
+        model_id.clone(),
         RepoType::Model,
         args.revision,
     ));
@@ -309,17 +349,40 @@ fn main() -> Result<()> {
 
     println!("loaded the model in {:?}", start.elapsed());
 
+    let prompt = format_prompt(
+        &args.prompt,
+        &model_id,
+        args.multimodal,
+        args.raw_prompt,
+        args.system_prompt.as_deref(),
+    );
+    if prompt != args.prompt {
+        eprintln!("using Gemma4 chat prompt formatting for instruct model `{model_id}`");
+    }
+
+    let (temperature, top_p, top_k) = if is_instruct_model
+        && !args.raw_prompt
+        && args.temperature.is_none()
+        && args.top_p.is_none()
+        && args.top_k.is_none()
+    {
+        eprintln!("using Gemma4 instruct sampling defaults: temperature=1.0 top_p=0.95 top_k=64");
+        (Some(1.0), Some(0.95), Some(64))
+    } else {
+        (args.temperature, args.top_p, args.top_k)
+    };
+
     let mut pipeline = TextGeneration::new(
         model,
         tokenizer,
         args.seed,
-        args.temperature,
-        args.top_p,
-        args.top_k,
+        temperature,
+        top_p,
+        top_k,
         args.repeat_penalty,
         args.repeat_last_n,
         &device,
     );
-    pipeline.run(&args.prompt, args.sample_len)?;
+    pipeline.run(&prompt, args.sample_len)?;
     Ok(())
 }

--- a/candle-nn/src/rotary_emb.rs
+++ b/candle-nn/src/rotary_emb.rs
@@ -239,9 +239,11 @@ fn rope_check_cs(cs: &Tensor, b_sz: usize) -> Result<(usize, usize)> {
 }
 
 pub fn rope_i(xs: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
+    let cos = cos.to_dtype(xs.dtype())?;
+    let sin = sin.to_dtype(xs.dtype())?;
     let (b_sz, _n_head, seq_len, n_embd) = xs.dims4()?;
-    let (cos_seq_len, cos_n_embd) = rope_check_cs(cos, b_sz)?;
-    let (sin_seq_len, sin_n_embd) = rope_check_cs(sin, b_sz)?;
+    let (cos_seq_len, cos_n_embd) = rope_check_cs(&cos, b_sz)?;
+    let (sin_seq_len, sin_n_embd) = rope_check_cs(&sin, b_sz)?;
     if cos_n_embd * 2 != n_embd
         || sin_n_embd * 2 != n_embd
         || seq_len > cos_seq_len
@@ -263,7 +265,7 @@ pub fn rope_i(xs: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
     if !sin.is_contiguous() {
         candle::bail!("sin has to be contiguous in rope")
     }
-    xs.apply_op3_no_bwd(cos, sin, &RotaryEmbI)
+    xs.apply_op3_no_bwd(&cos, &sin, &RotaryEmbI)
 }
 
 pub fn rope_i_slow(x: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
@@ -510,9 +512,11 @@ impl candle::CustomOp3 for RotaryEmb {
 }
 
 pub fn rope(xs: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
+    let cos = cos.to_dtype(xs.dtype())?;
+    let sin = sin.to_dtype(xs.dtype())?;
     let (b_sz, _n_head, seq_len, n_embd) = xs.dims4()?;
-    let (cos_seq_len, cos_n_embd) = rope_check_cs(cos, b_sz)?;
-    let (sin_seq_len, sin_n_embd) = rope_check_cs(sin, b_sz)?;
+    let (cos_seq_len, cos_n_embd) = rope_check_cs(&cos, b_sz)?;
+    let (sin_seq_len, sin_n_embd) = rope_check_cs(&sin, b_sz)?;
     if cos_n_embd * 2 != n_embd
         || sin_n_embd * 2 != n_embd
         || seq_len > cos_seq_len
@@ -534,7 +538,7 @@ pub fn rope(xs: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
     if !sin.is_contiguous() {
         candle::bail!("sin has to be contiguous in rope")
     }
-    xs.apply_op3_no_bwd(cos, sin, &RotaryEmb)
+    xs.apply_op3_no_bwd(&cos, &sin, &RotaryEmb)
 }
 
 fn rotate_half(xs: &Tensor) -> Result<Tensor> {
@@ -781,9 +785,11 @@ impl candle::CustomOp3 for RotaryEmbThd {
 }
 
 pub fn rope_thd(xs: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
+    let cos = cos.to_dtype(xs.dtype())?;
+    let sin = sin.to_dtype(xs.dtype())?;
     let (b_sz, seq_len, _n_head, n_embd) = xs.dims4()?;
-    let (cos_seq_len, cos_n_embd) = rope_check_cs(cos, b_sz)?;
-    let (sin_seq_len, sin_n_embd) = rope_check_cs(sin, b_sz)?;
+    let (cos_seq_len, cos_n_embd) = rope_check_cs(&cos, b_sz)?;
+    let (sin_seq_len, sin_n_embd) = rope_check_cs(&sin, b_sz)?;
     if cos_n_embd * 2 != n_embd
         || sin_n_embd * 2 != n_embd
         || seq_len > cos_seq_len
@@ -805,5 +811,5 @@ pub fn rope_thd(xs: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
     if !sin.is_contiguous() {
         candle::bail!("sin has to be contiguous in rope")
     }
-    xs.apply_op3_no_bwd(cos, sin, &RotaryEmbThd)
+    xs.apply_op3_no_bwd(&cos, &sin, &RotaryEmbThd)
 }

--- a/candle-transformers/src/models/gemma4/config.rs
+++ b/candle-transformers/src/models/gemma4/config.rs
@@ -46,6 +46,12 @@ fn default_global_head_dim() -> usize {
 fn default_use_flash_attn() -> bool {
     false
 }
+fn default_use_double_wide_mlp() -> bool {
+    false
+}
+fn default_num_kv_shared_layers() -> usize {
+    0
+}
 
 // ── Rope parameters ─────────────────────────────────────────────────────────
 
@@ -89,6 +95,7 @@ pub struct Gemma4TextConfig {
     #[serde(default = "default_vocab_size")]
     pub vocab_size: usize,
     pub sliding_window: usize,
+    pub attn_logit_softcapping: Option<f64>,
     pub final_logit_softcapping: Option<f64>,
     #[serde(default = "default_query_pre_attn_scalar")]
     pub query_pre_attn_scalar: usize,
@@ -109,6 +116,12 @@ pub struct Gemma4TextConfig {
     pub use_bidirectional_attention: Option<String>,
     #[serde(default = "default_use_flash_attn")]
     pub use_flash_attn: bool,
+    #[serde(default = "default_use_double_wide_mlp")]
+    pub use_double_wide_mlp: bool,
+    #[serde(default = "default_num_kv_shared_layers")]
+    pub num_kv_shared_layers: usize,
+    pub hidden_size_per_layer_input: Option<usize>,
+    pub vocab_size_per_layer_input: Option<usize>,
 }
 
 impl Gemma4TextConfig {

--- a/candle-transformers/src/models/gemma4/mod.rs
+++ b/candle-transformers/src/models/gemma4/mod.rs
@@ -167,7 +167,7 @@ impl Model {
         }
 
         self.language_model
-            .forward_embeds(&input_embeds, seqlen_offset, b_size, seq_len)
+            .forward_embeds(input_ids, &input_embeds, seqlen_offset, b_size, seq_len)
     }
 
     pub fn clear_kv_cache(&mut self) {

--- a/candle-transformers/src/models/gemma4/text.rs
+++ b/candle-transformers/src/models/gemma4/text.rs
@@ -9,7 +9,7 @@ use candle_nn::{linear_b as linear_bias, Activation, Linear, VarBuilder};
 
 use super::config::Gemma4TextConfig;
 
-// ── RmsNorm (Gemma-style with +1 offset) ────────────────────────────────────
+// ── RmsNorm ─────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
 struct RmsNorm {
@@ -35,9 +35,7 @@ impl Module for RmsNorm {
         let x = x.to_dtype(internal_dtype)?;
         let norm_x = (x.sqr()?.sum_keepdim(D::Minus1)? / hidden_size as f64)?;
         let x_normed = x.broadcast_div(&(norm_x + self.eps)?.sqrt()?)?;
-        x_normed
-            .to_dtype(x_dtype)?
-            .broadcast_mul(&(&self.weight + 1.0)?)
+        x_normed.to_dtype(x_dtype)?.broadcast_mul(&self.weight)
     }
 }
 
@@ -50,12 +48,66 @@ fn v_norm(v: &Tensor, eps: f64) -> Result<Tensor> {
     v_f32.broadcast_div(&rms)?.to_dtype(original_dtype)
 }
 
+fn first_kv_shared_layer_idx(cfg: &Gemma4TextConfig) -> usize {
+    cfg.num_hidden_layers
+        .saturating_sub(cfg.num_kv_shared_layers)
+}
+
+fn kv_shared_layer_index(cfg: &Gemma4TextConfig, layer_idx: usize) -> Result<Option<usize>> {
+    let first_shared = first_kv_shared_layer_idx(cfg);
+    if first_shared == 0 || layer_idx < first_shared {
+        return Ok(None);
+    }
+
+    let attention_type = cfg.layer_types.get(layer_idx).ok_or_else(|| {
+        candle::Error::msg(format!("missing Gemma4 layer type for layer {layer_idx}"))
+    })?;
+
+    cfg.layer_types[..first_shared]
+        .iter()
+        .rposition(|ty| ty == attention_type)
+        .map(Some)
+        .ok_or_else(|| {
+            candle::Error::msg(format!(
+                "Gemma4 layer {layer_idx} is configured to share KV without a prior `{attention_type}` donor layer."
+            ))
+        })
+}
+
+fn kv_donor_flags(cfg: &Gemma4TextConfig) -> Result<Vec<bool>> {
+    let first_shared = first_kv_shared_layer_idx(cfg);
+    let mut donors = vec![false; cfg.num_hidden_layers];
+    for shared_idx in first_shared..cfg.num_hidden_layers {
+        if let Some(donor_idx) = kv_shared_layer_index(cfg, shared_idx)? {
+            donors[donor_idx] = true;
+        }
+    }
+    Ok(donors)
+}
+
+fn gemma4_disable_ple() -> bool {
+    std::env::var_os("CANDLE_GEMMA4_DISABLE_PLE").is_some()
+}
+
+fn gemma4_disable_shared_kv() -> bool {
+    std::env::var_os("CANDLE_GEMMA4_DISABLE_SHARED_KV").is_some()
+}
+
+fn gemma4_force_f32_attn() -> bool {
+    std::env::var_os("CANDLE_GEMMA4_FORCE_F32_ATTN").is_some()
+}
+
+fn gemma4_disable_attn_softcap() -> bool {
+    std::env::var_os("CANDLE_GEMMA4_DISABLE_ATTN_SOFTCAP").is_some()
+}
+
 // ── RotaryEmbedding (standard, for sliding layers) ──────────────────────────
 
 #[derive(Debug, Clone)]
 struct RotaryEmbedding {
     sin: Tensor,
     cos: Tensor,
+    is_gpt_neox: bool,
 }
 
 impl RotaryEmbedding {
@@ -66,19 +118,31 @@ impl RotaryEmbedding {
         max_seq_len: usize,
         dev: &Device,
     ) -> Result<Self> {
+        Self::new_with_layout(dtype, head_dim, rope_theta, max_seq_len, dev, true)
+    }
+
+    fn new_with_layout(
+        _dtype: DType,
+        head_dim: usize,
+        rope_theta: f64,
+        max_seq_len: usize,
+        dev: &Device,
+        is_gpt_neox: bool,
+    ) -> Result<Self> {
         let inv_freq: Vec<_> = (0..head_dim)
             .step_by(2)
             .map(|i| 1f32 / rope_theta.powf(i as f64 / head_dim as f64) as f32)
             .collect();
         let inv_freq_len = inv_freq.len();
-        let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?.to_dtype(dtype)?;
+        let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?.to_dtype(DType::F32)?;
         let t = Tensor::arange(0u32, max_seq_len as u32, dev)?
-            .to_dtype(dtype)?
+            .to_dtype(DType::F32)?
             .reshape((max_seq_len, 1))?;
         let freqs = t.matmul(&inv_freq)?;
         Ok(Self {
             sin: freqs.sin()?,
             cos: freqs.cos()?,
+            is_gpt_neox,
         })
     }
 
@@ -91,8 +155,13 @@ impl RotaryEmbedding {
         let (_b_sz, _h, seq_len, _n_embd) = q.dims4()?;
         let cos = self.cos.narrow(0, seqlen_offset, seq_len)?;
         let sin = self.sin.narrow(0, seqlen_offset, seq_len)?;
-        let q_embed = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
-        let k_embed = candle_nn::rotary_emb::rope(&k.contiguous()?, &cos, &sin)?;
+        let rope = if self.is_gpt_neox {
+            candle_nn::rotary_emb::rope
+        } else {
+            candle_nn::rotary_emb::rope_i
+        };
+        let q_embed = rope(&q.contiguous()?, &cos, &sin)?;
+        let k_embed = rope(&k.contiguous()?, &cos, &sin)?;
         Ok((q_embed, k_embed))
     }
 }
@@ -103,6 +172,7 @@ impl RotaryEmbedding {
 struct ProportionalRotaryEmbedding {
     sin: Tensor,
     cos: Tensor,
+    is_gpt_neox: bool,
 }
 
 impl ProportionalRotaryEmbedding {
@@ -114,6 +184,26 @@ impl ProportionalRotaryEmbedding {
         max_seq_len: usize,
         dev: &Device,
     ) -> Result<Self> {
+        Self::new_with_layout(
+            dtype,
+            head_dim,
+            rope_theta,
+            partial_rotary_factor,
+            max_seq_len,
+            dev,
+            true,
+        )
+    }
+
+    fn new_with_layout(
+        _dtype: DType,
+        head_dim: usize,
+        rope_theta: f64,
+        partial_rotary_factor: f64,
+        max_seq_len: usize,
+        dev: &Device,
+        is_gpt_neox: bool,
+    ) -> Result<Self> {
         let rope_angles = (partial_rotary_factor * head_dim as f64 / 2.0) as usize;
         let half_dim = head_dim / 2;
 
@@ -122,17 +212,21 @@ impl ProportionalRotaryEmbedding {
             inv_freq_vec.push(1f32 / (rope_theta as f32).powf((2 * i) as f32 / head_dim as f32));
         }
         // Pad with zeros for non-rotated dimensions -> cos=1, sin=0 -> identity
-        inv_freq_vec.extend(std::iter::repeat_n(0f32, half_dim - rope_angles));
+        let _ = vec![0f32; half_dim - rope_angles];
 
         let inv_freq = Tensor::from_vec(inv_freq_vec, (1, half_dim), dev)?;
         let t = Tensor::arange(0u32, max_seq_len as u32, dev)?
             .to_dtype(DType::F32)?
             .reshape((max_seq_len, 1))?;
         let freqs = t.matmul(&inv_freq)?;
-        let cos = freqs.cos()?.to_dtype(dtype)?;
-        let sin = freqs.sin()?.to_dtype(dtype)?;
+        let cos = freqs.cos()?;
+        let sin = freqs.sin()?;
 
-        Ok(Self { cos, sin })
+        Ok(Self {
+            cos,
+            sin,
+            is_gpt_neox,
+        })
     }
 
     fn apply_rotary_emb_qkv(
@@ -144,8 +238,13 @@ impl ProportionalRotaryEmbedding {
         let (_b_sz, _h, seq_len, _n_embd) = q.dims4()?;
         let cos = self.cos.narrow(0, seqlen_offset, seq_len)?;
         let sin = self.sin.narrow(0, seqlen_offset, seq_len)?;
-        let q_embed = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
-        let k_embed = candle_nn::rotary_emb::rope(&k.contiguous()?, &cos, &sin)?;
+        let rope = if self.is_gpt_neox {
+            candle_nn::rotary_emb::rope
+        } else {
+            candle_nn::rotary_emb::rope_i
+        };
+        let q_embed = rope(&q.contiguous()?, &cos, &sin)?;
+        let k_embed = rope(&k.contiguous()?, &cos, &sin)?;
         Ok((q_embed, k_embed))
     }
 }
@@ -197,13 +296,31 @@ fn flash_attn(
     k: &Tensor,
     v: &Tensor,
     softmax_scale: f32,
+    window_size_left: Option<usize>,
     causal: bool,
 ) -> Result<Tensor> {
+    if window_size_left.is_some() {
+        return candle_flash_attn::flash_attn_windowed(
+            q,
+            k,
+            v,
+            softmax_scale,
+            window_size_left,
+            Some(0),
+        );
+    }
     candle_flash_attn::flash_attn(q, k, v, softmax_scale, causal)
 }
 
 #[cfg(not(feature = "flash-attn"))]
-fn flash_attn(_: &Tensor, _: &Tensor, _: &Tensor, _: f32, _: bool) -> Result<Tensor> {
+fn flash_attn(
+    _: &Tensor,
+    _: &Tensor,
+    _: &Tensor,
+    _: f32,
+    _: Option<usize>,
+    _: bool,
+) -> Result<Tensor> {
     unimplemented!("compile with '--features flash-attn'")
 }
 
@@ -213,6 +330,73 @@ fn flash_attn(_: &Tensor, _: &Tensor, _: &Tensor, _: f32, _: bool) -> Result<Ten
 enum KvCache {
     Normal(candle_nn::kv_cache::KvCache),
     Rotating(candle_nn::kv_cache::RotatingKvCache),
+}
+
+impl KvCache {
+    fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor)> {
+        match self {
+            Self::Normal(cache) => cache.append(k, v),
+            Self::Rotating(cache) => cache.append(k, v),
+        }
+    }
+
+    fn k(&self) -> Result<Option<Tensor>> {
+        match self {
+            Self::Normal(cache) => cache.k(),
+            Self::Rotating(cache) => cache.k(),
+        }
+    }
+
+    fn v(&self) -> Result<Option<Tensor>> {
+        match self {
+            Self::Normal(cache) => cache.v(),
+            Self::Rotating(cache) => cache.v(),
+        }
+    }
+
+    #[allow(unused)]
+    fn current_seq_len(&self) -> usize {
+        match self {
+            Self::Normal(cache) => cache.current_seq_len(),
+            Self::Rotating(cache) => cache.current_seq_len(),
+        }
+    }
+
+    fn positions(&self, seq_len: usize) -> Option<Vec<usize>> {
+        match self {
+            Self::Normal(_) => None,
+            Self::Rotating(cache) => Some(cache.positions(seq_len)),
+        }
+    }
+
+    fn reset(&mut self) {
+        match self {
+            Self::Normal(cache) => cache.reset(),
+            Self::Rotating(cache) => cache.reset(),
+        }
+    }
+}
+
+fn sliding_logit_bias_from_positions(
+    query_positions: &[usize],
+    key_positions: &[usize],
+    dtype: DType,
+    device: &Device,
+    sliding_window: usize,
+) -> Result<Tensor> {
+    let mask: Vec<_> = query_positions
+        .iter()
+        .flat_map(|&q_pos| {
+            key_positions.iter().map(move |&k_pos| {
+                if k_pos > q_pos || k_pos + sliding_window < q_pos {
+                    f32::NEG_INFINITY
+                } else {
+                    0.0
+                }
+            })
+        })
+        .collect();
+    Tensor::from_slice(&mask, (query_positions.len(), key_positions.len()), device)?.to_dtype(dtype)
 }
 
 // ── Attention ───────────────────────────────────────────────────────────────
@@ -231,9 +415,13 @@ struct Attention {
     head_dim: usize,
     rms_norm_eps: f64,
     is_sliding: bool,
+    sliding_window: Option<usize>,
+    attn_logit_softcapping: Option<f64>,
+    _query_pre_attn_scalar: usize,
     rotary_emb_global: Arc<ProportionalRotaryEmbedding>,
     rotary_emb_local: Arc<RotaryEmbedding>,
     kv_cache: KvCache,
+    kv_shared_layer_index: Option<usize>,
     use_flash_attn: bool,
 }
 
@@ -244,6 +432,8 @@ impl Attention {
         rotary_emb_local: Arc<RotaryEmbedding>,
         cfg: &Gemma4TextConfig,
         layer_idx: usize,
+        force_full_kv_cache: bool,
+        kv_shared_layer_index: Option<usize>,
         vb: VarBuilder,
     ) -> Result<Self> {
         let hidden_sz = cfg.hidden_size;
@@ -268,10 +458,10 @@ impl Attention {
         let q_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
         let k_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
 
-        let kv_cache = if is_sliding {
+        let kv_cache = if is_sliding && !force_full_kv_cache && kv_shared_layer_index.is_none() {
             KvCache::Rotating(candle_nn::kv_cache::RotatingKvCache::new(
                 2,
-                cfg.effective_sliding_window(),
+                cfg.effective_sliding_window() + 1,
             ))
         } else {
             KvCache::Normal(candle_nn::kv_cache::KvCache::new(
@@ -293,9 +483,17 @@ impl Attention {
             head_dim,
             rms_norm_eps: cfg.rms_norm_eps,
             is_sliding,
+            sliding_window: is_sliding.then_some(cfg.effective_sliding_window()),
+            attn_logit_softcapping: if gemma4_disable_attn_softcap() {
+                None
+            } else {
+                cfg.attn_logit_softcapping
+            },
+            _query_pre_attn_scalar: cfg.query_pre_attn_scalar,
             rotary_emb_global,
             rotary_emb_local,
             kv_cache,
+            kv_shared_layer_index,
             use_flash_attn: cfg.use_flash_attn,
         })
     }
@@ -305,13 +503,14 @@ impl Attention {
         xs: &Tensor,
         attention_mask: Option<&Tensor>,
         sliding_attention_mask: Option<&Tensor>,
+        donor_kv: Option<&(Tensor, Tensor)>,
         seqlen_offset: usize,
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
         let mut q = self.q_proj.forward(xs)?;
         let mut k = self.k_proj.forward(xs)?;
-        let v = self.v_proj.forward(xs)?;
+        let mut v = self.v_proj.forward(xs)?;
 
         q = q
             .reshape((b_sz, q_len, self.num_heads, self.head_dim))?
@@ -319,15 +518,14 @@ impl Attention {
         k = k
             .reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?
             .transpose(1, 2)?;
-        let v = v
+        v = v
             .reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?
             .transpose(1, 2)?;
 
         // Q/K norms
         q = self.q_norm.forward(&q)?;
         k = self.k_norm.forward(&k)?;
-        // V norm (RMS without learned weight)
-        let v = v_norm(&v, self.rms_norm_eps)?;
+        v = v_norm(&v, self.rms_norm_eps)?;
 
         // Apply RoPE
         let (q, k) = if self.is_sliding {
@@ -338,36 +536,142 @@ impl Attention {
                 .apply_rotary_emb_qkv(&q, &k, seqlen_offset)?
         };
 
-        let (k, v) = match &mut self.kv_cache {
-            KvCache::Normal(cache) => cache.append(&k, &v)?,
-            KvCache::Rotating(cache) => cache.append(&k, &v)?,
+        let rotating_sliding_prefill = self.is_sliding
+            && !self.use_flash_attn
+            && donor_kv.is_none()
+            && q_len > 1
+            && matches!(self.kv_cache, KvCache::Rotating(_));
+
+        let (k, v, explicit_sliding_mask) = if rotating_sliding_prefill {
+            let sliding_window = self
+                .sliding_window
+                .expect("sliding Gemma4 attention should have a sliding window");
+            let query_positions: Vec<_> = (seqlen_offset..seqlen_offset + q_len).collect();
+            let mut key_positions = self.kv_cache.positions(0).unwrap_or_default();
+            let prefix_k = self.kv_cache.k()?;
+            let prefix_v = self.kv_cache.v()?;
+            key_positions.extend(query_positions.iter().copied());
+
+            let k_for_attn = if let Some(prefix_k) = prefix_k {
+                Tensor::cat(&[&prefix_k, &k], 2)?
+            } else {
+                k.clone()
+            };
+            let v_for_attn = if let Some(prefix_v) = prefix_v {
+                Tensor::cat(&[&prefix_v, &v], 2)?
+            } else {
+                v.clone()
+            };
+            let sliding_mask = sliding_logit_bias_from_positions(
+                &query_positions,
+                &key_positions,
+                q.dtype(),
+                xs.device(),
+                sliding_window,
+            )?;
+            let _ = self.kv_cache.append(&k, &v)?;
+            (k_for_attn, v_for_attn, Some(sliding_mask))
+        } else {
+            let (k, v) = if let Some((k, v)) = donor_kv {
+                (k.clone(), v.clone())
+            } else {
+                self.kv_cache.append(&k, &v)?
+            };
+            (k, v, None)
         };
 
         let k = crate::utils::repeat_kv(k, self.num_kv_groups)?.contiguous()?;
         let v = crate::utils::repeat_kv(v, self.num_kv_groups)?.contiguous()?;
 
-        let mask = if self.is_sliding {
-            sliding_attention_mask
+        let mask = if let Some(mask) = explicit_sliding_mask {
+            Some(mask)
+        } else if self.is_sliding {
+            sliding_attention_mask.cloned()
         } else {
-            attention_mask
+            attention_mask.cloned()
+        };
+        let mask = if let Some(mask) = mask {
+            let kv_seq_len = k.dims()[2];
+            let mask_dims = mask.dims();
+            match mask.rank() {
+                2 if mask_dims[1] > kv_seq_len => {
+                    Some(mask.narrow(1, mask_dims[1] - kv_seq_len, kv_seq_len)?)
+                }
+                3 if mask_dims[2] > kv_seq_len => {
+                    Some(mask.narrow(2, mask_dims[2] - kv_seq_len, kv_seq_len)?)
+                }
+                4 if mask_dims[3] > kv_seq_len => {
+                    Some(mask.narrow(3, mask_dims[3] - kv_seq_len, kv_seq_len)?)
+                }
+                _ => Some(mask),
+            }
+        } else if self.is_sliding && !self.use_flash_attn {
+            let kv_seq_len = k.dims()[2];
+            let sliding_window = self
+                .sliding_window
+                .expect("sliding Gemma4 attention should have a sliding window");
+            let kv_start = seqlen_offset + q_len - kv_seq_len;
+            let sliding_mask: Vec<_> = (0..q_len)
+                .flat_map(|i| {
+                    let q_pos = seqlen_offset + i;
+                    (0..kv_seq_len).map(move |j| {
+                        let k_pos = kv_start + j;
+                        if k_pos > q_pos || k_pos + sliding_window < q_pos {
+                            f32::NEG_INFINITY
+                        } else {
+                            0.0
+                        }
+                    })
+                })
+                .collect();
+            Some(Tensor::from_slice(
+                &sliding_mask,
+                (q_len, kv_seq_len),
+                xs.device(),
+            )?)
+        } else {
+            None
         };
 
         let attn_output = if self.use_flash_attn {
             let q = q.transpose(1, 2)?;
             let k = k.transpose(1, 2)?;
             let v = v.transpose(1, 2)?;
-            let scale = 1f32 / (self.head_dim as f32).sqrt();
-            flash_attn(&q, &k, &v, scale, mask.is_some())?.transpose(1, 2)?
+            let scale = 1.0f32;
+            flash_attn(&q, &k, &v, scale, self.sliding_window, mask.is_some())?.transpose(1, 2)?
         } else {
-            let scale = 1f64 / f64::sqrt(self.head_dim as f64);
+            let attn_input_dtype = q.dtype();
+            let (q, k, v) = if gemma4_force_f32_attn() {
+                (
+                    q.to_dtype(DType::F32)?,
+                    k.to_dtype(DType::F32)?,
+                    v.to_dtype(DType::F32)?,
+                )
+            } else {
+                (q, k, v)
+            };
+            let scale = 1.0f64;
             let attn_weights = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
 
-            let attn_weights = match mask {
+            let attn_weights = match self.attn_logit_softcapping {
                 None => attn_weights,
-                Some(mask) => attn_weights.broadcast_add(mask)?,
+                Some(sc) => ((attn_weights / sc)?.tanh()? * sc)?,
+            };
+
+            let attn_weights = match mask.as_ref() {
+                None => attn_weights,
+                Some(mask) if mask.dtype() == attn_weights.dtype() => {
+                    attn_weights.broadcast_add(mask)?
+                }
+                Some(mask) => attn_weights.broadcast_add(&mask.to_dtype(attn_weights.dtype())?)?,
             };
             let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
-            attn_weights.matmul(&v)?
+            let attn_output = attn_weights.matmul(&v)?;
+            if attn_output.dtype() != attn_input_dtype {
+                attn_output.to_dtype(attn_input_dtype)?
+            } else {
+                attn_output
+            }
         };
         attn_output
             .transpose(1, 2)?
@@ -376,9 +680,14 @@ impl Attention {
     }
 
     fn clear_kv_cache(&mut self) {
-        match &mut self.kv_cache {
-            KvCache::Normal(c) => c.reset(),
-            KvCache::Rotating(c) => c.reset(),
+        self.kv_cache.reset()
+    }
+
+    fn cached_kv(&self) -> Result<Option<(Tensor, Tensor)>> {
+        match (self.kv_cache.k()?, self.kv_cache.v()?) {
+            (Some(k), Some(v)) => Ok(Some((k, v))),
+            (None, None) => Ok(None),
+            _ => candle::bail!("Gemma4 KV cache is internally inconsistent"),
         }
     }
 }
@@ -393,6 +702,11 @@ struct DecoderLayer {
     post_attention_layernorm: RmsNorm,
     pre_feedforward_layernorm: RmsNorm,
     post_feedforward_layernorm: RmsNorm,
+    per_layer_input_gate: Option<Linear>,
+    per_layer_projection: Option<Linear>,
+    post_per_layer_input_norm: Option<RmsNorm>,
+    layer_scalar: Option<Tensor>,
+    act: Activation,
     #[allow(dead_code)]
     is_sliding: bool,
 }
@@ -403,6 +717,8 @@ impl DecoderLayer {
         rotary_emb_local: Arc<RotaryEmbedding>,
         cfg: &Gemma4TextConfig,
         layer_idx: usize,
+        force_full_kv_cache: bool,
+        kv_shared_layer_index: Option<usize>,
         vb: VarBuilder,
     ) -> Result<Self> {
         let is_sliding = cfg.is_sliding(layer_idx);
@@ -411,11 +727,23 @@ impl DecoderLayer {
             rotary_emb_local,
             cfg,
             layer_idx,
+            force_full_kv_cache,
+            kv_shared_layer_index,
             vb.pp("self_attn"),
         )?;
+        let uses_double_wide_mlp = if gemma4_disable_shared_kv() {
+            layer_idx >= first_kv_shared_layer_idx(cfg)
+        } else {
+            kv_shared_layer_index.is_some()
+        };
+        let intermediate_size = if cfg.use_double_wide_mlp && uses_double_wide_mlp {
+            cfg.intermediate_size * 2
+        } else {
+            cfg.intermediate_size
+        };
         let mlp = MLP::new(
             cfg.hidden_size,
-            cfg.intermediate_size,
+            intermediate_size,
             cfg.hidden_activation,
             false,
             vb.pp("mlp"),
@@ -437,6 +765,30 @@ impl DecoderLayer {
             cfg.rms_norm_eps,
             vb.pp("post_feedforward_layernorm"),
         )?;
+        let ple_dim = cfg.hidden_size_per_layer_input.unwrap_or(0);
+        let (per_layer_input_gate, per_layer_projection, post_per_layer_input_norm) = if ple_dim > 0
+        {
+            (
+                Some(candle_nn::linear_no_bias(
+                    cfg.hidden_size,
+                    ple_dim,
+                    vb.pp("per_layer_input_gate"),
+                )?),
+                Some(candle_nn::linear_no_bias(
+                    ple_dim,
+                    cfg.hidden_size,
+                    vb.pp("per_layer_projection"),
+                )?),
+                Some(RmsNorm::new(
+                    cfg.hidden_size,
+                    cfg.rms_norm_eps,
+                    vb.pp("post_per_layer_input_norm"),
+                )?),
+            )
+        } else {
+            (None, None, None)
+        };
+        let layer_scalar = vb.get(1, "layer_scalar").ok();
         Ok(Self {
             self_attn,
             mlp,
@@ -444,6 +796,11 @@ impl DecoderLayer {
             post_attention_layernorm,
             pre_feedforward_layernorm,
             post_feedforward_layernorm,
+            per_layer_input_gate,
+            per_layer_projection,
+            post_per_layer_input_norm,
+            layer_scalar,
+            act: cfg.hidden_activation,
             is_sliding,
         })
     }
@@ -451,22 +808,48 @@ impl DecoderLayer {
     fn forward(
         &mut self,
         xs: &Tensor,
+        per_layer_input: Option<&Tensor>,
         attention_mask: Option<&Tensor>,
         sliding_attention_mask: Option<&Tensor>,
+        donor_kv: Option<&(Tensor, Tensor)>,
         seqlen_offset: usize,
     ) -> Result<Tensor> {
         let residual = xs;
         let xs = self.input_layernorm.forward(xs)?;
-        let xs =
-            self.self_attn
-                .forward(&xs, attention_mask, sliding_attention_mask, seqlen_offset)?;
+        let xs = self.self_attn.forward(
+            &xs,
+            attention_mask,
+            sliding_attention_mask,
+            donor_kv,
+            seqlen_offset,
+        )?;
         let xs = xs.apply(&self.post_attention_layernorm)?;
         let xs = (xs + residual)?;
         let residual = &xs;
         let xs = xs.apply(&self.pre_feedforward_layernorm)?;
         let xs = xs.apply(&self.mlp)?;
         let xs = xs.apply(&self.post_feedforward_layernorm)?;
-        residual + xs
+        let mut xs = (residual + xs)?;
+
+        if let (Some(gate), Some(proj), Some(norm), Some(per_layer_input)) = (
+            &self.per_layer_input_gate,
+            &self.per_layer_projection,
+            &self.post_per_layer_input_norm,
+            per_layer_input,
+        ) {
+            let residual = xs.clone();
+            let gated = gate.forward(&xs)?.apply(&self.act)?;
+            let gated = (gated * per_layer_input)?;
+            let projected = proj.forward(&gated)?;
+            let projected = norm.forward(&projected)?;
+            xs = (residual + projected)?;
+        }
+
+        if let Some(layer_scalar) = &self.layer_scalar {
+            xs = xs.broadcast_mul(layer_scalar)?;
+        }
+
+        Ok(xs)
     }
 
     fn clear_kv_cache(&mut self) {
@@ -484,11 +867,13 @@ fn prepare_decoder_attention_mask(
     dtype: DType,
     device: &Device,
 ) -> Result<Tensor> {
+    let total_kv_len = tgt_len + seqlen_offset;
     let mask: Vec<_> = if let Some(sliding_window) = sliding_window {
         (0..tgt_len)
             .flat_map(|i| {
-                (0..tgt_len).map(move |j| {
-                    if i < j || j + sliding_window < i {
+                let q_pos = seqlen_offset + i;
+                (0..total_kv_len).map(move |j| {
+                    if j > q_pos || j + sliding_window < q_pos {
                         f32::NEG_INFINITY
                     } else {
                         0.
@@ -498,17 +883,14 @@ fn prepare_decoder_attention_mask(
             .collect()
     } else {
         (0..tgt_len)
-            .flat_map(|i| (0..tgt_len).map(move |j| if i < j { f32::NEG_INFINITY } else { 0f32 }))
+            .flat_map(|i| {
+                let q_pos = seqlen_offset + i;
+                (0..total_kv_len).map(move |j| if j > q_pos { f32::NEG_INFINITY } else { 0. })
+            })
             .collect()
     };
-    let mask = Tensor::from_slice(&mask, (tgt_len, tgt_len), device)?;
-    let mask = if seqlen_offset > 0 {
-        let mask0 = Tensor::zeros((tgt_len, seqlen_offset), DType::F32, device)?;
-        Tensor::cat(&[&mask0, &mask], D::Minus1)?
-    } else {
-        mask
-    };
-    mask.expand((b_size, 1, tgt_len, tgt_len + seqlen_offset))?
+    Tensor::from_slice(&mask, (tgt_len, total_kv_len), device)?
+        .expand((b_size, 1, tgt_len, total_kv_len))?
         .to_dtype(dtype)
 }
 
@@ -517,6 +899,9 @@ fn prepare_decoder_attention_mask(
 #[derive(Debug, Clone)]
 pub struct TextModel {
     embed_tokens: candle_nn::Embedding,
+    embed_tokens_per_layer: Option<candle_nn::Embedding>,
+    per_layer_model_projection: Option<Linear>,
+    per_layer_projection_norm: Option<RmsNorm>,
     layers: Vec<DecoderLayer>,
     norm: RmsNorm,
     lm_head: Linear,
@@ -524,14 +909,89 @@ pub struct TextModel {
     device: Device,
     dtype: DType,
     hidden_size: usize,
+    hidden_size_per_layer_input: usize,
+    num_hidden_layers: usize,
+    per_layer_input_scale: f64,
+    per_layer_projection_scalar: f64,
     sliding_window: usize,
+}
+
+fn find_text_weights_root<'a>(vb: &VarBuilder<'a>, tensor_name: &str) -> Option<VarBuilder<'a>> {
+    let direct = vb.clone();
+    if direct.contains_tensor(tensor_name) {
+        return Some(direct);
+    }
+
+    let model = vb.pp("model");
+    if model.contains_tensor(tensor_name) {
+        return Some(model);
+    }
+
+    let language_model = vb.pp("language_model");
+    if language_model.contains_tensor(tensor_name) {
+        return Some(language_model);
+    }
+
+    let model_language_model = model.pp("language_model");
+    if model_language_model.contains_tensor(tensor_name) {
+        return Some(model_language_model);
+    }
+
+    None
+}
+
+fn validate_text_config(cfg: &Gemma4TextConfig) -> Result<()> {
+    if gemma4_disable_shared_kv() {
+        return Ok(());
+    }
+    for layer_idx in first_kv_shared_layer_idx(cfg)..cfg.num_hidden_layers {
+        kv_shared_layer_index(cfg, layer_idx)?;
+    }
+    Ok(())
 }
 
 impl TextModel {
     pub fn new(cfg: &Gemma4TextConfig, vb: VarBuilder) -> Result<Self> {
-        let vb_m = vb.pp("model");
+        validate_text_config(cfg)?;
+
+        let vb_m = find_text_weights_root(&vb, "embed_tokens.weight").ok_or_else(|| {
+            candle::Error::msg(
+                "cannot find Gemma 4 text weights, expected embed_tokens.weight under one of: ., model, language_model, model.language_model",
+            )
+        })?;
+
         let embed_tokens =
             candle_nn::embedding(cfg.vocab_size, cfg.hidden_size, vb_m.pp("embed_tokens"))?;
+        let ple_dim = if gemma4_disable_ple() {
+            0
+        } else {
+            cfg.hidden_size_per_layer_input.unwrap_or(0)
+        };
+        let (embed_tokens_per_layer, per_layer_model_projection, per_layer_projection_norm) =
+            if ple_dim > 0 {
+                let ple_vocab = cfg.vocab_size_per_layer_input.unwrap_or(cfg.vocab_size);
+                (
+                    Some(candle_nn::embedding(
+                        ple_vocab,
+                        cfg.num_hidden_layers * ple_dim,
+                        vb_m.clone()
+                            .set_device(Device::Cpu)
+                            .pp("embed_tokens_per_layer"),
+                    )?),
+                    Some(candle_nn::linear_no_bias(
+                        cfg.hidden_size,
+                        cfg.num_hidden_layers * ple_dim,
+                        vb_m.pp("per_layer_model_projection"),
+                    )?),
+                    Some(RmsNorm::new(
+                        ple_dim,
+                        cfg.rms_norm_eps,
+                        vb_m.pp("per_layer_projection_norm"),
+                    )?),
+                )
+            } else {
+                (None, None, None)
+            };
 
         let rotary_emb_global = Arc::new(ProportionalRotaryEmbedding::new(
             vb.dtype(),
@@ -551,12 +1011,24 @@ impl TextModel {
 
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         let vb_l = vb_m.pp("layers");
-        for layer_idx in 0..cfg.num_hidden_layers {
+        let donor_flags = if gemma4_disable_shared_kv() {
+            vec![false; cfg.num_hidden_layers]
+        } else {
+            kv_donor_flags(cfg)?
+        };
+        for (layer_idx, _donor_flag) in donor_flags.iter().enumerate().take(cfg.num_hidden_layers) {
+            let kv_shared_layer_index = if gemma4_disable_shared_kv() {
+                None
+            } else {
+                kv_shared_layer_index(cfg, layer_idx)?
+            };
             let layer = DecoderLayer::new(
                 rotary_emb_global.clone(),
                 rotary_emb_local.clone(),
                 cfg,
                 layer_idx,
+                donor_flags[layer_idx],
+                kv_shared_layer_index,
                 vb_l.pp(layer_idx),
             )?;
             layers.push(layer)
@@ -565,10 +1037,15 @@ impl TextModel {
         let lm_head = if cfg.tie_word_embeddings {
             Linear::new(embed_tokens.embeddings().clone(), None)
         } else {
-            candle_nn::linear_no_bias(cfg.hidden_size, cfg.vocab_size, vb.pp("lm_head"))?
+            let vb_lm_head =
+                find_text_weights_root(&vb, "lm_head.weight").unwrap_or_else(|| vb_m.clone());
+            candle_nn::linear_no_bias(cfg.hidden_size, cfg.vocab_size, vb_lm_head.pp("lm_head"))?
         };
         Ok(Self {
             embed_tokens,
+            embed_tokens_per_layer,
+            per_layer_model_projection,
+            per_layer_projection_norm,
             layers,
             norm,
             lm_head,
@@ -576,7 +1053,11 @@ impl TextModel {
             device: vb.device().clone(),
             dtype: vb.dtype(),
             hidden_size: cfg.hidden_size,
-            sliding_window: cfg.sliding_window,
+            hidden_size_per_layer_input: ple_dim,
+            num_hidden_layers: cfg.num_hidden_layers,
+            per_layer_input_scale: 2f64.powf(-0.5),
+            per_layer_projection_scalar: (cfg.hidden_size as f64).powf(-0.5),
+            sliding_window: cfg.effective_sliding_window(),
         })
     }
 
@@ -610,17 +1091,69 @@ impl TextModel {
 
     pub fn embed_tokens(&self, input_ids: &Tensor) -> Result<Tensor> {
         let xs = self.embed_tokens.forward(input_ids)?;
-        xs * (self.hidden_size as f64).sqrt()
+        let scale = (self.hidden_size as f64).sqrt();
+        xs * scale
     }
 
     pub fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
         let (b_size, seq_len) = input_ids.dims2()?;
         let xs = self.embed_tokens(input_ids)?;
-        self.forward_embeds(&xs, seqlen_offset, b_size, seq_len)
+        self.forward_embeds(input_ids, &xs, seqlen_offset, b_size, seq_len)
+    }
+
+    fn compute_ple(
+        &self,
+        input_ids: &Tensor,
+        inputs_embeds: &Tensor,
+    ) -> Result<Option<Vec<Tensor>>> {
+        if self.hidden_size_per_layer_input == 0 {
+            return Ok(None);
+        }
+
+        let ple_emb = self
+            .embed_tokens_per_layer
+            .as_ref()
+            .expect("PLE embedding missing");
+        let ple_proj = self
+            .per_layer_model_projection
+            .as_ref()
+            .expect("PLE projection missing");
+        let ple_norm = self
+            .per_layer_projection_norm
+            .as_ref()
+            .expect("PLE norm missing");
+
+        let ple_dim = self.hidden_size_per_layer_input;
+        let (b_size, seq_len, _) = inputs_embeds.dims3()?;
+        let ple_input_ids = if input_ids.device().is_cuda() {
+            input_ids.to_device(&Device::Cpu)?
+        } else {
+            input_ids.clone()
+        };
+        let embedded = ple_emb.forward(&ple_input_ids)?;
+        let embedded = (embedded * (ple_dim as f64).sqrt())?;
+        let embedded = embedded.reshape((b_size, seq_len, self.num_hidden_layers, ple_dim))?;
+        let embedded = embedded
+            .to_device(inputs_embeds.device())?
+            .to_dtype(inputs_embeds.dtype())?;
+
+        let projected = ple_proj.forward(inputs_embeds)?;
+        let projected = (projected * self.per_layer_projection_scalar)?;
+        let projected = projected.reshape((b_size, seq_len, self.num_hidden_layers, ple_dim))?;
+        let projected = ple_norm.forward(&projected)?;
+
+        let combined = ((projected + embedded)? * self.per_layer_input_scale)?;
+        let combined = combined.transpose(1, 2)?.contiguous()?;
+        let mut per_layer_inputs = Vec::with_capacity(self.num_hidden_layers);
+        for layer_idx in 0..self.num_hidden_layers {
+            per_layer_inputs.push(combined.narrow(1, layer_idx, 1)?.squeeze(1)?);
+        }
+        Ok(Some(per_layer_inputs))
     }
 
     pub fn forward_embeds(
         &mut self,
+        input_ids: &Tensor,
         xs: &Tensor,
         seqlen_offset: usize,
         batch_size: usize,
@@ -629,14 +1162,36 @@ impl TextModel {
         let (attention_mask, sliding_attention_mask) =
             self.create_attention_masks(batch_size, seq_len, seqlen_offset)?;
 
+        let per_layer_inputs = self.compute_ple(input_ids, xs)?;
         let mut xs = xs.clone();
-        for layer in self.layers.iter_mut() {
+        for layer_idx in 0..self.layers.len() {
+            let (before, current_and_after) = self.layers.split_at_mut(layer_idx);
+            let layer = &mut current_and_after[0];
+            let donor_kv = if let Some(donor_idx) = layer.self_attn.kv_shared_layer_index {
+                let donor = before.get(donor_idx).ok_or_else(|| {
+                    candle::Error::msg(format!(
+                        "Gemma4 shared KV layer {layer_idx} cannot find donor layer {donor_idx}"
+                    ))
+                })?;
+                Some(donor.self_attn.cached_kv()?.ok_or_else(|| {
+                    candle::Error::msg(format!(
+                        "Gemma4 shared KV layer {layer_idx} expected donor layer {donor_idx} cache to be populated"
+                    ))
+                })?)
+            } else {
+                None
+            };
+            let per_layer_input = per_layer_inputs
+                .as_ref()
+                .and_then(|inputs| inputs.get(layer_idx));
             xs = layer.forward(
                 &xs,
+                per_layer_input,
                 attention_mask.as_ref(),
                 sliding_attention_mask.as_ref(),
+                donor_kv.as_ref(),
                 seqlen_offset,
-            )?
+            )?;
         }
         let logits = xs
             .narrow(1, seq_len - 1, 1)?
@@ -644,7 +1199,11 @@ impl TextModel {
             .apply(&self.lm_head)?;
         match self.final_logit_softcapping {
             None => Ok(logits),
-            Some(sc) => Ok(((logits / sc)?.tanh()? * sc)?),
+            Some(sc) => {
+                let logits_dtype = logits.dtype();
+                let logits = logits.to_dtype(DType::F32)?;
+                Ok(((logits / sc)?.tanh()? * sc)?.to_dtype(logits_dtype)?)
+            }
         }
     }
 


### PR DESCRIPTION
### Description
Adds support for Gemma 4 Instruct variants with shared KV layers, adaptive MLP sizing, and configurable RoPE.

### Key Changes
- **Shared KV layers**: reuse key/value states across layers (`num_kv_shared_layers`)
- **Expanded MLPs**: optional double-width MLP for KV-sharing layers (`use_double_wide_mlp`)
- **Configurable RoPE**: finer control via `Gemma4RopeParameters`
- **Debug flags**: `CANDLE_GEMMA4_DISABLE_SHARED_KV`, `CANDLE_GEMMA4_DISABLE_PLE`
- **Refactoring**: updates to model, decoder, and attention for KV sharing

### Modified Files
- `gemma4/config.rs`: config + RoPE params  
- `gemma4/text.rs`: KV sharing + adaptive layers  
- `rotary_emb.rs`: RoPE updates  
- `examples/gemma4/main.rs`: updated example