### PR TITLE
construct attention mask if seqlen > 1 for Qwen3 VL forward()

### DIFF
--- a/candle-transformers/src/models/qwen3_vl/mod.rs
+++ b/candle-transformers/src/models/qwen3_vl/mod.rs
@@ -67,7 +67,7 @@ impl Qwen3VLModel {
         seqlen_offsets: &[usize],
     ) -> Result<Tensor> {
         let (bs, seqlen) = input_ids.dims2()?;
-        let attention_mask = if seqlen <= 1 {
+        let attention_mask = if seqlen > 1 {
             Some(self.prepare_decoder_attention_mask(
                 bs,
                 seqlen,


### PR DESCRIPTION
We want to construct the attention mask if seqlen > 1, or else we get bidirectional attention during prefill. Suspected typo when writing condition.

This fixes #3505 