### PR TITLE
Fix backprop for `UpsampleNearest1D` and `UpsampleNearest2D`

### DIFF
--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -385,7 +385,7 @@ impl Tensor {
                         let kernel = Tensor::ones((c, 1, scale), arg.dtype(), arg.device())?;
                         let conv_sum = grad.conv1d(&kernel, 0, scale, 1, c)?;
                         let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = conv_sum;
+                        *sum_grad = sum_grad.add(&conv_sum)?;
                     }
                     Op::UpsampleNearest2D {
                         arg,
@@ -406,7 +406,7 @@ impl Tensor {
                             Tensor::ones((c, 1, scale_h, scale_w), arg.dtype(), arg.device())?;
                         let conv_sum = grad.conv2d(&kernel, 0, scale_h, 1, c)?;
                         let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = conv_sum;
+                        *sum_grad = sum_grad.add(&conv_sum)?;
                     }
                     Op::UpsampleBilinear2D { .. } => {
                         crate::bail!("backward not supported for upsample_bilinear2d")

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -535,6 +535,33 @@ fn test_flip_backprop() -> Result<()> {
     Ok(())
 }
 
+fn test_upsample_grad(device: &Device) -> Result<()> {
+    /* interpolate1d test */
+    let shape = (1, 1, 2);
+    let x = Var::ones(shape, DType::F64, device)?;
+    // source and destination dimensions are the same, so `interpolated` == `x`
+    let interpolated = x.interpolate1d(shape.2)?;
+    // this is effectively x + x, so each element of the gradient should be 2
+    let interpolated_plus_x = (&interpolated + x.as_tensor())?;
+    let grads = interpolated_plus_x.backward()?;
+    let grad_x = grads.get_id(x.id()).unwrap();
+    let expected_grad_x = Tensor::from_vec(vec![2., 2.], shape, device)?;
+    test_utils::assert_tensor_eq(grad_x, &expected_grad_x)?;
+
+    /* interpolate2d test */
+    let shape = (1, 1, 2, 2);
+    let x = Var::ones(shape, DType::F64, device)?;
+    // source and destination dimensions are the same, so `interpolated` == `x`
+    let interpolated = x.interpolate2d(shape.2, shape.3)?;
+    // this is effectively x + x, so each element of the gradient should be 2
+    let interpolated_plus_x = (&interpolated + x.as_tensor())?;
+    let grads = interpolated_plus_x.backward()?;
+    let grad_x = grads.get_id(x.id()).unwrap();
+    let expected_grad_x = Tensor::from_vec(vec![2., 2., 2., 2.], shape, device)?;
+    test_utils::assert_tensor_eq(grad_x, &expected_grad_x)?;
+    Ok(())
+}
+
 test_device!(
     simple_grad,
     simple_grad_cpu,
@@ -560,4 +587,10 @@ test_device!(
     binary_grad_cpu,
     binary_grad_gpu,
     binary_grad_metal
+);
+test_device!(
+    test_upsample_grad,
+    test_upsample_cpu,
+    test_upsample_gpu,
+    test_upsample_metal
 );


### PR DESCRIPTION
I came across a small bug in backprop for these two operators while putting together a PR for [this](https://github.com/huggingface/candle/issues/1241#issuecomment-3273340567). I don't have a use case that this was causing a problem in, but if my understanding of these operations is correct, then the test case I added in the first commit exercises these bugs.

the branches in `Tensor::backward` generally add the operation's partial gradient to the accumulated gradient stored in `grads`, so that it accumulates the total gradient from all of the different operations the tensor was used in. The bug was that in the case of these two operators, they simply overwrote the stored gradient rather than adding to it. If you check out the first commit you should get that the test that I added fails; and then checking out the next commit makes the test pass.