### PR TITLE
Improve backprop memory usage by not computing unnecessary gradients and detaching gradients earlier

### DIFF
--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -156,53 +156,45 @@ impl Tensor {
 
     pub fn backward(&self) -> Result<GradStore> {
         let mut sorted_nodes = Vec::new();
-        let mut already_seen = HashMap::new();
-        self.walk(&mut sorted_nodes, &mut already_seen);
-        let mut grads = GradStore::new();
-        grads.insert(self, self.ones_like()?.contiguous()?);
-        for node in sorted_nodes.iter() {
+        let mut should_track = HashMap::new();
+        self.walk(&mut sorted_nodes, &mut should_track);
+        let mut grads = GradStoreBuilder::new(self, should_track)?;
+        while let Some(node) = sorted_nodes.pop() {
             if node.is_variable() {
                 continue;
             }
             let grad = grads
                 .remove(node)
                 .expect("candle internal error - grad not populated");
-            // https://github.com/huggingface/candle/issues/1241
-            // Ideally, we would make these operations in place where possible to ensure that we
-            // do not have to allocate too often. Here we just call `.detach` to avoid computing
-            // the backprop graph of the backprop itself. This would be an issue for second order
-            // derivatives but these are out of scope at the moment.
-            let do_not_detach = CANDLE_GRAD_DO_NOT_DETACH.with(|b| *b);
-            let grad = if do_not_detach { grad } else { grad.detach() };
             if let Some(op) = node.op() {
                 match op {
                     Op::Binary(lhs, rhs, BinaryOp::Add) => {
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&grad)?;
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        *rhs_sum_grad = rhs_sum_grad.add(&grad)?;
+                        grads.modify_if_tracked(lhs, |lhs_sum_grad| lhs_sum_grad.add(&grad))?;
+                        grads.modify_if_tracked(rhs, |rhs_sum_grad| rhs_sum_grad.add(&grad))?;
                     }
                     Op::Binary(lhs, rhs, BinaryOp::Sub) => {
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&grad)?;
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        *rhs_sum_grad = rhs_sum_grad.sub(&grad)?;
+                        grads.modify_if_tracked(lhs, |lhs_sum_grad| lhs_sum_grad.add(&grad))?;
+                        grads.modify_if_tracked(rhs, |rhs_sum_grad| rhs_sum_grad.sub(&grad))?;
                     }
                     Op::Binary(lhs, rhs, BinaryOp::Mul) => {
-                        let lhs_grad = grad.mul(rhs)?;
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&lhs_grad)?;
-                        let rhs_grad = grad.mul(lhs)?;
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        *rhs_sum_grad = rhs_sum_grad.add(&rhs_grad)?;
+                        grads.modify_if_tracked(lhs, |lhs_sum_grad| {
+                            let lhs_grad = grad.mul(rhs)?;
+                            lhs_sum_grad.add(&lhs_grad)
+                        })?;
+                        grads.modify_if_tracked(rhs, |rhs_sum_grad| {
+                            let rhs_grad = grad.mul(lhs)?;
+                            rhs_sum_grad.add(&rhs_grad)
+                        })?;
                     }
                     Op::Binary(lhs, rhs, BinaryOp::Div) => {
-                        let lhs_grad = grad.div(rhs)?;
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&lhs_grad)?;
-                        let rhs_grad = grad.mul(lhs)?.div(&rhs.sqr()?)?;
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        *rhs_sum_grad = rhs_sum_grad.sub(&rhs_grad)?;
+                        grads.modify_if_tracked(lhs, |lhs_sum_grad| {
+                            let lhs_grad = grad.div(rhs)?;
+                            lhs_sum_grad.add(&lhs_grad)
+                        })?;
+                        grads.modify_if_tracked(rhs, |rhs_sum_grad| {
+                            let rhs_grad = grad.mul(lhs)?.div(&rhs.sqr()?)?;
+                            rhs_sum_grad.sub(&rhs_grad)
+                        })?;
                     }
                     Op::Binary(lhs, rhs, BinaryOp::Minimum)
                     | Op::Binary(lhs, rhs, BinaryOp::Maximum) => {
@@ -211,22 +203,26 @@ impl Tensor {
 
                         // If both masks are 1 one the same point, we want to scale the
                         // gradient by 0.5 rather than 1.
-                        let lhs_grad = mask_lhs.mul(&grad)?.div(&(&mask_rhs + 1.)?)?;
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&lhs_grad)?;
+                        grads.modify_if_tracked(lhs, |lhs_sum_grad| {
+                            let lhs_grad = mask_lhs.mul(&grad)?.div(&(&mask_rhs + 1.)?)?;
+                            lhs_sum_grad.add(&lhs_grad)
+                        })?;
 
-                        let rhs_grad = mask_rhs.mul(&grad)?.div(&(&mask_lhs + 1.)?)?;
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        *rhs_sum_grad = rhs_sum_grad.add(&rhs_grad)?;
+                        grads.modify_if_tracked(rhs, |rhs_sum_grad| {
+                            let rhs_grad = mask_rhs.mul(&grad)?.div(&(&mask_lhs + 1.)?)?;
+                            rhs_sum_grad.add(&rhs_grad)
+                        })?;
                     }
                     Op::WhereCond(pred, t, f) => {
                         let zeros = grad.zeros_like()?;
-                        let t_sum_grad = grads.or_insert(t)?;
-                        let t_grad = pred.where_cond(&grad, &zeros)?;
-                        *t_sum_grad = t_sum_grad.add(&t_grad)?;
-                        let f_sum_grad = grads.or_insert(f)?;
-                        let f_grad = pred.where_cond(&zeros, &grad)?;
-                        *f_sum_grad = f_sum_grad.add(&f_grad)?;
+                        grads.modify_if_tracked(t, |t_sum_grad| {
+                            let t_grad = pred.where_cond(&grad, &zeros)?;
+                            t_sum_grad.add(&t_grad)
+                        })?;
+                        grads.modify_if_tracked(f, |f_sum_grad| {
+                            let f_grad = pred.where_cond(&zeros, &grad)?;
+                            f_sum_grad.add(&f_grad)
+                        })?;
                     }
                     Op::Conv1D {
                         arg,
@@ -242,30 +238,33 @@ impl Tensor {
                         let out_size =
                             (grad_l_in - 1) * stride + dilation * (k_size - 1) + 1 - 2 * padding;
                         let out_padding = arg.dim(2)? - out_size;
-                        let grad_arg = grad.conv_transpose1d(
-                            kernel,
-                            *padding,
-                            out_padding,
-                            *stride,
-                            *dilation,
-                            /* groups */ 1,
-                        )?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad_arg)?;
 
-                        let grad_kernel = arg
-                            .transpose(0, 1)?
-                            .conv1d(&grad.transpose(0, 1)?, *padding, *dilation, *stride, 1)?
-                            .transpose(0, 1)?;
-                        let sum_grad = grads.or_insert(kernel)?;
-                        let (_, _, k0) = kernel.dims3()?;
-                        let (_, _, g_k0) = grad_kernel.dims3()?;
-                        let grad_kernel = if g_k0 != k0 {
-                            grad_kernel.narrow(2, 0, k0)?
-                        } else {
-                            grad_kernel
-                        };
-                        *sum_grad = sum_grad.add(&grad_kernel)?;
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let grad_arg = grad.conv_transpose1d(
+                                kernel,
+                                *padding,
+                                out_padding,
+                                *stride,
+                                *dilation,
+                                /* groups */ 1,
+                            )?;
+                            sum_grad.add(&grad_arg)
+                        })?;
+
+                        grads.modify_if_tracked(kernel, |sum_grad| {
+                            let grad_kernel = arg
+                                .transpose(0, 1)?
+                                .conv1d(&grad.transpose(0, 1)?, *padding, *dilation, *stride, 1)?
+                                .transpose(0, 1)?;
+                            let (_, _, k0) = kernel.dims3()?;
+                            let (_, _, g_k0) = grad_kernel.dims3()?;
+                            let grad_kernel = if g_k0 != k0 {
+                                grad_kernel.narrow(2, 0, k0)?
+                            } else {
+                                grad_kernel
+                            };
+                            sum_grad.add(&grad_kernel)
+                        })?;
                     }
                     Op::Conv2D {
                         arg,
@@ -281,29 +280,32 @@ impl Tensor {
                         let out_size =
                             (grad_h - 1) * stride + dilation * (k_h - 1) + 1 - 2 * padding;
                         let out_padding = arg.dim(2)? - out_size;
-                        let grad_arg = grad.conv_transpose2d(
-                            kernel,
-                            *padding,
-                            out_padding,
-                            *stride,
-                            *dilation,
-                        )?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad_arg)?;
 
-                        let grad_kernel = arg
-                            .transpose(0, 1)?
-                            .conv2d(&grad.transpose(0, 1)?, *padding, *dilation, *stride, 1)?
-                            .transpose(0, 1)?;
-                        let sum_grad = grads.or_insert(kernel)?;
-                        let (_, _, k0, k1) = kernel.dims4()?;
-                        let (_, _, g_k0, g_k1) = grad_kernel.dims4()?;
-                        let grad_kernel = if g_k0 != k0 || g_k1 != k1 {
-                            grad_kernel.narrow(2, 0, k0)?.narrow(3, 0, k1)?
-                        } else {
-                            grad_kernel
-                        };
-                        *sum_grad = sum_grad.add(&grad_kernel)?;
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let grad_arg = grad.conv_transpose2d(
+                                kernel,
+                                *padding,
+                                out_padding,
+                                *stride,
+                                *dilation,
+                            )?;
+                            sum_grad.add(&grad_arg)
+                        })?;
+
+                        grads.modify_if_tracked(kernel, |sum_grad| {
+                            let grad_kernel = arg
+                                .transpose(0, 1)?
+                                .conv2d(&grad.transpose(0, 1)?, *padding, *dilation, *stride, 1)?
+                                .transpose(0, 1)?;
+                            let (_, _, k0, k1) = kernel.dims4()?;
+                            let (_, _, g_k0, g_k1) = grad_kernel.dims4()?;
+                            let grad_kernel = if g_k0 != k0 || g_k1 != k1 {
+                                grad_kernel.narrow(2, 0, k0)?.narrow(3, 0, k1)?
+                            } else {
+                                grad_kernel
+                            };
+                            sum_grad.add(&grad_kernel)
+                        })?;
                     }
                     Op::ConvTranspose1D { .. } => Err(Error::BackwardNotSupported {
                         op: "conv-transpose1d",
@@ -316,276 +318,310 @@ impl Tensor {
                         dilation,
                         output_padding: _output_padding,
                     } => {
-                        let grad_arg = grad.conv2d(kernel, *padding, *stride, *dilation, 1)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad_arg)?;
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let grad_arg = grad.conv2d(kernel, *padding, *stride, *dilation, 1)?;
+                            sum_grad.add(&grad_arg)
+                        })?;
 
