### PR TITLE
Simplify vec_dot_f32 in candle-core::cpu (compiler-vectorized over intrinsics)

### DIFF
--- a/candle-core/benches/bench_main.rs
+++ b/candle-core/benches/bench_main.rs
@@ -7,6 +7,7 @@ criterion_main!(
     benchmarks::binary::benches,
     benchmarks::broadcast::benches,
     benchmarks::copy::benches,
+    benchmarks::conv2d::benches,
     benchmarks::conv_transpose2d::benches,
     benchmarks::matmul::benches,
     benchmarks::qmatmul::benches,

--- a/candle-core/benches/benchmarks/conv2d.rs
+++ b/candle-core/benches/benchmarks/conv2d.rs
@@ -9,7 +9,7 @@ fn run(x: &Tensor, k: &Tensor, padding: usize, stride: usize, dilation: usize, g
 }
 
 fn run_benchmark(c: &mut Criterion, device: &Device, dtype: DType, name: &str) {
-    let t = Tensor::arange(0.0f32, (1 * 128 * 28 * 28) as f32, device)
+    let t = Tensor::arange(0.0f32, (128 * 28 * 28) as f32, device)
         .unwrap()
         .reshape((1, 128, 28, 28))
         .unwrap()

--- a/candle-core/benches/benchmarks/conv2d.rs
+++ b/candle-core/benches/benchmarks/conv2d.rs
@@ -1,0 +1,50 @@
+use crate::benchmarks::{BenchDevice, BenchDeviceHandler};
+use candle_core::{DType, Device, Tensor};
+use criterion::{criterion_group, Criterion, Throughput};
+use std::hint::black_box;
+use std::time::Instant;
+
+fn run(x: &Tensor, k: &Tensor, padding: usize, stride: usize, dilation: usize, groups: usize) {
+    x.conv2d(k, padding, stride, dilation, groups).unwrap();
+}
+
+fn run_benchmark(c: &mut Criterion, device: &Device, dtype: DType, name: &str) {
+    let t = Tensor::arange(0.0f32, (1 * 128 * 28 * 28) as f32, device)
+        .unwrap()
+        .reshape((1, 128, 28, 28))
+        .unwrap()
+        .to_dtype(dtype)
+        .unwrap();
+
+    let kernel = Tensor::arange(0.0f32, (256 * 128 * 3 * 3) as f32, device)
+        .unwrap()
+        .reshape((256, 128, 3, 3))
+        .unwrap()
+        .to_dtype(dtype)
+        .unwrap();
+
+    let flops = t.dims().iter().product::<usize>() * dtype.size_in_bytes();
+
+    let mut group = c.benchmark_group(device.bench_name(name));
+    group.throughput(Throughput::Bytes(flops as u64));
+    group.bench_function("iter", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            for _i in 0..iters {
+                run(black_box(&t), black_box(&kernel), 1, 1, 1, 1);
+            }
+            device.sync().unwrap();
+            start.elapsed()
+        })
+    });
+    group.finish();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let handler = BenchDeviceHandler::new().unwrap();
+    for device in handler.devices {
+        run_benchmark(c, &device, DType::F32, "conv2d_f32");
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);

--- a/candle-core/benches/benchmarks/mod.rs
+++ b/candle-core/benches/benchmarks/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod affine;
 pub(crate) mod binary;
 pub(crate) mod broadcast;
+pub(crate) mod conv2d;
 pub(crate) mod conv_transpose2d;
 pub(crate) mod copy;
 pub(crate) mod matmul;

--- a/candle-core/src/cpu/mod.rs
+++ b/candle-core/src/cpu/mod.rs
@@ -80,47 +80,24 @@ pub mod neon;
 #[cfg(target_feature = "neon")]
 pub use neon::CurrentCpu;
 
-#[cfg(any(
-    target_feature = "neon",
-    target_feature = "avx2",
-    target_feature = "simd128"
-))]
 #[inline(always)]
 pub(crate) unsafe fn vec_dot_f32(a_row: *const f32, b_row: *const f32, c: *mut f32, k: usize) {
-    let np = k & !(CurrentCpu::STEP - 1);
-
-    let mut sum = CurrentCpu::zero_array();
-    let mut ax = CurrentCpu::zero_array();
-    let mut ay = CurrentCpu::zero_array();
-
-    for i in (0..np).step_by(CurrentCpu::STEP) {
-        for j in 0..CurrentCpu::n() {
-            ax[j] = CurrentCpu::load(a_row.add(i + j * CurrentCpu::EPR));
-            ay[j] = CurrentCpu::load(b_row.add(i + j * CurrentCpu::EPR));
-
-            sum[j] = CurrentCpu::vec_fma(sum[j], ax[j], ay[j]);
-        }
+    let a = std::slice::from_raw_parts(a_row, k);
+    let b = std::slice::from_raw_parts(b_row, k);
+    let mut sum = 0.0f32;
+    let mut i = 0;
+    while i + 4 <= k {
+        sum += a[i] * b[i]
+            + a[i + 1] * b[i + 1]
+            + a[i + 2] * b[i + 2]
+            + a[i + 3] * b[i + 3];
+        i += 4;
     }
-
-    CurrentCpu::vec_reduce(sum, c);
-
-    // leftovers
-    for i in np..k {
-        *c += *a_row.add(i) * (*b_row.add(i));
+    while i < k {
+        sum += a[i] * b[i];
+        i += 1;
     }
-}
-
-#[cfg(not(any(
-    target_feature = "neon",
-    target_feature = "avx2",
-    target_feature = "simd128"
-)))]
-#[inline(always)]
-pub(crate) unsafe fn vec_dot_f32(a_row: *const f32, b_row: *const f32, c: *mut f32, k: usize) {
-    // leftovers
-    for i in 0..k {
-        *c += *a_row.add(i) * (*b_row.add(i));
-    }
+    *c = sum;
 }
 
 #[cfg(any(

