### PR TITLE
candle-kernels: build cleanly for Pascal (sm_60) and other pre-Volta GPUs

### DIFF
--- a/candle-kernels/build.rs
+++ b/candle-kernels/build.rs
@@ -21,33 +21,50 @@ fn main() -> Result<()> {
 
     bindings.write(&ptx_path)?;
 
+    // Detect compute capability up front so we can conditionally select
+    // kernel sources. The pre-Volta swap below depends on it; the bf16
+    // gate further down also reuses this value.
+    let compute_cap = cudaforge::detect_compute_cap()
+        .map(|arch| arch.base())
+        .unwrap_or(80);
+
+    // moe_wmma.cu and moe_wmma_gguf.cu both rely on `nvcuda::wmma`, which
+    // requires Volta+ tensor cores (sm >= 70). On Pascal (sm 60) and older
+    // they fail to compile with "namespace wmma not found". Substitute an
+    // aborting stub so the static link still resolves; dense models don't
+    // exercise these paths and MoE models can't run on Pascal regardless.
+    let wmma_sources: &[&str] = if compute_cap < 70 {
+        &["src/moe/moe_wmma_stub.cu"]
+    } else {
+        &["src/moe/moe_wmma.cu", "src/moe/moe_wmma_gguf.cu"]
+    };
+
     let mut moe_builder = KernelBuilder::default()
-        .source_files(vec![
-            "src/moe/moe_gguf.cu",
-            "src/moe/moe_wmma.cu",
-            "src/moe/moe_wmma_gguf.cu",
-            "src/mmvq_gguf.cu",
-            "src/mmq_gguf/mmq_quantize.cu",
-            "src/mmq_gguf/mmq_instance_q4_0.cu",
-            "src/mmq_gguf/mmq_instance_q4_1.cu",
-            "src/mmq_gguf/mmq_instance_q5_0.cu",
-            "src/mmq_gguf/mmq_instance_q5_1.cu",
-            "src/mmq_gguf/mmq_instance_q8_0.cu",
-            "src/mmq_gguf/mmq_instance_q2_k.cu",
-            "src/mmq_gguf/mmq_instance_q3_k.cu",
-            "src/mmq_gguf/mmq_instance_q4_k.cu",
-            "src/mmq_gguf/mmq_instance_q5_k.cu",
-            "src/mmq_gguf/mmq_instance_q6_k.cu",
-        ])
+        .source_files({
+            let mut files = vec!["src/moe/moe_gguf.cu"];
+            files.extend_from_slice(wmma_sources);
+            files.extend_from_slice(&[
+                "src/mmvq_gguf.cu",
+                "src/mmq_gguf/mmq_quantize.cu",
+                "src/mmq_gguf/mmq_instance_q4_0.cu",
+                "src/mmq_gguf/mmq_instance_q4_1.cu",
+                "src/mmq_gguf/mmq_instance_q5_0.cu",
+                "src/mmq_gguf/mmq_instance_q5_1.cu",
+                "src/mmq_gguf/mmq_instance_q8_0.cu",
+                "src/mmq_gguf/mmq_instance_q2_k.cu",
+                "src/mmq_gguf/mmq_instance_q3_k.cu",
+                "src/mmq_gguf/mmq_instance_q4_k.cu",
+                "src/mmq_gguf/mmq_instance_q5_k.cu",
+                "src/mmq_gguf/mmq_instance_q6_k.cu",
+            ]);
+            files
+        })
         .arg("--expt-relaxed-constexpr")
         .arg("-std=c++17")
         .arg("-O3");
 
     // Disable bf16 WMMA kernels on GPUs older than sm_80 (Ampere).
     // bf16 WMMA fragments require compute capability >= 8.0.
-    let compute_cap = cudaforge::detect_compute_cap()
-        .map(|arch| arch.base())
-        .unwrap_or(80);
     if compute_cap < 80 {
         moe_builder = moe_builder.arg("-DNO_BF16_KERNEL");
     }

--- a/candle-kernels/src/moe/moe_wmma_stub.cu
+++ b/candle-kernels/src/moe/moe_wmma_stub.cu
@@ -1,0 +1,75 @@
+/*
+ * Stub replacements for moe_wmma.cu and moe_wmma_gguf.cu on Pascal (sm_60)
+ * and other pre-Volta GPUs without tensor cores.
+ *
+ * Why this file exists
+ * --------------------
+ *
+ * `moe_wmma.cu` and `moe_wmma_gguf.cu` use `nvcuda::wmma` tensor-core
+ * fragments (Volta+, sm_70+). Compiling them for sm_60 fails with
+ * "unsupported function" / undeclared identifier errors because the
+ * `wmma` namespace and matrix fragment intrinsics simply don't exist
+ * for that target.
+ *
+ * Dense models (Llama, Qwen, Gemma, Phi, etc.) do not exercise the MoE
+ * GEMM path at all, so we provide stubs that abort with a clear error
+ * message in the unlikely event a Pascal user actually invokes a MoE
+ * model. This keeps the static link satisfied without forcing every
+ * Pascal user to manually patch their build.
+ *
+ * Mixtral and other MoE models cannot run on Pascal regardless of this
+ * stub — the abort just makes the failure mode obvious instead of a
+ * cryptic linker error at build time.
+ *
+ * The build system (`candle-kernels/build.rs`) substitutes this file
+ * for `moe_wmma.cu` + `moe_wmma_gguf.cu` when `CUDA_COMPUTE_CAP < 70`.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+
+extern "C" void moe_gemm_wmma(
+    const void * /*input*/,
+    const void * /*weights*/,
+    const int *  /*sorted_token_ids*/,
+    const int *  /*expert_ids*/,
+    const float *  /*topk_weights*/,
+    void * /*output*/,
+    int *  /*expert_counts*/,
+    int *  /*expert_offsets*/,
+    int /*num_experts*/,
+    int /*topk*/,
+    int /*size_m*/,
+    int /*size_n*/,
+    int /*size_k*/,
+    int /*dtype*/,
+    bool /*is_prefill*/,
+    long long /*stream*/) {
+    fprintf(stderr,
+        "candle-kernels: moe_gemm_wmma called on a GPU without tensor cores "
+        "(sm < 70). MoE models like Mixtral are not supported on Pascal. "
+        "Aborting.\n");
+    std::abort();
+}
+
+extern "C" void moe_gemm_gguf_prefill(
+    const void * /*input*/,
+    const unsigned char * /*weights*/,
+    const int *  /*sorted_token_ids*/,
+    const int *  /*expert_ids*/,
+    const float *  /*topk_weights*/,
+    void * /*output*/,
+    int /*num_experts*/,
+    int /*topk*/,
+    int /*size_m*/,
+    int /*size_n*/,
+    int /*size_k*/,
+    int /*input_dtype*/,
+    int /*gguf_dtype*/,
+    long long /*stream*/) {
+    fprintf(stderr,
+        "candle-kernels: moe_gemm_gguf_prefill called on a GPU without "
+        "tensor cores (sm < 70). MoE prefill is not supported on Pascal. "
+        "Aborting.\n");
+    std::abort();
+}

