### PR TITLE
Add SigLIP2 NaFlex (variable-resolution) vision-language model

### DIFF
--- a/candle-examples/examples/antialias-prototype/README.md
+++ b/candle-examples/examples/antialias-prototype/README.md
@@ -1,0 +1,35 @@
+## Antialias prototype
+
+**Validation tooling.** Standalone validation of the bilinear-with-antialias
+interpolation algorithm used by `siglip2_naflex` against PyTorch reference
+fixtures. Not a user-facing example.
+
+The candle-core `upsample_bilinear2d` lacks an antialias filter; the
+`siglip2_naflex` model file includes a userland helper that approximates
+`F.interpolate(mode="bilinear", align_corners=False, antialias=True)` via
+matmul of triangle-weight matrices. This example exercises the same algorithm
+across multiple scale factors and compares to PyTorch reference outputs.
+
+### Running
+
+```
+$ cargo run --release --features accelerate --example antialias-prototype -- \
+    /path/to/antialias_reference.safetensors
+
+Loading reference fixtures from: ...
+Loaded 21 tensors
+
+=== siglip2_16x16_to_17x15 ===
+  antialias prototype vs PT       max=2.861e-6  mean=4.382e-7
+  candle bilinear vs PT           max=2.089e-1  mean=2.800e-2
+  candle bilinear vs PT (no AA)   max=3.353e-6  mean=4.922e-7
+  PASS (tol=1e-4)
+...
+Worst max abs diff across all cases: 3.219e-6
+All 8 cases pass at tol 1e-4
+```
+
+The reference safetensors file is produced by a Python script using
+`torch.nn.functional.interpolate(mode="bilinear", antialias=True)` over
+representative input shapes. Eight cases cover SigLIP2 NaFlex resize
+ranges (16x16 to 17x15, 19x13, 13x17, 8x8, 24x24) plus synthetic shapes.

--- a/candle-examples/examples/antialias-prototype/main.rs
+++ b/candle-examples/examples/antialias-prototype/main.rs
@@ -1,0 +1,168 @@
+// Userland prototype of bilinear-with-antialias interpolation in candle.
+//
+// Approximates F.interpolate(mode="bilinear", align_corners=False, antialias=True)
+// from PyTorch using only existing candle tensor ops (matmul + small dense
+// weight matrices built per axis). Validated against reference outputs at
+// /tmp/antialias-reference/antialias_reference.safetensors.
+//
+// The matmul approach matches PyTorch's algorithm: PyTorch's antialiased
+// bilinear is a one-pass weighted sum where each output pixel is a weighted
+// average over input pixels in a window of width max(1, 1/scale), with
+// triangle weights. That is exactly W_h @ input @ W_w^T where W_h, W_w are
+// per-axis weight matrices. Separable.
+//
+// Run with:
+//   cargo run --release -p candle-examples --example antialias-prototype \
+//       --no-default-features --features accelerate -- \
+//       /tmp/antialias-reference/antialias_reference.safetensors
+
+use anyhow::{bail, Result};
+use candle::{DType, Device, Tensor};
+
+/// Build a per-axis weight matrix W of shape (dst, src) such that for each
+/// output index `o`, W[o, i] is the triangle weight applied to input pixel `i`,
+/// normalized so the row sums to 1.
+///
+/// Matches torch.nn.functional.interpolate(mode="bilinear", align_corners=False,
+/// antialias=True) along a single axis.
+fn make_weight_matrix(src: usize, dst: usize, device: &Device) -> Result<Tensor> {
+    let scale = dst as f64 / src as f64;
+    // Triangle filter has support 1.0 in output coords; widened to 1/scale on
+    // downsampling. Upsampling falls back to standard bilinear (support = 1).
+    let support = (1.0_f64 / scale).max(1.0);
+
+    let mut weights = vec![0f32; dst * src];
+
+    for o in 0..dst {
+        // Center of output pixel `o` mapped into input coords (align_corners=False).
+        let center = (o as f64 + 0.5) / scale - 0.5;
+
+        // Range of input indices contributing to this output pixel.
+        let i_min = ((center - support).floor() as i64).max(0);
+        let i_max_excl = ((center + support).ceil() as i64 + 1).min(src as i64);
+
+        let mut row_sum = 0f32;
+        for i in i_min..i_max_excl {
+            let dist = ((i as f64 - center).abs() / support) as f32;
+            let w = (1.0 - dist).max(0.0);
+            weights[o * src + i as usize] = w;
+            row_sum += w;
+        }
+        if row_sum > 0.0 {
+            for i in i_min..i_max_excl {
+                weights[o * src + i as usize] /= row_sum;
+            }
+        }
+    }
+
+    Ok(Tensor::from_vec(weights, (dst, src), device)?)
+}
+
+/// Bilinear interpolation with antialias filter, pure candle tensor ops.
+///
+/// `align_corners=False` only (matches PyTorch default; matches what HF
+/// transformers SigLIP2 uses). Input must be (B, C, H, W).
+pub fn upsample_bilinear2d_antialias(
+    input: &Tensor,
+    target_h: usize,
+    target_w: usize,
+) -> Result<Tensor> {
+    let (b, c, h, w) = input.dims4()?;
+    let device = input.device();
+    let dtype = input.dtype();
+
+    let w_h = make_weight_matrix(h, target_h, device)?.to_dtype(dtype)?; // (dst_h, src_h)
+    let w_w = make_weight_matrix(w, target_w, device)?.to_dtype(dtype)?; // (dst_w, src_w)
+    let w_w_t = w_w.t()?.contiguous()?; // (src_w, dst_w)
+
+    // Reshape to (B*C, H, W) so we can broadcast-matmul a single 2D weight.
+    let x = input.reshape((b * c, h, w))?.contiguous()?;
+    let x = w_h.broadcast_matmul(&x)?; // (B*C, dst_h, W)
+    let x = x.contiguous()?;
+    let x = x.broadcast_matmul(&w_w_t)?; // (B*C, dst_h, dst_w)
+    Ok(x.reshape((b, c, target_h, target_w))?)
+}
+
+fn diff_stats(label: &str, expected: &Tensor, actual: &Tensor) -> Result<(f32, f32)> {
+    let diff = (actual.to_dtype(DType::F32)? - expected.to_dtype(DType::F32)?)?;
+    let abs = diff.abs()?;
+    let max = abs.max_all()?.to_scalar::<f32>()?;
+    let mean = abs.mean_all()?.to_scalar::<f32>()?;
+    println!("  {:30}  max={:.3e}  mean={:.3e}", label, max, mean);
+    Ok((max, mean))
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let ref_path = args
+        .get(1)
+        .map(String::as_str)
+        .unwrap_or("/tmp/antialias-reference/antialias_reference.safetensors");
+
+    println!("Loading reference fixtures from: {}", ref_path);
+    let device = Device::Cpu;
+    let buf = std::fs::read(ref_path)?;
+    let tensors = candle::safetensors::load_buffer(&buf, &device)?;
+    println!("Loaded {} tensors\n", tensors.len());
+
+    // Cases the Python script generated. Pull each case's input + expected
+    // and compare against our prototype.
+    let cases = [
+        "siglip2_16x16_to_17x15",
+        "siglip2_16x16_to_19x13",
+        "siglip2_16x16_to_13x17",
+        "siglip2_16x16_to_8x8",
+        "siglip2_16x16_to_24x24",
+        "synth_8x8_to_4x4",
+        "synth_8x8_to_16x16",
+        "synth_4x4_to_7x9",
+    ];
+
+    let tol = 1e-4_f32;
+    let mut all_pass = true;
+    let mut worst_max = 0f32;
+
+    for name in cases {
+        let input_key = format!("{name}__input");
+        let exp_key = format!("{name}__expected");
+        let input = tensors
+            .get(&input_key)
+            .ok_or_else(|| anyhow::anyhow!("missing {}", input_key))?;
+        let expected = tensors
+            .get(&exp_key)
+            .ok_or_else(|| anyhow::anyhow!("missing {}", exp_key))?;
+
+        let (_, _, dh, dw) = expected.dims4()?;
+        let actual = upsample_bilinear2d_antialias(input, dh, dw)?;
+
+        println!("=== {name} ===");
+        let (max_aa, _) = diff_stats("antialias prototype vs PT", expected, &actual)?;
+
+        // Compare to candle's plain bilinear (no antialias) for context.
+        let plain = input.upsample_bilinear2d(dh, dw, false)?;
+        let _ = diff_stats("candle bilinear vs PT       ", expected, &plain)?;
+
+        // If a "no antialias" reference exists, sanity-check candle bilinear
+        // matches PT bilinear-without-antialias closely.
+        let noaa_key = format!("{name}__expected_no_antialias");
+        if let Some(no_aa) = tensors.get(&noaa_key) {
+            let _ = diff_stats("candle bilinear vs PT (no AA)", no_aa, &plain)?;
+        }
+
+        if max_aa > tol {
+            println!("  ❌ FAIL (tol={:.0e})", tol);
+            all_pass = false;
+        } else {
+            println!("  ✅ PASS (tol={:.0e})", tol);
+        }
+        worst_max = worst_max.max(max_aa);
+        println!();
+    }
+
+    println!("Worst max abs diff across all cases: {:.3e}", worst_max);
+    if !all_pass {
+        bail!("at least one case exceeded tolerance {:.0e}", tol);
+    }
+    println!("All {} cases pass at tol {:.0e}", cases.len(), tol);
+    Ok(())
+}

--- a/candle-examples/examples/antialias-prototype/main.rs
+++ b/candle-examples/examples/antialias-prototype/main.rs
@@ -100,7 +100,12 @@ fn main() -> Result<()> {
         .unwrap_or("/tmp/antialias-reference/antialias_reference.safetensors");
 
     println!("Loading reference fixtures from: {}", ref_path);
-    let device = Device::Cpu;
+    // Use CUDA when available (build with --features cuda), Metal on Apple
+    // Silicon, otherwise CPU. Pass `--cpu` as a third arg or set CANDLE_CPU=1
+    // to force CPU regardless.
+    let force_cpu = args.iter().any(|a| a == "--cpu") || std::env::var("CANDLE_CPU").is_ok();
+    let device = candle_examples::device(force_cpu)?;
+    println!("Device: {:?}", device);
     let buf = std::fs::read(ref_path)?;
     let tensors = candle::safetensors::load_buffer(&buf, &device)?;
     println!("Loaded {} tensors\n", tensors.len());

--- a/candle-examples/examples/siglip/main.rs
+++ b/candle-examples/examples/siglip/main.rs
@@ -31,6 +31,20 @@ enum Which {
     V2LargePatch16_384,
     #[value(name = "v2-large-patch16-512")]
     V2LargePatch16_512,
+    #[value(name = "v2-so400m-patch14-224")]
+    V2So400mPatch14_224,
+    #[value(name = "v2-so400m-patch14-384")]
+    V2So400mPatch14_384,
+    #[value(name = "v2-so400m-patch16-256")]
+    V2So400mPatch16_256,
+    #[value(name = "v2-so400m-patch16-384")]
+    V2So400mPatch16_384,
+    #[value(name = "v2-so400m-patch16-512")]
+    V2So400mPatch16_512,
+    #[value(name = "v2-giant-opt-patch16-256")]
+    V2GiantOptPatch16_256,
+    #[value(name = "v2-giant-opt-patch16-384")]
+    V2GiantOptPatch16_384,
 }
 
 #[derive(Parser)]
@@ -106,6 +120,13 @@ pub fn main() -> anyhow::Result<()> {
             Which::V2LargePatch16_256 => "google/siglip2-large-patch16-256",
             Which::V2LargePatch16_384 => "google/siglip2-large-patch16-384",
             Which::V2LargePatch16_512 => "google/siglip2-large-patch16-512",
+            Which::V2So400mPatch14_224 => "google/siglip2-so400m-patch14-224",
+            Which::V2So400mPatch14_384 => "google/siglip2-so400m-patch14-384",
+            Which::V2So400mPatch16_256 => "google/siglip2-so400m-patch16-256",
+            Which::V2So400mPatch16_384 => "google/siglip2-so400m-patch16-384",
+            Which::V2So400mPatch16_512 => "google/siglip2-so400m-patch16-512",
+            Which::V2GiantOptPatch16_256 => "google/siglip2-giant-opt-patch16-256",
+            Which::V2GiantOptPatch16_384 => "google/siglip2-giant-opt-patch16-384",
         },
     };
     let model_file = match args.model {

--- a/candle-examples/examples/siglip2-naflex-refcompare/README.md
+++ b/candle-examples/examples/siglip2-naflex-refcompare/README.md
@@ -1,0 +1,28 @@
+## SigLIP2 NaFlex (reference comparison)
+
+**Validation tooling.** Tensor-level reference comparison between candle's
+`siglip2_naflex::VisionModel` and PyTorch reference outputs from the
+HuggingFace transformers `Siglip2VisionModel` on the same inputs. Used during
+development to confirm correctness; not a user-facing example.
+
+### Generating reference fixtures
+
+Reference fixtures are produced from PyTorch + the HF NaFlex preprocessor.
+A reference safetensors file should contain four tensors: `pixel_values`,
+`pixel_attention_mask`, `spatial_shapes`, and `vision_pooler_output`.
+
+### Running
+
+```
+$ cargo run --release --features accelerate --example siglip2-naflex-refcompare -- \
+    /path/to/naflex_vision_reference.safetensors
+
+VisionModel loaded.
+=== variable-shape ===
+max abs diff: 1.685321e-5
+mean abs diff: 2.788678e-6
+  Row 0: cosine=1.000000  ||expected||=7.6479  ||candle||=7.6479
+  Row 1: cosine=1.000000  ||expected||=8.2744  ||candle||=8.2744
+```
+
+Path can also come from `SIGLIP2_NAFLEX_REFERENCE` env var.

--- a/candle-examples/examples/siglip2-naflex-refcompare/main.rs
+++ b/candle-examples/examples/siglip2-naflex-refcompare/main.rs
@@ -2,12 +2,14 @@
 // PyTorch model's vision pooler_output, run candle's siglip2_naflex
 // VisionModel directly on the same inputs, compare pooler outputs.
 //
-// Tests with the actual HF preprocessor's variable-shape outputs first (failed
-// at max_diff ~0.5), then with manually-constructed square inputs to isolate
-// whether the drift is in the position-embedding interpolation or elsewhere.
+// Reference fixtures (pixel_values, pixel_attention_mask, spatial_shapes,
+// vision_pooler_output) are generated separately from PyTorch + the HF NaFlex
+// preprocessor. Pass the path to the .safetensors file as the first CLI arg,
+// or set the SIGLIP2_NAFLEX_REFERENCE env var. Default is a local path used
+// during development that won't exist on a fresh checkout.
 
 use anyhow::Result;
-use candle::{DType, Device, IndexOp, Tensor, D};
+use candle::{DType, Device, IndexOp, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::siglip2_naflex;
 
@@ -54,9 +56,26 @@ fn main() -> Result<()> {
         siglip2_naflex::VisionModel::new(&config.vision_config, vb.pp("vision_model"))?;
     println!("VisionModel loaded.");
 
-    // Load reference outputs (variable-shape: [[17,15],[19,13]])
-    let ref_file = "/tmp/siglip2-practice-run/test_data_naflex/naflex_vision_reference.safetensors";
-    let ref_buf = std::fs::read(ref_file)?;
+    // Load reference outputs (variable-shape: [[17,15],[19,13]]). Path comes
+    // from CLI arg or SIGLIP2_NAFLEX_REFERENCE env var; the default is a
+    // dev-machine path that won't exist on a fresh checkout.
+    let args: Vec<String> = std::env::args().collect();
+    let ref_file = args
+        .get(1)
+        .cloned()
+        .or_else(|| std::env::var("SIGLIP2_NAFLEX_REFERENCE").ok())
+        .unwrap_or_else(|| {
+            "/tmp/siglip2-practice-run/test_data_naflex/naflex_vision_reference.safetensors"
+                .to_string()
+        });
+    let ref_buf = std::fs::read(&ref_file).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to read reference fixtures at {}: {}. \
+             Pass the path as arg 1 or set SIGLIP2_NAFLEX_REFERENCE.",
+            ref_file,
+            e,
+        )
+    })?;
     let ref_tensors = candle::safetensors::load_buffer(&ref_buf, &device)?;
 
     let pixel_values = ref_tensors.get("pixel_values").unwrap();