--- a/candle-core/src/cpu/mod.rs
+++ b/candle-core/src/cpu/mod.rs
@@ -87,10 +87,7 @@ pub(crate) unsafe fn vec_dot_f32(a_row: *const f32, b_row: *const f32, c: *mut f
     let mut sum = 0.0f32;
     let mut i = 0;
     while i + 4 <= k {
-        sum += a[i] * b[i]
-            + a[i + 1] * b[i + 1]
-            + a[i + 2] * b[i + 2]
-            + a[i + 3] * b[i + 3];
+        sum += a[i] * b[i] + a[i + 1] * b[i + 1] + a[i + 2] * b[i + 2] + a[i + 3] * b[i + 3];
         i += 4;
     }
     while i < k {


### PR DESCRIPTION
Brings the compiler-vectorized f32 dot loop into `candle-core::cpu::vec_dot_f32`, where it can serve conv1d / conv2d / convtranspose2d on the f32 CPU path.

The simple compiler-vectorized form was integrated into the cpu flash attention kernels (#3254, refined in #3513) because it was found faster than the hand-written `CurrentCpu::vec_dot_f32` intrinsics in that context. @ivarflakstad observed the same result more fundamentally https://github.com/huggingface/candle/pull/3254#discussion_r3133873546.

The best design across hardware is not fully settled (he also noted he had a tweaked intrinsics version that was slightly faster, "let's look into it later"). This PR makes the bet that the simpler version is at least as good in the cases that matter today, and trades the cfg-gated intrinsics complexity for portability and less unsafe.

### What changes                                                                                                                                                                                                                                                           
`candle-core/src/cpu/mod.rs::vec_dot_f32` body is replaced. The cfg-gated SIMD intrinsics path (NEON / AVX2 / SIMD128) and the scalar fallback are both replaced by one portable compiler-vectorized 4-wide loop. Same I/O contract: writes the dot product to `*c` (overwriting).
- Drops the unsafe pointer-arithmetic codepath through the `CurrentCpu` trait for f32.                                                                                                                    
- Drops the four cfg gates.                                                                                                                                                                               
- One function, ~17 lines, safe slice access via `from_raw_parts`.
- The intrinsics paths for `vec_dot_f16`, `vec_dot_bf16`, and `vec_sum`, plus the `CurrentCpu` trait itself, are unchanged.                                                                               
                                                                                                                                                                                                          
### Benchmark
Added a conv2d benchmark at `candle-core/benches/benchmarks/conv2d.rs`. Workload is a ResNet-style block: input `(1, 128, 28, 28)`, kernel `(256, 128, 3, 3)`, stride 1, padding 1. This is the codepath  that calls `T::vec_dot` for f32.                                
                                                                                                                                                                                                          
Hardware: MacBook Air, Apple M1 (NEON). N=4 runs for compiler-vectorized, N=2 for intrinsics, alternated to control for thermal state. 
| Version             | Run 1   | Run 2   | Run 3   | Run 4   | Median  |
|---------------------|---------|---------|---------|---------|---------|
| Compiler-vectorized | 3.60 ms | 4.90 ms | 4.13 ms | 4.74 ms | 4.43 ms |
| Intrinsics (main)   | 4.30 ms | 4.89 ms | --      | --      | 4.60 ms |
                                                                                         
Compiler-vectorized is at least as fast as intrinsics on M1 NEON, plausibly slightly faster (~4 percent on median, well within run-to-run noise). The clear win here is maintenance, not raw throughput.  AVX hardware not yet measured. 
               
### Out of scope
`vec_dot_f16`, `vec_dot_bf16`, and `vec_sum` still use the intrinsics path. Those involve narrow-type-to-f32 conversion in the inner loop where the autovectorizer is less reliably effective. Worth revisiting in a follow-up with measurements.