### PR TITLE
fix: make tokenizers dependency optional (left on by default though) in candle-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ candle-flash-attn = { path = "./candle-flash-attn", version = "0.10.2" }
 candle-flash-attn-v3 = { path = "./candle-flash-attn-v3", version = "0.10.2" }
 candle-kernels = { path = "./candle-kernels", version = "0.10.2" }
 candle-metal-kernels = { path = "./candle-metal-kernels", version = "0.10.2" }
-candle-nn = { path = "./candle-nn", version = "0.10.2" }
+candle-nn = { path = "./candle-nn", version = "0.10.2", default-features = false }
 candle-onnx = { path = "./candle-onnx", version = "0.10.2" }
 candle-transformers = { path = "./candle-transformers", version = "0.10.2" }
 candle-ug = { path = "./candle-ug", version = "0.10.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ ab_glyph = "0.2.23"
 accelerate-src = { version = "0.3.2" }
 anyhow = { version = "1", features = ["backtrace"] }
 byteorder = "1.4.3"
-candle = { path = "./candle-core", package = "candle-core", version = "0.10.2" }
+candle = { path = "./candle-core", package = "candle-core", version = "0.10.2", default-features = false }
 candle-datasets = { path = "./candle-datasets", version = "0.10.2" }
 candle-flash-attn = { path = "./candle-flash-attn", version = "0.10.2" }
 candle-flash-attn-v3 = { path = "./candle-flash-attn-v3", version = "0.10.2" }

--- a/candle-book/Cargo.toml
+++ b/candle-book/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 accelerate-src = { workspace = true, optional = true }
 candle = { workspace = true, features = ["default"] }
 candle-datasets = { workspace = true }
-candle-nn = { workspace = true }
+candle-nn = { workspace = true, features = ["default"] }
 candle-transformers = { workspace = true }
 candle-flash-attn = { workspace = true, optional = true }
 safetensors = { workspace = true }

--- a/candle-book/Cargo.toml
+++ b/candle-book/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 accelerate-src = { workspace = true, optional = true }
-candle = { workspace = true }
+candle = { workspace = true, features = ["default"] }
 candle-datasets = { workspace = true }
 candle-nn = { workspace = true }
 candle-transformers = { workspace = true }

--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = { workspace = true }
 yoke = { workspace = true }
 zip = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokenizers = { workspace = true, features = ["onig"] }
+tokenizers = { workspace = true, features = ["onig"], optional = true }
 
 [target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "ios")))'.dependencies]
 candle-ug = { workspace = true, optional = true }
@@ -45,7 +45,8 @@ clap = { workspace = true }
 criterion = { workspace = true }
 
 [features]
-default = []
+default = ["tokenizers"]
+tokenizers = ["dep:tokenizers"]
 cuda = ["cudarc", "dep:candle-kernels", "candle-ug?/cuda"]
 cudnn = ["cuda", "cudarc/cudnn"]
 nccl = ["cuda", "cudarc/nccl"]

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -14,7 +14,7 @@ pub mod imatrix_file;
 pub mod k_quants;
 #[cfg(feature = "metal")]
 pub mod metal;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "tokenizers"))]
 pub mod tokenizer;
 #[cfg(not(feature = "metal"))]
 mod metal {

--- a/candle-datasets/Cargo.toml
+++ b/candle-datasets/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 byteorder = { workspace = true }
 candle = { workspace = true, features = ["default"] }
-candle-nn = { workspace = true }
+candle-nn = { workspace = true, features = ["default"] }
 hf-hub = { workspace = true}
 intel-mkl-src = { workspace = true, optional = true }
 memmap2 = { workspace = true }

--- a/candle-datasets/Cargo.toml
+++ b/candle-datasets/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 byteorder = { workspace = true }
-candle = { workspace = true }
+candle = { workspace = true, features = ["default"] }
 candle-nn = { workspace = true }
 hf-hub = { workspace = true}
 intel-mkl-src = { workspace = true, optional = true }

--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 accelerate-src = { workspace = true, optional = true }
-candle = { workspace = true }
+candle = { workspace = true, features = ["default"] }
 candle-datasets = { workspace = true, optional = true }
 candle-nn = { workspace = true }
 candle-transformers = { workspace = true }

--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 accelerate-src = { workspace = true, optional = true }
 candle = { workspace = true, features = ["default"] }
 candle-datasets = { workspace = true, optional = true }
-candle-nn = { workspace = true }
+candle-nn = { workspace = true, features = ["default"] }
 candle-transformers = { workspace = true }
 candle-flash-attn = { workspace = true, optional = true }
 candle-onnx = { workspace = true, optional = true }

--- a/candle-nn/Cargo.toml
+++ b/candle-nn/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 accelerate-src = { workspace = true, optional = true }
-candle = { workspace = true }
+candle = { workspace = true, default-features = false }
 half = { workspace = true }
 thiserror = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
@@ -31,7 +31,8 @@ rand_distr = { workspace = true }
 criterion = { workspace = true }
 
 [features]
-default = []
+default = ["candle/default"]
+tokenizers = ["candle/tokenizers"]
 accelerate = ["dep:accelerate-src", "candle/accelerate"]
 cuda = ["candle/cuda"]
 cudnn = ["candle/cudnn"]

--- a/candle-pyo3/Cargo.toml
+++ b/candle-pyo3/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 [dependencies]
 accelerate-src = { workspace = true, optional = true }
 candle = { workspace = true, features = ["default"] }
-candle-nn = { workspace = true }
+candle-nn = { workspace = true, features = ["default"] }
 candle-onnx = { workspace = true, optional = true }
 half = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }

--- a/candle-pyo3/Cargo.toml
+++ b/candle-pyo3/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 accelerate-src = { workspace = true, optional = true }
-candle = { workspace = true }
+candle = { workspace = true, features = ["default"] }
 candle-nn = { workspace = true }
 candle-onnx = { workspace = true, optional = true }
 half = { workspace = true }

--- a/candle-transformers/Cargo.toml
+++ b/candle-transformers/Cargo.toml
@@ -14,7 +14,7 @@ accelerate-src = { workspace = true, optional = true }
 byteorder = { workspace = true }
 candle = { workspace = true, default-features = false }
 candle-flash-attn = { workspace = true, optional = true }
-candle-nn = { workspace = true }
+candle-nn = { workspace = true, default-features = false }
 fancy-regex = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
 num-traits = { workspace = true }

--- a/candle-transformers/Cargo.toml
+++ b/candle-transformers/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 accelerate-src = { workspace = true, optional = true }
 byteorder = { workspace = true }
-candle = { workspace = true }
+candle = { workspace = true, default-features = false }
 candle-flash-attn = { workspace = true, optional = true }
 candle-nn = { workspace = true }
 fancy-regex = { workspace = true }
@@ -26,7 +26,8 @@ serde_plain = { workspace = true }
 tracing = { workspace = true }
 
 [features]
-default = []
+default = ["candle/default", "candle-nn/default"]
+tokenizers = ["candle/tokenizers", "candle-nn/tokenizers"]
 accelerate = ["dep:accelerate-src", "candle/accelerate", "candle-nn/accelerate"]
 cuda = ["candle/cuda", "candle-nn/cuda"]
 cudnn = ["candle/cudnn", "candle-nn/cudnn"]

--- a/candle-wasm-tests/Cargo.toml
+++ b/candle-wasm-tests/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-candle = { workspace = true }
+candle = { workspace = true, features = ["default"] }
 rand = { workspace = true }
 getrandom = { version = "0.2", features = ["js"] }
 

--- a/tensor-tools/Cargo.toml
+++ b/tensor-tools/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-candle = { workspace = true }
+candle = { workspace = true, features = ["default"] }
 clap = { workspace = true }
 rayon = { workspace = true }
 safetensors = { workspace = true }


### PR DESCRIPTION
## Problem

candle-core 0.10 added an unconditional (non-wasm) dependency on `tokenizers` with the `onig` feature to support the new `quantized::tokenizer` module (GGUF tokenizer loading). This pulls the Oniguruma C regex library into every consumer of candle-core, even those that only use it for tensor operations or safetensors-based model loading.

Because candle-nn and candle-transformers depend on candle-core with default features, and Cargo unifies features across the dependency graph, downstream consumers have **no way to opt out** — even setting `default-features = false` on their own candle-core dependency doesn't help.

## Fix

Makes the `tokenizers` dependency **opt-out** (default on, so no breaking change):

**candle-core:**
- `tokenizers` is now `optional = true`
- New `tokenizers` feature flag, included in `default`
- `quantized::tokenizer` module gated behind `#[cfg(feature = "tokenizers")]`

**candle-nn / candle-transformers:**
- Forward the `tokenizers` feature through their own feature flags, following the existing pattern used for `cuda`, `metal`, `accelerate`, etc.
- Depend on candle-core (and candle-nn, for transformers) with `default-features = false`, re-enabling defaults via their own `default` feature

**Workspace:**
- Root `Cargo.toml` declares `candle` and `candle-nn` with `default-features = false`
- All other workspace members (examples, book, datasets, pyo3, wasm-tests, tensor-tools) explicitly enable `features = ["default"]`

### For existing consumers

**No change needed.** Default features include `tokenizers`, so the existing API surface is identical.

### To opt out

```toml
candle-core = { version = "0.10", default-features = false }
candle-nn = { version = "0.10", default-features = false }
candle-transformers = { version = "0.10", default-features = false }
```

## Testing

- `cargo check -p candle-transformers` passes with defaults (tokenizers included)
- `cargo check -p candle-transformers --no-default-features` passes without tokenizers
- Downstream project ([memory-mcp](https://github.com/butterflyskies/memory-mcp)) passes all 109 tests with the opt-out, confirmed `onig` is fully eliminated from the dependency tree