### PR TITLE
docs(wasm-examples): point Trunk link to canonical GitHub install section (#3460)

### DIFF
--- a/candle-wasm-examples/llama2-c/README.md
+++ b/candle-wasm-examples/llama2-c/README.md
@@ -4,7 +4,7 @@ Here, we provide two examples of how to run [llama2.c](https://github.com/karpat
 
 ### Pure Rust UI
 
-To build and test the UI made in Rust you will need [Trunk](https://trunkrs.dev/#install)
+To build and test the UI made in Rust you will need [Trunk](https://github.com/trunk-rs/trunk#install)
 From the `candle-wasm-examples/llama2-c` directory run:
 
 Download assets:

--- a/candle-wasm-examples/whisper/README.md
+++ b/candle-wasm-examples/whisper/README.md
@@ -4,7 +4,7 @@ Here, we provide two examples of how to run Whisper using a Candle-compiled WASM
 
 ### Pure Rust UI
 
-To build and test the UI made in Rust you will need [Trunk](https://trunkrs.dev/#install)
+To build and test the UI made in Rust you will need [Trunk](https://github.com/trunk-rs/trunk#install)
 From the `candle-wasm-examples/whisper` directory run:
 
 Download assets:

--- a/candle-wasm-examples/yolo/README.md
+++ b/candle-wasm-examples/yolo/README.md
@@ -4,7 +4,7 @@ Here, we provide two examples of how to run YOLOv8 using a Candle-compiled WASM 
 
 ### Pure Rust UI
 
-To build and test the UI made in Rust you will need [Trunk](https://trunkrs.dev/#install)
+To build and test the UI made in Rust you will need [Trunk](https://github.com/trunk-rs/trunk#install)
 From the `candle-wasm-examples/yolo` directory run:
 
 Download assets:


### PR DESCRIPTION
## Summary

The Trunk link in the wasm-example READMEs (`whisper`, `llama2-c`, `yolo`) used `https://trunkrs.dev/#install`, but `#install` is no longer a valid anchor on the current Trunk site, so readers landed on the homepage with no install guidance (and at least one drive-by report flagged the destination as confusing/spammy).

## Change

Switch all three READMEs to the upstream org's GitHub repo:
```
https://github.com/trunk-rs/trunk#install
```

This is the most durable canonical link — owned by the project org and pinned to the README's install section.

## Files touched
- `candle-wasm-examples/whisper/README.md`
- `candle-wasm-examples/llama2-c/README.md`
- `candle-wasm-examples/yolo/README.md`

Three identical one-line edits; no code paths affected.

Fixes #3460