### PR TITLE
README: add candle-3d (Lux3D) to Useful External Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ And then head over to
   out-of-the-box LoRA support for many models from Candle, which can be found
   [here](https://github.com/EricLBuehler/candle-lora/tree/master/candle-lora-transformers/examples).
 - [`candle-video`](https://github.com/FerrisMind/candle-video): Rust library for text-to-video generation (LTX-Video and related models) built on Candle, focused on fast, Python-free inference.
+- [`candle-3d`](https://github.com/FerrisMind/candle-3d): Clean-room Rust 3D inference toolkit for Pi3, Pi3X, and TripoSR with contract inspection and canonical weight tooling.
 - [`optimisers`](https://github.com/KGrewal1/optimisers): A collection of optimisers
   including SGD with momentum, AdaGrad, AdaDelta, AdaMax, NAdam, RAdam, and RMSprop.
 - [`candle-vllm`](https://github.com/EricLBuehler/candle-vllm): Efficient platform for inference and


### PR DESCRIPTION
Hi! I built **candle-3d / Lux3D** — a Rust-native clean-room 3D inference toolkit on top of Candle, focused on practical inference workflows and contract-driven model handling.

**Repository:** https://github.com/FerrisMind/candle-3d

### What it does

- Pi3 / Pi3X / TripoSR support
- clean-room contract inspection for model families
- canonical weight normalization and validation tooling
- CLI-first inference flows and geometry export (point cloud / mesh)

### Why this PR

I’m proposing to add `candle-3d` to README → **Useful External Resources** as an external community project (no maintenance burden on Candle team), similar to other ecosystem libraries already listed there.

### Added README entry

- [`candle-3d`](https://github.com/FerrisMind/candle-3d): Clean-room Rust 3D inference toolkit for Pi3, Pi3X, and TripoSR with contract inspection and canonical weight tooling.

### Notes

- This is an external project, independent from Candle core maintenance.
- Runtime is CUDA-first for validated paths.
- macOS Metal backend is noted as theoretically supported, but not yet fully validated in this repo.
