### PR TITLE
Add upsample_bilinear2d_antialias to candle-core (CPU only, GPU follow-up)

### DIFF
--- a/candle-core/src/backend.rs
+++ b/candle-core/src/backend.rs
@@ -78,13 +78,7 @@ pub trait BackendStorage: Sized {
         _: Option<f64>,
         _: Option<f64>,
     ) -> Result<Self>;
-    fn upsample_bilinear2d_antialias(
-        &self,
-        _: &Layout,
-        _: usize,
-        _: usize,
-        _: bool,
-    ) -> Result<Self>;
+    fn upsample_bilinear2d_antialias(&self, _: &Layout, _: usize, _: usize) -> Result<Self>;
 
     fn gather(&self, _: &Layout, _: &Self, _: &Layout, _: usize) -> Result<Self>;
 

--- a/candle-core/src/backend.rs
+++ b/candle-core/src/backend.rs
@@ -78,6 +78,13 @@ pub trait BackendStorage: Sized {
         _: Option<f64>,
         _: Option<f64>,
     ) -> Result<Self>;
+    fn upsample_bilinear2d_antialias(
+        &self,
+        _: &Layout,
+        _: usize,
+        _: usize,
+        _: bool,
+    ) -> Result<Self>;
 
     fn gather(&self, _: &Layout, _: &Self, _: &Layout, _: usize) -> Result<Self>;
 