-                        let grad_kernel = grad
-                            .transpose(0, 1)?
-                            .conv2d(&arg.transpose(0, 1)?, *padding, *dilation, *stride, 1)?
-                            .transpose(0, 1)?;
-                        let sum_grad = grads.or_insert(kernel)?;
-                        let (_, _, k0, k1) = kernel.dims4()?;
-                        let (_, _, g_k0, g_k1) = grad_kernel.dims4()?;
-                        let grad_kernel = if g_k0 != k0 || g_k1 != k1 {
-                            grad_kernel.narrow(2, 0, k0)?.narrow(3, 0, k1)?
-                        } else {
-                            grad_kernel
-                        };
-                        *sum_grad = sum_grad.add(&grad_kernel)?;
+                        grads.modify_if_tracked(kernel, |sum_grad| {
+                            let grad_kernel = grad
+                                .transpose(0, 1)?
+                                .conv2d(&arg.transpose(0, 1)?, *padding, *dilation, *stride, 1)?
+                                .transpose(0, 1)?;
+                            let (_, _, k0, k1) = kernel.dims4()?;
+                            let (_, _, g_k0, g_k1) = grad_kernel.dims4()?;
+                            let grad_kernel = if g_k0 != k0 || g_k1 != k1 {
+                                grad_kernel.narrow(2, 0, k0)?.narrow(3, 0, k1)?
+                            } else {
+                                grad_kernel
+                            };
+                            sum_grad.add(&grad_kernel)
+                        })?;
                     }
                     Op::AvgPool2D {
                         arg,
                         kernel_size,
                         stride,
                     } => {
-                        if kernel_size != stride {
-                            crate::bail!("backward not supported for avgpool2d if ksize {kernel_size:?} != stride {stride:?}")
-                        }
-                        let (_n, _c, h, w) = arg.dims4()?;
-                        let grad_arg = grad.upsample_nearest2d(h, w)?;
-                        let grad_arg =
-                            (grad_arg * (1f64 / (kernel_size.0 * kernel_size.1) as f64))?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad_arg)?;
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            if kernel_size != stride {
+                                crate::bail!("backward not supported for avgpool2d if ksize {kernel_size:?} != stride {stride:?}")
+                            }
+                            let (_n, _c, h, w) = arg.dims4()?;
+                            let grad_arg = grad.upsample_nearest2d(h, w)?;
+                            let grad_arg =
+                                (grad_arg * (1f64 / (kernel_size.0 * kernel_size.1) as f64))?;
+                            sum_grad.add(&grad_arg)
+                        })?;
                     }
                     Op::MaxPool2D {
                         arg,
                         kernel_size,
                         stride,
                     } => {
-                        if kernel_size != stride {
-                            crate::bail!("backward not supported for maxpool2d if ksize {kernel_size:?} != stride {stride:?}")
-                        }
-                        let (_n, _c, h, w) = arg.dims4()?;
-                        // For computing the max-pool gradient, we compute a mask where a 1 means
-                        // that the element is the maximum, then we apply this mask to the
-                        // upsampled gradient (taking into account that multiple max may exist so
-                        // we scale the gradient for this case).
-                        let node_upsampled = node.upsample_nearest2d(h, w)?;
-                        let mask = arg.eq(&node_upsampled)?.to_dtype(arg.dtype())?;
-                        let avg = mask.avg_pool2d_with_stride(*kernel_size, *stride)?;
-                        let grad_arg = ((grad * avg)?.upsample_nearest2d(h, w)? * mask)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad_arg)?;
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            if kernel_size != stride {
+                                crate::bail!("backward not supported for maxpool2d if ksize {kernel_size:?} != stride {stride:?}")
+                            }
+                            let (_n, _c, h, w) = arg.dims4()?;
+                            // For computing the max-pool gradient, we compute a mask where a 1 means
+                            // that the element is the maximum, then we apply this mask to the
+                            // upsampled gradient (taking into account that multiple max may exist so
+                            // we scale the gradient for this case).
+                            let node_upsampled = node.upsample_nearest2d(h, w)?;
+                            let mask = arg.eq(&node_upsampled)?.to_dtype(arg.dtype())?;
+                            let avg = mask.avg_pool2d_with_stride(*kernel_size, *stride)?;
+                            let grad_arg = ((grad * avg)?.upsample_nearest2d(h, w)? * mask)?;
+                            sum_grad.add(&grad_arg)
+                        })?;
                     }
                     Op::UpsampleNearest1D { arg, target_size } => {
-                        let (_n, c, size) = arg.dims3()?;
-                        if target_size % size != 0 {
-                            crate::bail!("backward not supported for non integer upscaling factors")
-                        }
-                        let scale = target_size / size;
+                        grads.modify_if_tracked(arg, |_sum_grad| {
+                            let (_n, c, size) = arg.dims3()?;
+                            if target_size % size != 0 {
+                                crate::bail!(
+                                    "backward not supported for non integer upscaling factors"
+                                )
+                            }
+                            let scale = target_size / size;
 
-                        let kernel = Tensor::ones((c, 1, scale), arg.dtype(), arg.device())?;
-                        let conv_sum = grad.conv1d(&kernel, 0, scale, 1, c)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = conv_sum;
+                            let kernel = Tensor::ones((c, 1, scale), arg.dtype(), arg.device())?;
+                            let conv_sum = grad.conv1d(&kernel, 0, scale, 1, c)?;
+                            // `sum_grad` being unused is an existing bug;
+                            // see https://github.com/huggingface/candle/pull/3507
+                            Ok(conv_sum)
+                        })?;
                     }
                     Op::UpsampleNearest2D {
                         arg,
                         target_h,
                         target_w,
                     } => {
-                        let (_n, c, h, w) = arg.dims4()?;
-                        if target_h % h != 0 || target_w % w != 0 {
-                            crate::bail!("backward not supported for non integer upscaling factors")
-                        }
-                        let scale_h = target_h / h;
-                        let scale_w = target_w / w;
+                        grads.modify_if_tracked(arg, |_sum_grad| {
+                            let (_n, c, h, w) = arg.dims4()?;
+                            if target_h % h != 0 || target_w % w != 0 {
+                                crate::bail!(
+                                    "backward not supported for non integer upscaling factors"
+                                )
+                            }
+                            let scale_h = target_h / h;
+                            let scale_w = target_w / w;
 
-                        if scale_h != scale_w {
-                            crate::bail!("backward not supported for non uniform upscaling factors")
-                        };
-                        let kernel =
-                            Tensor::ones((c, 1, scale_h, scale_w), arg.dtype(), arg.device())?;
-                        let conv_sum = grad.conv2d(&kernel, 0, scale_h, 1, c)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = conv_sum;
+                            if scale_h != scale_w {
+                                crate::bail!(
+                                    "backward not supported for non uniform upscaling factors"
+                                )
+                            };
+                            let kernel =
+                                Tensor::ones((c, 1, scale_h, scale_w), arg.dtype(), arg.device())?;
+                            let conv_sum = grad.conv2d(&kernel, 0, scale_h, 1, c)?;
+                            // `sum_grad` being unused is an existing bug;
+                            // see https://github.com/huggingface/candle/pull/3507
+                            Ok(conv_sum)
+                        })?;
                     }
                     Op::UpsampleBilinear2D { .. } => {
                         crate::bail!("backward not supported for upsample_bilinear2d")
                     }
                     Op::SliceScatter0(lhs, rhs, start_rhs) => {
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        let rhs_grad = grad.narrow(0, *start_rhs, rhs.dim(0)?)?;
-                        *rhs_sum_grad = rhs_sum_grad.add(&rhs_grad)?;
+                        grads.modify_if_tracked(rhs, |rhs_sum_grad| {
+                            let rhs_grad = grad.narrow(0, *start_rhs, rhs.dim(0)?)?;
+                            rhs_sum_grad.add(&rhs_grad)
+                        })?;
 
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        let lhs_grad = grad.slice_scatter0(&rhs.zeros_like()?, *start_rhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&lhs_grad)?
+                        grads.modify_if_tracked(lhs, |lhs_sum_grad| {
+                            let lhs_grad = grad.slice_scatter0(&rhs.zeros_like()?, *start_rhs)?;
+                            lhs_sum_grad.add(&lhs_grad)
+                        })?;
                     }
                     Op::Gather(arg, indexes, dim) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.scatter_add(indexes, &grad, *dim)?;
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            sum_grad.scatter_add(indexes, &grad, *dim)
+                        })?;
                     }
                     Op::Scatter(init, indexes, src, dim) => {
-                        let init_sum_grad = grads.or_insert(init)?;
-                        *init_sum_grad = init_sum_grad.add(&grad)?;
+                        grads.modify_if_tracked(init, |init_sum_grad| init_sum_grad.add(&grad))?;
 
-                        let src_grad = grad.gather(indexes, *dim)?;
-                        let src_sum_grad = grads.or_insert(src)?;
-                        *src_sum_grad = src_sum_grad.add(&src_grad)?;
+                        grads.modify_if_tracked(src, |src_sum_grad| {
+                            let src_grad = grad.gather(indexes, *dim)?;
+                            src_sum_grad.add(&src_grad)
+                        })?;
                     }
                     Op::ScatterAdd(init, indexes, src, dim) => {
-                        let init_sum_grad = grads.or_insert(init)?;
-                        let mask = init.ones_like()?;
-                        let mask = mask.scatter(indexes, &mask.zeros_like()?, *dim)?;
-                        *init_sum_grad = init_sum_grad.add(&grad.mul(&mask)?)?;
+                        grads.modify_if_tracked(init, |init_sum_grad| {
+                            let mask = init.ones_like()?;
+                            let mask = mask.scatter(indexes, &mask.zeros_like()?, *dim)?;
+                            init_sum_grad.add(&grad.mul(&mask)?)
+                        })?;
 
-                        let src_grad = grad.gather(indexes, *dim)?;
-                        let src_sum_grad = grads.or_insert(src)?;
-                        *src_sum_grad = src_sum_grad.add(&src_grad)?;
+                        grads.modify_if_tracked(src, |src_sum_grad| {
+                            let src_grad = grad.gather(indexes, *dim)?;
+                            src_sum_grad.add(&src_grad)
+                        })?;
                     }
                     Op::IndexAdd(init, indexes, src, dim) => {
-                        let init_sum_grad = grads.or_insert(init)?;
-                        *init_sum_grad = init_sum_grad.add(&grad)?;
+                        grads.modify_if_tracked(init, |init_sum_grad| init_sum_grad.add(&grad))?;
 
-                        let src_grad = grad.index_select(indexes, *dim)?;
-                        let src_sum_grad = grads.or_insert(src)?;
-                        *src_sum_grad = src_sum_grad.add(&src_grad)?;
+                        grads.modify_if_tracked(src, |src_sum_grad| {
+                            let src_grad = grad.index_select(indexes, *dim)?;
+                            src_sum_grad.add(&src_grad)
+                        })?;
                     }
                     Op::IndexSelect(arg, indexes, dim) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.index_add(indexes, &grad, *dim)?;
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            sum_grad.index_add(indexes, &grad, *dim)
+                        })?;
                     }
                     Op::Matmul(lhs, rhs) => {
                         // Skipping checks, the op went ok, we can skip
                         // the matmul size checks for now.
 
-                        let lhs_grad = grad.matmul(&rhs.t()?)?;
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&lhs_grad)?;
+                        grads.modify_if_tracked(lhs, |lhs_sum_grad| {
+                            let lhs_grad = grad.matmul(&rhs.t()?)?;
+                            lhs_sum_grad.add(&lhs_grad)
+                        })?;
 
