### PR TITLE
fix(qwen3_vl): build causal mask for prefill, not single-token decode (#3505)

### DIFF
--- a/candle-transformers/src/models/qwen3_vl/mod.rs
+++ b/candle-transformers/src/models/qwen3_vl/mod.rs
@@ -67,19 +67,14 @@ impl Qwen3VLModel {
         seqlen_offsets: &[usize],
     ) -> Result<Tensor> {
         let (bs, seqlen) = input_ids.dims2()?;
-        // The causal mask is only needed when processing more than one token at once
-        // (prefill / multi-token prompt). For single-token autoregressive decode steps
-        // we can rely on the KV cache and skip building the mask. The previous logic
-        // had this condition inverted (issue #3505), which built the mask only for
-        // single-token steps and skipped it during prefill — leaving the model with
-        // no attention mask when it actually needed one.
         let attention_mask = if seqlen <= 1 {
             None
         } else {
+            let seqlen_offset = seqlen_offsets.first().copied().unwrap_or(0);
             Some(self.prepare_decoder_attention_mask(
                 bs,
                 seqlen,
-                seqlen_offsets[0],
+                seqlen_offset,
                 self.text.dtype,
                 input_ids.device(),
             )?)

--- a/candle-transformers/src/models/qwen3_vl/mod.rs
+++ b/candle-transformers/src/models/qwen3_vl/mod.rs
@@ -67,7 +67,15 @@ impl Qwen3VLModel {
         seqlen_offsets: &[usize],
     ) -> Result<Tensor> {
         let (bs, seqlen) = input_ids.dims2()?;
+        // The causal mask is only needed when processing more than one token at once
+        // (prefill / multi-token prompt). For single-token autoregressive decode steps
+        // we can rely on the KV cache and skip building the mask. The previous logic
+        // had this condition inverted (issue #3505), which built the mask only for
+        // single-token steps and skipped it during prefill — leaving the model with
+        // no attention mask when it actually needed one.
         let attention_mask = if seqlen <= 1 {
+            None
+        } else {
             Some(self.prepare_decoder_attention_mask(
                 bs,
                 seqlen,
@@ -75,8 +83,6 @@ impl Qwen3VLModel {
                 self.text.dtype,
                 input_ids.device(),
             )?)
-        } else {
-            None
         };
 
         let mut input_embeds = self.text.embed_tokens(input_ids)?;


### PR DESCRIPTION
## Summary

In `Qwen3VLModel::forward`, the gate that decides whether to build a causal attention mask is inverted:

```rust
let attention_mask = if seqlen <= 1 {
    Some(self.prepare_decoder_attention_mask(...))   // mask built when *not* needed
} else {
    None                                             // mask skipped when needed
};
```

The decoder causal mask is only useful when **more than one token** is being processed at once (prefill / multi-token prompt). For single-token autoregressive decode steps the KV cache already constrains attention and the mask can be skipped. The current code does the opposite.

Every other candle text model (mistral, starcoder2, helium, olmo2, phi3, deepseek2, csm, gemma4, …) follows the canonical pattern, e.g. mistral.rs:

```rust
let attention_mask = if seq_len <= 1 {
    None
} else {
    let mask = self.prepare_decoder_attention_mask(seq_len, seqlen_offset)?;
    Some(mask)
};
```

This PR aligns Qwen3 VL with that shape and adds a comment explaining the invariant so the inversion isn't reintroduced.

## Test
- `cargo build -p candle-transformers` — clean
- `cargo clippy -p candle-transformers --lib -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Fixes #3505