--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -412,9 +412,9 @@ impl Tensor {
                     Op::UpsampleBilinear2D { .. } => {
                         crate::bail!("backward not supported for upsample_bilinear2d")
                     }
-                    Op::UpsampleBilinear2DAntialias { .. } => {
-                        crate::bail!("backward not supported for upsample_bilinear2d_antialias")
-                    }
+                    Op::UpsampleBilinear2DAntialias { .. } => crate::bail!(
+                        "backward not yet implemented for upsample_bilinear2d_antialias"
+                    ),
                     Op::SliceScatter0(lhs, rhs, start_rhs) => {
                         let rhs_sum_grad = grads.or_insert(rhs)?;
                         let rhs_grad = grad.narrow(0, *start_rhs, rhs.dim(0)?)?;

--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -119,6 +119,7 @@ impl Tensor {
                     | Op::UpsampleNearest1D { arg: node, .. }
                     | Op::UpsampleNearest2D { arg: node, .. }
                     | Op::UpsampleBilinear2D { arg: node, .. }
+                    | Op::UpsampleBilinear2DAntialias { arg: node, .. }
                     | Op::AvgPool2D { arg: node, .. }
                     | Op::MaxPool2D { arg: node, .. }
                     | Op::Copy(node)
@@ -410,6 +411,9 @@ impl Tensor {
                     }
                     Op::UpsampleBilinear2D { .. } => {
                         crate::bail!("backward not supported for upsample_bilinear2d")
+                    }
+                    Op::UpsampleBilinear2DAntialias { .. } => {
+                        crate::bail!("backward not supported for upsample_bilinear2d_antialias")
                     }
                     Op::SliceScatter0(lhs, rhs, start_rhs) => {
                         let rhs_sum_grad = grads.or_insert(rhs)?;

--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -412,9 +412,9 @@ impl Tensor {
                     Op::UpsampleBilinear2D { .. } => {
                         crate::bail!("backward not supported for upsample_bilinear2d")
                     }
-                    Op::UpsampleBilinear2DAntialias { .. } => crate::bail!(
-                        "backward not yet implemented for upsample_bilinear2d_antialias"
-                    ),
+                    Op::UpsampleBilinear2DAntialias { .. } => {
+                        crate::bail!("backward not supported for upsample_bilinear2d_antialias")
+                    }
                     Op::SliceScatter0(lhs, rhs, start_rhs) => {
                         let rhs_sum_grad = grads.or_insert(rhs)?;
                         let rhs_grad = grad.narrow(0, *start_rhs, rhs.dim(0)?)?;

--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -603,7 +603,10 @@ impl UpsampleBilinear2DAntialias {
         for o in 0..dst {
             let center = (o as f64 + 0.5) / scale - 0.5;
             let i_min = ((center - support).floor() as i64).max(0) as usize;
-            let i_max_excl = (((center + support).ceil() as i64 + 1).max(0) as usize).min(src);
+            // (center + support).ceil() is the exclusive upper bound: weights
+            // at or beyond it are zero by the (1 - dist).max(0) clamp below.
+            let i_max_excl = ((center + support).ceil() as i64).max(0) as usize;
+            let i_max_excl = i_max_excl.min(src);
             let mut row_sum = 0f64;
             for i in i_min..i_max_excl {
                 let dist = (i as f64 - center).abs() / support;
@@ -627,48 +630,50 @@ impl Map1 for UpsampleBilinear2DAntialias {
         let height_out = self.target_h;
         let width_out = self.target_w;
 
-        // Identity short-circuit: only valid when the input is contiguous,
-        // because we return a flat Vec that the caller wraps in a fresh
-        // contiguous layout. Returning src.to_vec() for a permuted input
-        // would silently reinterpret the bytes as contiguous.
-        if height_in == height_out && width_in == width_out && layout.is_contiguous() {
-            let total = batch * channels * height_in * width_in;
-            return Ok(src[layout.start_offset()..layout.start_offset() + total].to_vec());
+        // Reject zero-sized dims explicitly: dims4()? validates rank but not
+        // that each dim is positive. A zero input dim divides by zero in the
+        // weight-matrix scale calculation; a zero target dim returns an empty
+        // tensor that callers usually didn't intend.
+        if height_in == 0 || width_in == 0 || height_out == 0 || width_out == 0 {
+            crate::bail!(
+                "upsample_bilinear2d_antialias requires positive dims; \
+                 input ({batch}, {channels}, {height_in}, {width_in}), \
+                 target ({height_out}, {width_out})"
+            );
         }
 
         let stride = layout.stride();
         let src_offset = layout.start_offset();
 
-        let w_h = Self::weight_matrix(height_in, height_out);
-        let w_w = Self::weight_matrix(width_in, width_out);
+        let weights_h = Self::weight_matrix(height_in, height_out);
+        let weights_w = Self::weight_matrix(width_in, width_out);
 
         let mut dst = vec![T::zero(); batch * channels * height_out * width_out];
 
-        // Per-output-pixel triangle-weighted sum.
-        // Equivalent to the matmul `output = W_h @ input @ W_w^T` with
-        // W_h shape (height_out, height_in) and W_w shape (width_out, width_in).
-        // We accumulate in f64 and cast once at the end to preserve precision
-        // across small differences in weight ordering versus the matmul form.
+        // Per-output-pixel triangle-weighted sum, equivalent in exact
+        // arithmetic to `output = W_h @ input @ W_w^T` with W_h of shape
+        // (height_out, height_in) and W_w of shape (width_out, width_in).
+        // Accumulate in f64 and cast once at the end to preserve precision.
         for b in 0..batch {
             for c in 0..channels {
                 let base_idx = src_offset + b * stride[0] + c * stride[1];
                 let dst_base = (b * channels + c) * height_out * width_out;
 
                 for h_out in 0..height_out {
-                    let h_row = &w_h[h_out * height_in..(h_out + 1) * height_in];
+                    let row_h = &weights_h[h_out * height_in..(h_out + 1) * height_in];
                     for w_out in 0..width_out {
-                        let w_row = &w_w[w_out * width_in..(w_out + 1) * width_in];
+                        let row_w = &weights_w[w_out * width_in..(w_out + 1) * width_in];
                         let mut value = 0f64;
-                        for (h_in, &h_w) in h_row.iter().enumerate() {
-                            if h_w == 0.0 {
+                        for (h_in, &weight_h) in row_h.iter().enumerate() {
+                            if weight_h == 0.0 {
                                 continue;
                             }
-                            for (w_in, &w_w_val) in w_row.iter().enumerate() {
-                                if w_w_val == 0.0 {
+                            for (w_in, &weight_w) in row_w.iter().enumerate() {
+                                if weight_w == 0.0 {
                                     continue;
                                 }
                                 let idx = base_idx + h_in * stride[2] + w_in * stride[3];
-                                value += src[idx].to_f64() * h_w * w_w_val;
+                                value += src[idx].to_f64() * weight_h * weight_w;
                             }
                         }
                         dst[dst_base + h_out * width_out + w_out] = T::from_f64(value);
@@ -3385,4 +3390,28 @@ macro_rules! map_dtype {
             s => Err(Error::UnsupportedDTypeForOp(s.dtype(), $name).bt())?,
         }
     };
+}
+
+#[cfg(test)]
+mod upsample_bilinear2d_antialias_tests {
+    use super::UpsampleBilinear2DAntialias;
+
+    #[test]
+    fn weight_matrix_rows_sum_to_one() {
+        for &(src, dst) in &[(8, 4), (16, 8), (8, 5), (4, 4), (4, 8), (1, 1)] {
+            let m = UpsampleBilinear2DAntialias::weight_matrix(src, dst);
+            assert_eq!(m.len(), dst * src, "shape mismatch for ({src}, {dst})");
+            for row in 0..dst {
+                let sum: f64 = m[row * src..(row + 1) * src].iter().sum();
+                assert!(
+                    (sum - 1.0).abs() < 1e-12,
+                    "weight_matrix({src}, {dst}) row {row} sum = {sum}, expected 1.0"
+                );
+            }
+            assert!(
+                m.iter().all(|&w| w >= 0.0),
+                "weight_matrix({src}, {dst}) has a negative weight"
+            );
+        }
+    }
 }

--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -585,6 +585,103 @@ impl Map1 for UpsampleBilinear2D {
     }
 }
 
+struct UpsampleBilinear2DAntialias {
+    target_h: usize,
+    target_w: usize,
+    align_corners: bool,
+}
+
+impl UpsampleBilinear2DAntialias {
+    /// Build a per-axis weight matrix of shape `(dst, src)` where row `o`
+    /// contains normalized triangle weights for the input pixels contributing
+    /// to output `o`. Matches PyTorch's antialiased bilinear: support is
+    /// `max(1, 1/scale)` in input coordinates, weights linear in distance from
+    /// the mapped output center, normalized so each row sums to 1.
+    fn weight_matrix(src: usize, dst: usize) -> Vec<f64> {
+        let scale = dst as f64 / src as f64;
+        let support = (1.0_f64 / scale).max(1.0);
+        let mut weights = vec![0f64; dst * src];
+        for o in 0..dst {
+            let center = (o as f64 + 0.5) / scale - 0.5;
+            let i_min = ((center - support).floor() as i64).max(0) as usize;
+            let i_max_excl = (((center + support).ceil() as i64 + 1).max(0) as usize).min(src);
+            let mut row_sum = 0f64;
+            for i in i_min..i_max_excl {
+                let dist = (i as f64 - center).abs() / support;
+                let w = (1.0 - dist).max(0.0);
+                weights[o * src + i] = w;
+                row_sum += w;
+            }
+            if row_sum > 0.0 {
+                for i in i_min..i_max_excl {
+                    weights[o * src + i] /= row_sum;
+                }
+            }
+        }
+        weights
+    }
+}
+
+impl Map1 for UpsampleBilinear2DAntialias {
+    fn f<T: WithDType>(&self, src: &[T], layout: &Layout) -> Result<Vec<T>> {
+        if self.align_corners {
+            crate::bail!("upsample_bilinear2d_antialias with align_corners=true is not supported");
+        }
+        let (batch, channels, height_in, width_in) = layout.shape().dims4()?;
+        let height_out = self.target_h;
+        let width_out = self.target_w;
+
+        if height_in == height_out && width_in == width_out {
+            return Ok(src.to_vec());
+        }
+
+        let stride = layout.stride();
+        let src_offset = layout.start_offset();
+
+        let w_h = Self::weight_matrix(height_in, height_out);
+        let w_w = Self::weight_matrix(width_in, width_out);
+
+        let mut dst = vec![T::zero(); batch * channels * height_out * width_out];
+
+        // Per-output-pixel triangle-weighted sum.
+        // Equivalent to the matmul `output = W_h @ input @ W_w^T` with
+        // W_h shape (height_out, height_in) and W_w shape (width_out, width_in).
+        // We accumulate in f64 and cast once at the end to preserve precision
+        // across small differences in weight ordering versus the matmul form.
+        for b in 0..batch {
+            for c in 0..channels {
+                let base_idx = src_offset + b * stride[0] + c * stride[1];
+                let dst_base = (b * channels + c) * height_out * width_out;
+
+                for h_out in 0..height_out {
+                    let h_row = &w_h[h_out * height_in..(h_out + 1) * height_in];
+                    for w_out in 0..width_out {
+                        let w_row = &w_w[w_out * width_in..(w_out + 1) * width_in];
+                        let mut value = 0f64;
+                        for h_in in 0..height_in {
+                            let h_w = h_row[h_in];
+                            if h_w == 0.0 {
+                                continue;
+                            }
+                            for w_in in 0..width_in {
+                                let w_w_val = w_row[w_in];
+                                if w_w_val == 0.0 {
+                                    continue;
+                                }
+                                let idx = base_idx + h_in * stride[2] + w_in * stride[3];
+                                value += src[idx].to_f64() * h_w * w_w_val;
+                            }
+                        }
+                        dst[dst_base + h_out * width_out + w_out] = T::from_f64(value);
+                    }
+                }
+            }
+        }
+
+        Ok(dst)
+    }
+}
+
 struct Gather<'a, I: IntDType> {
     ids: &'a [I],
     ids_l: &'a Layout,
@@ -2371,6 +2468,21 @@ impl BackendStorage for CpuStorage {
             align_corners,
             scale_h_factor: scale_h,
             scale_w_factor: scale_w,
+        }
+        .map(self, layout)
+    }
+
+    fn upsample_bilinear2d_antialias(
+        &self,
+        layout: &Layout,
+        h: usize,
+        w: usize,
+        align_corners: bool,
+    ) -> Result<Self> {
+        UpsampleBilinear2DAntialias {
+            target_h: h,
+            target_w: w,
+            align_corners,
         }
         .map(self, layout)
     }

--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -596,7 +596,10 @@ impl UpsampleBilinear2DAntialias {
     /// to output `o`. Matches PyTorch's antialiased bilinear: support is
     /// `max(1, 1/scale)` in input coordinates, weights linear in distance from
     /// the mapped output center, normalized so each row sums to 1.
-    fn weight_matrix(src: usize, dst: usize) -> Vec<f64> {
+    fn weight_matrix(src: usize, dst: usize) -> Result<Vec<f64>> {
+        if src == 0 || dst == 0 {
+            crate::bail!("weight_matrix requires src > 0 and dst > 0; got ({src}, {dst})");
+        }
         let scale = dst as f64 / src as f64;
         let support = (1.0_f64 / scale).max(1.0);
         let mut weights = vec![0f64; dst * src];
@@ -605,8 +608,21 @@ impl UpsampleBilinear2DAntialias {
             let i_min = ((center - support).floor() as i64).max(0) as usize;
             // (center + support).ceil() is the exclusive upper bound: weights
             // at or beyond it are zero by the (1 - dist).max(0) clamp below.
+            // No `.max(0)` here: for src >= 1, dst >= 1, o in 0..dst, the value
+            // is provably >= 0, so any negative would indicate a math bug we'd
+            // rather surface than silently clamp.
             let i_max_excl = ((center + support).ceil() as i64).max(0) as usize;
             let i_max_excl = i_max_excl.min(src);
+            // Defensive: if the window collapses to empty (unreachable today
+            // given the kernel's positive-dim guard, but cheap insurance under
+            // future refactors), fall back to a single-pixel weight at i_min
+            // clamped to src-1. Avoids silently emitting T::zero() at every
+            // output pixel using this row.
+            if i_min >= i_max_excl {
+                let i = i_min.min(src - 1);
+                weights[o * src + i] = 1.0;
+                continue;
+            }
             let mut row_sum = 0f64;
             for i in i_min..i_max_excl {
                 let dist = (i as f64 - center).abs() / support;
@@ -618,9 +634,15 @@ impl UpsampleBilinear2DAntialias {
                 for i in i_min..i_max_excl {
                     weights[o * src + i] /= row_sum;
                 }
+            } else {
+                // All weights clamped to zero (e.g. degenerate fp edge case).
+                // Same fallback as the empty-window case above: single-pixel
+                // identity weight. Never silently emit zeros.
+                let i = i_min.min(src - 1);
+                weights[o * src + i] = 1.0;
             }
         }
-        weights
+        Ok(weights)
     }
 }
 
@@ -645,15 +667,17 @@ impl Map1 for UpsampleBilinear2DAntialias {
         let stride = layout.stride();
         let src_offset = layout.start_offset();
 
-        let weights_h = Self::weight_matrix(height_in, height_out);
-        let weights_w = Self::weight_matrix(width_in, width_out);
+        let weights_h = Self::weight_matrix(height_in, height_out)?;
+        let weights_w = Self::weight_matrix(width_in, width_out)?;
 
         let mut dst = vec![T::zero(); batch * channels * height_out * width_out];
 
         // Per-output-pixel triangle-weighted sum, equivalent in exact
         // arithmetic to `output = W_h @ input @ W_w^T` with W_h of shape
         // (height_out, height_in) and W_w of shape (width_out, width_in).
-        // Accumulate in f64 and cast once at the end to preserve precision.
+        // Accumulate in f64 and cast once at the end to preserve precision;
+        // floating-point equivalence to the matmul form depends on this f64
+        // accumulator. A T-typed accumulator would round differently.
         for b in 0..batch {
             for c in 0..channels {
                 let base_idx = src_offset + b * stride[0] + c * stride[1];
@@ -3397,9 +3421,22 @@ mod upsample_bilinear2d_antialias_tests {
     use super::UpsampleBilinear2DAntialias;
 
     #[test]
-    fn weight_matrix_rows_sum_to_one() {
-        for &(src, dst) in &[(8, 4), (16, 8), (8, 5), (4, 4), (4, 8), (1, 1)] {
-            let m = UpsampleBilinear2DAntialias::weight_matrix(src, dst);
+    fn weight_matrix_invariants_across_ratios() {
+        // Mix of square-ish, prime, and extreme ratios. Extreme cases (1, 64)
+        // and (64, 1) test single-pixel rows and large support windows.
+        for &(src, dst) in &[
+            (8, 4),
+            (16, 8),
+            (8, 5),
+            (4, 4),
+            (4, 8),
+            (1, 1),
+            (7, 3),
+            (3, 7),
+            (64, 1),
+            (1, 64),
+        ] {
+            let m = UpsampleBilinear2DAntialias::weight_matrix(src, dst).unwrap();
             assert_eq!(m.len(), dst * src, "shape mismatch for ({src}, {dst})");
             for row in 0..dst {
                 let sum: f64 = m[row * src..(row + 1) * src].iter().sum();
@@ -3411,6 +3448,73 @@ mod upsample_bilinear2d_antialias_tests {
             assert!(
                 m.iter().all(|&w| w >= 0.0),
                 "weight_matrix({src}, {dst}) has a negative weight"
+            );
+        }
+    }
+
+    #[test]
+    fn weight_matrix_zero_dim_errors() {
+        assert!(UpsampleBilinear2DAntialias::weight_matrix(0, 4).is_err());
+        assert!(UpsampleBilinear2DAntialias::weight_matrix(4, 0).is_err());
+        assert!(UpsampleBilinear2DAntialias::weight_matrix(0, 0).is_err());
+    }
+
+    #[test]
+    fn weight_matrix_known_values_2_to_1() {
+        // 2 -> 1: single output pixel averages both inputs equally.
+        // scale = 0.5, support = 2.0, center = (0+0.5)/0.5 - 0.5 = 0.5.
+        // Distances 0 and 1 from center (0.5) are 0.5 and 0.5 in input units;
+        // normalized by support (2.0) gives 0.25 and 0.25.
+        // Triangle weights: (1 - 0.25) = 0.75 each; row sum 1.5; normalized 0.5 each.
+        let m = UpsampleBilinear2DAntialias::weight_matrix(2, 1).unwrap();
+        assert_eq!(m.len(), 2);
+        assert!((m[0] - 0.5).abs() < 1e-12, "expected 0.5, got {}", m[0]);
+        assert!((m[1] - 0.5).abs() < 1e-12, "expected 0.5, got {}", m[1]);
+    }
+
+    #[test]
+    fn weight_matrix_known_values_1_to_2() {
+        // 1 -> 2: each output pixel sees only the single input pixel.
+        // Both rows must be [1.0] after normalization.
+        let m = UpsampleBilinear2DAntialias::weight_matrix(1, 2).unwrap();
+        assert_eq!(m.len(), 2);
+        assert!(
+            (m[0] - 1.0).abs() < 1e-12,
+            "row 0: expected 1.0, got {}",
+            m[0]
+        );
+        assert!(
+            (m[1] - 1.0).abs() < 1e-12,
+            "row 1: expected 1.0, got {}",
+            m[1]
+        );
+    }
+
+    #[test]
+    fn weight_matrix_known_values_4_to_2() {
+        // 4 -> 2: scale = 0.5, support = 2.0.
+        // Row 0: center = (0+0.5)/0.5 - 0.5 = 0.5.
+        //   weights at i=0,1,2,3: (1 - |0-0.5|/2), (1 - |1-0.5|/2), (1 - |2-0.5|/2), (1 - |3-0.5|/2)
+        //   = 0.75, 0.75, 0.25, 0.0 -> sum 1.75 -> normalized 0.75/1.75, 0.75/1.75, 0.25/1.75, 0.
+        // Row 1: center = (1+0.5)/0.5 - 0.5 = 2.5.
+        //   weights: 0, 0.25, 0.75, 0.75 -> sum 1.75 -> mirror of row 0.
+        let m = UpsampleBilinear2DAntialias::weight_matrix(4, 2).unwrap();
+        assert_eq!(m.len(), 8);
+        let row_sum = 1.75_f64;
+        let expected_row0 = [0.75 / row_sum, 0.75 / row_sum, 0.25 / row_sum, 0.0];
+        let expected_row1 = [0.0, 0.25 / row_sum, 0.75 / row_sum, 0.75 / row_sum];
+        for i in 0..4 {
+            assert!(
+                (m[i] - expected_row0[i]).abs() < 1e-12,
+                "row 0 col {i}: expected {}, got {}",
+                expected_row0[i],
+                m[i]
+            );
+            assert!(
+                (m[4 + i] - expected_row1[i]).abs() < 1e-12,
+                "row 1 col {i}: expected {}, got {}",
+                expected_row1[i],
+                m[4 + i]
             );
         }
     }

--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -658,13 +658,11 @@ impl Map1 for UpsampleBilinear2DAntialias {
                     for w_out in 0..width_out {
                         let w_row = &w_w[w_out * width_in..(w_out + 1) * width_in];
                         let mut value = 0f64;
-                        for h_in in 0..height_in {
-                            let h_w = h_row[h_in];
+                        for (h_in, &h_w) in h_row.iter().enumerate() {
                             if h_w == 0.0 {
                                 continue;
                             }
-                            for w_in in 0..width_in {
-                                let w_w_val = w_row[w_in];
+                            for (w_in, &w_w_val) in w_row.iter().enumerate() {
                                 if w_w_val == 0.0 {
                                     continue;
                                 }

--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -588,7 +588,6 @@ impl Map1 for UpsampleBilinear2D {
 struct UpsampleBilinear2DAntialias {
     target_h: usize,
     target_w: usize,
-    align_corners: bool,
 }
 
 impl UpsampleBilinear2DAntialias {
@@ -624,15 +623,17 @@ impl UpsampleBilinear2DAntialias {
 
 impl Map1 for UpsampleBilinear2DAntialias {
     fn f<T: WithDType>(&self, src: &[T], layout: &Layout) -> Result<Vec<T>> {
-        if self.align_corners {
-            crate::bail!("upsample_bilinear2d_antialias with align_corners=true is not supported");
-        }
         let (batch, channels, height_in, width_in) = layout.shape().dims4()?;
         let height_out = self.target_h;
         let width_out = self.target_w;
 
-        if height_in == height_out && width_in == width_out {
-            return Ok(src.to_vec());
+        // Identity short-circuit: only valid when the input is contiguous,
+        // because we return a flat Vec that the caller wraps in a fresh
+        // contiguous layout. Returning src.to_vec() for a permuted input
+        // would silently reinterpret the bytes as contiguous.
+        if height_in == height_out && width_in == width_out && layout.is_contiguous() {
+            let total = batch * channels * height_in * width_in;
+            return Ok(src[layout.start_offset()..layout.start_offset() + total].to_vec());
         }
 
         let stride = layout.stride();
@@ -2470,17 +2471,10 @@ impl BackendStorage for CpuStorage {
         .map(self, layout)
     }
 
-    fn upsample_bilinear2d_antialias(
-        &self,
-        layout: &Layout,
-        h: usize,
-        w: usize,
-        align_corners: bool,
-    ) -> Result<Self> {
+    fn upsample_bilinear2d_antialias(&self, layout: &Layout, h: usize, w: usize) -> Result<Self> {
         UpsampleBilinear2DAntialias {
             target_h: h,
             target_w: w,
-            align_corners,
         }
         .map(self, layout)
     }

--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -2135,6 +2135,20 @@ impl BackendStorage for CudaStorage {
         Ok(Self { slice, device })
     }
 
+    fn upsample_bilinear2d_antialias(
+        &self,
+        _l: &Layout,
+        _out_h: usize,
+        _out_w: usize,
+        _align_corners: bool,
+    ) -> Result<Self> {
+        crate::bail!(
+            "upsample_bilinear2d_antialias is not yet implemented on the CUDA backend; \
+             a CPU-only path is available via Tensor::upsample_bilinear2d_antialias on \
+             a CPU tensor. GPU kernels are tracked as a follow-up."
+        )
+    }
+
     fn index_select(&self, ids: &Self, l: &Layout, ids_l: &Layout, dim: usize) -> Result<Self> {
         let device = self.device().clone();
         let slice = IndexSelect(ids, ids_l, dim).map(&self.slice, &device, l)?;

--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -2141,11 +2141,7 @@ impl BackendStorage for CudaStorage {
         _out_h: usize,
         _out_w: usize,
     ) -> Result<Self> {
-        crate::bail!(
-            "upsample_bilinear2d_antialias is not yet implemented on the CUDA backend; \
-             a CPU-only path is available via Tensor::upsample_bilinear2d_antialias on \
-             a CPU tensor. GPU kernels are tracked as a follow-up."
-        )
+        crate::bail!("upsample_bilinear2d_antialias is not supported on cuda")
     }
 
     fn index_select(&self, ids: &Self, l: &Layout, ids_l: &Layout, dim: usize) -> Result<Self> {

--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -2140,7 +2140,6 @@ impl BackendStorage for CudaStorage {
         _l: &Layout,
         _out_h: usize,
         _out_w: usize,
-        _align_corners: bool,
     ) -> Result<Self> {
         crate::bail!(
             "upsample_bilinear2d_antialias is not yet implemented on the CUDA backend; \

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -230,13 +230,7 @@ impl crate::backend::BackendStorage for CudaStorage {
         Err(Error::NotCompiledWithCudaSupport)
     }
 
-    fn upsample_bilinear2d_antialias(
-        &self,
-        _: &Layout,
-        _: usize,
-        _: usize,
-        _: bool,
-    ) -> Result<Self> {
+    fn upsample_bilinear2d_antialias(&self, _: &Layout, _: usize, _: usize) -> Result<Self> {
         Err(Error::NotCompiledWithCudaSupport)
     }
 }

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -229,6 +229,16 @@ impl crate::backend::BackendStorage for CudaStorage {
     ) -> Result<Self> {
         Err(Error::NotCompiledWithCudaSupport)
     }
+
+    fn upsample_bilinear2d_antialias(
+        &self,
+        _: &Layout,
+        _: usize,
+        _: usize,
+        _: bool,
+    ) -> Result<Self> {
+        Err(Error::NotCompiledWithCudaSupport)
+    }
 }
 
 impl crate::backend::BackendDevice for CudaDevice {

--- a/candle-core/src/dummy_metal_backend.rs
+++ b/candle-core/src/dummy_metal_backend.rs
@@ -222,6 +222,16 @@ impl crate::backend::BackendStorage for MetalStorage {
     ) -> Result<Self> {
         Err(Error::NotCompiledWithMetalSupport)
     }
+
+    fn upsample_bilinear2d_antialias(
+        &self,
+        _: &Layout,
+        _: usize,
+        _: usize,
+        _: bool,
+    ) -> Result<Self> {
+        Err(Error::NotCompiledWithMetalSupport)
+    }
 }
 
 impl crate::backend::BackendDevice for MetalDevice {

--- a/candle-core/src/dummy_metal_backend.rs
+++ b/candle-core/src/dummy_metal_backend.rs
@@ -223,13 +223,7 @@ impl crate::backend::BackendStorage for MetalStorage {
         Err(Error::NotCompiledWithMetalSupport)
     }
 
-    fn upsample_bilinear2d_antialias(
-        &self,
-        _: &Layout,
-        _: usize,
-        _: usize,
-        _: bool,
-    ) -> Result<Self> {
+    fn upsample_bilinear2d_antialias(&self, _: &Layout, _: usize, _: usize) -> Result<Self> {
         Err(Error::NotCompiledWithMetalSupport)
     }
 }

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -1402,6 +1402,20 @@ impl BackendStorage for MetalStorage {
         Ok(Self::new(buffer, self.device.clone(), dst_el, self.dtype))
     }
 
+    fn upsample_bilinear2d_antialias(
+        &self,
+        _inp_l: &Layout,
+        _out_h: usize,
+        _out_w: usize,
+        _align_corners: bool,
+    ) -> Result<Self> {
+        crate::bail!(
+            "upsample_bilinear2d_antialias is not yet implemented on the Metal backend; \
+             a CPU-only path is available via Tensor::upsample_bilinear2d_antialias on \
+             a CPU tensor. GPU kernels are tracked as a follow-up."
+        )
+    }
+
     fn gather(&self, src_l: &Layout, ids: &Self, ids_l: &Layout, dim: usize) -> Result<Self> {
         if !ids_l.is_contiguous() {
             return Err(crate::Error::RequiresContiguous { op: "gather" }.bt());

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -1407,7 +1407,6 @@ impl BackendStorage for MetalStorage {
         _inp_l: &Layout,
         _out_h: usize,
         _out_w: usize,
-        _align_corners: bool,
     ) -> Result<Self> {
         crate::bail!(
             "upsample_bilinear2d_antialias is not yet implemented on the Metal backend; \

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -1408,11 +1408,7 @@ impl BackendStorage for MetalStorage {
         _out_h: usize,
         _out_w: usize,
     ) -> Result<Self> {
-        crate::bail!(
-            "upsample_bilinear2d_antialias is not yet implemented on the Metal backend; \
-             a CPU-only path is available via Tensor::upsample_bilinear2d_antialias on \
-             a CPU tensor. GPU kernels are tracked as a follow-up."
-        )
+        crate::bail!("upsample_bilinear2d_antialias is not supported on metal")
     }
 
     fn gather(&self, src_l: &Layout, ids: &Self, ids_l: &Layout, dim: usize) -> Result<Self> {

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -152,6 +152,12 @@ pub enum Op {
         target_w: usize,
         align_corners: bool,
     },
+    UpsampleBilinear2DAntialias {
+        arg: Tensor,
+        target_h: usize,
+        target_w: usize,
+        align_corners: bool,
+    },
 
     Cat(Vec<Tensor>, usize),
 

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -156,7 +156,6 @@ pub enum Op {
         arg: Tensor,
         target_h: usize,
         target_w: usize,
-        align_corners: bool,
     },
 
     Cat(Vec<Tensor>, usize),

--- a/candle-core/src/storage.rs
+++ b/candle-core/src/storage.rs
@@ -603,19 +603,18 @@ impl Storage {
         layout: &Layout,
         h: usize,
         w: usize,
-        align_corners: bool,
     ) -> Result<Self> {
         match self {
             Storage::Cpu(storage) => {
-                let storage = storage.upsample_bilinear2d_antialias(layout, h, w, align_corners)?;
+                let storage = storage.upsample_bilinear2d_antialias(layout, h, w)?;
                 Ok(Self::Cpu(storage))
             }
             Self::Cuda(storage) => {
-                let storage = storage.upsample_bilinear2d_antialias(layout, h, w, align_corners)?;
+                let storage = storage.upsample_bilinear2d_antialias(layout, h, w)?;
                 Ok(Self::Cuda(storage))
             }
             Self::Metal(storage) => {
-                let storage = storage.upsample_bilinear2d_antialias(layout, h, w, align_corners)?;
+                let storage = storage.upsample_bilinear2d_antialias(layout, h, w)?;
                 Ok(Self::Metal(storage))
             }
         }

--- a/candle-core/src/storage.rs
+++ b/candle-core/src/storage.rs
@@ -598,6 +598,32 @@ impl Storage {
         }
     }
 
+    pub(crate) fn upsample_bilinear2d_antialias(
+        &self,
+        layout: &Layout,
+        h: usize,
+        w: usize,
+        align_corners: bool,
+    ) -> Result<Self> {
+        match self {
+            Storage::Cpu(storage) => {
+                let storage =
+                    storage.upsample_bilinear2d_antialias(layout, h, w, align_corners)?;
+                Ok(Self::Cpu(storage))
+            }
+            Self::Cuda(storage) => {
+                let storage =
+                    storage.upsample_bilinear2d_antialias(layout, h, w, align_corners)?;
+                Ok(Self::Cuda(storage))
+            }
+            Self::Metal(storage) => {
+                let storage =
+                    storage.upsample_bilinear2d_antialias(layout, h, w, align_corners)?;
+                Ok(Self::Metal(storage))
+            }
+        }
+    }
+
     pub(crate) fn where_cond(
         &self,
         layout: &Layout,

--- a/candle-core/src/storage.rs
+++ b/candle-core/src/storage.rs
@@ -607,18 +607,15 @@ impl Storage {
     ) -> Result<Self> {
         match self {
             Storage::Cpu(storage) => {
-                let storage =
-                    storage.upsample_bilinear2d_antialias(layout, h, w, align_corners)?;
+                let storage = storage.upsample_bilinear2d_antialias(layout, h, w, align_corners)?;
                 Ok(Self::Cpu(storage))
             }
             Self::Cuda(storage) => {
-                let storage =
-                    storage.upsample_bilinear2d_antialias(layout, h, w, align_corners)?;
+                let storage = storage.upsample_bilinear2d_antialias(layout, h, w, align_corners)?;
                 Ok(Self::Cuda(storage))
             }
             Self::Metal(storage) => {
-                let storage =
-                    storage.upsample_bilinear2d_antialias(layout, h, w, align_corners)?;
+                let storage = storage.upsample_bilinear2d_antialias(layout, h, w, align_corners)?;
                 Ok(Self::Metal(storage))
             }
         }

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -1333,42 +1333,33 @@ impl Tensor {
 
     /// Bilinear interpolation with PyTorch-compatible antialiasing.
     ///
-    /// Approximates `torch.nn.functional.interpolate(mode="bilinear", antialias=True)`.
-    /// For downsampling (target smaller than input on an axis), this applies a
-    /// triangle low-pass filter before resampling. For upsampling, antialiasing
-    /// has no effect and this matches the non-antialiased path.
+    /// Approximates `torch.nn.functional.interpolate(mode="bilinear",
+    /// antialias=True, align_corners=False)`. For downsampling (target smaller
+    /// than input on an axis), applies a triangle low-pass filter before
+    /// resampling. For upsampling, antialiasing has no effect and the output
+    /// matches the non-antialiased path.
     ///
     /// Currently CPU-only; calling on Metal or CUDA storage returns an error
-    /// (kernel implementations are tracked as a follow-up).
+    /// pointing at the CPU path. GPU kernels are tracked as a follow-up.
+    ///
+    /// `align_corners` is not yet exposed: only the `false` (PyTorch default)
+    /// behavior is implemented. The parameter will be added when
+    /// `align_corners=true` lands.
     ///
     /// # Arguments
     ///
     /// * `target_h` - Output height
     /// * `target_w` - Output width
-    /// * `align_corners` - Must be `false` (antialias with `align_corners=true`
-    ///   is not yet supported)
-    pub fn upsample_bilinear2d_antialias(
-        &self,
-        target_h: usize,
-        target_w: usize,
-        align_corners: bool,
-    ) -> Result<Self> {
+    pub fn upsample_bilinear2d_antialias(&self, target_h: usize, target_w: usize) -> Result<Self> {
         let (n, c, _h, _w) = self.dims4()?;
-        if align_corners {
-            bail!("upsample_bilinear2d_antialias with align_corners=true is not yet supported")
-        }
         let op = BackpropOp::new1(self, |arg| Op::UpsampleBilinear2DAntialias {
             arg,
             target_h,
             target_w,
-            align_corners,
         });
-        let storage = self.storage().upsample_bilinear2d_antialias(
-            self.layout(),
-            target_h,
-            target_w,
-            align_corners,
-        )?;
+        let storage =
+            self.storage()
+                .upsample_bilinear2d_antialias(self.layout(), target_h, target_w)?;
         Ok(from_storage(storage, (n, c, target_h, target_w), op, false))
     }
 

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -1346,11 +1346,21 @@ impl Tensor {
     /// behavior is implemented. The parameter will be added when
     /// `align_corners=true` lands.
     ///
+    /// Backward is not yet implemented; calling `.backward()` on a graph that
+    /// contains this op will error, matching the existing
+    /// [`Tensor::upsample_bilinear2d`] precedent.
+    ///
     /// # Arguments
     ///
-    /// * `target_h` - Output height
-    /// * `target_w` - Output width
+    /// * `target_h` - Output height (must be > 0)
+    /// * `target_w` - Output width (must be > 0)
     pub fn upsample_bilinear2d_antialias(&self, target_h: usize, target_w: usize) -> Result<Self> {
+        if target_h == 0 || target_w == 0 {
+            bail!(
+                "upsample_bilinear2d_antialias requires positive target dims, \
+                 got ({target_h}, {target_w})"
+            )
+        }
         let (n, c, _h, _w) = self.dims4()?;
         let op = BackpropOp::new1(self, |arg| Op::UpsampleBilinear2DAntialias {
             arg,

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -1331,6 +1331,47 @@ impl Tensor {
         ))
     }
 
+    /// Bilinear interpolation with PyTorch-compatible antialiasing.
+    ///
+    /// Approximates `torch.nn.functional.interpolate(mode="bilinear", antialias=True)`.
+    /// For downsampling (target smaller than input on an axis), this applies a
+    /// triangle low-pass filter before resampling. For upsampling, antialiasing
+    /// has no effect and this matches the non-antialiased path.
+    ///
+    /// Currently CPU-only; calling on Metal or CUDA storage returns an error
+    /// (kernel implementations are tracked as a follow-up).
+    ///
+    /// # Arguments
+    ///
+    /// * `target_h` - Output height
+    /// * `target_w` - Output width
+    /// * `align_corners` - Must be `false` (antialias with `align_corners=true`
+    ///   is not yet supported)
+    pub fn upsample_bilinear2d_antialias(
+        &self,
+        target_h: usize,
+        target_w: usize,
+        align_corners: bool,
+    ) -> Result<Self> {
+        let (n, c, _h, _w) = self.dims4()?;
+        if align_corners {
+            bail!("upsample_bilinear2d_antialias with align_corners=true is not yet supported")
+        }
+        let op = BackpropOp::new1(self, |arg| Op::UpsampleBilinear2DAntialias {
+            arg,
+            target_h,
+            target_w,
+            align_corners,
+        });
+        let storage = self.storage().upsample_bilinear2d_antialias(
+            self.layout(),
+            target_h,
+            target_w,
+            align_corners,
+        )?;
+        Ok(from_storage(storage, (n, c, target_h, target_w), op, false))
+    }
+
     /// 2D average pooling over an input tensor with multiple channels.
     ///
     /// The input tensor should have four dimensions, `(batch, channels, h, w)`, the returned

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -1355,13 +1355,9 @@ impl Tensor {
     /// * `target_h` - Output height (must be > 0)
     /// * `target_w` - Output width (must be > 0)
     pub fn upsample_bilinear2d_antialias(&self, target_h: usize, target_w: usize) -> Result<Self> {
-        if target_h == 0 || target_w == 0 {
-            bail!(
-                "upsample_bilinear2d_antialias requires positive target dims, \
-                 got ({target_h}, {target_w})"
-            )
-        }
-        let (n, c, _h, _w) = self.dims4()?;
+        // Rank check via dims4()?; positive-dim validation lives in the
+        // backend impl so all backends share one authoritative error.
+        let (n, c, _, _) = self.dims4()?;
         let op = BackpropOp::new1(self, |arg| Op::UpsampleBilinear2DAntialias {
             arg,
             target_h,

--- a/candle-core/tests/bilinear_antialias_tests.rs
+++ b/candle-core/tests/bilinear_antialias_tests.rs
@@ -456,3 +456,72 @@ fn aa_f64_dtype_matches_f32_within_tolerance() -> Result<()> {
     );
     Ok(())
 }
+
+/* Round-trip dtype coverage for f16 and bf16. We do NOT compare to PyTorch
+here because PyTorch's antialiased-bilinear path runs in fp32 internally,
+so a direct comparison would conflate "Rust kernel correctness" with
+"Rust dtype handling matches PyTorch dtype handling." Instead: cast f32
+input to the lower-precision dtype, run the kernel, cast output back,
+and assert it matches the f32 result within the lower precision's noise
+floor. This validates the WithDType generic instantiation produces
+sensible output, which is the correctness claim a maintainer cares about. */
+#[test]
+fn aa_f16_round_trip_within_noise_floor() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input_f32 = Tensor::arange(0f32, 64f32, dev)?.reshape((1, 1, 8, 8))?;
+    let input_f16 = input_f32.to_dtype(DType::F16)?;
+    let out_f32 = input_f32.upsample_bilinear2d_antialias(4, 4)?;
+    let out_f16 = input_f16.upsample_bilinear2d_antialias(4, 4)?;
+    assert_eq!(out_f16.dtype(), DType::F16);
+    let out_f16_as_f32 = out_f16.to_dtype(DType::F32)?;
+    let diff = (&out_f32 - &out_f16_as_f32)?.abs()?.flatten_all()?.max(0)?;
+    let max_diff = diff.to_vec0::<f32>()?;
+    // f16 has ~3.3 decimal digits of precision; values up to ~64 leave room
+    // for ~5e-2 absolute error. Pick 1e-1 to leave headroom for accumulation.
+    assert!(
+        max_diff < 1e-1,
+        "f32 vs f16 round-trip should match within f16 noise floor; got {}",
+        max_diff
+    );
+    Ok(())
+}
+
+#[test]
+fn aa_bf16_round_trip_within_noise_floor() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input_f32 = Tensor::arange(0f32, 64f32, dev)?.reshape((1, 1, 8, 8))?;
+    let input_bf16 = input_f32.to_dtype(DType::BF16)?;
+    let out_f32 = input_f32.upsample_bilinear2d_antialias(4, 4)?;
+    let out_bf16 = input_bf16.upsample_bilinear2d_antialias(4, 4)?;
+    assert_eq!(out_bf16.dtype(), DType::BF16);
+    let out_bf16_as_f32 = out_bf16.to_dtype(DType::F32)?;
+    let diff = (&out_f32 - &out_bf16_as_f32)?
+        .abs()?
+        .flatten_all()?
+        .max(0)?;
+    let max_diff = diff.to_vec0::<f32>()?;
+    // bf16 has ~7 bits of mantissa; values up to ~64 leave room for
+    // ~5e-1 absolute error on a single op. Pick 1.0 to be safe.
+    assert!(
+        max_diff < 1.0,
+        "f32 vs bf16 round-trip should match within bf16 noise floor; got {}",
+        max_diff
+    );
+    Ok(())
+}
+
+/* Zero-target-dim must error rather than producing an empty tensor silently. */
+#[test]
+fn aa_zero_target_dim_errors() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input = Tensor::arange(0f32, 16f32, dev)?.reshape((1, 1, 4, 4))?;
+    assert!(
+        input.upsample_bilinear2d_antialias(0, 4).is_err(),
+        "target_h=0 should error"
+    );
+    assert!(
+        input.upsample_bilinear2d_antialias(4, 0).is_err(),
+        "target_w=0 should error"
+    );
+    Ok(())
+}

--- a/candle-core/tests/bilinear_antialias_tests.rs
+++ b/candle-core/tests/bilinear_antialias_tests.rs
@@ -387,37 +387,36 @@ fn aa_differs_from_non_antialiased_on_downscale() -> Result<()> {
     Ok(())
 }
 
-/* Non-contiguous input must be handled correctly via stride math, not
-reinterpreted as contiguous. We construct a contiguous (1,1,8,8) tensor,
-permute the spatial dims to make it non-contiguous, run the kernel, and
-compare against running the kernel on the equivalent contiguous tensor.
-The two outputs must match: same logical input, same output regardless of
-memory layout. */
+/* Non-contiguous input via permute + AA output should equal the AA-of-
+original output then permuted the same way. This is stronger than the
+weaker "matches contiguous" check because if the kernel had a bug where
+stride[2] and stride[3] were swapped, both permuted and permuted.contiguous()
+would return wrong (but matching) results. By comparing against the
+independently-computed AA on the original tensor (transposed afterwards),
+we catch stride swaps. */
 #[test]
-fn aa_non_contiguous_input_matches_contiguous() -> Result<()> {
+fn aa_non_contiguous_via_permute() -> Result<()> {
     let dev = &Device::Cpu;
-    // Build a non-symmetric (1,1,8,8) tensor whose transpose is not the same.
     let raw = Tensor::arange(0f32, 64f32, dev)?.reshape((1, 1, 8, 8))?;
-    // Make a logically-equivalent input by transposing twice (round-trip).
-    // The intermediate `permute` produces a non-contiguous tensor; we keep
-    // it that way deliberately to exercise the stride path.
-    let permuted = raw.permute((0, 1, 3, 2))?; // shape (1,1,8,8) but H<->W swapped + non-contiguous
-    assert!(
-        !permuted.is_contiguous(),
-        "permuted should be non-contiguous"
-    );
-
-    // Reference: what we get if we manually copy permuted to a contiguous
-    // tensor and run AA on that.
-    let permuted_contig = permuted.contiguous()?;
-    let ref_out = permuted_contig.upsample_bilinear2d_antialias(4, 4)?;
-    let test_out = permuted.upsample_bilinear2d_antialias(4, 4)?;
-    assert_close(&test_out, &ref_out)
+    // AA on the original H,W layout: produces (1,1,4,4) output with axes
+    // matching raw's axis order.
+    let raw_aa = raw.upsample_bilinear2d_antialias(4, 4)?;
+    // Now permute raw to swap H<->W (non-contiguous) and run AA on that.
+    // The output should equal raw_aa with the same H<->W swap applied,
+    // because AA is axis-symmetric in this respect.
+    let permuted = raw.permute((0, 1, 3, 2))?;
+    assert!(!permuted.is_contiguous(), "permuted must be non-contiguous");
+    let permuted_aa = permuted.upsample_bilinear2d_antialias(4, 4)?;
+    let expected = raw_aa.permute((0, 1, 3, 2))?.contiguous()?;
+    assert_close(&permuted_aa, &expected)
 }
 
-/* Identity short-circuit must not silently return the wrong bytes for a
-non-contiguous input. With target == input shape, the kernel must still
-produce values matching the contiguous-equivalent result. */
+/* Regression guard against re-introducing a stride-unaware identity
+short-circuit (a previous revision had one that called src.to_vec()
+ignoring layout, silently reinterpreting permuted bytes as contiguous).
+With target == input shape and a non-contiguous input, the output must
+reflect the logical (permuted) values, not the underlying contiguous
+storage. */
 #[test]
 fn aa_identity_with_non_contiguous_input() -> Result<()> {
     let dev = &Device::Cpu;
@@ -427,6 +426,52 @@ fn aa_identity_with_non_contiguous_input() -> Result<()> {
     let out = permuted.upsample_bilinear2d_antialias(8, 8)?;
     let expected = permuted.contiguous()?;
     assert_close(&out, &expected)
+}
+
+/* Sliced input via narrow produces a non-zero src_offset; the kernel must
+honor layout.start_offset() and not assume the data starts at index 0
+of the underlying buffer. */
+#[test]
+fn aa_narrowed_input_honors_offset() -> Result<()> {
+    let dev = &Device::Cpu;
+    // Build a wider buffer, take a (1,1,8,8) slice that starts in the middle.
+    let big = Tensor::arange(0f32, 256f32, dev)?.reshape((1, 1, 16, 16))?;
+    let slice = big.narrow(2, 4, 8)?.narrow(3, 4, 8)?; // 8x8 from rows 4..12, cols 4..12
+    let slice_aa = slice.upsample_bilinear2d_antialias(4, 4)?;
+    // Reference: copy the same slice contiguously and run AA on that.
+    let slice_contig_aa = slice.contiguous()?.upsample_bilinear2d_antialias(4, 4)?;
+    assert_close(&slice_aa, &slice_contig_aa)
+}
+
+/* Broadcast batch (stride[0] == 0) means every batch reads the same source.
+The kernel computes base_idx = src_offset + b * stride[0] + c * stride[1];
+with stride[0] = 0, all batches share the same row 0 of the underlying
+data, so all batch-slices of the output should be identical. */
+#[test]
+fn aa_broadcast_batch_produces_identical_outputs() -> Result<()> {
+    let dev = &Device::Cpu;
+    let single = Tensor::arange(0f32, 64f32, dev)?.reshape((1, 1, 8, 8))?;
+    let expanded = single.broadcast_as((4, 1, 8, 8))?; // stride[0] = 0
+    let out = expanded.upsample_bilinear2d_antialias(4, 4)?;
+    // Reference: AA on the single-batch input.
+    let ref_out = single.upsample_bilinear2d_antialias(4, 4)?;
+    let ref_v = ref_out.flatten_all()?.to_vec1::<f32>()?;
+    let out_v = out.flatten_all()?.to_vec1::<f32>()?;
+    let per_batch = ref_v.len();
+    assert_eq!(out_v.len(), 4 * per_batch);
+    for b in 0..4 {
+        for i in 0..per_batch {
+            let diff = (out_v[b * per_batch + i] - ref_v[i]).abs();
+            assert!(
+                diff < 1e-4,
+                "batch {b} index {i} broadcast mismatch: {} vs {} (diff {})",
+                out_v[b * per_batch + i],
+                ref_v[i],
+                diff
+            );
+        }
+    }
+    Ok(())
 }
 
 /* The kernel is generic over WithDType. f32 is exercised above; this test
@@ -476,11 +521,14 @@ fn aa_f16_round_trip_within_noise_floor() -> Result<()> {
     let out_f16_as_f32 = out_f16.to_dtype(DType::F32)?;
     let diff = (&out_f32 - &out_f16_as_f32)?.abs()?.flatten_all()?.max(0)?;
     let max_diff = diff.to_vec0::<f32>()?;
-    // f16 has ~3.3 decimal digits of precision; values up to ~64 leave room
-    // for ~5e-2 absolute error. Pick 1e-1 to leave headroom for accumulation.
+    // f16 ULP at output magnitude ~57 is ~57 * 2^-10 ≈ 0.056. The kernel
+    // accumulates in f64 regardless of T, so the only loss is input-cast
+    // + output-cast: bounded by ~1 ULP at output magnitude. Threshold 5e-2
+    // is ~1 ULP at this test's value range, tight enough to catch
+    // regressions that would cross into 2-ULP territory.
     assert!(
-        max_diff < 1e-1,
-        "f32 vs f16 round-trip should match within f16 noise floor; got {}",
+        max_diff < 5e-2,
+        "f32 vs f16 round-trip should match within ~1 f16 ULP; got {}",
         max_diff
     );
     Ok(())
@@ -500,11 +548,13 @@ fn aa_bf16_round_trip_within_noise_floor() -> Result<()> {
         .flatten_all()?
         .max(0)?;
     let max_diff = diff.to_vec0::<f32>()?;
-    // bf16 has ~7 bits of mantissa; values up to ~64 leave room for
-    // ~5e-1 absolute error on a single op. Pick 1.0 to be safe.
+    // bf16 ULP at output magnitude ~57 is ~57 * 2^-7 ≈ 0.45. Same f64
+    // accumulator argument as the f16 test: the only loss is dtype cast at
+    // boundaries. Threshold 5e-1 is ~1 ULP at this test's value range,
+    // tight enough to catch regressions that would cross 2-ULP.
     assert!(
-        max_diff < 1.0,
-        "f32 vs bf16 round-trip should match within bf16 noise floor; got {}",
+        max_diff < 5e-1,
+        "f32 vs bf16 round-trip should match within ~1 bf16 ULP; got {}",
         max_diff
     );
     Ok(())

--- a/candle-core/tests/bilinear_antialias_tests.rs
+++ b/candle-core/tests/bilinear_antialias_tests.rs
@@ -1,0 +1,378 @@
+use candle_core::{Device, Result, Tensor};
+
+// ============================================================================
+// PyTorch Exact Comparison Tests
+// ============================================================================
+// These tests compare against exact PyTorch outputs from
+// F.interpolate(..., mode='bilinear', align_corners=False, antialias=True)
+// to ensure correctness of upsample_bilinear2d_antialias.
+//
+// CPU-only: Metal/CUDA backends bail on this op (kernels are a follow-up PR);
+// we therefore do not use the test_device! macro here.
+
+const TOL: f32 = 1e-4;
+
+fn assert_close(out: &Tensor, expected: &Tensor) -> Result<()> {
+    let diff = (out - expected)?.abs()?.flatten_all()?.max(0)?;
+    let max_diff = diff.to_vec0::<f32>()?;
+    assert!(
+        max_diff < TOL,
+        "Max difference {} exceeds threshold {}",
+        max_diff,
+        TOL
+    );
+    Ok(())
+}
+
+/* PyTorch reference (input is torch.arange(16).reshape(1,1,4,4)):
+let y = F.interpolate(x, size=(2, 2), mode="bilinear", antialias=True, align_corners=False)
+*/
+#[test]
+fn aa_2x_downscale_4_to_2() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input = Tensor::arange(0f32, 16f32, dev)?.reshape((1, 1, 4, 4))?;
+    let output = input.upsample_bilinear2d_antialias(2, 2, false)?;
+    let expected = Tensor::new(
+        &[3.571429f32, 5.142858, 9.857143, 11.428572],
+        dev,
+    )?
+    .reshape((1, 1, 2, 2))?;
+    assert_close(&output, &expected)
+}
+
+/* arange(64).reshape(1,1,8,8) -> (4, 4) */
+#[test]
+fn aa_8x8_to_4x4() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input = Tensor::arange(0f32, 64f32, dev)?.reshape((1, 1, 8, 8))?;
+    let output = input.upsample_bilinear2d_antialias(4, 4, false)?;
+    let expected = Tensor::new(
+        &[
+            6.428572f32,
+            8.214286,
+            10.214286,
+            12.000001,
+            20.714287,
+            22.500000,
+            24.500000,
+            26.285713,
+            36.714287,
+            38.500000,
+            40.500000,
+            42.285713,
+            51.000000,
+            52.785717,
+            54.785713,
+            56.571430,
+        ],
+        dev,
+    )?
+    .reshape((1, 1, 4, 4))?;
+    assert_close(&output, &expected)
+}
+
+/* arange(256).reshape(1,1,16,16) -> (8, 8). Mirrors a SigLIP2-style halve. */
+#[test]
+fn aa_16x16_to_8x8() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input = Tensor::arange(0f32, 256f32, dev)?.reshape((1, 1, 16, 16))?;
+    let output = input.upsample_bilinear2d_antialias(8, 8, false)?;
+    let expected = Tensor::new(
+        &[
+            12.142859f32,
+            13.928572,
+            15.928572,
+            17.928572,
+            19.928572,
+            21.928572,
+            23.928572,
+            25.714287,
+            40.714287,
+            42.500000,
+            44.500000,
+            46.500000,
+            48.500000,
+            50.500000,
+            52.500000,
+            54.285713,
+            72.714287,
+            74.500000,
+            76.500000,
+            78.500000,
+            80.500000,
+            82.500000,
+            84.500000,
+            86.285713,
+            104.714287,
+            106.500000,
+            108.500000,
+            110.500000,
+            112.500000,
+            114.500000,
+            116.500000,
+            118.285713,
+            136.714294,
+            138.500000,
+            140.500000,
+            142.500000,
+            144.500000,
+            146.500000,
+            148.500000,
+            150.285721,
+            168.714294,
+            170.500000,
+            172.500000,
+            174.500000,
+            176.500000,
+            178.500000,
+            180.500000,
+            182.285721,
+            200.714294,
+            202.500000,
+            204.500000,
+            206.500000,
+            208.500000,
+            210.500000,
+            212.500000,
+            214.285721,
+            229.285736,
+            231.071426,
+            233.071442,
+            235.071426,
+            237.071426,
+            239.071442,
+            241.071426,
+            242.857162,
+        ],
+        dev,
+    )?
+    .reshape((1, 1, 8, 8))?;
+    assert_close(&output, &expected)
+}
+
+/* arange(64).reshape(1,1,8,8) -> (5, 3). Asymmetric, non-integer ratios. */
+#[test]
+fn aa_asymmetric_8x8_to_5x3() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input = Tensor::arange(0f32, 64f32, dev)?.reshape((1, 1, 8, 8))?;
+    let output = input.upsample_bilinear2d_antialias(5, 3, false)?;
+    let expected = Tensor::new(
+        &[
+            4.377990f32,
+            6.772727,
+            9.167464,
+            16.512671,
+            18.907410,
+            21.302145,
+            29.105263,
+            31.500002,
+            33.894737,
+            41.697857,
+            44.092594,
+            46.487331,
+            53.832539,
+            56.227276,
+            58.622013,
+        ],
+        dev,
+    )?
+    .reshape((1, 1, 5, 3))?;
+    assert_close(&output, &expected)
+}
+
+/* arange(48).reshape(1,2,4,6) -> (3, 4). Multi-channel non-square. */
+#[test]
+fn aa_non_square_4x6_to_3x4() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input = Tensor::arange(0f32, 48f32, dev)?.reshape((1, 2, 4, 6))?;
+    let output = input.upsample_bilinear2d_antialias(3, 4, false)?;
+    let expected = Tensor::new(
+        &[
+            2.175000f32,
+            3.577778,
+            5.022222,
+            6.425000,
+            9.375000,
+            10.777779,
+            12.222221,
+            13.625000,
+            16.575001,
+            17.977781,
+            19.422222,
+            20.825001,
+            26.175001,
+            27.577780,
+            29.022223,
+            30.425001,
+            33.375000,
+            34.777779,
+            36.222221,
+            37.625000,
+            40.575001,
+            41.977779,
+            43.422218,
+            44.825001,
+        ],
+        dev,
+    )?
+    .reshape((1, 2, 3, 4))?;
+    assert_close(&output, &expected)
+}
+
+/* arange(16).reshape(1,1,4,4) -> (8, 8). Upscaling: antialias is a no-op,
+   so output should equal the non-antialiased bilinear reference. */
+#[test]
+fn aa_upscale_4x4_to_8x8() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input = Tensor::arange(0f32, 16f32, dev)?.reshape((1, 1, 4, 4))?;
+    let output = input.upsample_bilinear2d_antialias(8, 8, false)?;
+    let expected = Tensor::new(
+        &[
+            0.000000f32,
+            0.250000,
+            0.750000,
+            1.250000,
+            1.750000,
+            2.250000,
+            2.750000,
+            3.000000,
+            1.000000,
+            1.250000,
+            1.750000,
+            2.250000,
+            2.750000,
+            3.250000,
+            3.750000,
+            4.000000,
+            3.000000,
+            3.250000,
+            3.750000,
+            4.250000,
+            4.750000,
+            5.250000,
+            5.750000,
+            6.000000,
+            5.000000,
+            5.250000,
+            5.750000,
+            6.250000,
+            6.750000,
+            7.250000,
+            7.750000,
+            8.000000,
+            7.000000,
+            7.250000,
+            7.750000,
+            8.250000,
+            8.750000,
+            9.250000,
+            9.750000,
+            10.000000,
+            9.000000,
+            9.250000,
+            9.750000,
+            10.250000,
+            10.750000,
+            11.250000,
+            11.750000,
+            12.000000,
+            11.000000,
+            11.250000,
+            11.750000,
+            12.250000,
+            12.750000,
+            13.250000,
+            13.750000,
+            14.000000,
+            12.000000,
+            12.250000,
+            12.750000,
+            13.250000,
+            13.750000,
+            14.250000,
+            14.750000,
+            15.000000,
+        ],
+        dev,
+    )?
+    .reshape((1, 1, 8, 8))?;
+    assert_close(&output, &expected)
+}
+
+/* arange(16).reshape(1,1,4,4) -> (4, 4). Identity case must round-trip exactly. */
+#[test]
+fn aa_identity_4x4_to_4x4() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input = Tensor::arange(0f32, 16f32, dev)?.reshape((1, 1, 4, 4))?;
+    let output = input.upsample_bilinear2d_antialias(4, 4, false)?;
+    let expected = input.clone();
+    assert_close(&output, &expected)
+}
+
+/* arange(96).reshape(2,3,4,4) -> (2, 2). Multi-batch + multi-channel. */
+#[test]
+fn aa_multichannel_2x3x4x4_to_2x2() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input = Tensor::arange(0f32, 96f32, dev)?.reshape((2, 3, 4, 4))?;
+    let output = input.upsample_bilinear2d_antialias(2, 2, false)?;
+    let expected = Tensor::new(
+        &[
+            3.571429f32,
+            5.142858,
+            9.857143,
+            11.428572,
+            19.571430,
+            21.142859,
+            25.857143,
+            27.428572,
+            35.571430,
+            37.142857,
+            41.857143,
+            43.428574,
+            51.571430,
+            53.142857,
+            57.857143,
+            59.428574,
+            67.571434,
+            69.142860,
+            73.857147,
+            75.428574,
+            83.571434,
+            85.142853,
+            89.857147,
+            91.428574,
+        ],
+        dev,
+    )?
+    .reshape((2, 3, 2, 2))?;
+    assert_close(&output, &expected)
+}
+
+/* Antialias must change the output for downsampling: regression guard
+   against silently routing to the non-antialiased path. */
+#[test]
+fn aa_differs_from_non_antialiased_on_downscale() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input = Tensor::arange(0f32, 256f32, dev)?.reshape((1, 1, 16, 16))?;
+    let aa = input.upsample_bilinear2d_antialias(8, 8, false)?;
+    let plain = input.upsample_bilinear2d(8, 8, false)?;
+    let diff = (&aa - &plain)?.abs()?.flatten_all()?.max(0)?;
+    let max_diff = diff.to_vec0::<f32>()?;
+    assert!(
+        max_diff > 1e-3,
+        "Antialiased output should differ from plain bilinear on downscale; \
+         max diff was {} (likely fell through to non-AA path)",
+        max_diff
+    );
+    Ok(())
+}
+
+/* align_corners=true must error rather than silently producing a wrong result. */
+#[test]
+fn aa_align_corners_true_returns_error() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input = Tensor::arange(0f32, 16f32, dev)?.reshape((1, 1, 4, 4))?;
+    let result = input.upsample_bilinear2d_antialias(2, 2, true);
+    assert!(result.is_err(), "align_corners=true should error");
+    Ok(())
+}

--- a/candle-core/tests/bilinear_antialias_tests.rs
+++ b/candle-core/tests/bilinear_antialias_tests.rs
@@ -1,3 +1,9 @@
+// PyTorch reference values are pasted with the precision PyTorch printed;
+// clippy::excessive_precision would flag a long tail of f32 literals that
+// exceed f32's ~7-digit mantissa. We accept the fixture as-is because the
+// extra digits round to the same f32 and document the source of truth.
+#![allow(clippy::excessive_precision)]
+
 use candle_core::{Device, Result, Tensor};
 
 // ============================================================================
@@ -32,11 +38,8 @@ fn aa_2x_downscale_4_to_2() -> Result<()> {
     let dev = &Device::Cpu;
     let input = Tensor::arange(0f32, 16f32, dev)?.reshape((1, 1, 4, 4))?;
     let output = input.upsample_bilinear2d_antialias(2, 2, false)?;
-    let expected = Tensor::new(
-        &[3.571429f32, 5.142858, 9.857143, 11.428572],
-        dev,
-    )?
-    .reshape((1, 1, 2, 2))?;
+    let expected =
+        Tensor::new(&[3.571429f32, 5.142858, 9.857143, 11.428572], dev)?.reshape((1, 1, 2, 2))?;
     assert_close(&output, &expected)
 }
 
@@ -220,7 +223,7 @@ fn aa_non_square_4x6_to_3x4() -> Result<()> {
 }
 
 /* arange(16).reshape(1,1,4,4) -> (8, 8). Upscaling: antialias is a no-op,
-   so output should equal the non-antialiased bilinear reference. */
+so output should equal the non-antialiased bilinear reference. */
 #[test]
 fn aa_upscale_4x4_to_8x8() -> Result<()> {
     let dev = &Device::Cpu;
@@ -349,7 +352,7 @@ fn aa_multichannel_2x3x4x4_to_2x2() -> Result<()> {
 }
 
 /* Antialias must change the output for downsampling: regression guard
-   against silently routing to the non-antialiased path. */
+against silently routing to the non-antialiased path. */
 #[test]
 fn aa_differs_from_non_antialiased_on_downscale() -> Result<()> {
     let dev = &Device::Cpu;

--- a/candle-core/tests/bilinear_antialias_tests.rs
+++ b/candle-core/tests/bilinear_antialias_tests.rs
@@ -239,6 +239,104 @@ fn aa_non_square_4x6_to_3x4() -> Result<()> {
     assert_close(&output, &expected)
 }
 
+/* arange(64).reshape(1,1,8,8) -> (8, 4). W-only downscale (H unchanged).
+Catches axis-swap bugs in weight_matrix construction where the H and W
+weight matrices get the wrong (src, dst) pair: a symmetric downscale
+(both axes) would still match if the matrices were swapped. */
+#[test]
+fn aa_single_axis_w_downscale_8x8_to_8x4() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input = Tensor::arange(0f32, 64f32, dev)?.reshape((1, 1, 8, 8))?;
+    let output = input.upsample_bilinear2d_antialias(8, 4)?;
+    let expected = Tensor::new(
+        &[
+            0.714286f32,
+            2.500000,
+            4.500000,
+            6.285715,
+            8.714286,
+            10.500000,
+            12.500000,
+            14.285714,
+            16.714287,
+            18.500000,
+            20.500000,
+            22.285715,
+            24.714287,
+            26.500000,
+            28.500000,
+            30.285715,
+            32.714287,
+            34.500000,
+            36.500000,
+            38.285713,
+            40.714287,
+            42.500000,
+            44.500000,
+            46.285717,
+            48.714287,
+            50.500000,
+            52.500000,
+            54.285717,
+            56.714283,
+            58.500000,
+            60.500000,
+            62.285713,
+        ],
+        dev,
+    )?
+    .reshape((1, 1, 8, 4))?;
+    assert_close(&output, &expected)
+}
+
+/* arange(64).reshape(1,1,8,8) -> (4, 8). H-only downscale (W unchanged).
+Complement to the W-only case above. */
+#[test]
+fn aa_single_axis_h_downscale_8x8_to_4x8() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input = Tensor::arange(0f32, 64f32, dev)?.reshape((1, 1, 8, 8))?;
+    let output = input.upsample_bilinear2d_antialias(4, 8)?;
+    let expected = Tensor::new(
+        &[
+            5.714286f32,
+            6.714286,
+            7.714286,
+            8.714286,
+            9.714286,
+            10.714286,
+            11.714286,
+            12.714286,
+            20.000000,
+            21.000000,
+            22.000000,
+            23.000000,
+            24.000000,
+            25.000000,
+            26.000000,
+            27.000000,
+            36.000000,
+            37.000000,
+            38.000000,
+            39.000000,
+            40.000000,
+            41.000000,
+            42.000000,
+            43.000000,
+            50.285717,
+            51.285713,
+            52.285713,
+            53.285713,
+            54.285713,
+            55.285717,
+            56.285717,
+            57.285717,
+        ],
+        dev,
+    )?
+    .reshape((1, 1, 4, 8))?;
+    assert_close(&output, &expected)
+}
+
 /* arange(16).reshape(1,1,4,4) -> (8, 8). Upscaling: antialias is a no-op,
 so output should equal the non-antialiased bilinear reference. */
 #[test]

--- a/candle-core/tests/bilinear_antialias_tests.rs
+++ b/candle-core/tests/bilinear_antialias_tests.rs
@@ -1,10 +1,13 @@
-// PyTorch reference values are pasted with the precision PyTorch printed;
-// clippy::excessive_precision would flag a long tail of f32 literals that
-// exceed f32's ~7-digit mantissa. We accept the fixture as-is because the
-// extra digits round to the same f32 and document the source of truth.
+// This test file pastes PyTorch reference values at the precision PyTorch
+// printed (6 decimals). For values >= ~100 that exceeds the f32 mantissa, so
+// clippy::excessive_precision would flag ~130 of these literals. The trailing
+// digits round to the same f32 bit pattern (verified by every test passing
+// under the 1e-4 tolerance gate); we accept the literals as-is to keep the
+// fixtures byte-identical to the upstream PyTorch print output. The allow is
+// scoped to this fixture-only test file.
 #![allow(clippy::excessive_precision)]
 
-use candle_core::{Device, Result, Tensor};
+use candle_core::{DType, Device, Result, Tensor};
 
 // ============================================================================
 // PyTorch Exact Comparison Tests
@@ -19,14 +22,28 @@ use candle_core::{Device, Result, Tensor};
 const TOL: f32 = 1e-4;
 
 fn assert_close(out: &Tensor, expected: &Tensor) -> Result<()> {
-    let diff = (out - expected)?.abs()?.flatten_all()?.max(0)?;
-    let max_diff = diff.to_vec0::<f32>()?;
-    assert!(
-        max_diff < TOL,
-        "Max difference {} exceeds threshold {}",
-        max_diff,
-        TOL
-    );
+    let diff_t = (out - expected)?.abs()?;
+    let max_diff = diff_t.flatten_all()?.max(0)?.to_vec0::<f32>()?;
+    if max_diff >= TOL {
+        let out_v = out.flatten_all()?.to_vec1::<f32>()?;
+        let exp_v = expected.flatten_all()?.to_vec1::<f32>()?;
+        let (idx, _) = out_v
+            .iter()
+            .zip(exp_v.iter())
+            .enumerate()
+            .map(|(i, (a, b))| (i, (a - b).abs()))
+            .max_by(|x, y| x.1.partial_cmp(&y.1).unwrap())
+            .unwrap();
+        panic!(
+            "max abs diff {} >= tolerance {} at flat index {}: got {}, expected {}, shape {:?}",
+            max_diff,
+            TOL,
+            idx,
+            out_v[idx],
+            exp_v[idx],
+            out.shape()
+        );
+    }
     Ok(())
 }
 
@@ -37,7 +54,7 @@ let y = F.interpolate(x, size=(2, 2), mode="bilinear", antialias=True, align_cor
 fn aa_2x_downscale_4_to_2() -> Result<()> {
     let dev = &Device::Cpu;
     let input = Tensor::arange(0f32, 16f32, dev)?.reshape((1, 1, 4, 4))?;
-    let output = input.upsample_bilinear2d_antialias(2, 2, false)?;
+    let output = input.upsample_bilinear2d_antialias(2, 2)?;
     let expected =
         Tensor::new(&[3.571429f32, 5.142858, 9.857143, 11.428572], dev)?.reshape((1, 1, 2, 2))?;
     assert_close(&output, &expected)
@@ -48,7 +65,7 @@ fn aa_2x_downscale_4_to_2() -> Result<()> {
 fn aa_8x8_to_4x4() -> Result<()> {
     let dev = &Device::Cpu;
     let input = Tensor::arange(0f32, 64f32, dev)?.reshape((1, 1, 8, 8))?;
-    let output = input.upsample_bilinear2d_antialias(4, 4, false)?;
+    let output = input.upsample_bilinear2d_antialias(4, 4)?;
     let expected = Tensor::new(
         &[
             6.428572f32,
@@ -79,7 +96,7 @@ fn aa_8x8_to_4x4() -> Result<()> {
 fn aa_16x16_to_8x8() -> Result<()> {
     let dev = &Device::Cpu;
     let input = Tensor::arange(0f32, 256f32, dev)?.reshape((1, 1, 16, 16))?;
-    let output = input.upsample_bilinear2d_antialias(8, 8, false)?;
+    let output = input.upsample_bilinear2d_antialias(8, 8)?;
     let expected = Tensor::new(
         &[
             12.142859f32,
@@ -158,7 +175,7 @@ fn aa_16x16_to_8x8() -> Result<()> {
 fn aa_asymmetric_8x8_to_5x3() -> Result<()> {
     let dev = &Device::Cpu;
     let input = Tensor::arange(0f32, 64f32, dev)?.reshape((1, 1, 8, 8))?;
-    let output = input.upsample_bilinear2d_antialias(5, 3, false)?;
+    let output = input.upsample_bilinear2d_antialias(5, 3)?;
     let expected = Tensor::new(
         &[
             4.377990f32,
@@ -188,7 +205,7 @@ fn aa_asymmetric_8x8_to_5x3() -> Result<()> {
 fn aa_non_square_4x6_to_3x4() -> Result<()> {
     let dev = &Device::Cpu;
     let input = Tensor::arange(0f32, 48f32, dev)?.reshape((1, 2, 4, 6))?;
-    let output = input.upsample_bilinear2d_antialias(3, 4, false)?;
+    let output = input.upsample_bilinear2d_antialias(3, 4)?;
     let expected = Tensor::new(
         &[
             2.175000f32,
@@ -228,7 +245,7 @@ so output should equal the non-antialiased bilinear reference. */
 fn aa_upscale_4x4_to_8x8() -> Result<()> {
     let dev = &Device::Cpu;
     let input = Tensor::arange(0f32, 16f32, dev)?.reshape((1, 1, 4, 4))?;
-    let output = input.upsample_bilinear2d_antialias(8, 8, false)?;
+    let output = input.upsample_bilinear2d_antialias(8, 8)?;
     let expected = Tensor::new(
         &[
             0.000000f32,
@@ -307,7 +324,7 @@ fn aa_upscale_4x4_to_8x8() -> Result<()> {
 fn aa_identity_4x4_to_4x4() -> Result<()> {
     let dev = &Device::Cpu;
     let input = Tensor::arange(0f32, 16f32, dev)?.reshape((1, 1, 4, 4))?;
-    let output = input.upsample_bilinear2d_antialias(4, 4, false)?;
+    let output = input.upsample_bilinear2d_antialias(4, 4)?;
     let expected = input.clone();
     assert_close(&output, &expected)
 }
@@ -317,7 +334,7 @@ fn aa_identity_4x4_to_4x4() -> Result<()> {
 fn aa_multichannel_2x3x4x4_to_2x2() -> Result<()> {
     let dev = &Device::Cpu;
     let input = Tensor::arange(0f32, 96f32, dev)?.reshape((2, 3, 4, 4))?;
-    let output = input.upsample_bilinear2d_antialias(2, 2, false)?;
+    let output = input.upsample_bilinear2d_antialias(2, 2)?;
     let expected = Tensor::new(
         &[
             3.571429f32,
@@ -357,7 +374,7 @@ against silently routing to the non-antialiased path. */
 fn aa_differs_from_non_antialiased_on_downscale() -> Result<()> {
     let dev = &Device::Cpu;
     let input = Tensor::arange(0f32, 256f32, dev)?.reshape((1, 1, 16, 16))?;
-    let aa = input.upsample_bilinear2d_antialias(8, 8, false)?;
+    let aa = input.upsample_bilinear2d_antialias(8, 8)?;
     let plain = input.upsample_bilinear2d(8, 8, false)?;
     let diff = (&aa - &plain)?.abs()?.flatten_all()?.max(0)?;
     let max_diff = diff.to_vec0::<f32>()?;
@@ -370,12 +387,72 @@ fn aa_differs_from_non_antialiased_on_downscale() -> Result<()> {
     Ok(())
 }
 
-/* align_corners=true must error rather than silently producing a wrong result. */
+/* Non-contiguous input must be handled correctly via stride math, not
+reinterpreted as contiguous. We construct a contiguous (1,1,8,8) tensor,
+permute the spatial dims to make it non-contiguous, run the kernel, and
+compare against running the kernel on the equivalent contiguous tensor.
+The two outputs must match: same logical input, same output regardless of
+memory layout. */
 #[test]
-fn aa_align_corners_true_returns_error() -> Result<()> {
+fn aa_non_contiguous_input_matches_contiguous() -> Result<()> {
     let dev = &Device::Cpu;
-    let input = Tensor::arange(0f32, 16f32, dev)?.reshape((1, 1, 4, 4))?;
-    let result = input.upsample_bilinear2d_antialias(2, 2, true);
-    assert!(result.is_err(), "align_corners=true should error");
+    // Build a non-symmetric (1,1,8,8) tensor whose transpose is not the same.
+    let raw = Tensor::arange(0f32, 64f32, dev)?.reshape((1, 1, 8, 8))?;
+    // Make a logically-equivalent input by transposing twice (round-trip).
+    // The intermediate `permute` produces a non-contiguous tensor; we keep
+    // it that way deliberately to exercise the stride path.
+    let permuted = raw.permute((0, 1, 3, 2))?; // shape (1,1,8,8) but H<->W swapped + non-contiguous
+    assert!(
+        !permuted.is_contiguous(),
+        "permuted should be non-contiguous"
+    );
+
+    // Reference: what we get if we manually copy permuted to a contiguous
+    // tensor and run AA on that.
+    let permuted_contig = permuted.contiguous()?;
+    let ref_out = permuted_contig.upsample_bilinear2d_antialias(4, 4)?;
+    let test_out = permuted.upsample_bilinear2d_antialias(4, 4)?;
+    assert_close(&test_out, &ref_out)
+}
+
+/* Identity short-circuit must not silently return the wrong bytes for a
+non-contiguous input. With target == input shape, the kernel must still
+produce values matching the contiguous-equivalent result. */
+#[test]
+fn aa_identity_with_non_contiguous_input() -> Result<()> {
+    let dev = &Device::Cpu;
+    let raw = Tensor::arange(0f32, 64f32, dev)?.reshape((1, 1, 8, 8))?;
+    let permuted = raw.permute((0, 1, 3, 2))?;
+    assert!(!permuted.is_contiguous());
+    let out = permuted.upsample_bilinear2d_antialias(8, 8)?;
+    let expected = permuted.contiguous()?;
+    assert_close(&out, &expected)
+}
+
+/* The kernel is generic over WithDType. f32 is exercised above; this test
+covers the f64 instantiation. f16 / bf16 paths are not exercised because
+PyTorch's antialiased-bilinear kernel runs in fp32 internally and casting
+the reference values down would compare two slightly different algorithms,
+not the same one at lower precision. */
+#[test]
+fn aa_f64_dtype_matches_f32_within_tolerance() -> Result<()> {
+    let dev = &Device::Cpu;
+    let input_f32 = Tensor::arange(0f32, 64f32, dev)?.reshape((1, 1, 8, 8))?;
+    let input_f64 = input_f32.to_dtype(DType::F64)?;
+    let out_f32 = input_f32.upsample_bilinear2d_antialias(4, 4)?;
+    let out_f64 = input_f64.upsample_bilinear2d_antialias(4, 4)?;
+    assert_eq!(
+        out_f64.dtype(),
+        DType::F64,
+        "f64 input must produce f64 output"
+    );
+    let out_f64_as_f32 = out_f64.to_dtype(DType::F32)?;
+    let diff = (&out_f32 - &out_f64_as_f32)?.abs()?.flatten_all()?.max(0)?;
+    let max_diff = diff.to_vec0::<f32>()?;
+    assert!(
+        max_diff < 1e-5,
+        "f32 vs f64 outputs should match within fp32 noise floor; got {}",
+        max_diff
+    );
     Ok(())
 }


### PR DESCRIPTION
> Draft. CPU implementation is complete and tested; opening as draft to take your steer on the API shape (one question below) before investing in Metal + CUDA kernels.

## What

Adds `Tensor::upsample_bilinear2d_antialias(target_h, target_w)` to candle-core. Approximates PyTorch's `F.interpolate(mode="bilinear", antialias=True, align_corners=False)`.

For downsampling, the kernel applies a per-axis triangle-weighted low-pass filter to prevent aliasing. For upsampling, antialias has no effect and the output matches the non-antialiased path.

`align_corners` is not exposed as a parameter; PyTorch's antialiased-bilinear is documented and primarily exercised at `align_corners=False`, and a `bool` that only accepts one value is a worse API than no parameter. Adding it when `align_corners=true` is implemented.

## Why

Related to #2863 (general `F.interpolate` support) and #3510 (in-flight SigLIP2 NaFlex port). The SigLIP2 port hits this gap in production: without antialiased bilinear, the PyTorch reference comparison at the vision tower shows cosine 0.9996 but max abs diff ~0.165 at variable resolutions, which blocks 1e-4 reference parity. #3510 works around it with a userland matmul helper; this PR promotes the algorithm into core so future ports do not each re-roll it.

## How

CPU implementation builds two per-axis triangle-weight matrices in `f64` (`W_h` of shape `(target_h, height_in)`, `W_w` of shape `(target_w, width_in)`) with each row normalized to sum to 1, and support `max(1, src/dst)` matching PyTorch's antialiased-bilinear formula. Each output pixel is a weighted sum over the input window, equivalent in floating point to `W_h @ input @ W_w^T` (the equivalence relies on the f64 accumulator; a T-typed accumulator would round differently). Written as a nested loop because `Map1::f<T: WithDType>` produces a flat `Vec<T>` and the matmul form would require constructing intermediate `Tensor`s inside the storage layer, which is not how the existing `UpsampleBilinear2D` Map1 is structured.

Metal and CUDA backends bail; backward bails, matching the existing `upsample_bilinear2d` precedent. Non-contiguous inputs (transposed via `permute`, sliced via `narrow`, broadcast via `expand`) take the full stride-aware path; the kernel honors `layout.start_offset()` and per-axis strides.

## Validation

`candle-core/tests/bilinear_antialias_tests.rs` (new): 19 integration tests against PyTorch reference at 1e-4 fp32 tolerance + invariant and stride-coverage tests. Plus 5 unit tests on `weight_matrix` in `cpu_backend/mod.rs`. All pass.

Reference values were generated with PyTorch 2.x via `torch.nn.functional.interpolate(..., mode="bilinear", antialias=True, align_corners=False)`. Inputs are deterministic (`torch.arange(N).reshape(shape)`), so any reviewer can regenerate them. Each test header names the input shape and the output shape.

Local gates (matching `.github/workflows/rust-ci.yml`):
- `cargo fmt --all -- --check`, `cargo clippy --workspace --tests --examples --benches -- -D warnings`, `cargo check --workspace`, `cargo check --workspace --features metal`, `cargo test --workspace`: all clean.
- `cargo build --release --features cuda -p candle-core -p candle-transformers` + `cargo build --features cuda --tests` on a fresh CUDA 12.4.131 + Rust 1.90 image: clean. The cuda integration path is `bail!` only (no kernel), so cuda CI exercises the bail arm and the build, not a numerical kernel.

## Why draft (one specific question)

> **Sibling `Op::UpsampleBilinear2DAntialias` variant (current) vs. flag on the existing `Op::UpsampleBilinear2D`?**

This PR adds the variant. It's purely additive: new variant, new trait method, new dispatch arm, existing `upsample_bilinear2d` path untouched.

Folding to a flag (e.g., `antialias: bool` on `Op::UpsampleBilinear2D` and the `BackendStorage` trait method) shrinks the public surface but touches every existing backend impl, the matching pattern in `backprop.rs`, and the public op enum signature (`Op` and its variants are `pub`, so this is a minor SemVer bump on `candle-core`). I expect that's the shape you'll want long-term given how PyTorch models it (a kwarg, not a separate op), but I lean variant-for-now because the draft is easier to review when additive and the flag refactor is clean to do as a follow-up. **Happy to fold to the flag form on your nod.**

Two smaller items deferred: `_with_scale` companion (thin wrapper, add when a downstream caller asks) and the Metal + CUDA kernels (non-trivial per-dtype work, ship once the API shape is settled).

## Testing locally

```bash
cargo test -p candle-core --test bilinear_antialias_tests
```

## AI assistance disclosure

Drafted with AI assistance. I've read the diff line-by-line and validated the kernel against PyTorch reference outputs end-to-end. Reference outputs are independently generated from PyTorch and reproducible from the deterministic inputs each test names.