-                        let rhs_grad = lhs.t()?.matmul(&grad)?;
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        *rhs_sum_grad = rhs_sum_grad.add(&rhs_grad)?;
+                        grads.modify_if_tracked(rhs, |rhs_sum_grad| {
+                            let rhs_grad = lhs.t()?.matmul(&grad)?;
+                            rhs_sum_grad.add(&rhs_grad)
+                        })?;
                     }
                     Op::Cat(args, dim) => {
                         let mut start_idx = 0;
                         for arg in args {
                             let len = arg.dims()[*dim];
-                            let arg_grad = grad.narrow(*dim, start_idx, len)?;
-                            let sum_grad = grads.or_insert(arg)?;
-                            *sum_grad = sum_grad.add(&arg_grad)?;
+                            grads.modify_if_tracked(arg, |sum_grad| {
+                                let arg_grad = grad.narrow(*dim, start_idx, len)?;
+                                sum_grad.add(&arg_grad)
+                            })?;
                             start_idx += len;
                         }
                     }
                     Op::Broadcast(arg) => {
-                        let arg_dims = arg.dims();
-                        let node_dims = node.dims();
-                        // The number of dims that have been inserted on the left.
-                        let left_dims = node_dims.len() - arg_dims.len();
-                        let mut sum_dims: Vec<usize> = (0..left_dims).collect();
-                        for (dim, (node_dim, arg_dim)) in node_dims[left_dims..]
-                            .iter()
-                            .zip(arg_dims.iter())
-                            .enumerate()
-                        {
-                            if node_dim != arg_dim {
-                                sum_dims.push(dim + left_dims)
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let arg_dims = arg.dims();
+                            let node_dims = node.dims();
+                            // The number of dims that have been inserted on the left.
+                            let left_dims = node_dims.len() - arg_dims.len();
+                            let mut sum_dims: Vec<usize> = (0..left_dims).collect();
+                            for (dim, (node_dim, arg_dim)) in node_dims[left_dims..]
+                                .iter()
+                                .zip(arg_dims.iter())
+                                .enumerate()
+                            {
+                                if node_dim != arg_dim {
+                                    sum_dims.push(dim + left_dims)
+                                }
                             }
-                        }
 
-                        let mut arg_grad = grad.sum_keepdim(sum_dims.as_slice())?;
-                        for _i in 0..left_dims {
-                            arg_grad = arg_grad.squeeze(0)?
-                        }
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad.broadcast_as(sum_grad.dims())?)?;
+                            let mut arg_grad = grad.sum_keepdim(sum_dims.as_slice())?;
+                            for _i in 0..left_dims {
+                                arg_grad = arg_grad.squeeze(0)?
+                            }
+                            sum_grad.add(&arg_grad.broadcast_as(sum_grad.dims())?)
+                        })?;
                     }
                     Op::Reduce(arg, ReduceOp::Sum, reduced_dims) => {
-                        let grad = broadcast_back(arg, &grad, reduced_dims)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad)?;
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let grad = broadcast_back(arg, &grad, reduced_dims)?;
+                            sum_grad.add(&grad)
+                        })?;
                     }
                     Op::Reduce(arg, ReduceOp::Max, reduced_dims) => {
-                        let node = broadcast_back(arg, node, reduced_dims)?;
-                        let grad = broadcast_back(arg, &grad, reduced_dims)?;
-                        let grad = node.eq(arg)?.to_dtype(grad.dtype())?.mul(&grad)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad.broadcast_as(sum_grad.dims())?)?;
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let node = broadcast_back(arg, node, reduced_dims)?;
+                            let grad = broadcast_back(arg, &grad, reduced_dims)?;
+                            let grad = node.eq(arg)?.to_dtype(grad.dtype())?.mul(&grad)?;
+                            sum_grad.add(&grad.broadcast_as(sum_grad.dims())?)
+                        })?;
                     }
                     Op::Reduce(arg, ReduceOp::Min, reduced_dims) => {
-                        let node = broadcast_back(arg, node, reduced_dims)?;
-                        let grad = broadcast_back(arg, &grad, reduced_dims)?;
-                        let grad = node.eq(arg)?.to_dtype(grad.dtype())?.mul(&grad)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad.broadcast_as(sum_grad.dims())?)?;
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let node = broadcast_back(arg, node, reduced_dims)?;
+                            let grad = broadcast_back(arg, &grad, reduced_dims)?;
+                            let grad = node.eq(arg)?.to_dtype(grad.dtype())?.mul(&grad)?;
+                            sum_grad.add(&grad.broadcast_as(sum_grad.dims())?)
+                        })?;
                     }
                     Op::ToDType(arg) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad.to_dtype(arg.dtype())?)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            sum_grad.add(&grad.to_dtype(arg.dtype())?)