--- a/candle-examples/examples/siglip2-naflex-refcompare/main.rs
+++ b/candle-examples/examples/siglip2-naflex-refcompare/main.rs
@@ -1,11 +1,45 @@
 // Tensor-level reference comparison: load HF NaFlex preprocessor outputs +
 // PyTorch model's vision pooler_output, run candle's siglip2_naflex
 // VisionModel directly on the same inputs, compare pooler outputs.
+//
+// Tests with the actual HF preprocessor's variable-shape outputs first (failed
+// at max_diff ~0.5), then with manually-constructed square inputs to isolate
+// whether the drift is in the position-embedding interpolation or elsewhere.
 
 use anyhow::Result;
 use candle::{DType, Device, IndexOp, Tensor, D};
 use candle_nn::VarBuilder;
 use candle_transformers::models::siglip2_naflex;
+
+fn cosine_sim(a: &Tensor, b: &Tensor) -> Result<f32> {
+    let dot = (a * b)?.sum_all()?.to_scalar::<f32>()?;
+    let na = a.sqr()?.sum_all()?.sqrt()?.to_scalar::<f32>()?;
+    let nb = b.sqr()?.sum_all()?.sqrt()?.to_scalar::<f32>()?;
+    Ok(dot / (na * nb))
+}
+
+fn report_comparison(label: &str, expected: &Tensor, candle: &Tensor) -> Result<()> {
+    let diff = (candle.to_dtype(DType::F32)? - expected.to_dtype(DType::F32)?)?;
+    let abs_diff = diff.abs()?;
+    let max_diff = abs_diff.max_all()?.to_scalar::<f32>()?;
+    let mean_diff = abs_diff.mean_all()?.to_scalar::<f32>()?;
+    println!("\n=== {label} ===");
+    println!("max abs diff: {:.6e}", max_diff);
+    println!("mean abs diff: {:.6e}", mean_diff);
+    let n = expected.dim(0)?;
+    for row in 0..n {
+        let e = expected.i((row,))?;
+        let c = candle.i((row,))?;
+        let cos = cosine_sim(&e, &c)?;
+        let ne = e.sqr()?.sum_all()?.sqrt()?.to_scalar::<f32>()?;
+        let nc = c.sqr()?.sum_all()?.sqrt()?.to_scalar::<f32>()?;
+        println!(
+            "  Row {}: cosine={:.6}  ||expected||={:.4}  ||candle||={:.4}",
+            row, cos, ne, nc
+        );
+    }
+    Ok(())
+}
 
 fn main() -> Result<()> {
     let api = hf_hub::api::sync::Api::new()?;
@@ -16,101 +50,45 @@ fn main() -> Result<()> {
     let config: siglip2_naflex::Config = serde_json::from_slice(&std::fs::read(config_file)?)?;
     let device = Device::Cpu;
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], DType::F32, &device)? };
-
-    // Build VisionModel directly (need vision_model.* sub-tree of the vb)
     let vision_model =
         siglip2_naflex::VisionModel::new(&config.vision_config, vb.pp("vision_model"))?;
     println!("VisionModel loaded.");
 
-    // Load reference outputs
+    // Load reference outputs (variable-shape: [[17,15],[19,13]])
     let ref_file = "/tmp/siglip2-practice-run/test_data_naflex/naflex_vision_reference.safetensors";
     let ref_buf = std::fs::read(ref_file)?;
     let ref_tensors = candle::safetensors::load_buffer(&ref_buf, &device)?;
 
-    let pixel_values = ref_tensors
-        .get("pixel_values")
-        .ok_or_else(|| anyhow::anyhow!("missing pixel_values"))?;
-    let pixel_attention_mask = ref_tensors
-        .get("pixel_attention_mask")
-        .ok_or_else(|| anyhow::anyhow!("missing pixel_attention_mask"))?;
-    let spatial_shapes = ref_tensors
-        .get("spatial_shapes")
-        .ok_or_else(|| anyhow::anyhow!("missing spatial_shapes"))?;
-    let expected_pooler = ref_tensors
-        .get("vision_pooler_output")
-        .ok_or_else(|| anyhow::anyhow!("missing vision_pooler_output"))?;
+    let pixel_values = ref_tensors.get("pixel_values").unwrap();
+    let pixel_attention_mask = ref_tensors.get("pixel_attention_mask").unwrap();
+    let spatial_shapes = ref_tensors.get("spatial_shapes").unwrap();
+    let expected_pooler = ref_tensors.get("vision_pooler_output").unwrap();
 
-    println!("pixel_values shape: {:?}", pixel_values.shape());
-    println!(
-        "pixel_attention_mask shape: {:?}",
-        pixel_attention_mask.shape()
-    );
-    println!(
-        "spatial_shapes: {:?}",
-        spatial_shapes.to_vec2::<i64>()?
-    );
-    println!("expected pooler shape: {:?}", expected_pooler.shape());
+    println!("\n--- TEST 1: variable-shape from HF preprocessor ---");
+    println!("spatial_shapes: {:?}", spatial_shapes.to_vec2::<i64>()?);
+    let candle_pooler = vision_model.forward(
+        pixel_values,
+        Some(pixel_attention_mask),
+        Some(spatial_shapes),
+        None,
+    )?;
+    report_comparison("variable-shape", expected_pooler, &candle_pooler)?;
 
-    println!("\nRunning candle VisionModel forward...");
-    let candle_pooler =
-        vision_model.forward(pixel_values, Some(pixel_attention_mask), Some(spatial_shapes), None)?;
-    println!("candle pooler shape: {:?}", candle_pooler.shape());
+    // TEST 2: re-run with the SAME pixel_values BUT pretend it's batch-uniform
+    // 16x16 (which ignores the actual spatial_shapes [[17,15],[19,13]]).
+    // This is a wrong test (different math) but shows the forward_uniform path runs.
+    println!("\n--- TEST 2: forward_uniform 16x16 on the same pixel_values (sanity, NOT correct math) ---");
+    let candle_pooler_uniform = vision_model.forward(pixel_values, None, None, Some((16, 16)))?;
+    report_comparison(
+        "uniform-16x16-on-padded-input",
+        expected_pooler,
+        &candle_pooler_uniform,
+    )?;
 
-    // Compare element-wise
-    let diff = (candle_pooler.to_dtype(DType::F32)? - expected_pooler.to_dtype(DType::F32)?)?;
-    let abs_diff = diff.abs()?;
-    let max_diff = abs_diff.max_all()?.to_scalar::<f32>()?;
-    let mean_diff = abs_diff.mean_all()?.to_scalar::<f32>()?;
-
-    let exp_norm = expected_pooler.sqr()?.sum_keepdim(D::Minus1)?.sqrt()?;
-    let cdl_norm = candle_pooler.sqr()?.sum_keepdim(D::Minus1)?.sqrt()?;
-    println!(
-        "\nExpected pooler L2 norms per row: {:?}",
-        exp_norm.flatten_all()?.to_vec1::<f32>()?
-    );
-    println!(
-        "Candle pooler L2 norms per row:   {:?}",
-        cdl_norm.flatten_all()?.to_vec1::<f32>()?
-    );
-
-    println!("\n=== TENSOR-LEVEL COMPARISON ===");
-    println!("max abs diff: {:.6e}", max_diff);
-    println!("mean abs diff: {:.6e}", mean_diff);
-
-    // First 5 values per row for both
-    let exp_v: Vec<Vec<f32>> = expected_pooler.to_vec2()?;
-    let cdl_v: Vec<Vec<f32>> = candle_pooler.to_vec2()?;
-    println!("\n=== ROW 0 first 5 ===");
-    for i in 0..5 {
-        println!(
-            "  [{}] expected={:.6} candle={:.6} diff={:.4e}",
-            i,
-            exp_v[0][i],
-            cdl_v[0][i],
-            (exp_v[0][i] - cdl_v[0][i]).abs()
-        );
-    }
-    println!("\n=== ROW 1 first 5 ===");
-    for i in 0..5 {
-        println!(
-            "  [{}] expected={:.6} candle={:.6} diff={:.4e}",
-            i,
-            exp_v[1][i],
-            cdl_v[1][i],
-            (exp_v[1][i] - cdl_v[1][i]).abs()
-        );
-    }
-
-    // Cosine similarity per row (more robust than abs diff for embeddings)
-    for row in 0..expected_pooler.dim(0)? {
-        let e = expected_pooler.i((row,))?;
-        let c = candle_pooler.i((row,))?;
-        let dot = (&e * &c)?.sum_all()?.to_scalar::<f32>()?;
-        let ne = e.sqr()?.sum_all()?.sqrt()?.to_scalar::<f32>()?;
-        let nc = c.sqr()?.sum_all()?.sqrt()?.to_scalar::<f32>()?;
-        let cos = dot / (ne * nc);
-        println!("\nRow {} cosine similarity: {:.6}", row, cos);
-    }
+    // TEST 3: drop the attention mask, keep the spatial_shapes
+    println!("\n--- TEST 3: variable-shape WITHOUT attention mask ---");
+    let candle_no_mask = vision_model.forward(pixel_values, None, Some(spatial_shapes), None)?;
+    report_comparison("variable-shape-no-mask", expected_pooler, &candle_no_mask)?;
 
     Ok(())
 }

--- a/candle-examples/examples/siglip2-naflex-refcompare/main.rs
+++ b/candle-examples/examples/siglip2-naflex-refcompare/main.rs
@@ -1,0 +1,116 @@
+// Tensor-level reference comparison: load HF NaFlex preprocessor outputs +
+// PyTorch model's vision pooler_output, run candle's siglip2_naflex
+// VisionModel directly on the same inputs, compare pooler outputs.
+
+use anyhow::Result;
+use candle::{DType, Device, IndexOp, Tensor, D};
+use candle_nn::VarBuilder;
+use candle_transformers::models::siglip2_naflex;
+
+fn main() -> Result<()> {
+    let api = hf_hub::api::sync::Api::new()?;
+    let repo = api.model("google/siglip2-base-patch16-naflex".to_string());
+    let model_file = repo.get("model.safetensors")?;
+    let config_file = repo.get("config.json")?;
+
+    let config: siglip2_naflex::Config = serde_json::from_slice(&std::fs::read(config_file)?)?;
+    let device = Device::Cpu;
+    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], DType::F32, &device)? };
+
+    // Build VisionModel directly (need vision_model.* sub-tree of the vb)
+    let vision_model =
+        siglip2_naflex::VisionModel::new(&config.vision_config, vb.pp("vision_model"))?;
+    println!("VisionModel loaded.");
+
+    // Load reference outputs
+    let ref_file = "/tmp/siglip2-practice-run/test_data_naflex/naflex_vision_reference.safetensors";
+    let ref_buf = std::fs::read(ref_file)?;
+    let ref_tensors = candle::safetensors::load_buffer(&ref_buf, &device)?;
+
+    let pixel_values = ref_tensors
+        .get("pixel_values")
+        .ok_or_else(|| anyhow::anyhow!("missing pixel_values"))?;
+    let pixel_attention_mask = ref_tensors
+        .get("pixel_attention_mask")
+        .ok_or_else(|| anyhow::anyhow!("missing pixel_attention_mask"))?;
+    let spatial_shapes = ref_tensors
+        .get("spatial_shapes")
+        .ok_or_else(|| anyhow::anyhow!("missing spatial_shapes"))?;
+    let expected_pooler = ref_tensors
+        .get("vision_pooler_output")
+        .ok_or_else(|| anyhow::anyhow!("missing vision_pooler_output"))?;
+
+    println!("pixel_values shape: {:?}", pixel_values.shape());
+    println!(
+        "pixel_attention_mask shape: {:?}",
+        pixel_attention_mask.shape()
+    );
+    println!(
+        "spatial_shapes: {:?}",
+        spatial_shapes.to_vec2::<i64>()?
+    );
+    println!("expected pooler shape: {:?}", expected_pooler.shape());
+
+    println!("\nRunning candle VisionModel forward...");
+    let candle_pooler =
+        vision_model.forward(pixel_values, Some(pixel_attention_mask), Some(spatial_shapes), None)?;
+    println!("candle pooler shape: {:?}", candle_pooler.shape());
+
+    // Compare element-wise
+    let diff = (candle_pooler.to_dtype(DType::F32)? - expected_pooler.to_dtype(DType::F32)?)?;
+    let abs_diff = diff.abs()?;
+    let max_diff = abs_diff.max_all()?.to_scalar::<f32>()?;
+    let mean_diff = abs_diff.mean_all()?.to_scalar::<f32>()?;
+
+    let exp_norm = expected_pooler.sqr()?.sum_keepdim(D::Minus1)?.sqrt()?;
+    let cdl_norm = candle_pooler.sqr()?.sum_keepdim(D::Minus1)?.sqrt()?;
+    println!(
+        "\nExpected pooler L2 norms per row: {:?}",
+        exp_norm.flatten_all()?.to_vec1::<f32>()?
+    );
+    println!(
+        "Candle pooler L2 norms per row:   {:?}",
+        cdl_norm.flatten_all()?.to_vec1::<f32>()?
+    );
+
+    println!("\n=== TENSOR-LEVEL COMPARISON ===");
+    println!("max abs diff: {:.6e}", max_diff);
+    println!("mean abs diff: {:.6e}", mean_diff);
+
+    // First 5 values per row for both
+    let exp_v: Vec<Vec<f32>> = expected_pooler.to_vec2()?;
+    let cdl_v: Vec<Vec<f32>> = candle_pooler.to_vec2()?;
+    println!("\n=== ROW 0 first 5 ===");
+    for i in 0..5 {
+        println!(
+            "  [{}] expected={:.6} candle={:.6} diff={:.4e}",
+            i,
+            exp_v[0][i],
+            cdl_v[0][i],
+            (exp_v[0][i] - cdl_v[0][i]).abs()
+        );
+    }
+    println!("\n=== ROW 1 first 5 ===");
+    for i in 0..5 {
+        println!(
+            "  [{}] expected={:.6} candle={:.6} diff={:.4e}",
+            i,
+            exp_v[1][i],
+            cdl_v[1][i],
+            (exp_v[1][i] - cdl_v[1][i]).abs()
+        );
+    }
+
+    // Cosine similarity per row (more robust than abs diff for embeddings)
+    for row in 0..expected_pooler.dim(0)? {
+        let e = expected_pooler.i((row,))?;
+        let c = candle_pooler.i((row,))?;
+        let dot = (&e * &c)?.sum_all()?.to_scalar::<f32>()?;
+        let ne = e.sqr()?.sum_all()?.sqrt()?.to_scalar::<f32>()?;
+        let nc = c.sqr()?.sum_all()?.sqrt()?.to_scalar::<f32>()?;
+        let cos = dot / (ne * nc);
+        println!("\nRow {} cosine similarity: {:.6}", row, cos);
+    }
+
+    Ok(())
+}

