### PR TITLE
fix(metal): add x86 Mac/Intel GPU support for Metal backend

### DIFF
--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -309,6 +309,10 @@ impl QMetalStorage {
             [vec![1; 4 - src_shape.rank()], src_shape.dims().to_vec()].concat(),
         );
 
+        if device.device().device_type() == candle_metal_kernels::metal::MetalDeviceType::IntelMac {
+            return self.fwd_mv(self_shape, storage, layout);
+        }
+
         candle_metal_kernels::call_quantized_matmul_mm_t(
             device.device(),
             &encoder,

--- a/candle-metal-kernels/src/kernel.rs
+++ b/candle-metal-kernels/src/kernel.rs
@@ -60,11 +60,15 @@ impl From<String> for KernelName {
 
 type Libraries = HashMap<Source, Library>;
 type Pipelines = HashMap<(KernelName, Option<ConstantValues>), ComputePipeline>;
+// Tracks kernel names that failed pipeline creation (e.g. unsupported on the current GPU).
+// Keyed by name alone since failing kernels are unconditionally unsupported.
+type FailedPipelines = std::collections::HashSet<KernelName>;
 
 #[derive(Debug)]
 pub struct Kernels {
     libraries: RwLock<Libraries>,
     pipelines: RwLock<Pipelines>,
+    failed_pipelines: RwLock<FailedPipelines>,
 }
 
 impl Default for Kernels {
@@ -77,9 +81,11 @@ impl Kernels {
     pub fn new() -> Self {
         let libraries = RwLock::new(Libraries::new());
         let pipelines = RwLock::new(Pipelines::new());
+        let failed_pipelines = RwLock::new(FailedPipelines::new());
         Self {
             libraries,
             pipelines,
+            failed_pipelines,
         }
     }
 
@@ -149,8 +155,21 @@ impl Kernels {
         name: impl Into<KernelName>,
         constants: Option<ConstantValues>,
     ) -> Result<ComputePipeline, MetalKernelError> {
+        let name: KernelName = name.into();
+
+        // Fast-path: return a cached failure for kernels that are known to be unsupported.
+        {
+            let failed = self.failed_pipelines.read()?;
+            if failed.contains(&name) {
+                return Err(MetalKernelError::FailedToCreatePipeline(format!(
+                    "kernel '{}' is not supported on this GPU (cached)",
+                    name.as_ref()
+                )));
+            }
+        }
+
         let mut pipelines = self.pipelines.write()?;
-        let key = (name.into(), constants);
+        let key = (name, constants);
         if let Some(pipeline) = pipelines.get(&key) {
             Ok(pipeline.clone())
         } else {
@@ -158,7 +177,13 @@ impl Kernels {
             let func = self.load_function(device, source, name.as_ref(), constants.as_ref())?;
             let pipeline = device
                 .new_compute_pipeline_state_with_function(&func)
-                .map_err(|e| MetalKernelError::FailedToCreatePipeline(e.to_string()))?;
+                .map_err(|e| {
+                    // Cache the failure so we don't retry this kernel.
+                    if let Ok(mut failed) = self.failed_pipelines.write() {
+                        failed.insert(name.clone());
+                    }
+                    MetalKernelError::FailedToCreatePipeline(e.to_string())
+                })?;
             pipelines.insert((name, constants), pipeline.clone());
 
             Ok(pipeline)

--- a/candle-metal-kernels/src/kernels/mlx_gemm.rs
+++ b/candle-metal-kernels/src/kernels/mlx_gemm.rs
@@ -139,8 +139,8 @@ fn select_tile_config(
                 }
             }
         }
-        // Medium devices: max ('s') and unknown
-        MetalDeviceType::Max | MetalDeviceType::Medium => {
+        // Medium devices: max ('s') and unknown (IntelMac uses naive GEMM, not this path)
+        MetalDeviceType::Max | MetalDeviceType::IntelMac | MetalDeviceType::Medium => {
             // MLX: default medium device config
             // Use the same logic as before but with medium device defaults
             match dtype {
@@ -409,7 +409,22 @@ pub fn call_mlx_gemm(
         trans_str, dtype_str, dtype_str, bm, bn, bk, wm, wn
     );
 
-    let pipeline = kernels.load_pipeline_with_constants(device, Source::Gemm, name, constants)?;
+    let naive_name = format!("naive_gemm_{}_{}", trans_str, dtype_str);
+    let (pipeline, use_naive) = if device_type == MetalDeviceType::IntelMac {
+        (
+            kernels.load_pipeline(device, Source::Gemm, naive_name)?,
+            true,
+        )
+    } else {
+        match kernels.load_pipeline_with_constants(device, Source::Gemm, name, constants) {
+            Ok(p) => (p, false),
+            Err(_) => {
+                let p = kernels.load_pipeline(device, Source::Gemm, naive_name)?;
+                (p, true)
+            }
+        }
+    };
+
     let encoder = ep.encoder();
     let encoder: &ComputeCommandEncoder = encoder.as_ref();
     encoder.set_compute_pipeline_state(&pipeline);
@@ -437,19 +452,34 @@ pub fn call_mlx_gemm(
         )
     );
 
-    let grid_size = MTLSize {
-        width: tn,
-        height: tm,
-        depth: /* batch_size_out */ b,
-    };
-    let group_size = MTLSize {
-        width: 32,
-        height: wn,
-        depth: wm,
-    };
     encoder.use_resource(lhs_buffer, MTLResourceUsage::Read);
     encoder.use_resource(rhs_buffer, MTLResourceUsage::Read);
     encoder.use_resource(output, MTLResourceUsage::Write);
-    encoder.dispatch_thread_groups(grid_size, group_size);
+
+    if use_naive {
+        let group_size = MTLSize {
+            width: 8,
+            height: 8,
+            depth: 1,
+        };
+        let grid_size = MTLSize {
+            width: m.div_ceil(group_size.width),
+            height: n.div_ceil(group_size.height),
+            depth: b,
+        };
+        encoder.dispatch_thread_groups(grid_size, group_size);
+    } else {
+        let grid_size = MTLSize {
+            width: tn,
+            height: tm,
+            depth: /* batch_size_out */ b,
+        };
+        let group_size = MTLSize {
+            width: 32,
+            height: wn,
+            depth: wm,
+        };
+        encoder.dispatch_thread_groups(grid_size, group_size);
+    }
     Ok(())
 }

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -2,7 +2,7 @@ use crate::utils::EncoderProvider;
 use crate::{set_params, Buffer, ComputeCommandEncoder, Device, Kernels, MetalKernelError, Source};
 use objc2_metal::{MTLResourceUsage, MTLSize};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GgmlDType {
     Q4_0,
     Q4_1,

--- a/candle-metal-kernels/src/metal/device.rs
+++ b/candle-metal-kernels/src/metal/device.rs
@@ -25,6 +25,8 @@ pub enum MetalDeviceType {
     Max,
     /// Ultra device (M1/M2 Ultra, 'd' suffix)
     Ultra,
+    /// Intel GPU on x86 Mac (no architecture name available, no simdgroup_matrix)
+    IntelMac,
     /// Unknown or medium device (default)
     Medium,
 }
@@ -133,6 +135,8 @@ impl Device {
     /// - 'g': base/pro
     /// - 's': max
     /// - 'd': ultra
+    ///
+    /// Returns `"unknown"` if the architecture is not available (e.g., on x86 Macs).
     pub fn architecture_name(&self) -> String {
         // On tvOS/iOS simulators the emulated Metal device returns NULL from
         // -[MTLDevice architecture], which causes objc2 to panic.  Guard
@@ -151,6 +155,9 @@ impl Device {
     /// Reference: refs/mlx/mlx/backend/metal/device.cpp
     pub fn device_type(&self) -> MetalDeviceType {
         let arch = self.architecture_name();
+        if arch == "unknown" && cfg!(target_arch = "x86_64") {
+            return MetalDeviceType::IntelMac;
+        }
         match arch.chars().last() {
             Some('p') => MetalDeviceType::Phone,
             Some('g') => MetalDeviceType::BasePro,

--- a/candle-metal-kernels/src/metal_src/mlx_gemm.metal
+++ b/candle-metal-kernels/src/metal_src/mlx_gemm.metal
@@ -1481,3 +1481,59 @@ instantiate_gemm_transpose_helper(f16, half, f16, half, 32, 64, 16, 1, 2)
 #if defined(__HAVE_BFLOAT__)
 instantiate_gemm_transpose_helper(bf16, bfloat, bf16, bfloat, 32, 64, 16, 1, 2)
 #endif
+
+// ============================================================
+// Naive GEMM fallback for GPUs without simdgroup_matrix support
+// (e.g., Intel integrated GPUs on x86 Macs).
+// Uses one thread per output element — slow but universally compatible.
+// Buffer layout intentionally matches the main gemm kernel.
+// ============================================================
+
+template<typename T, bool ta, bool tb>
+[[kernel]] void naive_gemm(
+    const device T *A              [[buffer(0)]],
+    const device T *B              [[buffer(1)]],
+    device T *D                    [[buffer(3)]],
+    constant GEMMParams &params    [[buffer(4)]],
+    constant int &batch_size       [[buffer(6)]],
+    constant long *batch_strides   [[buffer(7)]],
+    uint3 gid [[thread_position_in_grid]])
+{
+    const int row   = gid.x;
+    const int col   = gid.y;
+    const int batch = gid.z;
+
+    if (row >= params.M || col >= params.N) return;
+
+    A += batch_strides[0] * batch;
+    B += batch_strides[1] * batch;
+    D += params.batch_stride_d * (size_t)batch;
+
+    float acc = 0.0f;
+    for (int k = 0; k < params.K; k++) {
+        const float a = ta ? float(A[k * params.lda + row]) : float(A[row * params.lda + k]);
+        const float b = tb ? float(B[col * params.ldb + k]) : float(B[k * params.ldb + col]);
+        acc += a * b;
+    }
+    D[row * params.ldd + col] = T(acc);
+}
+
+typedef decltype(naive_gemm<float, false, false>) naive_gemm_f32_t;
+template [[host_name("naive_gemm_nn_f32")]] kernel naive_gemm_f32_t naive_gemm<float, false, false>;
+template [[host_name("naive_gemm_tn_f32")]] kernel naive_gemm_f32_t naive_gemm<float, true,  false>;
+template [[host_name("naive_gemm_nt_f32")]] kernel naive_gemm_f32_t naive_gemm<float, false, true>;
+template [[host_name("naive_gemm_tt_f32")]] kernel naive_gemm_f32_t naive_gemm<float, true,  true>;
+
+typedef decltype(naive_gemm<half, false, false>) naive_gemm_f16_t;
+template [[host_name("naive_gemm_nn_f16")]] kernel naive_gemm_f16_t naive_gemm<half, false, false>;
+template [[host_name("naive_gemm_tn_f16")]] kernel naive_gemm_f16_t naive_gemm<half, true,  false>;
+template [[host_name("naive_gemm_nt_f16")]] kernel naive_gemm_f16_t naive_gemm<half, false, true>;
+template [[host_name("naive_gemm_tt_f16")]] kernel naive_gemm_f16_t naive_gemm<half, true,  true>;
+
+#if defined(__HAVE_BFLOAT__)
+typedef decltype(naive_gemm<bfloat, false, false>) naive_gemm_bf16_t;
+template [[host_name("naive_gemm_nn_bf16")]] kernel naive_gemm_bf16_t naive_gemm<bfloat, false, false>;
+template [[host_name("naive_gemm_tn_bf16")]] kernel naive_gemm_bf16_t naive_gemm<bfloat, true,  false>;
+template [[host_name("naive_gemm_nt_bf16")]] kernel naive_gemm_bf16_t naive_gemm<bfloat, false, true>;
+template [[host_name("naive_gemm_tt_bf16")]] kernel naive_gemm_bf16_t naive_gemm<bfloat, true,  true>;
+#endif

--- a/candle-metal-kernels/src/metal_src/scaled_dot_product_attention.metal
+++ b/candle-metal-kernels/src/metal_src/scaled_dot_product_attention.metal
@@ -258,6 +258,7 @@ bfloat_inplace_op_addr_space_helper(/, operator/=);
 /////////////////////////////////////////////////////////////////////////////
 
 typedef struct _MLX_BFloat16 bfloat16_t;
+typedef half float16_t;
 
 #endif
 


### PR DESCRIPTION
Fixes multiple issues preventing Metal from working on x86 Macs with Intel integrated GPUs:

- Add MetalDeviceType::IntelMac variant, detected via empty architecture name on x86_64
- Add naive GEMM fallback for GPUs without simdgroup_matrix support (mlx_gemm.metal)
- Route IntelMac directly to naive GEMM, skipping doomed simdgroup pipeline attempts (mlx_gemm.rs)
- Route IntelMac quantized matmul to mv path, bypassing mm kernels (metal.rs)
- Cache failed pipeline creation to avoid repeated attempts (kernel.rs)
- Define float16_t for Intel GPU compatibility (scaled_dot_product_attention.metal)