+                        })?;
                     }
                     Op::Copy(arg) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad)?
+                        grads.modify_if_tracked(arg, |sum_grad| sum_grad.add(&grad))?;
                     }
                     Op::Affine { arg, mul, .. } => {
-                        let arg_grad = grad.affine(*mul, 0.)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let arg_grad = grad.affine(*mul, 0.)?;
+                            sum_grad.add(&arg_grad)
+                        })?;
                     }
                     Op::Unary(arg, UnaryOp::Log) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&(grad / arg)?)?
+                        grads.modify_if_tracked(arg, |sum_grad| sum_grad.add(&(grad / arg)?))?;
                     }
                     Op::Unary(arg, UnaryOp::Sin) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&(&grad * arg.cos())?)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            sum_grad.add(&(&grad * arg.cos())?)
+                        })?;
                     }
                     Op::Unary(arg, UnaryOp::Cos) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.sub(&(&grad * arg.sin())?)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            sum_grad.sub(&(&grad * arg.sin())?)
+                        })?;
                     }
                     Op::Unary(arg, UnaryOp::Tanh) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        let minus_dtanh = (node.sqr()? - 1.)?;
-                        *sum_grad = sum_grad.sub(&(&grad * &minus_dtanh)?)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let minus_dtanh = (node.sqr()? - 1.)?;
+                            sum_grad.sub(&(&grad * &minus_dtanh)?)
+                        })?;
                     }
                     Op::Unary(arg, UnaryOp::Abs) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        let ones = arg.ones_like()?;
-                        let abs_grad = arg.ge(&arg.zeros_like()?)?.where_cond(&ones, &ones.neg()?);
-                        *sum_grad = sum_grad.add(&(&grad * abs_grad)?)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let ones = arg.ones_like()?;
+                            let abs_grad =
+                                arg.ge(&arg.zeros_like()?)?.where_cond(&ones, &ones.neg()?);
+                            sum_grad.add(&(&grad * abs_grad)?)
+                        })?;
                     }
                     Op::Unary(arg, UnaryOp::Exp) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&(&grad * *node)?)?
+                        grads.modify_if_tracked(arg, |sum_grad| sum_grad.add(&(&grad * node)?))?;
                     }
                     Op::Unary(arg, UnaryOp::Neg) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.sub(&grad)?
+                        grads.modify_if_tracked(arg, |sum_grad| sum_grad.sub(&grad))?;
                     }
                     Op::Unary(arg, UnaryOp::Recip) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        let grad = (grad / arg.sqr()?)?;