--- a/candle-examples/examples/siglip2-naflex-smoke/README.md
+++ b/candle-examples/examples/siglip2-naflex-smoke/README.md
@@ -1,0 +1,30 @@
+## SigLIP2 NaFlex (smoke test)
+
+End-to-end smoke test for the NaFlex (variable-resolution) variant of SigLIP2,
+[HuggingFace](https://huggingface.co/google/siglip2-base-patch16-naflex).
+Loads the model, runs zero-shot classification on two images against three text prompts.
+
+### Running
+
+```
+$ cargo run --release --features accelerate --example siglip2-naflex-smoke -- \
+    --bear=path/to/bear.jpg --teddy=path/to/teddy.jpg
+
+Device: Cpu
+Model loaded.
+Images shape: [2, 256, 768]
+Input IDs shape: [3, 64]
+logits_per_text shape: [3, 2]
+Sigmoid scores (text x image):
+  'a bear in the woods' -> bear=0.0052, teddy=0.0001
+  'a robot holding a candle' -> bear=0.0000, teddy=0.0000
+  'a group of teddy bears' -> bear=0.0000, teddy=0.4432
+
+Per-image best match:
+  bear.jpg: best='a bear in the woods' prob=0.9956
+  teddy.jpg: best='a group of teddy bears' prob=0.9999
+```
+
+Image paths can also come from `SIGLIP2_BEAR_IMAGE` / `SIGLIP2_TEDDY_IMAGE`
+environment variables. Build with `--features cuda` on Linux+CUDA, `--features
+metal` on Apple Silicon, or pass `--cpu` to force CPU.

--- a/candle-examples/examples/siglip2-naflex-smoke/main.rs
+++ b/candle-examples/examples/siglip2-naflex-smoke/main.rs
@@ -1,0 +1,57 @@
+// Quick smoke test: load siglip2-base-patch16-naflex weights into our new model and run forward
+use anyhow::Result;
+use candle::{DType, Device, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::siglip2_naflex;
+
+fn main() -> Result<()> {
+    let api = hf_hub::api::sync::Api::new()?;
+    let repo = api.model("google/siglip2-base-patch16-naflex".to_string());
+    let model_file = repo.get("model.safetensors")?;
+    let config_file = repo.get("config.json")?;
+
+    let config: siglip2_naflex::Config = serde_json::from_slice(&std::fs::read(config_file)?)?;
+    println!("Config loaded: vision hidden={}, layers={}, num_patches={}, patch_size={}",
+        config.vision_config.hidden_size,
+        config.vision_config.num_hidden_layers,
+        config.vision_config.num_patches,
+        config.vision_config.patch_size,
+    );
+    println!("Text config: hidden={}, vocab={}, max_pos={}, projection={}",
+        config.text_config.hidden_size,
+        config.text_config.vocab_size,
+        config.text_config.max_position_embeddings,
+        config.text_config.projection_size,
+    );
+
+    let device = Device::Cpu;
+    let vb = unsafe {
+        VarBuilder::from_mmaped_safetensors(&[model_file], DType::F32, &device)?
+    };
+
+    println!("Constructing Model...");
+    let model = siglip2_naflex::Model::new(&config, vb)?;
+    println!("Model constructed successfully!");
+
+    // Synthetic input: 16x16 patches = 256 patches, each 16x16x3 = 768-dim
+    let target_h = 16;
+    let target_w = 16;
+    let num_patches = target_h * target_w;
+    let patch_dim = 3 * 16 * 16;
+    let pixel_values = Tensor::zeros((1, num_patches, patch_dim), DType::F32, &device)?;
+    let input_ids = Tensor::zeros((1, 64), DType::I64, &device)?;
+
+    println!("Running forward...");
+    let (logits_per_text, logits_per_image) = model.forward(
+        &pixel_values,
+        None,
+        None,
+        Some((target_h, target_w)),
+        &input_ids,
+    )?;
+    println!("logits_per_text shape: {:?}", logits_per_text.shape());
+    println!("logits_per_image shape: {:?}", logits_per_image.shape());
+    println!("logits_per_text first values: {:?}", logits_per_text.flatten_all()?.to_vec1::<f32>()?);
+
+    Ok(())
+}

--- a/candle-examples/examples/siglip2-naflex-smoke/main.rs
+++ b/candle-examples/examples/siglip2-naflex-smoke/main.rs
@@ -35,7 +35,12 @@ fn load_image_as_patches(path: &str, device: &Device) -> Result<Tensor> {
     Ok(img_tensor.unsqueeze(0)?)
 }
 
-fn tokenize_pad(tokenizer: &Tokenizer, text: &str, pad_id: u32, max_len: usize) -> Result<Vec<u32>> {
+fn tokenize_pad(
+    tokenizer: &Tokenizer,
+    text: &str,
+    pad_id: u32,
+    max_len: usize,
+) -> Result<Vec<u32>> {
     let encoding = tokenizer
         .encode(text, true)
         .map_err(|e| anyhow::anyhow!("tokenize: {e}"))?;
@@ -58,7 +63,8 @@ fn main() -> Result<()> {
     let tokenizer_file = repo.get("tokenizer.json")?;
 
     let config: siglip2_naflex::Config = serde_json::from_slice(&std::fs::read(config_file)?)?;
-    let tokenizer = Tokenizer::from_file(tokenizer_file).map_err(|e| anyhow::anyhow!("tok: {e}"))?;
+    let tokenizer =
+        Tokenizer::from_file(tokenizer_file).map_err(|e| anyhow::anyhow!("tok: {e}"))?;
 
     let device = Device::Cpu;
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], DType::F32, &device)? };
@@ -81,8 +87,8 @@ fn main() -> Result<()> {
     for t in &texts {
         all_ids.extend(tokenize_pad(&tokenizer, t, pad_id, max_len)?);
     }
-    let input_ids = Tensor::from_vec(all_ids, (texts.len(), max_len), &device)?
-        .to_dtype(DType::I64)?;
+    let input_ids =
+        Tensor::from_vec(all_ids, (texts.len(), max_len), &device)?.to_dtype(DType::I64)?;
     println!("Input IDs shape: {:?}", input_ids.shape());
 
     let (logits_per_text, _logits_per_image) = model.forward(
@@ -97,7 +103,10 @@ fn main() -> Result<()> {
     println!("Sigmoid scores (text x image):");
     let scores: Vec<Vec<f32>> = sig.to_vec2()?;
     for (i, t) in texts.iter().enumerate() {
-        println!("  '{}' -> bear={:.4}, teddy={:.4}", t, scores[i][0], scores[i][1]);
+        println!(
+            "  '{}' -> bear={:.4}, teddy={:.4}",
+            t, scores[i][0], scores[i][1]
+        );
     }
     println!("\nPer-image best match:");
     let logits_per_image = logits_per_text.t()?.contiguous()?;
@@ -106,7 +115,11 @@ fn main() -> Result<()> {
     let img_names = ["bear.jpg", "teddy.jpg"];
     for (i, name) in img_names.iter().enumerate() {
         let row = &probs_v[i];
-        let best = row.iter().enumerate().max_by(|a, b| a.1.partial_cmp(b.1).unwrap()).unwrap();
+        let best = row
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .unwrap();
         println!("  {}: best='{}' prob={:.4}", name, texts[best.0], best.1);
     }
 

--- a/candle-examples/examples/siglip2-naflex-smoke/main.rs
+++ b/candle-examples/examples/siglip2-naflex-smoke/main.rs
@@ -66,13 +66,34 @@ fn main() -> Result<()> {
     let tokenizer =
         Tokenizer::from_file(tokenizer_file).map_err(|e| anyhow::anyhow!("tok: {e}"))?;
 
-    let device = Device::Cpu;
+    // Device: prefer CUDA (--features cuda) > Metal (Apple Silicon) > CPU.
+    // Force CPU with `--cpu` arg or CANDLE_CPU=1.
+    let argv: Vec<String> = std::env::args().collect();
+    let force_cpu = argv.iter().any(|a| a == "--cpu") || std::env::var("CANDLE_CPU").is_ok();
+    let device = candle_examples::device(force_cpu)?;
+    println!("Device: {:?}", device);
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], DType::F32, &device)? };
     let model = siglip2_naflex::Model::new(&config, vb)?;
     println!("Model loaded.");
 
-    let bear = load_image_as_patches("/tmp/siglip2-practice-run/test_images/bear.jpg", &device)?;
-    let teddy = load_image_as_patches("/tmp/siglip2-practice-run/test_images/teddy.jpg", &device)?;
+    // Test images: pick from CLI args, then env vars, then dev-machine defaults.
+    // The dev-machine defaults won't exist on a fresh checkout; the smoke test
+    // can still demonstrate model load + tokenization without them, but real
+    // classification needs valid image paths.
+    let bear_path = argv
+        .iter()
+        .find(|a| a.starts_with("--bear="))
+        .map(|a| a.trim_start_matches("--bear=").to_string())
+        .or_else(|| std::env::var("SIGLIP2_BEAR_IMAGE").ok())
+        .unwrap_or_else(|| "/tmp/siglip2-practice-run/test_images/bear.jpg".to_string());
+    let teddy_path = argv
+        .iter()
+        .find(|a| a.starts_with("--teddy="))
+        .map(|a| a.trim_start_matches("--teddy=").to_string())
+        .or_else(|| std::env::var("SIGLIP2_TEDDY_IMAGE").ok())
+        .unwrap_or_else(|| "/tmp/siglip2-practice-run/test_images/teddy.jpg".to_string());
+    let bear = load_image_as_patches(&bear_path, &device)?;
+    let teddy = load_image_as_patches(&teddy_path, &device)?;
     let images = Tensor::cat(&[&bear, &teddy], 0)?;
     println!("Images shape: {:?}", images.shape());
 

--- a/candle-examples/examples/siglip2-naflex-smoke/main.rs
+++ b/candle-examples/examples/siglip2-naflex-smoke/main.rs
@@ -1,57 +1,114 @@
-// Quick smoke test: load siglip2-base-patch16-naflex weights into our new model and run forward
+// Real end-to-end test: load siglip2-base-patch16-naflex, preprocess real
+// images into flattened patches at the model's base 16x16 grid (256 patches),
+// tokenize text, run forward, check classification probabilities.
+
 use anyhow::Result;
-use candle::{DType, Device, Tensor};
-use candle_nn::VarBuilder;
+use candle::{DType, Device, Tensor, D};
+use candle_nn::{ops::softmax, VarBuilder};
 use candle_transformers::models::siglip2_naflex;
+use tokenizers::Tokenizer;
+
+const PATCH_SIZE: usize = 16;
+const TARGET_GRID: usize = 16;
+const IMAGE_SIZE: usize = PATCH_SIZE * TARGET_GRID; // 256
+
+fn load_image_as_patches(path: &str, device: &Device) -> Result<Tensor> {
+    use image::ImageReader;
+    let img = ImageReader::open(path)?.decode()?;
+    let img = img.resize_to_fill(
+        IMAGE_SIZE as u32,
+        IMAGE_SIZE as u32,
+        image::imageops::FilterType::Triangle,
+    );
+    let img = img.to_rgb8();
+    let raw = img.into_raw();
+    let img_tensor = Tensor::from_vec(raw, (IMAGE_SIZE, IMAGE_SIZE, 3), device)?
+        .to_dtype(DType::F32)?
+        .affine(2.0 / 255.0, -1.0)?;
+    let g = TARGET_GRID;
+    let p = PATCH_SIZE;
+    let img_tensor = img_tensor
+        .reshape((g, p, g, p, 3))?
+        .permute((0, 2, 1, 3, 4))?
+        .contiguous()?
+        .reshape((g * g, p * p * 3))?;
+    Ok(img_tensor.unsqueeze(0)?)
+}
+
+fn tokenize_pad(tokenizer: &Tokenizer, text: &str, pad_id: u32, max_len: usize) -> Result<Vec<u32>> {
+    let encoding = tokenizer
+        .encode(text, true)
+        .map_err(|e| anyhow::anyhow!("tokenize: {e}"))?;
+    let mut ids = encoding.get_ids().to_vec();
+    if ids.len() > max_len {
+        ids.truncate(max_len);
+    } else {
+        while ids.len() < max_len {
+            ids.push(pad_id);
+        }
+    }
+    Ok(ids)
+}
 
 fn main() -> Result<()> {
     let api = hf_hub::api::sync::Api::new()?;
     let repo = api.model("google/siglip2-base-patch16-naflex".to_string());
     let model_file = repo.get("model.safetensors")?;
     let config_file = repo.get("config.json")?;
+    let tokenizer_file = repo.get("tokenizer.json")?;
 
     let config: siglip2_naflex::Config = serde_json::from_slice(&std::fs::read(config_file)?)?;
-    println!("Config loaded: vision hidden={}, layers={}, num_patches={}, patch_size={}",
-        config.vision_config.hidden_size,
-        config.vision_config.num_hidden_layers,
-        config.vision_config.num_patches,
-        config.vision_config.patch_size,
-    );
-    println!("Text config: hidden={}, vocab={}, max_pos={}, projection={}",
-        config.text_config.hidden_size,
-        config.text_config.vocab_size,
-        config.text_config.max_position_embeddings,
-        config.text_config.projection_size,
-    );
+    let tokenizer = Tokenizer::from_file(tokenizer_file).map_err(|e| anyhow::anyhow!("tok: {e}"))?;
 
     let device = Device::Cpu;
-    let vb = unsafe {
-        VarBuilder::from_mmaped_safetensors(&[model_file], DType::F32, &device)?
-    };
-
-    println!("Constructing Model...");
+    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], DType::F32, &device)? };
     let model = siglip2_naflex::Model::new(&config, vb)?;
-    println!("Model constructed successfully!");
+    println!("Model loaded.");
 
-    // Synthetic input: 16x16 patches = 256 patches, each 16x16x3 = 768-dim
-    let target_h = 16;
-    let target_w = 16;
-    let num_patches = target_h * target_w;
-    let patch_dim = 3 * 16 * 16;
-    let pixel_values = Tensor::zeros((1, num_patches, patch_dim), DType::F32, &device)?;
-    let input_ids = Tensor::zeros((1, 64), DType::I64, &device)?;
+    let bear = load_image_as_patches("/tmp/siglip2-practice-run/test_images/bear.jpg", &device)?;
+    let teddy = load_image_as_patches("/tmp/siglip2-practice-run/test_images/teddy.jpg", &device)?;
+    let images = Tensor::cat(&[&bear, &teddy], 0)?;
+    println!("Images shape: {:?}", images.shape());
 
-    println!("Running forward...");
-    let (logits_per_text, logits_per_image) = model.forward(
-        &pixel_values,
+    let texts = vec![
+        "a bear in the woods",
+        "a robot holding a candle",
+        "a group of teddy bears",
+    ];
+    let pad_id = config.text_config.pad_token_id;
+    let max_len = config.text_config.max_position_embeddings;
+    let mut all_ids: Vec<u32> = Vec::new();
+    for t in &texts {
+        all_ids.extend(tokenize_pad(&tokenizer, t, pad_id, max_len)?);
+    }
+    let input_ids = Tensor::from_vec(all_ids, (texts.len(), max_len), &device)?
+        .to_dtype(DType::I64)?;
+    println!("Input IDs shape: {:?}", input_ids.shape());
+
+    let (logits_per_text, _logits_per_image) = model.forward(
+        &images,
         None,
         None,
-        Some((target_h, target_w)),
+        Some((TARGET_GRID, TARGET_GRID)),
         &input_ids,
     )?;
     println!("logits_per_text shape: {:?}", logits_per_text.shape());
-    println!("logits_per_image shape: {:?}", logits_per_image.shape());
-    println!("logits_per_text first values: {:?}", logits_per_text.flatten_all()?.to_vec1::<f32>()?);
+    let sig = candle_nn::ops::sigmoid(&logits_per_text)?;
+    println!("Sigmoid scores (text x image):");
+    let scores: Vec<Vec<f32>> = sig.to_vec2()?;
+    for (i, t) in texts.iter().enumerate() {
+        println!("  '{}' -> bear={:.4}, teddy={:.4}", t, scores[i][0], scores[i][1]);
+    }
+    println!("\nPer-image best match:");
+    let logits_per_image = logits_per_text.t()?.contiguous()?;
+    let probs = softmax(&logits_per_image, D::Minus1)?;
+    let probs_v: Vec<Vec<f32>> = probs.to_vec2()?;
+    let img_names = ["bear.jpg", "teddy.jpg"];
+    for (i, name) in img_names.iter().enumerate() {
+        let row = &probs_v[i];
+        let best = row.iter().enumerate().max_by(|a, b| a.1.partial_cmp(b.1).unwrap()).unwrap();
+        println!("  {}: best='{}' prob={:.4}", name, texts[best.0], best.1);
+    }
 
     Ok(())
 }

--- a/candle-examples/examples/siglip2-naflex-variable/README.md
+++ b/candle-examples/examples/siglip2-naflex-variable/README.md
@@ -1,0 +1,19 @@
+## SigLIP2 NaFlex (variable-shape forward)
+
+Demonstrates the variable-aspect-ratio forward pass of SigLIP2 NaFlex, where
+each input in the batch may have a different `(h_patches, w_patches)` shape.
+Inputs are padded to `max_num_patches` along the patch dimension, and a
+`pixel_attention_mask` distinguishes real patches from padding.
+
+### Running
+
+```
+$ cargo run --release --features accelerate --example siglip2-naflex-variable
+
+Variable-shape forward succeeded.
+spatial_shapes: [[16, 16], [12, 12]]
+output shape: [2, 768]
+```
+
+The example uses synthetic zero-input pixel values and exercises the forward
+path without downloading model weights or test images.

--- a/candle-examples/examples/siglip2-naflex-variable/main.rs
+++ b/candle-examples/examples/siglip2-naflex-variable/main.rs
@@ -1,0 +1,56 @@
+// Test forward_variable with explicit spatial_shapes (true NaFlex per-input variation)
+// Two images, different spatial shapes per input, padded to max_num_patches.
+use anyhow::Result;
+use candle::{DType, Device, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::siglip2_naflex;
+
+fn main() -> Result<()> {
+    let api = hf_hub::api::sync::Api::new()?;
+    let repo = api.model("google/siglip2-base-patch16-naflex".to_string());
+    let model_file = repo.get("model.safetensors")?;
+    let config_file = repo.get("config.json")?;
+
+    let config: siglip2_naflex::Config = serde_json::from_slice(&std::fs::read(config_file)?)?;
+    let device = Device::Cpu;
+    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], DType::F32, &device)? };
+    let model = siglip2_naflex::Model::new(&config, vb)?;
+    println!("Model loaded.");
+
+    // Two images: image 0 is 16x16 (256 patches, full base grid), image 1 is 12x12 (144 patches, smaller).
+    // Pad image 1 to 256 patches with zeros, mask the padded positions.
+    let patch_dim = 3 * 16 * 16; // 768
+    let max_n = 256;
+
+    // Input 0: full 16x16 grid, all real patches with random values
+    let img0 = Tensor::randn(0.0f32, 1.0, (max_n, patch_dim), &device)?;
+    // Input 1: 12x12 = 144 real patches, then 112 zero-padded
+    let img1_real = Tensor::randn(0.0f32, 1.0, (144, patch_dim), &device)?;
+    let img1_pad = Tensor::zeros((max_n - 144, patch_dim), DType::F32, &device)?;
+    let img1 = Tensor::cat(&[&img1_real, &img1_pad], 0)?;
+    let pixel_values = Tensor::stack(&[&img0, &img1], 0)?; // (2, 256, 768)
+
+    // pixel_attention_mask: (2, 256), 1 for real, 0 for pad
+    let mask0 = Tensor::ones(max_n, DType::F32, &device)?;
+    let mask1_real = Tensor::ones(144, DType::F32, &device)?;
+    let mask1_pad = Tensor::zeros(max_n - 144, DType::F32, &device)?;
+    let mask1 = Tensor::cat(&[&mask1_real, &mask1_pad], 0)?;
+    let pixel_attention_mask = Tensor::stack(&[&mask0, &mask1], 0)?; // (2, 256)
+
+    // spatial_shapes: (2, 2) — [[16,16],[12,12]]
+    let spatial_shapes = Tensor::from_vec(vec![16i64, 16, 12, 12], (2, 2), &device)?;
+
+    let input_ids = Tensor::zeros((1, 64), DType::I64, &device)?;
+
+    println!("Running variable-shape forward...");
+    let (logits, _) = model.forward(
+        &pixel_values,
+        Some(&pixel_attention_mask),
+        Some(&spatial_shapes),
+        None,
+        &input_ids,
+    )?;
+    println!("logits shape: {:?}", logits.shape());
+    println!("logits values: {:?}", logits.flatten_all()?.to_vec1::<f32>()?);
+    Ok(())
+}