--- a/candle-kernels/src/reduce.cu
+++ b/candle-kernels/src/reduce.cu
@@ -669,7 +669,13 @@ SOFTMAX_OP(__half, float, softmax_f16)
 RMSNORM_OP(__half, rmsnorm_f16)
 LAYERNORM_OP(__half, layernorm_f16)
 ROPE_OP(__half, rope_f16, rope_i_f16, rope_thd_f16)
+// SUM_OP for __half requires atomicAdd(__half *, __half), which is sm_70+.
+// Gate it separately so candle still compiles for Pascal (sm_60). On sm_60
+// callers will get an "unsupported reduction over __half" link error, which
+// is the correct failure mode — bf16 is gated the same way (>= 800).
+#if __CUDA_ARCH__ >= 700
 SUM_OP(__half, sum_f16)
+#endif
 FAST_OP(__half, fast_min_f16, fast_max_f16, fast_argmin_f16, fast_argmax_f16, fast_sum_f16)
 #endif
 


### PR DESCRIPTION
## Summary

Two compilation failures currently block `candle-kernels` for compute capability < 7.0:

1. **`reduce.cu` line 672** registers `SUM_OP(__half, sum_f16)` inside `#if __CUDA_ARCH__ >= 530`, but the `SUM_OP` macro internally calls `atomicAdd(__half *, __half)` (lines 576/589), which is **sm_70+ only**. There is no `atomicAdd` overload for `__half *` on Pascal — `cuda_fp16.hpp` only declares one for `__half2 *` starting at sm_60, and the scalar-half overload starts at sm_70.

   bf16 already has the parallel gate at `>= 800` for the same reason; this PR adds the matching `>= 700` gate for fp16.

2. **`moe/moe_wmma.cu` and `moe/moe_wmma_gguf.cu`** use `nvcuda::wmma` tensor-core fragments, which require **Volta+** (sm_70+). Compiling them for sm_60 fails with `namespace "nvcuda::wmma" has no member "fragment"` and similar errors.

   A new `moe_wmma_stub.cu` provides `extern "C"` aborting stubs for the two FFI symbols (`moe_gemm_wmma`, `moe_gemm_gguf_prefill`) so the static link resolves on pre-Volta. `build.rs` substitutes the stub when `cudaforge::detect_compute_cap()` reports `< 70`.

   Dense models (Llama, Qwen, Gemma, Phi, etc.) never invoke these MoE symbols; MoE models like Mixtral cannot run on Pascal regardless of this stub — the abort just makes the failure mode obvious instead of a cryptic linker error at build time.

## Why this matters

Pascal cards (P40 24GB, P100 16GB, GTX 10-series 8/11GB) remain in production use across HPC clusters, research labs, and homelab setups. They are the cheapest entry point for getting >= 16GB of compute-capable VRAM (used P100s are routinely $200-300). Restoring buildability for them broadens candle's hardware reach without affecting any existing supported configuration.

## Verified on

- **Tesla P100 PCIe 16GB** (sm_60), CUDA 12.8 + gcc-13 + Rust 1.93.1 on openSUSE MicroOS — `candle-kernels` builds clean, downstream `qwen-lora-train` example links and runs.
- No effect on sm >= 70 builds: the wmma sources are still the original files, the bf16 gate is unchanged, and the half-precision sum is still registered for any Volta+ target.

## Notes for review

- The half-precision `SUM_OP` gate could alternatively be unblocked on sm_60 with a software shim using `atomicCAS` on the containing 32-bit word. That's a larger change worth its own PR; this PR takes the conservative path of declaring it unsupported on pre-Volta (matching how bf16 is already handled).
- The `moe_wmma_stub.cu` aborts with a clear stderr message rather than returning silently. If you'd prefer a different error path (e.g. logging via `tracing`, or returning a sentinel), happy to adapt.