-                        *sum_grad = sum_grad.sub(&grad)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let grad = (grad / arg.sqr()?)?;
+                            sum_grad.sub(&grad)
+                        })?;
                     }
                     &Op::Narrow(ref arg, dim, start_idx, len) => {
-                        let arg_dims = arg.dims();
-                        let left_pad = if start_idx == 0 {
-                            None
-                        } else {
-                            let mut dims = arg_dims.to_vec();
-                            dims[dim] = start_idx;
-                            Some(Tensor::zeros(dims, grad.dtype(), grad.device())?)
-                        };
-                        let right_pad = arg_dims[dim] - start_idx - len;
-                        let right_pad = if right_pad == 0 {
-                            None
-                        } else {
-                            let mut dims = arg_dims.to_vec();
-                            dims[dim] = right_pad;
-                            Some(Tensor::zeros(dims, grad.dtype(), grad.device())?)
-                        };
-                        let arg_grad = match (left_pad, right_pad) {
-                            (None, None) => grad,
-                            (Some(l), None) => Tensor::cat(&[&l, &grad], dim)?,
-                            (None, Some(r)) => Tensor::cat(&[&grad, &r], dim)?,
-                            (Some(l), Some(r)) => Tensor::cat(&[&l, &grad, &r], dim)?,
-                        };
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let arg_dims = arg.dims();
+                            let left_pad = if start_idx == 0 {
+                                None
+                            } else {
+                                let mut dims = arg_dims.to_vec();
+                                dims[dim] = start_idx;
+                                Some(Tensor::zeros(dims, grad.dtype(), grad.device())?)
+                            };
+                            let right_pad = arg_dims[dim] - start_idx - len;
+                            let right_pad = if right_pad == 0 {
+                                None
+                            } else {
+                                let mut dims = arg_dims.to_vec();
+                                dims[dim] = right_pad;
+                                Some(Tensor::zeros(dims, grad.dtype(), grad.device())?)
+                            };
+                            let arg_grad = match (left_pad, right_pad) {
+                                (None, None) => grad,
+                                (Some(l), None) => Tensor::cat(&[&l, &grad], dim)?,
+                                (None, Some(r)) => Tensor::cat(&[&grad, &r], dim)?,
+                                (Some(l), Some(r)) => Tensor::cat(&[&l, &grad, &r], dim)?,
+                            };
+                            sum_grad.add(&arg_grad)
+                        })?;
                     }
                     Op::Unary(_, UnaryOp::Floor)
                     | Op::Unary(_, UnaryOp::Round)
@@ -594,131 +630,201 @@ impl Tensor {
                     | Op::Unary(_, UnaryOp::Sign)
                     | Op::Cmp(_, _) => {}
                     Op::Reshape(arg) => {
-                        let arg_grad = grad.reshape(arg.dims())?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let arg_grad = grad.reshape(arg.dims())?;
+                            sum_grad.add(&arg_grad)
+                        })?;
                     }
                     Op::Unary(_, UnaryOp::Ceil) => Err(Error::BackwardNotSupported { op: "ceil" })?,
                     Op::Unary(arg, UnaryOp::Gelu) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        let cube = arg.powf(3.)?;
-                        let tanh = (0.0356774 * &cube + (0.797885 * arg)?)?.tanh()?;
-                        let gelu_grad = (((0.5 * &tanh)?
-                            + (0.0535161 * cube + (0.398942 * arg)?)? * (1. - tanh.powf(2.)?))?
-                            + 0.5)?;
-                        *sum_grad = sum_grad.add(&(&grad * gelu_grad)?)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let cube = arg.powf(3.)?;
+                            let tanh = (0.0356774 * &cube + (0.797885 * arg)?)?.tanh()?;
+                            let gelu_grad = (((0.5 * &tanh)?
+                                + (0.0535161 * cube + (0.398942 * arg)?)?
+                                    * (1. - tanh.powf(2.)?)?)?
+                                + 0.5)?;
+                            sum_grad.add(&(&grad * gelu_grad)?)
+                        })?;
                     }
                     Op::Unary(arg, UnaryOp::Erf) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        // d/dx erf(x) = 2/sqrt(pi) * e^(-x^2)
-                        let erf_grad =
-                            (2. / std::f64::consts::PI.sqrt()) * (arg.sqr()?.neg()?).exp()?;
-                        *sum_grad = sum_grad.add(&(&grad * erf_grad)?)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            // d/dx erf(x) = 2/sqrt(pi) * e^(-x^2)
+                            let erf_grad =
+                                (2. / std::f64::consts::PI.sqrt()) * (arg.sqr()?.neg()?).exp()?;
+                            sum_grad.add(&(&grad * erf_grad)?)
+                        })?;
                     }
                     Op::Unary(arg, UnaryOp::GeluErf) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        // d/dx gelu_erf(x) = 0.5 + 0.398942 e^(-x^2/2) x + 0.5 erf(x/sqrt(2))
-                        let neg_half_square = (arg.sqr()?.neg()? / 2.)?;
-                        let scaled_exp_arg = (0.398942 * neg_half_square.exp()? * arg)?;
-                        let arg_scaled_sqrt = (arg / 2f64.sqrt())?;
-                        let erf_scaled_sqrt = (0.5 * arg_scaled_sqrt.erf()?)?;
-                        let gelu_erf_grad = (0.5 + scaled_exp_arg + erf_scaled_sqrt)?;
-                        *sum_grad = sum_grad.add(&(&grad * gelu_erf_grad)?)?;
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            // d/dx gelu_erf(x) = 0.5 + 0.398942 e^(-x^2/2) x + 0.5 erf(x/sqrt(2))
+                            let neg_half_square = (arg.sqr()?.neg()? / 2.)?;
+                            let scaled_exp_arg = (0.398942 * neg_half_square.exp()? * arg)?;
+                            let arg_scaled_sqrt = (arg / 2f64.sqrt())?;
+                            let erf_scaled_sqrt = (0.5 * arg_scaled_sqrt.erf()?)?;
+                            let gelu_erf_grad = (0.5 + scaled_exp_arg + erf_scaled_sqrt)?;
+                            sum_grad.add(&(&grad * gelu_erf_grad)?)
+                        })?;
                     }
                     Op::Unary(arg, UnaryOp::Relu) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        let relu_grad = arg.ge(&arg.zeros_like()?)?.to_dtype(arg.dtype())?;
-                        *sum_grad = sum_grad.add(&(&grad * relu_grad)?)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let relu_grad = arg.ge(&arg.zeros_like()?)?.to_dtype(arg.dtype())?;
+                            sum_grad.add(&(&grad * relu_grad)?)
+                        })?;
                     }
                     Op::Unary(arg, UnaryOp::Silu) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        // d/dx silu = sigmoid(x) * (1 + x * (1 - sigmoid(x))) = sigmoid(x) * (1 - node) + node