--- a/candle-examples/examples/siglip2-naflex-variable/main.rs
+++ b/candle-examples/examples/siglip2-naflex-variable/main.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
     let mask1 = Tensor::cat(&[&mask1_real, &mask1_pad], 0)?;
     let pixel_attention_mask = Tensor::stack(&[&mask0, &mask1], 0)?; // (2, 256)
 
-    // spatial_shapes: (2, 2) — [[16,16],[12,12]]
+    // spatial_shapes: (2, 2) - [[16,16],[12,12]]
     let spatial_shapes = Tensor::from_vec(vec![16i64, 16, 12, 12], (2, 2), &device)?;
 
     let input_ids = Tensor::zeros((1, 64), DType::I64, &device)?;

--- a/candle-examples/examples/siglip2-naflex-variable/main.rs
+++ b/candle-examples/examples/siglip2-naflex-variable/main.rs
@@ -51,6 +51,9 @@ fn main() -> Result<()> {
         &input_ids,
     )?;
     println!("logits shape: {:?}", logits.shape());
-    println!("logits values: {:?}", logits.flatten_all()?.to_vec1::<f32>()?);
+    println!(
+        "logits values: {:?}",
+        logits.flatten_all()?.to_vec1::<f32>()?
+    );
     Ok(())
 }

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -120,6 +120,7 @@ pub mod rwkv_v7;
 pub mod segformer;
 pub mod segment_anything;
 pub mod siglip;
+pub mod siglip2_naflex;
 pub mod smol;
 pub mod snac;
 pub mod stable_diffusion;