-                        let sigmoid_arg = (arg.neg()?.exp()? + 1.)?.recip()?;
-                        let silu_grad = &sigmoid_arg * (1. - *node) + *node;
-                        *sum_grad = sum_grad.add(&(&grad * silu_grad)?)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            // d/dx silu = sigmoid(x) * (1 + x * (1 - sigmoid(x))) = sigmoid(x) * (1 - node) + node
+                            let sigmoid_arg = (arg.neg()?.exp()? + 1.)?.recip()?;
+                            let silu_grad = &sigmoid_arg * (1. - node) + node;
+                            sum_grad.add(&(&grad * silu_grad)?)
+                        })?;
                     }
                     Op::Elu(arg, alpha) => {
-                        // d/dx elu(x) = 1 for x > 0, alpha * e^x for x <= 0
-                        let sum_grad = grads.or_insert(arg)?;
-                        let zeros = arg.zeros_like()?;
-                        let positive_mask = arg.gt(&zeros)?.to_dtype(arg.dtype())?;
-                        let negative_mask = arg.le(&zeros)?.to_dtype(arg.dtype())?;
-                        // node == alpha * (e^x - 1) for x <= 0, reuse it
-                        let negative_exp_mask = (negative_mask * (*node + *alpha))?;
-                        let combined_mask = (positive_mask + negative_exp_mask)?;
-                        *sum_grad = sum_grad.add(&(grad * combined_mask)?)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            // d/dx elu(x) = 1 for x > 0, alpha * e^x for x <= 0
+                            let zeros = arg.zeros_like()?;
+                            let positive_mask = arg.gt(&zeros)?.to_dtype(arg.dtype())?;
+                            let negative_mask = arg.le(&zeros)?.to_dtype(arg.dtype())?;
+                            // node == alpha * (e^x - 1) for x <= 0, reuse it
+                            let negative_exp_mask = (negative_mask * (node + *alpha))?;
+                            let combined_mask = (positive_mask + negative_exp_mask)?;
+                            sum_grad.add(&(grad * combined_mask)?)
+                        })?;
                     }
                     Op::Powf(arg, e) => {
-                        let arg_grad = (&(grad * arg.powf(e - 1.)?)? * *e)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let arg_grad = (&(grad * arg.powf(e - 1.)?)? * *e)?;
+                            sum_grad.add(&arg_grad)
+                        })?;
                     }
                     Op::CustomOp1(arg, c) => {
                         if let Some(arg_grad) = c.bwd(arg, node, &grad)? {
-                            let sum_grad = grads.or_insert(arg)?;
-                            *sum_grad = sum_grad.add(&arg_grad)?
+                            grads.modify_if_tracked(arg, |sum_grad| sum_grad.add(&arg_grad))?
                         }
                     }
                     Op::CustomOp2(arg1, arg2, c) => {
                         let (arg_grad1, arg_grad2) = c.bwd(arg1, arg2, node, &grad)?;
                         if let Some(arg_grad1) = arg_grad1 {
-                            let sum_grad = grads.or_insert(arg1)?;
-                            *sum_grad = sum_grad.add(&arg_grad1)?
+                            grads.modify_if_tracked(arg1, |sum_grad| sum_grad.add(&arg_grad1))?
                         }
                         if let Some(arg_grad2) = arg_grad2 {
-                            let sum_grad = grads.or_insert(arg2)?;
-                            *sum_grad = sum_grad.add(&arg_grad2)?
+                            grads.modify_if_tracked(arg2, |sum_grad| sum_grad.add(&arg_grad2))?
                         }
                     }
                     Op::CustomOp3(arg1, arg2, arg3, c) => {
                         let (arg_grad1, arg_grad2, arg_grad3) =
                             c.bwd(arg1, arg2, arg3, node, &grad)?;
                         if let Some(arg_grad1) = arg_grad1 {
-                            let sum_grad = grads.or_insert(arg1)?;
-                            *sum_grad = sum_grad.add(&arg_grad1)?
+                            grads.modify_if_tracked(arg1, |sum_grad| sum_grad.add(&arg_grad1))?
                         }
                         if let Some(arg_grad2) = arg_grad2 {
-                            let sum_grad = grads.or_insert(arg2)?;
-                            *sum_grad = sum_grad.add(&arg_grad2)?
+                            grads.modify_if_tracked(arg2, |sum_grad| sum_grad.add(&arg_grad2))?
                         }
                         if let Some(arg_grad3) = arg_grad3 {
-                            let sum_grad = grads.or_insert(arg3)?;
-                            *sum_grad = sum_grad.add(&arg_grad3)?
+                            grads.modify_if_tracked(arg3, |sum_grad| sum_grad.add(&arg_grad3))?
                         }
                     }
                     Op::Unary(arg, UnaryOp::Sqr) => {
-                        let arg_grad = arg.mul(&grad)?.affine(2., 0.)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let arg_grad = arg.mul(&grad)?.affine(2., 0.)?;
+                            sum_grad.add(&arg_grad)
+                        })?;
                     }
                     Op::Unary(arg, UnaryOp::Sqrt) => {
-                        let arg_grad = grad.div(node)?.affine(0.5, 0.)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let arg_grad = grad.div(node)?.affine(0.5, 0.)?;
+                            sum_grad.add(&arg_grad)
+                        })?;
                     }
                     Op::ToDevice(arg) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        let arg_grad = grad.to_device(sum_grad.device())?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let arg_grad = grad.to_device(sum_grad.device())?;
+                            sum_grad.add(&arg_grad)
+                        })?;
                     }
                     Op::Transpose(arg, dim1, dim2) => {
-                        let arg_grad = grad.transpose(*dim1, *dim2)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let arg_grad = grad.transpose(*dim1, *dim2)?;
+                            sum_grad.add(&arg_grad)
+                        })?;
                     }
                     Op::Permute(arg, dims) => {
-                        let mut inv_dims = vec![0; dims.len()];
-                        for (i, &dim_idx) in dims.iter().enumerate() {
-                            inv_dims[dim_idx] = i
-                        }
-                        let arg_grad = grad.permute(inv_dims)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.modify_if_tracked(arg, |sum_grad| {
+                            let mut inv_dims = vec![0; dims.len()];
+                            for (i, &dim_idx) in dims.iter().enumerate() {
+                                inv_dims[dim_idx] = i
+                            }
+                            let arg_grad = grad.permute(inv_dims)?;
+                            sum_grad.add(&arg_grad)
+                        })?;
                     }
                 };
             }
         }
-        Ok(grads)
+        Ok(grads.into_inner())
+    }
+}
+
+struct GradStoreBuilder {
+    grads: GradStore,
+    /// whether we should compute a gradient for any given tensor
+    should_track: HashMap<TensorId, bool>,
+}
+
+impl GradStoreBuilder {
+    /// Create a new builder with the given `track_grads` map,
+    /// and with the gradient of `root` intitialized to ones.
+    fn new(root: &Tensor, should_track: HashMap<TensorId, bool>) -> Result<Self> {
+        let mut grads = GradStore::new();
+        grads.insert(root, root.ones_like()?.contiguous()?);
+        Ok(Self {
+            grads,
+            should_track,
+        })
+    }
+
+    /// Remove the gradient tensor associated with the given tensor, returning it if it exists
+    fn remove(&mut self, tensor: &Tensor) -> Option<Tensor> {
+        self.grads.remove(tensor)
+    }
+
+    /// PRECONDITION: the given tensor is in `self.track_grads`
+    /// POSTCONDITION:
+    /// if `self.should_track` indicates that we should compute a gradient for the given tensor,
+    /// then uses the given function to modify the gradient stored for this tensor,
+    /// inserting a tensor of zeros first if we don't yet have a gradient stored.
+    /// No-op if `self.track_grads` says NOT to compute a gradient for the given tensor.
+    fn modify_if_tracked(
+        &mut self,
+        tensor: &Tensor,
+        f: impl FnOnce(&Tensor) -> Result<Tensor>,
+    ) -> Result<()> {
+        if *self
+            .should_track
+            .get(&tensor.id())
+            .expect("candle internal error - encountered untracked tensor in backprop")
+        {
+            let grad = self.grads.or_insert(tensor)?;
+            let new_grad = f(grad)?;
+            // https://github.com/huggingface/candle/issues/1241
+            // Ideally, we would make these operations in place where possible to ensure that we
+            // do not have to allocate too often. Here we just call `.detach` to avoid computing
+            // the backprop graph of the backprop itself. This would be an issue for second order
+            // derivatives but these are out of scope at the moment.
+            *grad = CANDLE_GRAD_DO_NOT_DETACH.with(|&do_not_detach| {
+                if do_not_detach {
+                    new_grad
+                } else {
+                    new_grad.detach()
+                }
+            })
+        }
+        Ok(())
+    }
+
+    fn into_inner(self) -> GradStore {
+        self.grads
     }
 }
 

--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -28,142 +28,136 @@ thread_local! {
 }
 
 impl Tensor {
+    /// PRECONDITION: the op graph is a DAG
+    /// POSTCONDITION:
+    /// - `nodes` contains `self` and all of its dependencies in reverse topological order;
+    ///   e.g. if A depends on B, then B will appear before A in `nodes`.
+    /// - `already_seen` contains the IDs of `self` and all of its dependencies
+    /// - `already_seen[tensor.id]` is true iff the gradient of `tensor` can reach a variable
+    ///   through backpropagation (and therefore needs to be computed)
+    fn walk<'a>(
+        &'a self,
+        nodes: &mut Vec<&'a Tensor>,
+        already_seen: &mut HashMap<TensorId, bool>,
+    ) -> bool {
+        if let Some(&tg) = already_seen.get(&self.id()) {
+            return tg;
+        }
+        let track_grad = if self.is_variable() {
+            // Do not call recursively on the "leaf" nodes.
+            true
+        } else if self.dtype().is_int() {
+            false
+        } else if let Some(op) = self.op() {
+            match op {
+                Op::IndexAdd(t1, t2, t3, _)
+                | Op::Scatter(t1, t2, t3, _)
+                | Op::ScatterAdd(t1, t2, t3, _)
+                | Op::CustomOp3(t1, t2, t3, _)
+                | Op::WhereCond(t1, t2, t3) => {
+                    let track_t1 = t1.walk(nodes, already_seen);
+                    let track_t2 = t2.walk(nodes, already_seen);
+                    let track_t3 = t3.walk(nodes, already_seen);
+                    track_t1 || track_t2 || track_t3
+                }
+                Op::Conv1D {
+                    arg: lhs,
+                    kernel: rhs,
+                    ..
+                }
+                | Op::ConvTranspose1D {
+                    arg: lhs,
+                    kernel: rhs,
+                    ..
+                }
+                | Op::Conv2D {
+                    arg: lhs,
+                    kernel: rhs,
+                    ..
+                }
+                | Op::ConvTranspose2D {
+                    arg: lhs,
+                    kernel: rhs,
+                    ..
+                }
+                | Op::CustomOp2(lhs, rhs, _)
+                | Op::Binary(lhs, rhs, _)
+                | Op::Gather(lhs, rhs, _)
+                | Op::IndexSelect(lhs, rhs, _)
+                | Op::Matmul(lhs, rhs)
+                | Op::SliceScatter0(lhs, rhs, _) => {
+                    let track_lhs = lhs.walk(nodes, already_seen);
+                    let track_rhs = rhs.walk(nodes, already_seen);
+                    track_lhs || track_rhs
+                }
+                Op::Cat(args, _) => args.iter().fold(false, |track_acc, arg| {
+                    let track_arg = arg.walk(nodes, already_seen);
+                    track_acc || track_arg
+                }),
+                Op::Affine { arg, mul, .. } => {
+                    if *mul == 0. {
+                        false
+                    } else {
+                        arg.walk(nodes, already_seen)
+                    }
+                }
+                Op::Unary(_node, UnaryOp::Ceil)
+                | Op::Unary(_node, UnaryOp::Floor)
+                | Op::Unary(_node, UnaryOp::Round)
+                | Op::Unary(_node, UnaryOp::Sign) => false,
+                Op::Reshape(node)
+                | Op::UpsampleNearest1D { arg: node, .. }
+                | Op::UpsampleNearest2D { arg: node, .. }
+                | Op::UpsampleBilinear2D { arg: node, .. }
+                | Op::AvgPool2D { arg: node, .. }
+                | Op::MaxPool2D { arg: node, .. }
+                | Op::Copy(node)
+                | Op::Broadcast(node)
+                | Op::Cmp(node, _)
+                | Op::Reduce(node, ReduceOp::Min | ReduceOp::Sum | ReduceOp::Max, _)
+                | Op::ToDevice(node)
+                | Op::Transpose(node, _, _)
+                | Op::Permute(node, _)
+                | Op::Narrow(node, _, _, _)
+                | Op::Unary(node, _)
+                | Op::Elu(node, _)
+                | Op::Powf(node, _)
+                | Op::CustomOp1(node, _) => node.walk(nodes, already_seen),
+                Op::ToDType(node) => {
+                    if node.dtype().is_float() {
+                        node.walk(nodes, already_seen)
+                    } else {
+                        false
+                    }
+                }
+                Op::Reduce(_, ReduceOp::ArgMin | ReduceOp::ArgMax, _) => false,
+            }
+        } else {
+            false
+        };
+        already_seen.insert(self.id(), track_grad);
+        if track_grad {
+            nodes.push(self);
+        }
+        track_grad
+    }
+
     /// Return all the nodes that lead to this value in a topologically sorted vec, the first
     /// elements having dependencies on the latter ones, e.g. the first element if any is the
     /// argument.
     /// This assumes that the op graph is a DAG.
     pub fn sorted_nodes(&self) -> Vec<&Tensor> {
-        // The vec of sorted nodes is passed as an owned value rather than a mutable reference
-        // to get around some lifetime limitations.
-        fn walk<'a>(
-            node: &'a Tensor,
-            nodes: Vec<&'a Tensor>,
-            already_seen: &mut HashMap<TensorId, bool>,
-        ) -> (bool, Vec<&'a Tensor>) {
-            if let Some(&tg) = already_seen.get(&node.id()) {
-                return (tg, nodes);
-            }
-            let mut track_grad = false;
-            let mut nodes = if node.is_variable() {
-                // Do not call recursively on the "leaf" nodes.
-                track_grad = true;
-                nodes
-            } else if node.dtype().is_int() {
-                nodes
-            } else if let Some(op) = node.op() {
-                match op {
-                    Op::IndexAdd(t1, t2, t3, _)
-                    | Op::Scatter(t1, t2, t3, _)
-                    | Op::ScatterAdd(t1, t2, t3, _)
-                    | Op::CustomOp3(t1, t2, t3, _)
-                    | Op::WhereCond(t1, t2, t3) => {
-                        let (tg, nodes) = walk(t1, nodes, already_seen);
-                        track_grad |= tg;
-                        let (tg, nodes) = walk(t2, nodes, already_seen);
-                        track_grad |= tg;
-                        let (tg, nodes) = walk(t3, nodes, already_seen);
-                        track_grad |= tg;
-                        nodes
-                    }
-                    Op::Conv1D {
-                        arg: lhs,
-                        kernel: rhs,
-                        ..
-                    }
-                    | Op::ConvTranspose1D {
-                        arg: lhs,
-                        kernel: rhs,
-                        ..
-                    }
-                    | Op::Conv2D {
-                        arg: lhs,
-                        kernel: rhs,
-                        ..
-                    }
-                    | Op::ConvTranspose2D {
-                        arg: lhs,
-                        kernel: rhs,
-                        ..
-                    }
-                    | Op::CustomOp2(lhs, rhs, _)
-                    | Op::Binary(lhs, rhs, _)
-                    | Op::Gather(lhs, rhs, _)
-                    | Op::IndexSelect(lhs, rhs, _)
-                    | Op::Matmul(lhs, rhs)
-                    | Op::SliceScatter0(lhs, rhs, _) => {
-                        let (tg, nodes) = walk(lhs, nodes, already_seen);
-                        track_grad |= tg;
-                        let (tg, nodes) = walk(rhs, nodes, already_seen);
-                        track_grad |= tg;
-                        nodes
-                    }
-                    Op::Cat(args, _) => args.iter().fold(nodes, |nodes, arg| {
-                        let (tg, nodes) = walk(arg, nodes, already_seen);
-                        track_grad |= tg;
-                        nodes
-                    }),
-                    Op::Affine { arg, mul, .. } => {
-                        if *mul == 0. {
-                            nodes
-                        } else {
-                            let (tg, nodes) = walk(arg, nodes, already_seen);
-                            track_grad |= tg;
-                            nodes
-                        }
-                    }
-                    Op::Unary(_node, UnaryOp::Ceil)
-                    | Op::Unary(_node, UnaryOp::Floor)
-                    | Op::Unary(_node, UnaryOp::Round)
-                    | Op::Unary(_node, UnaryOp::Sign) => nodes,
-                    Op::Reshape(node)
-                    | Op::UpsampleNearest1D { arg: node, .. }
-                    | Op::UpsampleNearest2D { arg: node, .. }
-                    | Op::UpsampleBilinear2D { arg: node, .. }
-                    | Op::AvgPool2D { arg: node, .. }
-                    | Op::MaxPool2D { arg: node, .. }
-                    | Op::Copy(node)
-                    | Op::Broadcast(node)
-                    | Op::Cmp(node, _)
-                    | Op::Reduce(node, ReduceOp::Min | ReduceOp::Sum | ReduceOp::Max, _)
-                    | Op::ToDevice(node)
-                    | Op::Transpose(node, _, _)
-                    | Op::Permute(node, _)
-                    | Op::Narrow(node, _, _, _)
-                    | Op::Unary(node, _)
-                    | Op::Elu(node, _)
-                    | Op::Powf(node, _)
-                    | Op::CustomOp1(node, _) => {
-                        let (tg, nodes) = walk(node, nodes, already_seen);
-                        track_grad |= tg;
-                        nodes
-                    }
-                    Op::ToDType(node) => {
-                        if node.dtype().is_float() {
-                            let (tg, nodes) = walk(node, nodes, already_seen);
-                            track_grad |= tg;
-                            nodes
-                        } else {
-                            nodes
-                        }
-                    }
-                    Op::Reduce(_, ReduceOp::ArgMin | ReduceOp::ArgMax, _) => nodes,
-                }
-            } else {
-                nodes
-            };
-            already_seen.insert(node.id(), track_grad);
-            if track_grad {
-                nodes.push(node);
-            }
-            (track_grad, nodes)
-        }
-        let (_tg, mut nodes) = walk(self, vec![], &mut HashMap::new());
+        let mut already_seen = HashMap::new();
+        let mut nodes = Vec::new();
+        self.walk(&mut nodes, &mut already_seen);
         nodes.reverse();
         nodes
     }
 
     pub fn backward(&self) -> Result<GradStore> {
-        let sorted_nodes = self.sorted_nodes();
+        let mut sorted_nodes = Vec::new();
+        let mut already_seen = HashMap::new();
+        self.walk(&mut sorted_nodes, &mut already_seen);
         let mut grads = GradStore::new();
         grads.insert(self, self.ones_like()?.contiguous()?);
         for node in sorted_nodes.iter() {

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -535,6 +535,47 @@ fn test_flip_backprop() -> Result<()> {
     Ok(())
 }
 
+fn omit_unnecessary_gradients(device: &Device) -> Result<()> {
+    let x = Var::ones((2, 2), DType::F64, device)?;
+    let x = x.as_tensor();
+    let a = x.ones_like()?;
+    let b = x.ones_like()?;
+    let c = x.ones_like()?;
+    let r1 = (x * x + &a)?;
+    let r2 = (&r1 * &r1 + &b)?;
+    let y = (&r2 * &r2 + &c)?;
+    let grads = y.backward()?;
+
+    /* We only needed to compute the gradients for r2 and r1 to find the
+     * gradient for x; make sure the gradstore doesn't have gradients for a, b, or c.
+     * Note: this only checks that the gradstore doesn't _currently_ contain a/b/c;
+     * ideally, we'd want to make sure we _never_ computed those gradients. */
+
+    let x_grad = grads
+        .get(&x)
+        .expect("computed gradient for x since it's a variable");
+    assert!(grads.get(&a).is_none(), "gradient of `a` not needed");
+    assert!(grads.get(&b).is_none(), "gradient of `b` not needed");
+    assert!(grads.get(&c).is_none(), "gradient of `c` not needed");
+
+    /* also make sure that we don't unnecessarily keep
+     * intermediate tensors used to compute the gradient
+     * alive for longer than necessary. */
+
+    if std::env::var("CANDLE_GRAD_DO_NOT_DETACH").is_ok_and(|s| !["", "0"].contains(&&*s)) {
+        // ignore the "make sure gradients are detached" part of this test
+        // if we are in "do not make sure gradients are detached" mode
+        return Ok(());
+    }
+
+    assert!(
+        !x_grad.track_op(),
+        "gradient should not prevent its operands from being freed"
+    );
+
+    Ok(())
+}
+
 test_device!(
     simple_grad,
     simple_grad_cpu,
@@ -560,4 +601,10 @@ test_device!(
     binary_grad_cpu,
     binary_grad_gpu,
     binary_grad_metal
+);
+test_device!(
+    omit_unnecessary_gradients,
+    omit_unnecessary_gradients_cpu,
+    omit_unnecessary_gradients_gpu,
+    omit_unnecessary_gradients_metal
 );


### PR DESCRIPTION
This should help address #1241. In my experience this optimization has made the difference between OOMing the GPU 5% of the way through backprop versus completing the full backprop pass successfully. I don't have empirical measurements of the impact, but I included a test that exercises the problem/solution; let me know if it'd also be helpful to get some example measurements. For reviewers: this looks like a lot of code, but 90% of it is lift-and-shift that leaves the logic unchanged.

This change does two key things:
1. Avoids computing gradients that are not needed for any variables
2. Detaches gradient tensors on their way _into_ the `GradStore`, instead of on the way out.

I wrote some detail about these issues in [this comment](https://github.com/huggingface/candle/issues/1241#issuecomment-3273340567).

## 1. Avoiding computing unnecessary gradients

### Problem
The old implementation would compute gradients for all operands of any given `BackpropOp`, even the ones that don't lead to a variable. The impact of this unnecessary computation/allocation was also exacerbated by the fact that `backprop` never ends up removing these from the `GradStore`; so each unnecessary gradient ends up holding onto its memory for the entirety of `backward` (and then the lifetime of the returned `GradStore`).
### Solution
The fix leverages the fact that the existing implementation already kept track of whether any given tensor in the graph leads to a variable, in the `already_seen` hashmap in the `walk` function. I refactored `walk` out into a function that `backward` can call directly, so that `backward` can use the results it populates into the `already_seen` hashmap. Aside: since `walk` builds up the `sorted_nodes` vector in reverse, I just switched the `backward` loop to pop off the stack in reverse order rather than reversing it like the original implementation did.

I wanted to make the gradient computations conditional while leaving the code as unchanged as possible, which was tricky with how the code was structured. The approach I took was to move the gradient-computing code into closures, which can then be conditionally called if the `already_seen` hashmap says that we should compute the gradient. I introduced a new (internal-only) struct `GradStoreBuilder` which contains the hashmap along with the `GradStore`, and provides a new method `modify_if_tracked` to be used in place of the original `GradStore::or_insert` calls throughout the code. 

## 2. Detaching gradients earlier

### Problem
[As @iwanders found](https://github.com/huggingface/candle/issues/1241#issuecomment-2254229442), #1243 doesn't fully solve the problem of gradients using up too much vram by storing their own backprop graph. Each iteration of the loop basically does (pseudocode):
```rust
let old_grad = grads[node];
let new_grad = old_grad + partial_grad;
grads[node] = new_grad
```
In the existing implementation, whenever we do one of these, memory ends up storing `old_grad` and `partial_grad` along with `new_grad`, even though we really only need to store `new_grad`. This happens because `new_grad` stores its operands in its backprop op. #1243 made some progress at mitigating this, but it only deallocates these operand vectors when the gradient ends up being _used_; keeping them alive for the entire time between a gradient being computed and being used. When the loop reaches a point where enough gradients are computed-but-not-yet-used, it can OOM the GPU unnecessarily.

### Solution
The new `GradStoreBuilder::modify_if_tracked` function made it easy to move the `detach()` calls to be in between computing a gradient and storing it in the `GradStore`, instead of only after removal from the `GradStore`.

## Notes for reviewers

There are two big lift-and-shifts that make the code diff look a lot bigger than it is:
- refactoring `walk` into a separate function
- refactoring the big `match` in `backward` to use `GradStoreBuilder::modify_if_tracked` instead of `GradStore::or_insert`

I tried to keep each of those isolated in their own commits. Reviewing these should just be a matter of making sure that I kept the underlying logic intact. I'd recommend turning off whitespace in the diff viewer. Beyond these two lift-and-shifts, the only new code is the `GradStoreBuilder` and the test case I added to `grad_tests`.