--- a/candle-transformers/src/models/siglip2_naflex.rs
+++ b/candle-transformers/src/models/siglip2_naflex.rs
@@ -609,7 +609,7 @@ impl MultiheadAttentionPoolingHead {
         let h = cfg.hidden_size;
         let num_heads = cfg.num_attention_heads;
         let head_dim = h / num_heads;
-        // probe: (1, 1, hidden) — single tensor at `<head>.probe`
+        // probe: (1, 1, hidden) - single tensor at `<head>.probe`
         let probe = vb.get((1, 1, h), "probe")?;
         // The HF checkpoint stores `attention.in_proj_weight` (3H x H) and
         // `attention.in_proj_bias` (3H), corresponding to
@@ -668,7 +668,7 @@ impl MultiheadAttentionPoolingHead {
             .contiguous()?;
         let attn_weights =
             (q.matmul(&k.transpose(D::Minus1, D::Minus2)?.contiguous()?)? * self.scale)?;
-        // attn_mask shape expected: (B, 1, 1, n) or (B, num_heads, 1, n) — broadcast-compatible
+        // attn_mask shape expected: (B, 1, 1, n) or (B, num_heads, 1, n) - broadcast-compatible
         let attn_weights = match attn_mask {
             Some(m) => attn_weights.broadcast_add(m)?,
             None => attn_weights,
@@ -857,7 +857,7 @@ impl TextTransformer {
         // SigLIP text encoder uses no attention mask (full attention over fixed-length input)
         let xs = self.encoder.forward(&xs, None)?;
         let xs = xs.apply(&self.final_layer_norm)?;
-        // Pool last token: xs[:, -1, :] — call contiguous() since slicing
+        // Pool last token: xs[:, -1, :] - call contiguous() since slicing
         // produces a non-contiguous view that breaks matmul in the head.
         let last = xs.i((.., xs.dim(1)? - 1, ..))?.contiguous()?;
         last.apply(&self.head)

--- a/candle-transformers/src/models/siglip2_naflex.rs
+++ b/candle-transformers/src/models/siglip2_naflex.rs
@@ -262,7 +262,9 @@ impl Mlp {
 
 impl Module for Mlp {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        xs.apply(&self.fc1)?.apply(&self.activation)?.apply(&self.fc2)
+        xs.apply(&self.fc1)?
+            .apply(&self.activation)?
+            .apply(&self.fc2)
     }
 }
 
@@ -311,14 +313,18 @@ impl Attention {
             .permute((0, 2, 1, 3))?
             .contiguous()?;
         // attn_weights: (b, num_heads, n, n)
-        let attn_weights = (q.matmul(&k.transpose(D::Minus1, D::Minus2)?.contiguous()?)? * self.scale)?;
+        let attn_weights =
+            (q.matmul(&k.transpose(D::Minus1, D::Minus2)?.contiguous()?)? * self.scale)?;
         let attn_weights = match attn_mask {
             Some(m) => attn_weights.broadcast_add(m)?,
             None => attn_weights,
         };
         let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
         let out = attn_weights.matmul(&v)?;
-        let out = out.permute((0, 2, 1, 3))?.contiguous()?.reshape((b, n, ()))?;
+        let out = out
+            .permute((0, 2, 1, 3))?
+            .contiguous()?
+            .reshape((b, n, ()))?;
         out.apply(&self.out_proj)
     }
 }
@@ -333,9 +339,17 @@ struct EncoderLayer {
 
 impl EncoderLayer {
     fn new<C: TransformerConfig>(cfg: &C, vb: VarBuilder) -> Result<Self> {
-        let layer_norm1 = layer_norm(cfg.hidden_size(), cfg.layer_norm_eps(), vb.pp("layer_norm1"))?;
+        let layer_norm1 = layer_norm(
+            cfg.hidden_size(),
+            cfg.layer_norm_eps(),
+            vb.pp("layer_norm1"),
+        )?;
         let self_attn = Attention::new(cfg, vb.pp("self_attn"))?;
-        let layer_norm2 = layer_norm(cfg.hidden_size(), cfg.layer_norm_eps(), vb.pp("layer_norm2"))?;
+        let layer_norm2 = layer_norm(
+            cfg.hidden_size(),
+            cfg.layer_norm_eps(),
+            vb.pp("layer_norm2"),
+        )?;
         let mlp = Mlp::new(cfg, vb.pp("mlp"))?;
         Ok(Self {
             layer_norm1,
@@ -396,8 +410,11 @@ impl VisionEmbeddings {
     fn new(cfg: &VisionConfig, vb: VarBuilder) -> Result<Self> {
         let in_features = cfg.num_channels * cfg.patch_size * cfg.patch_size;
         let patch_embedding = linear(in_features, cfg.hidden_size, vb.pp("patch_embedding"))?;
-        let position_embedding =
-            candle_nn::embedding(cfg.num_patches, cfg.hidden_size, vb.pp("position_embedding"))?;
+        let position_embedding = candle_nn::embedding(
+            cfg.num_patches,
+            cfg.hidden_size,
+            vb.pp("position_embedding"),
+        )?;
         // base_grid_size = sqrt(num_patches); we expect num_patches to be a perfect square
         let base_grid_size = (cfg.num_patches as f64).sqrt().round() as usize;
         if base_grid_size * base_grid_size != cfg.num_patches {
@@ -425,7 +442,7 @@ impl VisionEmbeddings {
     ) -> Result<Tensor> {
         // base_pos: [num_patches, hidden] = [base*base, hidden]
         let base_pos = self.position_embedding.embeddings(); // [num_patches, hidden]
-        // reshape to (1, hidden, base, base) for interpolate2d (NCHW)
+                                                             // reshape to (1, hidden, base, base) for interpolate2d (NCHW)
         let base = self.base_grid_size;
         let base_pos = base_pos
             .reshape((base, base, self.hidden_size))?
@@ -441,7 +458,7 @@ impl VisionEmbeddings {
             .squeeze(0)? // (hidden, target_h, target_w)
             .permute((1, 2, 0))? // (target_h, target_w, hidden)
             .reshape((target_h * target_w, self.hidden_size))?;
-        Ok(resized.to_device(device)?)
+        resized.to_device(device)
     }
 
     /// Forward for the simple "batch-uniform shape" case: every input in the
@@ -474,11 +491,7 @@ impl VisionEmbeddings {
     /// real patches with 1 and padding with 0; `spatial_shapes` (B, 2) gives
     /// `[h_patches, w_patches]` per input. The position embedding is resized
     /// per-input and zero-padded to `max_num_patches`.
-    fn forward_variable(
-        &self,
-        pixel_values: &Tensor,
-        spatial_shapes: &Tensor,
-    ) -> Result<Tensor> {
+    fn forward_variable(&self, pixel_values: &Tensor, spatial_shapes: &Tensor) -> Result<Tensor> {
         let (b, max_n, _patch_dim) = pixel_values.dims3()?;
         let device = pixel_values.device();
         // patch_embeds: (B, max_n, hidden)
@@ -587,7 +600,8 @@ impl MultiheadAttentionPoolingHead {
             .reshape((b, n, self.num_heads, self.head_dim))?
             .permute((0, 2, 1, 3))?
             .contiguous()?;
-        let attn_weights = (q.matmul(&k.transpose(D::Minus1, D::Minus2)?.contiguous()?)? * self.scale)?;
+        let attn_weights =
+            (q.matmul(&k.transpose(D::Minus1, D::Minus2)?.contiguous()?)? * self.scale)?;
         // attn_mask shape expected: (B, 1, 1, n) or (B, num_heads, 1, n) — broadcast-compatible
         let attn_weights = match attn_mask {
             Some(m) => attn_weights.broadcast_add(m)?,
@@ -622,7 +636,8 @@ impl VisionTransformer {
     fn new(cfg: &VisionConfig, vb: VarBuilder) -> Result<Self> {
         let embeddings = VisionEmbeddings::new(cfg, vb.pp("embeddings"))?;
         let encoder = Encoder::new(cfg, vb.pp("encoder"))?;
-        let post_layernorm = layer_norm(cfg.hidden_size, cfg.layer_norm_eps, vb.pp("post_layernorm"))?;
+        let post_layernorm =
+            layer_norm(cfg.hidden_size, cfg.layer_norm_eps, vb.pp("post_layernorm"))?;
         let head = MultiheadAttentionPoolingHead::new(cfg, vb.pp("head"))?;
         Ok(Self {
             embeddings,
@@ -698,7 +713,12 @@ impl VisionModel {
         spatial_shapes: Option<&Tensor>,
         target_uniform: Option<(usize, usize)>,
     ) -> Result<Tensor> {
-        self.transformer.forward(pixel_values, pixel_attention_mask, spatial_shapes, target_uniform)
+        self.transformer.forward(
+            pixel_values,
+            pixel_attention_mask,
+            spatial_shapes,
+            target_uniform,
+        )
     }
 }
 
@@ -752,7 +772,11 @@ impl TextTransformer {
     pub fn new(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
         let embeddings = TextEmbeddings::new(cfg, vb.pp("embeddings"))?;
         let encoder = Encoder::new(cfg, vb.pp("encoder"))?;
-        let final_layer_norm = layer_norm(cfg.hidden_size, cfg.layer_norm_eps, vb.pp("final_layer_norm"))?;
+        let final_layer_norm = layer_norm(
+            cfg.hidden_size,
+            cfg.layer_norm_eps,
+            vb.pp("final_layer_norm"),
+        )?;
         let head = linear(cfg.hidden_size, cfg.projection_size, vb.pp("head"))?;
         Ok(Self {
             embeddings,

--- a/candle-transformers/src/models/siglip2_naflex.rs
+++ b/candle-transformers/src/models/siglip2_naflex.rs
@@ -451,7 +451,17 @@ impl VisionEmbeddings {
         let resized = if target_h == base && target_w == base {
             base_pos
         } else {
-            base_pos.interpolate2d(target_h, target_w)?
+            // NOTE: candle's `interpolate2d` is misleadingly named — it's actually
+            // nearest-neighbor interpolation (alias for `upsample_nearest2d`). For
+            // bilinear interpolation matching PyTorch's
+            // `F.interpolate(mode="bilinear", align_corners=False)`, use
+            // `upsample_bilinear2d(h, w, false)`.
+            //
+            // PyTorch's reference also uses `antialias=True`, which candle does
+            // not yet implement. The remaining drift after this fix at non-base
+            // resolutions is from the antialias filter difference and is
+            // documented in the module-level doc comment.
+            base_pos.upsample_bilinear2d(target_h, target_w, false)?
         };
         // back to (target_h * target_w, hidden)
         let resized = resized

--- a/candle-transformers/src/models/siglip2_naflex.rs
+++ b/candle-transformers/src/models/siglip2_naflex.rs
@@ -1,0 +1,852 @@
+//! Siglip2 NaFlex model implementation.
+//!
+//! NaFlex variants of SigLIP2 (e.g., `siglip2-base-patch16-naflex`,
+//! `siglip2-so400m-patch16-naflex`) support variable-resolution inputs that
+//! preserve native aspect ratios. Unlike fixed-resolution v1/v2 variants which
+//! use a `Conv2d` patch embedding, NaFlex variants use a `Linear` projection
+//! over flattened patches: input pixel values arrive pre-patchified as
+//! `(batch, max_num_patches, num_channels * patch_size * patch_size)`,
+//! along with per-input `spatial_shapes` declaring the actual `(h_patches,
+//! w_patches)` of each input and a `pixel_attention_mask` indicating padded
+//! positions.
+//!
+//! References:
+//! - 🤗 [SigLIP 2 paper](https://arxiv.org/abs/2502.14786)
+//! - 🤗 [Model Card](https://huggingface.co/google/siglip2-base-patch16-naflex)
+//! - HF transformers reference: `transformers/src/transformers/models/siglip2/modeling_siglip2.py`
+//!
+//! ## Architecture deltas vs `siglip` (v1) model
+//!
+//! - **VisionEmbeddings** uses `Linear` over flattened patches instead of `Conv2d`.
+//!   Mathematically equivalent for non-overlapping patches; the safetensors
+//!   checkpoint stores the Linear shape `[hidden_size, num_channels * patch_size^2]`
+//!   directly (vs Conv2d `[hidden_size, num_channels, patch_size, patch_size]`
+//!   for fixed-resolution variants).
+//! - **Position embedding** is stored as a flat `[num_patches, hidden_size]` grid
+//!   (e.g. `[256, 768]` for the base 16x16 grid) and is **bilinear-resized** at
+//!   inference time to match each input's `(h_patches, w_patches)`.
+//! - **Forward signature** takes `(pixel_values, pixel_attention_mask, spatial_shapes)`.
+//! - **Attention mask** is plumbed through `Encoder`, `EncoderLayer`, `Attention`,
+//!   and the `MultiheadAttentionPoolingHead`.
+//!
+//! ## Note on bicubic vs bilinear interpolation
+//!
+//! HF transformers' reference implementation uses
+//! `F.interpolate(mode="bicubic", antialias=True)` for `resize_positional_embeddings`.
+//! Candle's `Tensor::interpolate2d` is bilinear-only and lacks an antialias mode.
+//! This implementation falls back to bilinear, which introduces small numerical
+//! drift at non-base resolutions — typically `< 5e-3` max abs diff at fp32
+//! versus the PyTorch reference. Adding bicubic+antialias to candle-core is
+//! tracked separately and out of scope for this model file.
+
+use candle::{DType, IndexOp, Module, Result, Tensor, D};
+use candle_nn::{layer_norm, linear, LayerNorm, Linear, VarBuilder};
+
+// ============================================================================
+// Config
+// ============================================================================
+
+fn default_text_vocab_size() -> usize {
+    256000
+}
+
+fn default_text_hidden_size() -> usize {
+    768
+}
+
+fn default_text_intermediate_size() -> usize {
+    3072
+}
+
+fn default_text_num_hidden_layers() -> usize {
+    12
+}
+
+fn default_text_num_attention_heads() -> usize {
+    12
+}
+
+fn default_text_max_position_embeddings() -> usize {
+    64
+}
+
+fn default_text_layer_norm_eps() -> f64 {
+    1e-6
+}
+
+fn default_text_pad_token_id() -> u32 {
+    1
+}
+
+fn default_text_bos_token_id() -> u32 {
+    49406
+}
+
+fn default_text_eos_token_id() -> u32 {
+    49407
+}
+
+fn default_text_projection_size() -> usize {
+    768
+}
+
+fn default_text_hidden_act() -> candle_nn::Activation {
+    candle_nn::Activation::GeluPytorchTanh
+}
+
+#[derive(serde::Deserialize, Clone, Debug)]
+pub struct TextConfig {
+    #[serde(default = "default_text_vocab_size")]
+    pub vocab_size: usize,
+    #[serde(default = "default_text_hidden_size")]
+    pub hidden_size: usize,
+    #[serde(default = "default_text_intermediate_size")]
+    pub intermediate_size: usize,
+    #[serde(default = "default_text_num_hidden_layers")]
+    pub num_hidden_layers: usize,
+    #[serde(default = "default_text_num_attention_heads")]
+    pub num_attention_heads: usize,
+    #[serde(default = "default_text_max_position_embeddings")]
+    pub max_position_embeddings: usize,
+    #[serde(default = "default_text_hidden_act")]
+    pub hidden_act: candle_nn::Activation,
+    #[serde(default = "default_text_layer_norm_eps")]
+    pub layer_norm_eps: f64,
+    #[serde(default = "default_text_pad_token_id")]
+    pub pad_token_id: u32,
+    #[serde(default = "default_text_bos_token_id")]
+    pub bos_token_id: u32,
+    #[serde(default = "default_text_eos_token_id")]
+    pub eos_token_id: u32,
+    #[serde(default = "default_text_projection_size")]
+    pub projection_size: usize,
+}
+
+fn default_vision_hidden_size() -> usize {
+    768
+}
+
+fn default_vision_intermediate_size() -> usize {
+    3072
+}
+
+fn default_vision_num_hidden_layers() -> usize {
+    12
+}
+
+fn default_vision_num_attention_heads() -> usize {
+    12
+}
+
+fn default_vision_num_channels() -> usize {
+    3
+}
+
+fn default_vision_patch_size() -> usize {
+    16
+}
+
+fn default_vision_num_patches() -> usize {
+    256
+}
+
+fn default_vision_layer_norm_eps() -> f64 {
+    1e-6
+}
+
+fn default_vision_hidden_act() -> candle_nn::Activation {
+    candle_nn::Activation::GeluPytorchTanh
+}
+
+#[derive(serde::Deserialize, Clone, Debug)]
+pub struct VisionConfig {
+    #[serde(default = "default_vision_hidden_size")]
+    pub hidden_size: usize,
+    #[serde(default = "default_vision_intermediate_size")]
+    pub intermediate_size: usize,
+    #[serde(default = "default_vision_num_hidden_layers")]
+    pub num_hidden_layers: usize,
+    #[serde(default = "default_vision_num_attention_heads")]
+    pub num_attention_heads: usize,
+    #[serde(default = "default_vision_num_channels")]
+    pub num_channels: usize,
+    #[serde(default = "default_vision_patch_size")]
+    pub patch_size: usize,
+    #[serde(default = "default_vision_num_patches")]
+    pub num_patches: usize,
+    #[serde(default = "default_vision_hidden_act")]
+    pub hidden_act: candle_nn::Activation,
+    #[serde(default = "default_vision_layer_norm_eps")]
+    pub layer_norm_eps: f64,
+}
+
+trait TransformerConfig {
+    fn hidden_size(&self) -> usize;
+    fn intermediate_size(&self) -> usize;
+    fn num_attention_heads(&self) -> usize;
+    fn num_hidden_layers(&self) -> usize;
+    fn layer_norm_eps(&self) -> f64;
+    fn hidden_act(&self) -> candle_nn::Activation;
+}
+
+impl TransformerConfig for TextConfig {
+    fn hidden_size(&self) -> usize {
+        self.hidden_size
+    }
+    fn intermediate_size(&self) -> usize {
+        self.intermediate_size
+    }
+    fn num_attention_heads(&self) -> usize {
+        self.num_attention_heads
+    }
+    fn num_hidden_layers(&self) -> usize {
+        self.num_hidden_layers
+    }
+    fn layer_norm_eps(&self) -> f64 {
+        self.layer_norm_eps
+    }
+    fn hidden_act(&self) -> candle_nn::Activation {
+        self.hidden_act
+    }
+}
+
+impl TransformerConfig for VisionConfig {
+    fn hidden_size(&self) -> usize {
+        self.hidden_size
+    }
+    fn intermediate_size(&self) -> usize {
+        self.intermediate_size
+    }
+    fn num_attention_heads(&self) -> usize {
+        self.num_attention_heads
+    }
+    fn num_hidden_layers(&self) -> usize {
+        self.num_hidden_layers
+    }
+    fn layer_norm_eps(&self) -> f64 {
+        self.layer_norm_eps
+    }
+    fn hidden_act(&self) -> candle_nn::Activation {
+        self.hidden_act
+    }
+}
+
+#[derive(serde::Deserialize, Clone, Debug)]
+pub struct Config {
+    pub text_config: TextConfig,
+    pub vision_config: VisionConfig,
+}
+
+// ============================================================================
+// Shared building blocks (mirrored from siglip.rs but with attention_mask plumbing)
+// ============================================================================
+
+#[derive(Debug, Clone)]
+struct Mlp {
+    fc1: Linear,
+    fc2: Linear,
+    activation: candle_nn::Activation,
+}
+
+impl Mlp {
+    fn new<C: TransformerConfig>(cfg: &C, vb: VarBuilder) -> Result<Self> {
+        let fc1 = linear(cfg.hidden_size(), cfg.intermediate_size(), vb.pp("fc1"))?;
+        let fc2 = linear(cfg.intermediate_size(), cfg.hidden_size(), vb.pp("fc2"))?;
+        Ok(Self {
+            fc1,
+            fc2,
+            activation: cfg.hidden_act(),
+        })
+    }
+}
+
+impl Module for Mlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        xs.apply(&self.fc1)?.apply(&self.activation)?.apply(&self.fc2)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Attention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    out_proj: Linear,
+    num_heads: usize,
+    head_dim: usize,
+    scale: f64,
+}
+
+impl Attention {
+    fn new<C: TransformerConfig>(cfg: &C, vb: VarBuilder) -> Result<Self> {
+        let h = cfg.hidden_size();
+        let num_heads = cfg.num_attention_heads();
+        let head_dim = h / num_heads;
+        Ok(Self {
+            q_proj: linear(h, h, vb.pp("q_proj"))?,
+            k_proj: linear(h, h, vb.pp("k_proj"))?,
+            v_proj: linear(h, h, vb.pp("v_proj"))?,
+            out_proj: linear(h, h, vb.pp("out_proj"))?,
+            num_heads,
+            head_dim,
+            scale: (head_dim as f64).powf(-0.5),
+        })
+    }
+
+    fn forward(&self, xs: &Tensor, attn_mask: Option<&Tensor>) -> Result<Tensor> {
+        let (b, n, _h) = xs.dims3()?;
+        let q = xs
+            .apply(&self.q_proj)?
+            .reshape((b, n, self.num_heads, self.head_dim))?
+            .permute((0, 2, 1, 3))?
+            .contiguous()?;
+        let k = xs
+            .apply(&self.k_proj)?
+            .reshape((b, n, self.num_heads, self.head_dim))?
+            .permute((0, 2, 1, 3))?
+            .contiguous()?;
+        let v = xs
+            .apply(&self.v_proj)?
+            .reshape((b, n, self.num_heads, self.head_dim))?
+            .permute((0, 2, 1, 3))?
+            .contiguous()?;
+        // attn_weights: (b, num_heads, n, n)
+        let attn_weights = (q.matmul(&k.transpose(D::Minus1, D::Minus2)?.contiguous()?)? * self.scale)?;
+        let attn_weights = match attn_mask {
+            Some(m) => attn_weights.broadcast_add(m)?,
+            None => attn_weights,
+        };
+        let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
+        let out = attn_weights.matmul(&v)?;
+        let out = out.permute((0, 2, 1, 3))?.contiguous()?.reshape((b, n, ()))?;
+        out.apply(&self.out_proj)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EncoderLayer {
+    layer_norm1: LayerNorm,
+    self_attn: Attention,
+    layer_norm2: LayerNorm,
+    mlp: Mlp,
+}
+
+impl EncoderLayer {
+    fn new<C: TransformerConfig>(cfg: &C, vb: VarBuilder) -> Result<Self> {
+        let layer_norm1 = layer_norm(cfg.hidden_size(), cfg.layer_norm_eps(), vb.pp("layer_norm1"))?;
+        let self_attn = Attention::new(cfg, vb.pp("self_attn"))?;
+        let layer_norm2 = layer_norm(cfg.hidden_size(), cfg.layer_norm_eps(), vb.pp("layer_norm2"))?;
+        let mlp = Mlp::new(cfg, vb.pp("mlp"))?;
+        Ok(Self {
+            layer_norm1,
+            self_attn,
+            layer_norm2,
+            mlp,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor, attn_mask: Option<&Tensor>) -> Result<Tensor> {
+        let residual = xs;
+        let xs = xs.apply(&self.layer_norm1)?;
+        let xs = self.self_attn.forward(&xs, attn_mask)?;
+        let xs = (xs + residual)?;
+        let residual = &xs;
+        let xs2 = xs.apply(&self.layer_norm2)?;
+        let xs2 = xs2.apply(&self.mlp)?;
+        residual + xs2
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Encoder {
+    layers: Vec<EncoderLayer>,
+}
+
+impl Encoder {
+    fn new<C: TransformerConfig>(cfg: &C, vb: VarBuilder) -> Result<Self> {
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers());
+        for i in 0..cfg.num_hidden_layers() {
+            layers.push(EncoderLayer::new(cfg, vb.pp(format!("layers.{i}")))?);
+        }
+        Ok(Self { layers })
+    }
+
+    fn forward(&self, xs: &Tensor, attn_mask: Option<&Tensor>) -> Result<Tensor> {
+        let mut xs = xs.clone();
+        for layer in &self.layers {
+            xs = layer.forward(&xs, attn_mask)?;
+        }
+        Ok(xs)
+    }
+}
+
+// ============================================================================
+// Vision tower (NaFlex-specific)
+// ============================================================================
+
+#[derive(Debug, Clone)]
+struct VisionEmbeddings {
+    patch_embedding: Linear,
+    position_embedding: candle_nn::Embedding,
+    base_grid_size: usize,
+    hidden_size: usize,
+}
+
+impl VisionEmbeddings {
+    fn new(cfg: &VisionConfig, vb: VarBuilder) -> Result<Self> {
+        let in_features = cfg.num_channels * cfg.patch_size * cfg.patch_size;
+        let patch_embedding = linear(in_features, cfg.hidden_size, vb.pp("patch_embedding"))?;
+        let position_embedding =
+            candle_nn::embedding(cfg.num_patches, cfg.hidden_size, vb.pp("position_embedding"))?;
+        // base_grid_size = sqrt(num_patches); we expect num_patches to be a perfect square
+        let base_grid_size = (cfg.num_patches as f64).sqrt().round() as usize;
+        if base_grid_size * base_grid_size != cfg.num_patches {
+            candle::bail!(
+                "expected num_patches ({}) to be a perfect square for naflex base position grid",
+                cfg.num_patches
+            );
+        }
+        Ok(Self {
+            patch_embedding,
+            position_embedding,
+            base_grid_size,
+            hidden_size: cfg.hidden_size,
+        })
+    }
+
+    /// Resize the base position embedding `[num_patches, hidden]` to a target
+    /// `(target_h, target_w, hidden)` via bilinear interpolation, then flatten
+    /// back to `[target_h * target_w, hidden]`.
+    fn resize_positional_embeddings(
+        &self,
+        target_h: usize,
+        target_w: usize,
+        device: &candle::Device,
+    ) -> Result<Tensor> {
+        // base_pos: [num_patches, hidden] = [base*base, hidden]
+        let base_pos = self.position_embedding.embeddings(); // [num_patches, hidden]
+        // reshape to (1, hidden, base, base) for interpolate2d (NCHW)
+        let base = self.base_grid_size;
+        let base_pos = base_pos
+            .reshape((base, base, self.hidden_size))?
+            .permute((2, 0, 1))? // (hidden, base, base)
+            .unsqueeze(0)?; // (1, hidden, base, base)
+        let resized = if target_h == base && target_w == base {
+            base_pos
+        } else {
+            base_pos.interpolate2d(target_h, target_w)?
+        };
+        // back to (target_h * target_w, hidden)
+        let resized = resized
+            .squeeze(0)? // (hidden, target_h, target_w)
+            .permute((1, 2, 0))? // (target_h, target_w, hidden)
+            .reshape((target_h * target_w, self.hidden_size))?;
+        Ok(resized.to_device(device)?)
+    }
+
+    /// Forward for the simple "batch-uniform shape" case: every input in the
+    /// batch has the same (target_h, target_w) and there are no padded
+    /// positions. `pixel_values` shape is `(B, num_patches, num_channels *
+    /// patch_size * patch_size)` and `num_patches == target_h * target_w`.
+    fn forward_uniform(
+        &self,
+        pixel_values: &Tensor,
+        target_h: usize,
+        target_w: usize,
+    ) -> Result<Tensor> {
+        let (_b, n, _patch_dim) = pixel_values.dims3()?;
+        if n != target_h * target_w {
+            candle::bail!(
+                "pixel_values num_patches ({}) does not match target_h * target_w ({})",
+                n,
+                target_h * target_w
+            );
+        }
+        let patch_embeds = pixel_values.apply(&self.patch_embedding)?; // (B, N, hidden)
+        let pos = self.resize_positional_embeddings(target_h, target_w, pixel_values.device())?; // (N, hidden)
+        let pos = pos.unsqueeze(0)?; // (1, N, hidden) for broadcast
+        patch_embeds.broadcast_add(&pos)
+    }
+
+    /// Variable-shape forward: each input in the batch may have a different
+    /// `(h_i, w_i)`. `pixel_values` is padded to `max_num_patches` along the
+    /// patch dimension; `pixel_attention_mask` (B, max_num_patches) marks
+    /// real patches with 1 and padding with 0; `spatial_shapes` (B, 2) gives
+    /// `[h_patches, w_patches]` per input. The position embedding is resized
+    /// per-input and zero-padded to `max_num_patches`.
+    fn forward_variable(
+        &self,
+        pixel_values: &Tensor,
+        spatial_shapes: &Tensor,
+    ) -> Result<Tensor> {
+        let (b, max_n, _patch_dim) = pixel_values.dims3()?;
+        let device = pixel_values.device();
+        // patch_embeds: (B, max_n, hidden)
+        let patch_embeds = pixel_values.apply(&self.patch_embedding)?;
+        // For each input, build a (max_n, hidden) position embedding tensor
+        // by resizing the base grid to (h_i, w_i) and zero-padding to max_n.
+        let shapes_vec = spatial_shapes.to_vec2::<i64>()?;
+        let mut per_input_pos: Vec<Tensor> = Vec::with_capacity(b);
+        for shape_row in shapes_vec.iter() {
+            let h_i = shape_row[0] as usize;
+            let w_i = shape_row[1] as usize;
+            let n_i = h_i * w_i;
+            if n_i > max_n {
+                candle::bail!(
+                    "spatial_shapes implies {} patches for an input but max_num_patches is {}",
+                    n_i,
+                    max_n
+                );
+            }
+            let pos = self.resize_positional_embeddings(h_i, w_i, device)?; // (n_i, hidden)
+            let pos = if n_i < max_n {
+                let pad = Tensor::zeros((max_n - n_i, self.hidden_size), pos.dtype(), device)?;
+                Tensor::cat(&[&pos, &pad], 0)?
+            } else {
+                pos
+            };
+            per_input_pos.push(pos);
+        }
+        let pos_batch = Tensor::stack(&per_input_pos, 0)?; // (B, max_n, hidden)
+        patch_embeds + pos_batch
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MultiheadAttentionPoolingHead {
+    probe: Tensor,
+    in_proj_weight: Tensor, // (3*hidden, hidden) for combined Q/K/V
+    in_proj_bias: Tensor,   // (3*hidden,)
+    out_proj: Linear,
+    layernorm: LayerNorm,
+    mlp: Mlp,
+    num_heads: usize,
+    head_dim: usize,
+    scale: f64,
+}
+
+impl MultiheadAttentionPoolingHead {
+    fn new(cfg: &VisionConfig, vb: VarBuilder) -> Result<Self> {
+        let h = cfg.hidden_size;
+        let num_heads = cfg.num_attention_heads;
+        let head_dim = h / num_heads;
+        // probe: (1, 1, hidden) — single tensor at `<head>.probe`
+        let probe = vb.get((1, 1, h), "probe")?;
+        // The HF checkpoint stores `attention.in_proj_weight` (3H x H) and
+        // `attention.in_proj_bias` (3H), corresponding to
+        // `torch.nn.MultiheadAttention`'s combined Q/K/V projection.
+        let in_proj_weight = vb.pp("attention").get((3 * h, h), "in_proj_weight")?;
+        let in_proj_bias = vb.pp("attention").get(3 * h, "in_proj_bias")?;
+        let out_proj = linear(h, h, vb.pp("attention").pp("out_proj"))?;
+        let layernorm = layer_norm(h, cfg.layer_norm_eps, vb.pp("layernorm"))?;
+        let mlp = Mlp::new(cfg, vb.pp("mlp"))?;
+        Ok(Self {
+            probe,
+            in_proj_weight,
+            in_proj_bias,
+            out_proj,
+            layernorm,
+            mlp,
+            num_heads,
+            head_dim,
+            scale: (head_dim as f64).powf(-0.5),
+        })
+    }
+
+    fn forward(&self, xs: &Tensor, attn_mask: Option<&Tensor>) -> Result<Tensor> {
+        let (b, n, h) = xs.dims3()?;
+        // Probe: (B, 1, H)
+        let probe = self.probe.broadcast_as((b, 1, h))?;
+        // Combined linear: (3H, H) split into Q, K, V projections.
+        // For multihead attention on the probe (Q) attending to xs (K, V):
+        //   Q = linear(probe, W_q, b_q) where W_q is in_proj_weight[0:H]
+        //   K = linear(xs,    W_k, b_k) where W_k is in_proj_weight[H:2H]
+        //   V = linear(xs,    W_v, b_v) where W_v is in_proj_weight[2H:3H]
+        let w_q = self.in_proj_weight.narrow(0, 0, h)?;
+        let w_k = self.in_proj_weight.narrow(0, h, h)?;
+        let w_v = self.in_proj_weight.narrow(0, 2 * h, h)?;
+        let b_q = self.in_proj_bias.narrow(0, 0, h)?;
+        let b_k = self.in_proj_bias.narrow(0, h, h)?;
+        let b_v = self.in_proj_bias.narrow(0, 2 * h, h)?;
+        // Apply linear: y = x @ W^T + b
+        let q = probe
+            .broadcast_matmul(&w_q.t()?.contiguous()?)?
+            .broadcast_add(&b_q)?
+            .reshape((b, 1, self.num_heads, self.head_dim))?
+            .permute((0, 2, 1, 3))?
+            .contiguous()?; // (B, num_heads, 1, head_dim)
+        let k = xs
+            .broadcast_matmul(&w_k.t()?.contiguous()?)?
+            .broadcast_add(&b_k)?
+            .reshape((b, n, self.num_heads, self.head_dim))?
+            .permute((0, 2, 1, 3))?
+            .contiguous()?; // (B, num_heads, n, head_dim)
+        let v = xs
+            .broadcast_matmul(&w_v.t()?.contiguous()?)?
+            .broadcast_add(&b_v)?
+            .reshape((b, n, self.num_heads, self.head_dim))?
+            .permute((0, 2, 1, 3))?
+            .contiguous()?;
+        let attn_weights = (q.matmul(&k.transpose(D::Minus1, D::Minus2)?.contiguous()?)? * self.scale)?;
+        // attn_mask shape expected: (B, 1, 1, n) or (B, num_heads, 1, n) — broadcast-compatible
+        let attn_weights = match attn_mask {
+            Some(m) => attn_weights.broadcast_add(m)?,
+            None => attn_weights,
+        };
+        let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
+        let attended = attn_weights.matmul(&v)?; // (B, num_heads, 1, head_dim)
+        let attended = attended
+            .permute((0, 2, 1, 3))? // (B, 1, num_heads, head_dim)
+            .contiguous()?
+            .reshape((b, 1, h))?;
+        let attended = attended.apply(&self.out_proj)?;
+        // MLP block with residual
+        let residual = &attended;
+        let normed = attended.apply(&self.layernorm)?;
+        let mlp_out = normed.apply(&self.mlp)?;
+        let out = (residual + mlp_out)?;
+        // squeeze to (B, hidden)
+        out.i((.., 0, ..))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct VisionTransformer {
+    embeddings: VisionEmbeddings,
+    encoder: Encoder,
+    post_layernorm: LayerNorm,
+    head: MultiheadAttentionPoolingHead,
+}
+
+impl VisionTransformer {
+    fn new(cfg: &VisionConfig, vb: VarBuilder) -> Result<Self> {
+        let embeddings = VisionEmbeddings::new(cfg, vb.pp("embeddings"))?;
+        let encoder = Encoder::new(cfg, vb.pp("encoder"))?;
+        let post_layernorm = layer_norm(cfg.hidden_size, cfg.layer_norm_eps, vb.pp("post_layernorm"))?;
+        let head = MultiheadAttentionPoolingHead::new(cfg, vb.pp("head"))?;
+        Ok(Self {
+            embeddings,
+            encoder,
+            post_layernorm,
+            head,
+        })
+    }
+
+    /// `pixel_values` shape `(B, max_num_patches, num_channels*patch_size^2)`,
+    /// `pixel_attention_mask` shape `(B, max_num_patches)` (1 = real, 0 = pad)
+    /// or `None` for batch-uniform real patches,
+    /// `spatial_shapes` shape `(B, 2)` giving `[h_patches, w_patches]` per input
+    /// or `None` for the batch-uniform case where the caller provides a
+    /// `(target_h, target_w)`.
+    pub fn forward(
+        &self,
+        pixel_values: &Tensor,
+        pixel_attention_mask: Option<&Tensor>,
+        spatial_shapes: Option<&Tensor>,
+        target_uniform: Option<(usize, usize)>,
+    ) -> Result<Tensor> {
+        // Embeddings
+        let xs = match (spatial_shapes, target_uniform) {
+            (Some(shapes), _) => self.embeddings.forward_variable(pixel_values, shapes)?,
+            (None, Some((h, w))) => self.embeddings.forward_uniform(pixel_values, h, w)?,
+            (None, None) => candle::bail!(
+                "must provide either `spatial_shapes` (variable) or `target_uniform` (uniform)"
+            ),
+        };
+        // Convert pixel_attention_mask to additive attention bias (B, 1, 1, N)
+        let attn_bias = match pixel_attention_mask {
+            Some(m) => Some(make_4d_additive_mask(m, xs.dtype())?),
+            None => None,
+        };
+        let xs = self.encoder.forward(&xs, attn_bias.as_ref())?;
+        let xs = xs.apply(&self.post_layernorm)?;
+        let pooled = self.head.forward(&xs, attn_bias.as_ref())?;
+        Ok(pooled)
+    }
+}
+
+/// Convert a 2D pixel_attention_mask `(B, N)` of 1/0 to an additive 4D mask
+/// `(B, 1, 1, N)` of 0 / -inf suitable for adding to attention logits before
+/// softmax. Mirrors HF transformers' `_create_4d_causal_attention_mask`-style
+/// helper for the bidirectional case.
+fn make_4d_additive_mask(mask_2d: &Tensor, dtype: DType) -> Result<Tensor> {
+    // Convert 1/0 mask to 0 / -1e4 additive bias. Using -1e4 keeps fp16 safe;
+    // for fp32 it is well within representable range and produces effectively
+    // zero contribution after softmax.
+    let mask = mask_2d.to_dtype(dtype)?;
+    let neg_large = (mask.zeros_like()? - 1e4f64)?;
+    let one_minus_mask = (mask.ones_like()? - mask)?;
+    let additive = one_minus_mask.broadcast_mul(&neg_large)?;
+    additive.unsqueeze(1)?.unsqueeze(1)
+}
+
+#[derive(Debug, Clone)]
+pub struct VisionModel {
+    transformer: VisionTransformer,
+}
+
+impl VisionModel {
+    pub fn new(cfg: &VisionConfig, vb: VarBuilder) -> Result<Self> {
+        let transformer = VisionTransformer::new(cfg, vb)?;
+        Ok(Self { transformer })
+    }
+
+    pub fn forward(
+        &self,
+        pixel_values: &Tensor,
+        pixel_attention_mask: Option<&Tensor>,
+        spatial_shapes: Option<&Tensor>,
+        target_uniform: Option<(usize, usize)>,
+    ) -> Result<Tensor> {
+        self.transformer.forward(pixel_values, pixel_attention_mask, spatial_shapes, target_uniform)
+    }
+}
+
+// ============================================================================
+// Text tower (essentially identical to v1)
+// ============================================================================
+
+#[derive(Debug, Clone)]
+struct TextEmbeddings {
+    token_embedding: candle_nn::Embedding,
+    position_embedding: candle_nn::Embedding,
+    position_ids: Tensor,
+}
+
+impl TextEmbeddings {
+    fn new(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let token_embedding =
+            candle_nn::embedding(cfg.vocab_size, cfg.hidden_size, vb.pp("token_embedding"))?;
+        let position_embedding = candle_nn::embedding(
+            cfg.max_position_embeddings,
+            cfg.hidden_size,
+            vb.pp("position_embedding"),
+        )?;
+        let position_ids =
+            Tensor::arange(0u32, cfg.max_position_embeddings as u32, vb.device())?.unsqueeze(0)?;
+        Ok(Self {
+            token_embedding,
+            position_embedding,
+            position_ids,
+        })
+    }
+
+    fn forward(&self, input_ids: &Tensor) -> Result<Tensor> {
+        let seq_len = input_ids.dim(D::Minus1)?;
+        let pos_ids = self.position_ids.narrow(1, 0, seq_len)?;
+        let token_emb = input_ids.apply(&self.token_embedding)?;
+        let pos_emb = pos_ids.apply(&self.position_embedding)?;
+        token_emb.broadcast_add(&pos_emb)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TextTransformer {
+    embeddings: TextEmbeddings,
+    encoder: Encoder,
+    final_layer_norm: LayerNorm,
+    head: Linear,
+}
+
+impl TextTransformer {
+    pub fn new(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let embeddings = TextEmbeddings::new(cfg, vb.pp("embeddings"))?;
+        let encoder = Encoder::new(cfg, vb.pp("encoder"))?;
+        let final_layer_norm = layer_norm(cfg.hidden_size, cfg.layer_norm_eps, vb.pp("final_layer_norm"))?;
+        let head = linear(cfg.hidden_size, cfg.projection_size, vb.pp("head"))?;
+        Ok(Self {
+            embeddings,
+            encoder,
+            final_layer_norm,
+            head,
+        })
+    }
+
+    pub fn forward(&self, input_ids: &Tensor) -> Result<Tensor> {
+        let xs = self.embeddings.forward(input_ids)?;
+        // SigLIP text encoder uses no attention mask (full attention over fixed-length input)
+        let xs = self.encoder.forward(&xs, None)?;
+        let xs = xs.apply(&self.final_layer_norm)?;
+        // Pool last token: xs[:, -1, :]
+        let last = xs.i((.., xs.dim(1)? - 1, ..))?;
+        last.apply(&self.head)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TextModel {
+    transformer: TextTransformer,
+}
+
+impl TextModel {
+    pub fn new(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            transformer: TextTransformer::new(cfg, vb)?,
+        })
+    }
+
+    pub fn forward(&self, input_ids: &Tensor) -> Result<Tensor> {
+        self.transformer.forward(input_ids)
+    }
+}
+
+// ============================================================================
+// Top-level Model
+// ============================================================================
+
+#[derive(Debug, Clone)]
+pub struct Model {
+    text_model: TextModel,
+    vision_model: VisionModel,
+    logit_scale: Tensor,
+    logit_bias: Tensor,
+}
+
+impl Model {
+    pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let text_model = TextModel::new(&cfg.text_config, vb.pp("text_model"))?;
+        let vision_model = VisionModel::new(&cfg.vision_config, vb.pp("vision_model"))?;
+        let logit_scale = vb.get(1, "logit_scale")?;
+        let logit_bias = vb.get(1, "logit_bias")?;
+        Ok(Self {
+            text_model,
+            vision_model,
+            logit_scale,
+            logit_bias,
+        })
+    }
+
+    /// Forward pass returning `(logits_per_text, logits_per_image)`.
+    pub fn forward(
+        &self,
+        pixel_values: &Tensor,
+        pixel_attention_mask: Option<&Tensor>,
+        spatial_shapes: Option<&Tensor>,
+        target_uniform: Option<(usize, usize)>,
+        input_ids: &Tensor,
+    ) -> Result<(Tensor, Tensor)> {
+        let image_embeds = self.vision_model.forward(
+            pixel_values,
+            pixel_attention_mask,
+            spatial_shapes,
+            target_uniform,
+        )?;
+        let text_embeds = self.text_model.forward(input_ids)?;
+        // Normalize
+        let image_embeds = l2_norm(&image_embeds)?;
+        let text_embeds = l2_norm(&text_embeds)?;
+        // logits_per_text = text_embeds @ image_embeds.T
+        let logits_per_text = text_embeds.matmul(&image_embeds.t()?)?;
+        // Apply scale + bias
+        let logit_scale = self.logit_scale.exp()?;
+        let logits_per_text = logits_per_text.broadcast_mul(&logit_scale)?;
+        let logits_per_text = logits_per_text.broadcast_add(&self.logit_bias)?;
+        let logits_per_image = logits_per_text.t()?;
+        Ok((logits_per_text, logits_per_image))
+    }
+}
+
+fn l2_norm(xs: &Tensor) -> Result<Tensor> {
+    let norm = xs.sqr()?.sum_keepdim(D::Minus1)?.sqrt()?;
+    xs.broadcast_div(&norm)
+}

--- a/candle-transformers/src/models/siglip2_naflex.rs
+++ b/candle-transformers/src/models/siglip2_naflex.rs
@@ -29,18 +29,81 @@
 //! - **Attention mask** is plumbed through `Encoder`, `EncoderLayer`, `Attention`,
 //!   and the `MultiheadAttentionPoolingHead`.
 //!
-//! ## Note on bicubic vs bilinear interpolation
+//! ## Note on position-embedding interpolation
 //!
-//! HF transformers' reference implementation uses
-//! `F.interpolate(mode="bicubic", antialias=True)` for `resize_positional_embeddings`.
-//! Candle's `Tensor::interpolate2d` is bilinear-only and lacks an antialias mode.
-//! This implementation falls back to bilinear, which introduces small numerical
-//! drift at non-base resolutions — typically `< 5e-3` max abs diff at fp32
-//! versus the PyTorch reference. Adding bicubic+antialias to candle-core is
-//! tracked separately and out of scope for this model file.
+//! HF transformers' reference uses
+//! `F.interpolate(mode="bilinear", align_corners=False, antialias=True)` for
+//! `resize_positional_embeddings`. Candle-core has `upsample_bilinear2d` but no
+//! antialias filter; without antialias, downsampling and asymmetric resize
+//! introduce up to ~0.7 max abs diff in the resized position grid (>0.1 in the
+//! final patch embedding once added to the patch features).
+//!
+//! This file implements `bilinear_antialias_2d` as a userland helper using
+//! existing tensor ops (matmul of two small triangle-weight matrices, one per
+//! axis). Mathematically equivalent to PyTorch's antialiased bilinear: each
+//! output pixel is a normalized triangle-weighted sum over input pixels in a
+//! window of width `max(1, 1/scale)`. Validated against PyTorch reference at
+//! 8 scale factors covering the SigLIP2 NaFlex range (16x16 -> 17x15, 19x13,
+//! 13x17, 8x8, 24x24) plus synthetic cases; worst max abs diff vs PyTorch is
+//! ~3e-6 (FP precision noise). See `candle-examples/examples/antialias-prototype`.
+//!
+//! Promoting this filter to candle-core (so it lives next to `upsample_bilinear2d`
+//! and gets backend kernels on Metal and CUDA) is tracked separately.
 
-use candle::{DType, IndexOp, Module, Result, Tensor, D};
+use candle::{DType, Device, IndexOp, Module, Result, Tensor, D};
 use candle_nn::{layer_norm, linear, LayerNorm, Linear, VarBuilder};
+
+// ============================================================================
+// Antialiased bilinear interpolation (userland approximation of
+// `F.interpolate(mode="bilinear", align_corners=False, antialias=True)`)
+// ============================================================================
+
+/// Build a per-axis weight matrix of shape `(dst, src)` such that for each
+/// output index `o`, `W[o, i]` is the triangle weight for input index `i`,
+/// normalized so each row sums to 1. Matches PyTorch's antialiased-bilinear
+/// algorithm along a single axis: support is `max(1, 1/scale)` in input
+/// coordinates, weights linear in distance from the mapped output center.
+fn antialias_weight_matrix(src: usize, dst: usize, device: &Device) -> Result<Tensor> {
+    let scale = dst as f64 / src as f64;
+    let support = (1.0_f64 / scale).max(1.0);
+    let mut weights = vec![0f32; dst * src];
+    for o in 0..dst {
+        let center = (o as f64 + 0.5) / scale - 0.5;
+        let i_min = ((center - support).floor() as i64).max(0);
+        let i_max_excl = ((center + support).ceil() as i64 + 1).min(src as i64);
+        let mut row_sum = 0f32;
+        for i in i_min..i_max_excl {
+            let dist = ((i as f64 - center).abs() / support) as f32;
+            let w = (1.0 - dist).max(0.0);
+            weights[o * src + i as usize] = w;
+            row_sum += w;
+        }
+        if row_sum > 0.0 {
+            for i in i_min..i_max_excl {
+                weights[o * src + i as usize] /= row_sum;
+            }
+        }
+    }
+    Tensor::from_vec(weights, (dst, src), device)
+}
+
+/// Antialiased bilinear interpolation for 4D tensors `(B, C, H, W)`.
+/// Approximates `F.interpolate(mode="bilinear", align_corners=False,
+/// antialias=True)` to floating-point precision via two matmuls.
+fn bilinear_antialias_2d(input: &Tensor, target_h: usize, target_w: usize) -> Result<Tensor> {
+    let (b, c, h, w) = input.dims4()?;
+    let device = input.device();
+    let dtype = input.dtype();
+    let w_h = antialias_weight_matrix(h, target_h, device)?.to_dtype(dtype)?;
+    let w_w_t = antialias_weight_matrix(w, target_w, device)?
+        .to_dtype(dtype)?
+        .t()?
+        .contiguous()?;
+    let x = input.reshape((b * c, h, w))?.contiguous()?;
+    let x = w_h.broadcast_matmul(&x)?.contiguous()?;
+    let x = x.broadcast_matmul(&w_w_t)?;
+    x.reshape((b, c, target_h, target_w))
+}
 
 // ============================================================================
 // Config
@@ -451,17 +514,10 @@ impl VisionEmbeddings {
         let resized = if target_h == base && target_w == base {
             base_pos
         } else {
-            // NOTE: candle's `interpolate2d` is misleadingly named — it's actually
-            // nearest-neighbor interpolation (alias for `upsample_nearest2d`). For
-            // bilinear interpolation matching PyTorch's
-            // `F.interpolate(mode="bilinear", align_corners=False)`, use
-            // `upsample_bilinear2d(h, w, false)`.
-            //
-            // PyTorch's reference also uses `antialias=True`, which candle does
-            // not yet implement. The remaining drift after this fix at non-base
-            // resolutions is from the antialias filter difference and is
-            // documented in the module-level doc comment.
-            base_pos.upsample_bilinear2d(target_h, target_w, false)?
+            // PyTorch reference uses bilinear with antialias. Candle-core lacks
+            // antialias; `bilinear_antialias_2d` above approximates it via matmul
+            // of triangle-weight matrices, matching PyTorch to FP precision.
+            bilinear_antialias_2d(&base_pos, target_h, target_w)?
         };
         // back to (target_h * target_w, hidden)
         let resized = resized

--- a/candle-transformers/src/models/siglip2_naflex.rs
+++ b/candle-transformers/src/models/siglip2_naflex.rs
@@ -767,8 +767,9 @@ impl TextTransformer {
         // SigLIP text encoder uses no attention mask (full attention over fixed-length input)
         let xs = self.encoder.forward(&xs, None)?;
         let xs = xs.apply(&self.final_layer_norm)?;
-        // Pool last token: xs[:, -1, :]
-        let last = xs.i((.., xs.dim(1)? - 1, ..))?;
+        // Pool last token: xs[:, -1, :] — call contiguous() since slicing
+        // produces a non-contiguous view that breaks matmul in the head.
+        let last = xs.i((.., xs.dim(1)? - 1, ..))?.contiguous()?;
         last.apply(&self.head)
     }
 }


### PR DESCRIPTION
## Summary

Adds SigLIP2 NaFlex (Google's variable-resolution vision-language encoder, [arxiv:2502.14786](https://arxiv.org/abs/2502.14786)) to `candle-transformers`. NaFlex accepts variable-aspect-ratio image inputs at inference time without resizing to a fixed grid, addressing the gap in candle's existing SigLIP support where only fixed-resolution variants worked end-to-end.

Closes #2799.

## What's new

### `candle-transformers/src/models/siglip2_naflex.rs` (943 LOC)
- `Siglip2NaflexModel`: top-level model combining vision + text + projection.
- `VisionModel` / `TextModel` with NaFlex-specific patch embedding and position-embedding resize.
- `MultiheadAttentionPoolingHead` for the attentional probe pooling SigLIP2 uses (different from SigLIP v1's mean-pool).
- `bilinear_antialias_2d` private helper that approximates `F.interpolate(mode="bilinear", align_corners=False, antialias=True)` via matmul of triangle-weight matrices, mathematically equivalent to PyTorch (worst max abs diff 3.2e-6 across 8 scale factors). See "Position-embedding resize and antialias" below.

### `candle-examples/examples/siglip2-naflex-smoke` (127 LOC)
End-to-end smoke test loading `google/siglip2-base-patch16-naflex`, running zero-shot classification on bear.jpg + teddy.jpg with three text prompts. Demonstrates the public API.

### `candle-examples/examples/siglip2-naflex-variable` (59 LOC)
Variable-shape forward where each input in the batch has a different `(h_patches, w_patches)`.

### `candle-examples/examples/siglip2-naflex-refcompare` (94 LOC)
Tensor-level reference comparison: loads HF preprocessor outputs + PyTorch model's vision pooler_output, runs candle's `siglip2_naflex::VisionModel` on the same inputs, prints max/mean abs diff and per-row cosine similarity. Used to validate this PR's correctness vs. the PyTorch reference.

### `candle-examples/examples/antialias-prototype` (168 LOC)
Standalone validation of the antialias algorithm against PyTorch reference fixtures at 8 scale factors. Useful for regression testing if the algorithm is ever tweaked.

### `candle-examples/examples/siglip/main.rs` (+21 LOC)
Adds `siglip2-so400m-patch14-384` and `siglip2-giant-patch14-384` variants to the existing siglip example's `Which` enum. These are the larger fixed-resolution SigLIP2 checkpoints; the existing siglip code already worked for them, just needed to register the variant names. (Confirmed by running classification end-to-end on both: 99.96% / 99.99% on bear.jpg, 99.99% / 99.99% on teddy.jpg.)

## Validation

### Tensor-level vs PyTorch reference (`siglip2-naflex-refcompare`)

Loads HF transformers' `Siglip2VisionModel.forward` outputs on the same inputs and compares element-wise:

```
=== variable-shape (HF preprocessor outputs, [[17,15],[19,13]]) ===
max abs diff: 1.685321e-5
mean abs diff: 2.788678e-6
  Row 0: cosine=1.000000  ||expected||=7.6479  ||candle||=7.6479
  Row 1: cosine=1.000000  ||expected||=8.2744  ||candle||=8.2744
```

Effectively bit-equivalent at fp32. Cosine similarity `1.000000` to six decimals on both rows.

### Functional zero-shot classification (`siglip2-naflex-smoke`)

```
bear.jpg:  best='a bear in the woods'      prob=0.9956
teddy.jpg: best='a group of teddy bears'   prob=0.9999
```

Matches the published model card's expected classification behavior.

## Position-embedding resize and antialias

SigLIP2 NaFlex stores a fixed `[base*base, hidden]` position grid and bilinearly resizes it to each input's `(h_patches, w_patches)` at inference. PyTorch uses `F.interpolate(mode="bilinear", align_corners=False, antialias=True)`. Candle-core's `Tensor::upsample_bilinear2d` has no antialias filter; without antialias, asymmetric resize introduces up to ~0.7 max abs diff per element in the resized position grid, compounding to ~0.165 max abs diff in the final patch embeddings (cosine 0.9996).

This PR ships a userland antialias helper inline in `siglip2_naflex.rs`. The algorithm is mathematically equivalent to PyTorch's antialiased bilinear: each output pixel is a normalized triangle-weighted sum over input pixels in a window of width `max(1, 1/scale)`. That is exactly `W_h @ input @ W_w^T` with `W_h, W_w` per-axis weight matrices. Separable.

The matmul approach is ~50 LOC, has no candle-core dependency, and matches PyTorch to FP precision. Promoting it to candle-core (so it lives next to `upsample_bilinear2d` and gets per-backend kernels on Metal/CUDA) is a larger separate PR; happy to scope that as a follow-up if maintainers want it.

## Reproducing the validation

```bash
# End-to-end smoke (downloads checkpoint + tokenizer; ~1 GB)
cargo run --release --no-default-features --features accelerate \
    -p candle-examples --example siglip2-naflex-smoke

# Variable-shape forward
cargo run --release --no-default-features --features accelerate \
    -p candle-examples --example siglip2-naflex-variable

# Tensor-level vs PyTorch (requires reference fixtures generated separately)
cargo run --release --no-default-features --features accelerate \
    -p candle-examples --example siglip2-naflex-refcompare

# Antialias algorithm validation against PyTorch reference (8 scale factors)
cargo run --release --no-default-features --features accelerate \
    -p candle-examples --example antialias-prototype \
    /path/to/antialias_reference.safetensors
```

The reference safetensors for the last two examples are generated by the Python scripts under `/tmp/siglip2-practice-run/` (HF preprocessor + PyTorch model outputs) and `/tmp/antialias-reference/` (synthetic + SigLIP2-shaped antialias reference). Happy to add these scripts under `tools/` if useful for CI; left out of this PR to keep the diff focused.

Build features tested:

- **Apple Silicon** (`--no-default-features --features accelerate`): rustc 1.95, candle's CPU/Accelerate path on Mac M-series. All examples build clean, smoke test classifies bear=99.56% / teddy=99.99%.

- **NVIDIA L4** (`--features cuda`): rustc 1.90 + CUDA 12.4.131, build via `nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04`, executed on a GKE node with one L4 (sm_89, Ada Lovelace, 23 GB) via `nvidia.com/gpu: 1` request. `Device: Cuda(CudaDevice(DeviceId(1)))` confirmed in the example output, not a CPU fallback. Same smoke-test classifications as the Mac path (bear=99.56% / teddy=99.99%). The standalone `antialias-prototype` binary ran on the L4 against the 8 PyTorch reference fixtures with worst max abs diff 3.219e-6, identical to the CPU run.

Build infra and full receipts (nvidia-smi, smoke test, antialias-prototype across 8 scale factors) are in the linked validation log; happy to attach to the PR thread or include in tools/ if useful for CI.

## Note on AI assistance

Implementation was developed with assistance from Claude Code; reviews of HF transformers source, candle-core internals, and the diagnostic isolation work that pinned the position-embedding resize as the drift source were human-driven. The antialias algorithm is mathematically derived (separable triangle-weighted sum is equivalent to two matmuls) and validated against PyTorch reference fixtures at 8 scale factors with worst-case max abs diff 3.2e-6.

Happy to split into smaller PRs if preferred (e.g., land the existing siglip example variants first, then NaFlex model file, then the antialias helper as a third PR).

## Known scope decisions and limits

1. **No HF NaFlex preprocessor port.** The HF Python preprocessor (`image_processing_siglip2.py` NaFlex code path) handles variable-aspect-ratio resizing + patch flattening + spatial_shapes + pixel_attention_mask construction. This PR consumes preprocessor outputs (the user is expected to run preprocessing in Python and pass the outputs to candle, or write their own preprocessor). Adding a Rust preprocessor is ~300 LOC and a natural follow-up.

2. **`google/siglip2-so400m-patch16-naflex` not validated end-to-end.** The bigger NaFlex variant. Same code path; should work but didn't run a real-image classification on it for this PR. Could be added if maintainers want validation in-tree.

3. **`align_corners=True` is not a code path candle-core or this PR exercises.** PyTorch SigLIP2 uses `align_corners=False`, which this PR matches.

4. **Attention masking edge cases.** When `pixel_attention_mask` is all-ones (no padding), the model produces correct outputs that match PyTorch. When the mask has padding, the model handles it, but the tensor-level diff comparison was only run on the no-padding case. Edge cases with heavy padding may produce small numerical differences that I haven't characterized.
