### PR TITLE
WIP: testing only ATM. Upgrade hf-hub to 1.0.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ cudarc = { version = "0.19.4", features = [
 ], default-features = false }
 fancy-regex = "0.17.0"
 gemm = { version = "0.19.0", features = ["wasm-simd128-enable"] }
-hf-hub = "0.4.1"
+hf-hub = "1.0.0-rc.1"
 half = { version = "2.5.0", features = [
     "num-traits",
     "use-intrinsics",

--- a/candle-book/Cargo.toml
+++ b/candle-book/Cargo.toml
@@ -29,7 +29,7 @@ tokio = "1.48.0"
 
 [dev-dependencies]
 byteorder = { workspace = true }
-hf-hub = { workspace = true, features=["tokio"]}
+hf-hub = { workspace = true, features = ["blocking"] }
 clap = { workspace = true }
 memmap2 = { workspace = true }
 rand = { workspace = true }

--- a/candle-book/src/lib.rs
+++ b/candle-book/src/lib.rs
@@ -13,12 +13,17 @@ mod tests {
     async fn book_hub_1() {
 // ANCHOR: book_hub_1
 use candle::Device;
-use hf_hub::api::tokio::Api;
+use hf_hub::HFClient;
 
-let api = Api::new().unwrap();
-let repo = api.model("bert-base-uncased".to_string());
+let client = HFClient::new().unwrap();
+let repo = client.model("", "bert-base-uncased");
 
-let weights_filename = repo.get("model.safetensors").await.unwrap();
+let weights_filename = repo
+    .download_file()
+    .filename("model.safetensors")
+    .send()
+    .await
+    .unwrap();
 
 let weights = candle::safetensors::load(weights_filename, &Device::Cpu).unwrap();
 // ANCHOR_END: book_hub_1
@@ -31,13 +36,17 @@ let weights = candle::safetensors::load(weights_filename, &Device::Cpu).unwrap()
         {
 // ANCHOR: book_hub_2
 use candle::Device;
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use memmap2::Mmap;
 use std::fs;
 
-let api = Api::new().unwrap();
-let repo = api.model("bert-base-uncased".to_string());
-let weights_filename = repo.get("model.safetensors").unwrap();
+let client = HFClientSync::new().unwrap();
+let repo = client.model("", "bert-base-uncased");
+let weights_filename = repo
+    .download_file()
+    .filename("model.safetensors")
+    .send()
+    .unwrap();
 
 let file = fs::File::open(weights_filename).unwrap();
 let mmap = unsafe { Mmap::map(&file).unwrap() };
@@ -52,15 +61,19 @@ let weights = candle::safetensors::load_buffer(&mmap[..], &Device::Cpu).unwrap()
     {
 // ANCHOR: book_hub_3
 use candle::{DType, Device, Tensor};
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use memmap2::Mmap;
 use safetensors::slice::IndexOp;
 use safetensors::SafeTensors;
 use std::fs;
 
-let api = Api::new().unwrap();
-let repo = api.model("bert-base-uncased".to_string());
-let weights_filename = repo.get("model.safetensors").unwrap();
+let client = HFClientSync::new().unwrap();
+let repo = client.model("", "bert-base-uncased");
+let weights_filename = repo
+    .download_file()
+    .filename("model.safetensors")
+    .send()
+    .unwrap();
 
 let file = fs::File::open(weights_filename).unwrap();
 let mmap = unsafe { Mmap::map(&file).unwrap() };
@@ -110,19 +123,20 @@ let tp_tensor = Tensor::from_raw_buffer(&raw, dtype, &tp_shape, &Device::Cpu).un
     #[rustfmt::skip]
     fn book_training_1() -> Result<()>{
 // ANCHOR: book_training_1
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 
-let dataset_id = "mnist".to_string();
-
-let api = Api::new()?;
-let repo = Repo::with_revision(
-    dataset_id,
-    RepoType::Dataset,
-    "refs/convert/parquet".to_string(),
-);
-let repo = api.repo(repo);
-let test_parquet_filename = repo.get("mnist/test/0000.parquet")?;
-let train_parquet_filename = repo.get("mnist/train/0000.parquet")?;
+let client = HFClientSync::new()?;
+let repo = client.dataset("", "mnist");
+let test_parquet_filename = repo
+    .download_file()
+    .filename("mnist/test/0000.parquet")
+    .revision("refs/convert/parquet")
+    .send()?;
+let train_parquet_filename = repo
+    .download_file()
+    .filename("mnist/train/0000.parquet")
+    .revision("refs/convert/parquet")
+    .send()?;
 let test_parquet =
     SerializedFileReader::new(std::fs::File::open(test_parquet_filename)?)?;
 let train_parquet =
@@ -137,8 +151,16 @@ for row in test_parquet {
     }
 }
 // ANCHOR_END: book_training_2
-let test_parquet_filename = repo.get("mnist/test/0000.parquet")?;
-let train_parquet_filename = repo.get("mnist/train/0000.parquet")?;
+let test_parquet_filename = repo
+    .download_file()
+    .filename("mnist/test/0000.parquet")
+    .revision("refs/convert/parquet")
+    .send()?;
+let train_parquet_filename = repo
+    .download_file()
+    .filename("mnist/train/0000.parquet")
+    .revision("refs/convert/parquet")
+    .send()?;
 let test_parquet = SerializedFileReader::new(std::fs::File::open(test_parquet_filename)?)?;
 let train_parquet = SerializedFileReader::new(std::fs::File::open(train_parquet_filename)?)?;
 // ANCHOR: book_training_3

--- a/candle-datasets/Cargo.toml
+++ b/candle-datasets/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 byteorder = { workspace = true }
 candle = { workspace = true }
 candle-nn = { workspace = true }
-hf-hub = { workspace = true}
+hf-hub = { workspace = true, features = ["blocking"] }
 intel-mkl-src = { workspace = true, optional = true }
 memmap2 = { workspace = true }
 tokenizers = { workspace = true, features = ["onig"] }

--- a/candle-datasets/src/hub.rs
+++ b/candle-datasets/src/hub.rs
@@ -63,7 +63,8 @@ pub fn from_hub(
     client: &HFClientSync,
     dataset_id: String,
 ) -> Result<Vec<SerializedFileReader<File>>, Error> {
-    let repo = client.dataset("", dataset_id);
+    let (owner, name) = dataset_id.split_once('/').unwrap_or(("", dataset_id.as_str()));
+    let repo = client.dataset(owner, name);
     let info = repo
         .info()
         .revision("refs/convert/parquet".to_string())

--- a/candle-datasets/src/hub.rs
+++ b/candle-datasets/src/hub.rs
@@ -1,7 +1,4 @@
-use hf_hub::{
-    api::sync::{Api, ApiRepo},
-    Repo, RepoType,
-};
+use hf_hub::{HFClientSync, HFRepositorySync, RepoTypeDataset};
 use parquet::file::reader::SerializedFileReader;
 use std::fs::File;
 
@@ -19,8 +16,8 @@ use std::fs::File;
 /// # Example
 /// ```
 /// use candle_datasets::hub::{from_hub, FileReader};  // Re-exported trait
-/// let api = hf_hub::api::sync::Api::new().unwrap();
-/// let files = from_hub(&api, "hf-internal-testing/dummy_image_text_data".to_string()).unwrap();
+/// let client = hf_hub::HFClientSync::new().unwrap();
+/// let files = from_hub(&client, "hf-internal-testing/dummy_image_text_data".to_string()).unwrap();
 /// let num_rows = files[0].metadata().file_metadata().num_rows();
 /// ```
 pub use parquet::file::reader::FileReader;
@@ -28,7 +25,7 @@ pub use parquet::file::reader::FileReader;
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("ApiError : {0}")]
-    ApiError(#[from] hf_hub::api::sync::ApiError),
+    ApiError(#[from] hf_hub::HFError),
 
     #[error("IoError : {0}")]
     IoError(#[from] std::io::Error),
@@ -39,9 +36,13 @@ pub enum Error {
 
 fn sibling_to_parquet(
     rfilename: &str,
-    repo: &ApiRepo,
+    repo: &HFRepositorySync<RepoTypeDataset>,
 ) -> Result<SerializedFileReader<File>, Error> {
-    let local = repo.get(rfilename)?;
+    let local = repo
+        .download_file()
+        .filename(rfilename)
+        .revision("refs/convert/parquet")
+        .send()?;
     let file = File::open(local)?;
     Ok(SerializedFileReader::new(file)?)
 }
@@ -53,21 +54,23 @@ fn sibling_to_parquet(
 /// # Example
 /// ```
 /// use candle_datasets::hub::{from_hub, FileReader};
-/// let api = hf_hub::api::sync::Api::new().unwrap();
-/// let readers = from_hub(&api, "hf-internal-testing/dummy_image_text_data".to_string()).unwrap();
+/// let client = hf_hub::HFClientSync::new().unwrap();
+/// let readers = from_hub(&client, "hf-internal-testing/dummy_image_text_data".to_string()).unwrap();
 /// let metadata = readers[0].metadata();
 /// assert_eq!(metadata.file_metadata().num_rows(), 20);
 /// ```
-pub fn from_hub(api: &Api, dataset_id: String) -> Result<Vec<SerializedFileReader<File>>, Error> {
-    let repo = Repo::with_revision(
-        dataset_id,
-        RepoType::Dataset,
-        "refs/convert/parquet".to_string(),
-    );
-    let repo = api.repo(repo);
-    let info = repo.info()?;
+pub fn from_hub(
+    client: &HFClientSync,
+    dataset_id: String,
+) -> Result<Vec<SerializedFileReader<File>>, Error> {
+    let repo = client.dataset("", dataset_id);
+    let info = repo
+        .info()
+        .revision("refs/convert/parquet".to_string())
+        .send()?;
 
     info.siblings
+        .unwrap_or_default()
         .into_iter()
         .filter(|s| s.rfilename.ends_with(".parquet"))
         .map(|s| sibling_to_parquet(&s.rfilename, &repo))
@@ -80,9 +83,9 @@ mod tests {
 
     #[test]
     fn test_dataset() {
-        let api = Api::new().unwrap();
+        let client = HFClientSync::new().unwrap();
         let files = from_hub(
-            &api,
+            &client,
             "hf-internal-testing/dummy_image_text_data".to_string(),
         )
         .unwrap();

--- a/candle-datasets/src/vision/cifar.rs
+++ b/candle-datasets/src/vision/cifar.rs
@@ -5,7 +5,7 @@
 //! The binary version of the dataset is used.
 use crate::vision::Dataset;
 use candle::{DType, Device, Error, Result, Tensor};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use std::fs::File;
 use std::io::{BufReader, Read};
@@ -93,19 +93,19 @@ fn load_parquet(parquet: SerializedFileReader<std::fs::File>) -> Result<(Tensor,
 }
 
 pub fn load() -> Result<Dataset> {
-    let api = Api::new().map_err(|e| Error::Msg(format!("Api error: {e}")))?;
-    let dataset_id = "cifar10".to_string();
-    let repo = Repo::with_revision(
-        dataset_id,
-        RepoType::Dataset,
-        "refs/convert/parquet".to_string(),
-    );
-    let repo = api.repo(repo);
+    let client = HFClientSync::new().map_err(|e| Error::Msg(format!("Api error: {e}")))?;
+    let repo = client.dataset("", "cifar10");
     let test_parquet_filename = repo
-        .get("plain_text/test/0000.parquet")
+        .download_file()
+        .filename("plain_text/test/0000.parquet")
+        .revision("refs/convert/parquet")
+        .send()
         .map_err(|e| Error::Msg(format!("Api error: {e}")))?;
     let train_parquet_filename = repo
-        .get("plain_text/train/0000.parquet")
+        .download_file()
+        .filename("plain_text/train/0000.parquet")
+        .revision("refs/convert/parquet")
+        .send()
         .map_err(|e| Error::Msg(format!("Api error: {e}")))?;
     let test_parquet = SerializedFileReader::new(std::fs::File::open(test_parquet_filename)?)
         .map_err(|e| Error::Msg(format!("Parquet error: {e}")))?;

--- a/candle-datasets/src/vision/mnist.rs
+++ b/candle-datasets/src/vision/mnist.rs
@@ -3,7 +3,7 @@
 //! The files can be obtained from the following link:
 //! <http://yann.lecun.com/exdb/mnist/>
 use candle::{DType, Device, Error, Result, Tensor};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use std::fs::File;
 use std::io::{self, BufReader, Read};
@@ -92,18 +92,19 @@ pub(crate) fn load_mnist_like(
     test_filename: &str,
     train_filename: &str,
 ) -> Result<crate::vision::Dataset> {
-    let api = Api::new().map_err(|e| Error::Msg(format!("Api error: {e}")))?;
-    let repo = Repo::with_revision(
-        dataset_id.to_string(),
-        RepoType::Dataset,
-        revision.to_string(),
-    );
-    let repo = api.repo(repo);
+    let client = HFClientSync::new().map_err(|e| Error::Msg(format!("Api error: {e}")))?;
+    let repo = client.dataset("", dataset_id);
     let test_parquet_filename = repo
-        .get(test_filename)
+        .download_file()
+        .filename(test_filename)
+        .revision(revision)
+        .send()
         .map_err(|e| Error::Msg(format!("Api error: {e}")))?;
     let train_parquet_filename = repo
-        .get(train_filename)
+        .download_file()
+        .filename(train_filename)
+        .revision(revision)
+        .send()
         .map_err(|e| Error::Msg(format!("Api error: {e}")))?;
     let test_parquet = SerializedFileReader::new(std::fs::File::open(test_parquet_filename)?)
         .map_err(|e| Error::Msg(format!("Parquet error: {e}")))?;

--- a/candle-datasets/src/vision/mnist.rs
+++ b/candle-datasets/src/vision/mnist.rs
@@ -93,7 +93,8 @@ pub(crate) fn load_mnist_like(
     train_filename: &str,
 ) -> Result<crate::vision::Dataset> {
     let client = HFClientSync::new().map_err(|e| Error::Msg(format!("Api error: {e}")))?;
-    let repo = client.dataset("", dataset_id);
+    let (owner, name) = dataset_id.split_once('/').unwrap_or(("", dataset_id));
+    let repo = client.dataset(owner, name);
     let test_parquet_filename = repo
         .download_file()
         .filename(test_filename)

--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -22,7 +22,7 @@ chrono = "0.4"
 csv = "1.3.0"
 cudarc = { workspace = true, optional = true }
 half = { workspace = true, optional = true }
-hf-hub = { workspace = true, features = ["tokio"] }
+hf-hub = { workspace = true, features = ["blocking"] }
 image = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
 num-traits = { workspace = true }
@@ -61,7 +61,7 @@ tokio = "1.48.0"
 [build-dependencies]
 anyhow = { workspace = true }
 cudaforge = { version = "0.1.2", optional = true }
-hf-hub = { workspace = true, features = ["tokio"] }
+hf-hub = { workspace = true, features = ["blocking"] }
 
 [features]
 default = []

--- a/candle-examples/buildtime_downloader.rs
+++ b/candle-examples/buildtime_downloader.rs
@@ -8,7 +8,8 @@ pub fn download_model(model_and_revision: &str) -> Result<()> {
     };
     let (config_filename, tokenizer_filename, weights_filename) = {
         let client = HFClientSync::new()?;
-        let repo = client.model("", model_id);
+        let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id));
+        let repo = client.model(owner, name);
         let dl = |file: &str| -> Result<String> {
             Ok(repo
                 .download_file()

--- a/candle-examples/buildtime_downloader.rs
+++ b/candle-examples/buildtime_downloader.rs
@@ -1,19 +1,28 @@
 use anyhow::Result;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 
 pub fn download_model(model_and_revision: &str) -> Result<()> {
     let (model_id, revision) = match model_and_revision.split_once(":") {
         Some((model_id, revision)) => (model_id, revision),
         None => (model_and_revision, "main"),
     };
-    let repo = Repo::with_revision(model_id.to_string(), RepoType::Model, revision.to_string());
     let (config_filename, tokenizer_filename, weights_filename) = {
-        let api = Api::new()?;
-        let api = api.repo(repo);
-        let config = api.get("config.json")?.to_string_lossy().to_string();
-        let tokenizer = api.get("tokenizer.json")?.to_string_lossy().to_string();
-        let weights = api.get("model.safetensors")?.to_string_lossy().to_string();
-        (config, tokenizer, weights)
+        let client = HFClientSync::new()?;
+        let repo = client.model("", model_id);
+        let dl = |file: &str| -> Result<String> {
+            Ok(repo
+                .download_file()
+                .filename(file)
+                .revision(revision.to_string())
+                .send()?
+                .to_string_lossy()
+                .to_string())
+        };
+        (
+            dl("config.json")?,
+            dl("tokenizer.json")?,
+            dl("model.safetensors")?,
+        )
     };
     println!("cargo::rustc-env=CANDLE_BUILDTIME_MODEL_CONFIG={config_filename}");
     println!("cargo::rustc-env=CANDLE_BUILDTIME_MODEL_TOKENIZER={tokenizer_filename}");

--- a/candle-examples/examples/based/main.rs
+++ b/candle-examples/examples/based/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -207,7 +207,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => match args.which {
@@ -216,27 +216,31 @@ fn main() -> Result<()> {
             Which::W1b50b => "hazyresearch/based-1b-50b".to_string(),
         },
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let repo = api.model("", &model_id);
     let config_file = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(args.revision.clone())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => vec![repo.get("model.safetensors")?],
+        None => vec![repo
+            .download_file()
+            .filename("model.safetensors")
+            .revision(args.revision.clone())
+            .send()?],
     };
 
-    let repo = api.model("openai-community/gpt2".to_string());
+    let repo = api.model("", "openai-community/gpt2");
     let tokenizer_file = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").send()?,
     };
 
     println!("retrieved the files in {:?}", start.elapsed());

--- a/candle-examples/examples/based/main.rs
+++ b/candle-examples/examples/based/main.rs
@@ -216,7 +216,8 @@ fn main() -> Result<()> {
             Which::W1b50b => "hazyresearch/based-1b-50b".to_string(),
         },
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let config_file = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
         None => repo
@@ -237,7 +238,7 @@ fn main() -> Result<()> {
             .send()?],
     };
 
-    let repo = api.model("", "openai-community/gpt2");
+    let repo = api.model("openai-community", "gpt2");
     let tokenizer_file = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => repo.download_file().filename("tokenizer.json").send()?,

--- a/candle-examples/examples/beit/main.rs
+++ b/candle-examples/examples/beit/main.rs
@@ -54,7 +54,7 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "vincent-espitalier/candle-beit");
+            let api = api.model("vincent-espitalier", "candle-beit");
             api.download_file()
                 .filename("beit_base_patch16_384.in22k_ft_in22k_in1k.safetensors")
                 .send()?

--- a/candle-examples/examples/beit/main.rs
+++ b/candle-examples/examples/beit/main.rs
@@ -53,9 +53,11 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("vincent-espitalier/candle-beit".into());
-            api.get("beit_base_patch16_384.in22k_ft_in22k_in1k.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "vincent-espitalier/candle-beit");
+            api.download_file()
+                .filename("beit_base_patch16_384.in22k_ft_in22k_in1k.safetensors")
+                .send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/bert/main.rs
+++ b/candle-examples/examples/bert/main.rs
@@ -69,7 +69,8 @@ impl Args {
 
         let (config_filename, tokenizer_filename, weights_filename) = {
             let api = HFClientSync::new()?;
-            let api = api.model("", &model_id);
+            let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+            let api = api.model(owner, name);
             let config = api
                 .download_file()
                 .filename("config.json")

--- a/candle-examples/examples/bert/main.rs
+++ b/candle-examples/examples/bert/main.rs
@@ -9,7 +9,7 @@ use anyhow::{Error as E, Result};
 use candle::Tensor;
 use candle_nn::VarBuilder;
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingParams, Tokenizer};
 
 #[derive(Parser, Debug)]
@@ -67,16 +67,29 @@ impl Args {
             (None, None) => (default_model, default_revision),
         };
 
-        let repo = Repo::with_revision(model_id, RepoType::Model, revision);
         let (config_filename, tokenizer_filename, weights_filename) = {
-            let api = Api::new()?;
-            let api = api.repo(repo);
-            let config = api.get("config.json")?;
-            let tokenizer = api.get("tokenizer.json")?;
+            let api = HFClientSync::new()?;
+            let api = api.model("", &model_id);
+            let config = api
+                .download_file()
+                .filename("config.json")
+                .revision(revision.clone())
+                .send()?;
+            let tokenizer = api
+                .download_file()
+                .filename("tokenizer.json")
+                .revision(revision.clone())
+                .send()?;
             let weights = if self.use_pth {
-                api.get("pytorch_model.bin")?
+                api.download_file()
+                    .filename("pytorch_model.bin")
+                    .revision(revision.clone())
+                    .send()?
             } else {
-                api.get("model.safetensors")?
+                api.download_file()
+                    .filename("model.safetensors")
+                    .revision(revision.clone())
+                    .send()?
             };
             (config, tokenizer, weights)
         };

--- a/candle-examples/examples/bigcode/main.rs
+++ b/candle-examples/examples/bigcode/main.rs
@@ -12,7 +12,7 @@ use candle_transformers::models::bigcode::{Config, GPTBigCode};
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -121,18 +121,23 @@ fn main() -> Result<()> {
     let args = Args::parse();
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id,
-        RepoType::Model,
-        args.revision,
-    ));
-    let tokenizer_filename = repo.get("tokenizer.json")?;
+    let api = HFClientSync::new()?;
+    let repo = api.model("", &args.model_id);
+    let tokenizer_filename = repo
+        .download_file()
+        .filename("tokenizer.json")
+        .revision(args.revision.clone())
+        .send()?;
     let filenames = match args.weight_file {
         Some(weight_file) => vec![std::path::PathBuf::from(weight_file)],
         None => ["model.safetensors"]
             .iter()
-            .map(|f| repo.get(f))
+            .map(|f| {
+                repo.download_file()
+                    .filename(*f)
+                    .revision(args.revision.clone())
+                    .send()
+            })
             .collect::<std::result::Result<Vec<_>, _>>()?,
     };
     println!("retrieved the files in {:?}", start.elapsed());

--- a/candle-examples/examples/bigcode/main.rs
+++ b/candle-examples/examples/bigcode/main.rs
@@ -122,7 +122,8 @@ fn main() -> Result<()> {
 
     let start = std::time::Instant::now();
     let api = HFClientSync::new()?;
-    let repo = api.model("", &args.model_id);
+    let (owner, name) = args.model_id.split_once('/').unwrap_or(("", args.model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = repo
         .download_file()
         .filename("tokenizer.json")

--- a/candle-examples/examples/blip/main.rs
+++ b/candle-examples/examples/blip/main.rs
@@ -78,12 +78,12 @@ pub fn main() -> anyhow::Result<()> {
         None => {
             let api = hf_hub::HFClientSync::new()?;
             if args.quantized {
-                let api = api.model("", "lmz/candle-blip");
+                let api = api.model("lmz", "candle-blip");
                 api.download_file()
                     .filename("blip-image-captioning-large-q4k.gguf")
                     .send()?
             } else {
-                let api = api.model("", "Salesforce/blip-image-captioning-large");
+                let api = api.model("Salesforce", "blip-image-captioning-large");
                 api.download_file()
                     .filename("model.safetensors")
                     .revision("refs/pr/18")
@@ -95,7 +95,7 @@ pub fn main() -> anyhow::Result<()> {
     let tokenizer = match args.tokenizer {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "Salesforce/blip-image-captioning-large");
+            let api = api.model("Salesforce", "blip-image-captioning-large");
             api.download_file().filename("tokenizer.json").send()?
         }
         Some(file) => file.into(),

--- a/candle-examples/examples/blip/main.rs
+++ b/candle-examples/examples/blip/main.rs
@@ -76,26 +76,27 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
+            let api = hf_hub::HFClientSync::new()?;
             if args.quantized {
-                let api = api.model("lmz/candle-blip".to_string());
-                api.get("blip-image-captioning-large-q4k.gguf")?
+                let api = api.model("", "lmz/candle-blip");
+                api.download_file()
+                    .filename("blip-image-captioning-large-q4k.gguf")
+                    .send()?
             } else {
-                let api = api.repo(hf_hub::Repo::with_revision(
-                    "Salesforce/blip-image-captioning-large".to_string(),
-                    hf_hub::RepoType::Model,
-                    "refs/pr/18".to_string(),
-                ));
-                api.get("model.safetensors")?
+                let api = api.model("", "Salesforce/blip-image-captioning-large");
+                api.download_file()
+                    .filename("model.safetensors")
+                    .revision("refs/pr/18")
+                    .send()?
             }
         }
         Some(model) => model.into(),
     };
     let tokenizer = match args.tokenizer {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("Salesforce/blip-image-captioning-large".to_string());
-            api.get("tokenizer.json")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "Salesforce/blip-image-captioning-large");
+            api.download_file().filename("tokenizer.json").send()?
         }
         Some(file) => file.into(),
     };

--- a/candle-examples/examples/chatglm/main.rs
+++ b/candle-examples/examples/chatglm/main.rs
@@ -12,7 +12,7 @@ use candle_transformers::models::chatglm::{Config, Model};
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -190,21 +190,23 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id.to_string(),
         None => "THUDM/chatglm3-6b".to_string(),
     };
-    let revision = match args.revision {
+    let _revision = match args.revision {
         Some(rev) => rev.to_string(),
         None => "main".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .model("lmz/candle-chatglm".to_string())
-            .get("chatglm-tokenizer.json")?,
+            .model("", "lmz/candle-chatglm")
+            .download_file()
+            .filename("chatglm-tokenizer.json")
+            .send()?,
     };
     let filenames = match args.weight_file {
         Some(weight_file) => vec![std::path::PathBuf::from(weight_file)],

--- a/candle-examples/examples/chatglm/main.rs
+++ b/candle-examples/examples/chatglm/main.rs
@@ -199,11 +199,12 @@ fn main() -> Result<()> {
         Some(rev) => rev.to_string(),
         None => "main".to_string(),
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .model("", "lmz/candle-chatglm")
+            .model("lmz", "candle-chatglm")
             .download_file()
             .filename("chatglm-tokenizer.json")
             .send()?,

--- a/candle-examples/examples/chinese_clip/main.rs
+++ b/candle-examples/examples/chinese_clip/main.rs
@@ -81,7 +81,7 @@ pub fn load_weights(model: Option<String>, device: &Device) -> anyhow::Result<nn
     let model_file = match model {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "OFA-Sys/chinese-clip-vit-base-patch16");
+            let api = api.model("OFA-Sys", "chinese-clip-vit-base-patch16");
             api.download_file()
                 .filename("model.safetensors")
                 .revision("refs/pr/3")
@@ -96,7 +96,7 @@ pub fn load_weights(model: Option<String>, device: &Device) -> anyhow::Result<nn
 pub fn load_tokenizer() -> anyhow::Result<Tokenizer> {
     let tokenizer_file = {
         let api = hf_hub::HFClientSync::new()?;
-        let api = api.model("", "OFA-Sys/chinese-clip-vit-base-patch16");
+        let api = api.model("OFA-Sys", "chinese-clip-vit-base-patch16");
         api.download_file()
             .filename("tokenizer.json")
             .revision("refs/pr/3")

--- a/candle-examples/examples/chinese_clip/main.rs
+++ b/candle-examples/examples/chinese_clip/main.rs
@@ -80,14 +80,12 @@ fn main() -> anyhow::Result<()> {
 pub fn load_weights(model: Option<String>, device: &Device) -> anyhow::Result<nn::VarBuilder<'_>> {
     let model_file = match model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let repo = hf_hub::Repo::with_revision(
-                "OFA-Sys/chinese-clip-vit-base-patch16".to_string(),
-                hf_hub::RepoType::Model,
-                "refs/pr/3".to_string(),
-            );
-            let api = api.repo(repo);
-            api.get("model.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "OFA-Sys/chinese-clip-vit-base-patch16");
+            api.download_file()
+                .filename("model.safetensors")
+                .revision("refs/pr/3")
+                .send()?
         }
         Some(model) => model.into(),
     };
@@ -97,14 +95,12 @@ pub fn load_weights(model: Option<String>, device: &Device) -> anyhow::Result<nn
 
 pub fn load_tokenizer() -> anyhow::Result<Tokenizer> {
     let tokenizer_file = {
-        let api = hf_hub::api::sync::Api::new()?;
-        let repo = hf_hub::Repo::with_revision(
-            "OFA-Sys/chinese-clip-vit-base-patch16".to_string(),
-            hf_hub::RepoType::Model,
-            "refs/pr/3".to_string(),
-        );
-        let api = api.repo(repo);
-        api.get("tokenizer.json")?
+        let api = hf_hub::HFClientSync::new()?;
+        let api = api.model("", "OFA-Sys/chinese-clip-vit-base-patch16");
+        api.download_file()
+            .filename("tokenizer.json")
+            .revision("refs/pr/3")
+            .send()?
     };
 
     Tokenizer::from_file(tokenizer_file).map_err(anyhow::Error::msg)

--- a/candle-examples/examples/clip/main.rs
+++ b/candle-examples/examples/clip/main.rs
@@ -66,7 +66,7 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "openai/clip-vit-base-patch32");
+            let api = api.model("openai", "clip-vit-base-patch32");
             api.download_file()
                 .filename("model.safetensors")
                 .revision("refs/pr/15")
@@ -115,7 +115,7 @@ pub fn get_tokenizer(tokenizer: Option<String>) -> anyhow::Result<Tokenizer> {
     let tokenizer = match tokenizer {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "openai/clip-vit-base-patch32");
+            let api = api.model("openai", "clip-vit-base-patch32");
             api.download_file()
                 .filename("tokenizer.json")
                 .revision("refs/pr/15")

--- a/candle-examples/examples/clip/main.rs
+++ b/candle-examples/examples/clip/main.rs
@@ -65,15 +65,12 @@ pub fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-
-            let api = api.repo(hf_hub::Repo::with_revision(
-                "openai/clip-vit-base-patch32".to_string(),
-                hf_hub::RepoType::Model,
-                "refs/pr/15".to_string(),
-            ));
-
-            api.get("model.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "openai/clip-vit-base-patch32");
+            api.download_file()
+                .filename("model.safetensors")
+                .revision("refs/pr/15")
+                .send()?
         }
         Some(model) => model.into(),
     };
@@ -117,13 +114,12 @@ pub fn main() -> anyhow::Result<()> {
 pub fn get_tokenizer(tokenizer: Option<String>) -> anyhow::Result<Tokenizer> {
     let tokenizer = match tokenizer {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.repo(hf_hub::Repo::with_revision(
-                "openai/clip-vit-base-patch32".to_string(),
-                hf_hub::RepoType::Model,
-                "refs/pr/15".to_string(),
-            ));
-            api.get("tokenizer.json")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "openai/clip-vit-base-patch32");
+            api.download_file()
+                .filename("tokenizer.json")
+                .revision("refs/pr/15")
+                .send()?
         }
         Some(file) => file.into(),
     };

--- a/candle-examples/examples/codegeex4-9b/main.rs
+++ b/candle-examples/examples/codegeex4-9b/main.rs
@@ -204,11 +204,12 @@ fn main() -> anyhow::Result<()> {
         Some(rev) => rev.to_string(),
         None => "main".to_string(),
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .model("", "THUDM/codegeex4-all-9b")
+            .model("THUDM", "codegeex4-all-9b")
             .download_file()
             .filename("tokenizer.json")
             .send()

--- a/candle-examples/examples/codegeex4-9b/main.rs
+++ b/candle-examples/examples/codegeex4-9b/main.rs
@@ -3,7 +3,6 @@ use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
 use candle_transformers::models::codegeex4_9b::*;
 use clap::Parser;
-use hf_hub::{Repo, RepoType};
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -189,32 +188,35 @@ fn main() -> anyhow::Result<()> {
 
     let start = std::time::Instant::now();
     let api = match args.cache_path.as_ref() {
-        None => hf_hub::api::sync::Api::new()?,
-        Some(path) => {
-            hf_hub::api::sync::ApiBuilder::from_cache(hf_hub::Cache::new(path.to_string().into()))
+        None => hf_hub::HFClientSync::new()?,
+        Some(path) => hf_hub::HFClientSync::from_inner(
+            hf_hub::HFClient::builder()
+                .cache_dir(std::path::PathBuf::from(path.to_string()))
                 .build()
-                .map_err(anyhow::Error::msg)?
-        }
+                .map_err(anyhow::Error::msg)?,
+        )?,
     };
     let model_id = match args.model_id {
         Some(model_id) => model_id.to_string(),
         None => "THUDM/codegeex4-all-9b".to_string(),
     };
-    let revision = match args.revision {
+    let _revision = match args.revision {
         Some(rev) => rev.to_string(),
         None => "main".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .model("THUDM/codegeex4-all-9b".to_string())
-            .get("tokenizer.json")
+            .model("", "THUDM/codegeex4-all-9b")
+            .download_file()
+            .filename("tokenizer.json")
+            .send()
             .map_err(anyhow::Error::msg)?,
     };
     let config_filename = match &args.weight_path {
         Some(path) => std::path::Path::new(path).join("config.json"),
-        None => repo.get("config.json")?,
+        None => repo.download_file().filename("config.json").send()?,
     };
 
     let filenames = match &args.weight_path {

--- a/candle-examples/examples/colpali/main.rs
+++ b/candle-examples/examples/colpali/main.rs
@@ -4,7 +4,7 @@ use candle_nn::VarBuilder;
 use candle_transformers::models::colpali::Model;
 use candle_transformers::models::{colpali, paligemma};
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use image::DynamicImage;
 use pdf2image::{RenderOptionsBuilder, PDF};
 use tokenizers::Tokenizer;
@@ -195,26 +195,21 @@ fn main() -> Result<()> {
         candle::utils::with_f16c()
     );
 
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => "vidore/colpali-v1.2-merged".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let repo = api.model("", &model_id);
+    let _revision = args.revision;
 
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .repo(Repo::with_revision(
-                "vidore/colpali".to_string(),
-                RepoType::Model,
-                "main".to_string(),
-            ))
-            .get("tokenizer.json")?,
+            .model("", "vidore/colpali")
+            .download_file()
+            .filename("tokenizer.json")
+            .send()?,
     };
 
     let filenames = match args.weight_files {

--- a/candle-examples/examples/colpali/main.rs
+++ b/candle-examples/examples/colpali/main.rs
@@ -200,13 +200,14 @@ fn main() -> Result<()> {
         Some(model_id) => model_id.to_string(),
         None => "vidore/colpali-v1.2-merged".to_string(),
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let _revision = args.revision;
 
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .model("", "vidore/colpali")
+            .model("vidore", "colpali")
             .download_file()
             .filename("tokenizer.json")
             .send()?,

--- a/candle-examples/examples/convmixer/main.rs
+++ b/candle-examples/examples/convmixer/main.rs
@@ -33,9 +33,11 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("lmz/candle-convmixer".into());
-            api.get("convmixer_1024_20_ks9_p14.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "lmz/candle-convmixer");
+            api.download_file()
+                .filename("convmixer_1024_20_ks9_p14.safetensors")
+                .send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/convmixer/main.rs
+++ b/candle-examples/examples/convmixer/main.rs
@@ -34,7 +34,7 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "lmz/candle-convmixer");
+            let api = api.model("lmz", "candle-convmixer");
             api.download_file()
                 .filename("convmixer_1024_20_ks9_p14.safetensors")
                 .send()?

--- a/candle-examples/examples/convnext/main.rs
+++ b/candle-examples/examples/convnext/main.rs
@@ -99,9 +99,9 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", &model_name);
+            api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/convnext/main.rs
+++ b/candle-examples/examples/convnext/main.rs
@@ -100,7 +100,8 @@ pub fn main() -> anyhow::Result<()> {
         None => {
             let model_name = args.which.model_filename();
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", &model_name);
+            let (owner, name) = model_name.split_once('/').unwrap_or(("", model_name.as_str()));
+            let api = api.model(owner, name);
             api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),

--- a/candle-examples/examples/csm/main.rs
+++ b/candle-examples/examples/csm/main.rs
@@ -11,7 +11,7 @@ use candle_transformers::models::csm::{Config, Model};
 
 use candle::{DType, IndexOp, Tensor};
 use candle_nn::VarBuilder;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -124,7 +124,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => {
@@ -134,29 +134,34 @@ fn main() -> Result<()> {
             name.to_string()
         }
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let repo = api.model("", &model_id);
+    let revision = args.revision;
     let filenames = match args.weights {
         Some(files) => files
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => vec![repo.get("model.safetensors")?],
+        None => vec![repo
+            .download_file()
+            .filename("model.safetensors")
+            .revision(revision.clone())
+            .send()?],
     };
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .model("meta-llama/Llama-3.2-1B".to_string())
-            .get("tokenizer.json")?,
+            .model("", "meta-llama/Llama-3.2-1B")
+            .download_file()
+            .filename("tokenizer.json")
+            .send()?,
     };
     let mimi_filename = match args.mimi_weights {
         Some(model) => std::path::PathBuf::from(model),
-        None => Api::new()?
-            .model("kyutai/mimi".to_string())
-            .get("model.safetensors")?,
+        None => HFClientSync::new()?
+            .model("", "kyutai/mimi")
+            .download_file()
+            .filename("model.safetensors")
+            .send()?,
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
@@ -165,7 +170,11 @@ fn main() -> Result<()> {
     let config: Config = match args.config {
         Some(config_file) => serde_json::from_slice(&std::fs::read(config_file)?)?,
         None => {
-            let config_file = repo.get("config.json")?;
+            let config_file = repo
+                .download_file()
+                .filename("config.json")
+                .revision(revision.clone())
+                .send()?;
             serde_json::from_slice(&std::fs::read(config_file)?)?
         }
     };

--- a/candle-examples/examples/csm/main.rs
+++ b/candle-examples/examples/csm/main.rs
@@ -134,7 +134,8 @@ fn main() -> Result<()> {
             name.to_string()
         }
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let revision = args.revision;
     let filenames = match args.weights {
         Some(files) => files
@@ -150,7 +151,7 @@ fn main() -> Result<()> {
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .model("", "meta-llama/Llama-3.2-1B")
+            .model("meta-llama", "Llama-3.2-1B")
             .download_file()
             .filename("tokenizer.json")
             .send()?,
@@ -158,7 +159,7 @@ fn main() -> Result<()> {
     let mimi_filename = match args.mimi_weights {
         Some(model) => std::path::PathBuf::from(model),
         None => HFClientSync::new()?
-            .model("", "kyutai/mimi")
+            .model("kyutai", "mimi")
             .download_file()
             .filename("model.safetensors")
             .send()?,

--- a/candle-examples/examples/debertav2/main.rs
+++ b/candle-examples/examples/debertav2/main.rs
@@ -16,7 +16,7 @@ use candle_transformers::models::debertav2::{Config as DebertaV2Config, DebertaV
 use candle_transformers::models::debertav2::{DebertaV2SeqClassificationModel, Id2Label};
 use candle_transformers::models::debertav2::{NERItem, TextClassificationItem};
 use clap::{ArgGroup, Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{Encoding, PaddingParams, Tokenizer};
 
 enum TaskType {
@@ -114,19 +114,30 @@ impl Args {
                     (config, tokenizer, weights)
                 }
                 None => {
-                    let repo = Repo::with_revision(
-                        self.model_id.as_ref().unwrap().clone(),
-                        RepoType::Model,
-                        self.revision.clone(),
-                    );
-                    let api = Api::new()?;
-                    let api = api.repo(repo);
-                    let config = api.get("config.json")?;
-                    let tokenizer = api.get("tokenizer.json")?;
+                    let model_id = self.model_id.as_ref().unwrap().clone();
+                    let revision = self.revision.clone();
+                    let api = HFClientSync::new()?;
+                    let api = api.model("", &model_id);
+                    let config = api
+                        .download_file()
+                        .filename("config.json")
+                        .revision(revision.clone())
+                        .send()?;
+                    let tokenizer = api
+                        .download_file()
+                        .filename("tokenizer.json")
+                        .revision(revision.clone())
+                        .send()?;
                     let weights = if self.use_pth {
-                        api.get("pytorch_model.bin")?
+                        api.download_file()
+                            .filename("pytorch_model.bin")
+                            .revision(revision.clone())
+                            .send()?
                     } else {
-                        api.get("model.safetensors")?
+                        api.download_file()
+                            .filename("model.safetensors")
+                            .revision(revision.clone())
+                            .send()?
                     };
                     (config, tokenizer, weights)
                 }

--- a/candle-examples/examples/debertav2/main.rs
+++ b/candle-examples/examples/debertav2/main.rs
@@ -117,7 +117,8 @@ impl Args {
                     let model_id = self.model_id.as_ref().unwrap().clone();
                     let revision = self.revision.clone();
                     let api = HFClientSync::new()?;
-                    let api = api.model("", &model_id);
+                    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+                    let api = api.model(owner, name);
                     let config = api
                         .download_file()
                         .filename("config.json")

--- a/candle-examples/examples/deepseekv2/main.rs
+++ b/candle-examples/examples/deepseekv2/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -226,7 +226,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => match args.which {
@@ -237,19 +237,24 @@ fn main() -> Result<()> {
             Which::V2Chat => "deepseek-ai/DeepSeek-V2-Chat".to_string(),
         },
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
-    let tokenizer_filename = repo.get("tokenizer.json")?;
+    let repo = api.model("", &model_id);
+    let revision = args.revision;
+    let tokenizer_filename = repo
+        .download_file()
+        .filename("tokenizer.json")
+        .revision(revision.clone())
+        .send()?;
     let filenames = candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?;
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
 
     let start = std::time::Instant::now();
     let config: DeepSeekV2Config = {
-        let config_file = repo.get("config.json")?;
+        let config_file = repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.clone())
+            .send()?;
         serde_json::from_slice(&std::fs::read(config_file)?)?
     };
     let device = candle_examples::device(args.cpu)?;

--- a/candle-examples/examples/deepseekv2/main.rs
+++ b/candle-examples/examples/deepseekv2/main.rs
@@ -237,7 +237,8 @@ fn main() -> Result<()> {
             Which::V2Chat => "deepseek-ai/DeepSeek-V2-Chat".to_string(),
         },
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let revision = args.revision;
     let tokenizer_filename = repo
         .download_file()

--- a/candle-examples/examples/depth_anything_v2/main.rs
+++ b/candle-examples/examples/depth_anything_v2/main.rs
@@ -53,9 +53,11 @@ pub fn main() -> anyhow::Result<()> {
 
     let dinov2_model_file = match args.dinov2_model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("lmz/candle-dino-v2".into());
-            api.get("dinov2_vits14.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "lmz/candle-dino-v2");
+            api.download_file()
+                .filename("dinov2_vits14.safetensors")
+                .send()?
         }
         Some(dinov2_model) => dinov2_model,
     };
@@ -67,9 +69,11 @@ pub fn main() -> anyhow::Result<()> {
 
     let depth_anything_model_file = match args.depth_anything_v2_model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("jeroenvlek/depth-anything-v2-safetensors".into());
-            api.get("depth_anything_v2_vits.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "jeroenvlek/depth-anything-v2-safetensors");
+            api.download_file()
+                .filename("depth_anything_v2_vits.safetensors")
+                .send()?
         }
         Some(depth_anything_model) => depth_anything_model,
     };

--- a/candle-examples/examples/depth_anything_v2/main.rs
+++ b/candle-examples/examples/depth_anything_v2/main.rs
@@ -54,7 +54,7 @@ pub fn main() -> anyhow::Result<()> {
     let dinov2_model_file = match args.dinov2_model {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "lmz/candle-dino-v2");
+            let api = api.model("lmz", "candle-dino-v2");
             api.download_file()
                 .filename("dinov2_vits14.safetensors")
                 .send()?
@@ -70,7 +70,7 @@ pub fn main() -> anyhow::Result<()> {
     let depth_anything_model_file = match args.depth_anything_v2_model {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "jeroenvlek/depth-anything-v2-safetensors");
+            let api = api.model("jeroenvlek", "depth-anything-v2-safetensors");
             api.download_file()
                 .filename("depth_anything_v2_vits.safetensors")
                 .send()?

--- a/candle-examples/examples/dinov2/main.rs
+++ b/candle-examples/examples/dinov2/main.rs
@@ -37,7 +37,7 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "lmz/candle-dino-v2");
+            let api = api.model("lmz", "candle-dino-v2");
             api.download_file()
                 .filename("dinov2_vits14.safetensors")
                 .send()?

--- a/candle-examples/examples/dinov2/main.rs
+++ b/candle-examples/examples/dinov2/main.rs
@@ -36,9 +36,11 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("lmz/candle-dino-v2".into());
-            api.get("dinov2_vits14.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "lmz/candle-dino-v2");
+            api.download_file()
+                .filename("dinov2_vits14.safetensors")
+                .send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/dinov2reg4/main.rs
+++ b/candle-examples/examples/dinov2reg4/main.rs
@@ -45,12 +45,14 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
+            let api = hf_hub::HFClientSync::new()?;
             let api =
-                api.model("vincent-espitalier/dino-v2-reg4-with-plantclef2024-weights".into());
-            api.get(
-                "vit_base_patch14_reg4_dinov2_lvd142m_pc24_onlyclassifier_then_all.safetensors",
-            )?
+                api.model("", "vincent-espitalier/dino-v2-reg4-with-plantclef2024-weights");
+            api.download_file()
+                .filename(
+                    "vit_base_patch14_reg4_dinov2_lvd142m_pc24_onlyclassifier_then_all.safetensors",
+                )
+                .send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/dinov2reg4/main.rs
+++ b/candle-examples/examples/dinov2reg4/main.rs
@@ -47,7 +47,7 @@ pub fn main() -> anyhow::Result<()> {
         None => {
             let api = hf_hub::HFClientSync::new()?;
             let api =
-                api.model("", "vincent-espitalier/dino-v2-reg4-with-plantclef2024-weights");
+                api.model("vincent-espitalier", "dino-v2-reg4-with-plantclef2024-weights");
             api.download_file()
                 .filename(
                     "vit_base_patch14_reg4_dinov2_lvd142m_pc24_onlyclassifier_then_all.safetensors",

--- a/candle-examples/examples/distilbert/main.rs
+++ b/candle-examples/examples/distilbert/main.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Error as E, Result};
 use candle::{Device, Tensor};
 use candle_nn::VarBuilder;
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use std::path::PathBuf;
 use tokenizers::Tokenizer;
 
@@ -119,16 +119,29 @@ impl Args {
         model_id: &str,
         revision: &str,
     ) -> Result<(PathBuf, PathBuf, PathBuf)> {
-        let repo = Repo::with_revision(model_id.to_string(), RepoType::Model, revision.to_string());
-        let api = Api::new()?;
-        let api = api.repo(repo);
+        let api = HFClientSync::new()?;
+        let api = api.model("", model_id);
 
-        let config = api.get("config.json")?;
-        let tokenizer = api.get("tokenizer.json")?;
+        let config = api
+            .download_file()
+            .filename("config.json")
+            .revision(revision.to_string())
+            .send()?;
+        let tokenizer = api
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.to_string())
+            .send()?;
         let weights = if self.use_pth {
-            api.get("pytorch_model.bin")?
+            api.download_file()
+                .filename("pytorch_model.bin")
+                .revision(revision.to_string())
+                .send()?
         } else {
-            api.get("model.safetensors")?
+            api.download_file()
+                .filename("model.safetensors")
+                .revision(revision.to_string())
+                .send()?
         };
 
         Ok((config, tokenizer, weights))

--- a/candle-examples/examples/distilbert/main.rs
+++ b/candle-examples/examples/distilbert/main.rs
@@ -120,7 +120,8 @@ impl Args {
         revision: &str,
     ) -> Result<(PathBuf, PathBuf, PathBuf)> {
         let api = HFClientSync::new()?;
-        let api = api.model("", model_id);
+        let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id));
+        let api = api.model(owner, name);
 
         let config = api
             .download_file()

--- a/candle-examples/examples/efficientnet/main.rs
+++ b/candle-examples/examples/efficientnet/main.rs
@@ -53,7 +53,7 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "lmz/candle-efficientnet");
+            let api = api.model("lmz", "candle-efficientnet");
             let filename = match args.which {
                 Which::B0 => "efficientnet-b0.safetensors",
                 Which::B1 => "efficientnet-b1.safetensors",

--- a/candle-examples/examples/efficientnet/main.rs
+++ b/candle-examples/examples/efficientnet/main.rs
@@ -52,8 +52,8 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("lmz/candle-efficientnet".into());
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "lmz/candle-efficientnet");
             let filename = match args.which {
                 Which::B0 => "efficientnet-b0.safetensors",
                 Which::B1 => "efficientnet-b1.safetensors",
@@ -64,7 +64,7 @@ pub fn main() -> anyhow::Result<()> {
                 Which::B6 => "efficientnet-b6.safetensors",
                 Which::B7 => "efficientnet-b7.safetensors",
             };
-            api.get(filename)?
+            api.download_file().filename(filename).send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/efficientvit/main.rs
+++ b/candle-examples/examples/efficientvit/main.rs
@@ -72,9 +72,9 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", &model_name);
+            api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/efficientvit/main.rs
+++ b/candle-examples/examples/efficientvit/main.rs
@@ -73,7 +73,8 @@ pub fn main() -> anyhow::Result<()> {
         None => {
             let model_name = args.which.model_filename();
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", &model_name);
+            let (owner, name) = model_name.split_once('/').unwrap_or(("", model_name.as_str()));
+            let api = api.model(owner, name);
             api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),

--- a/candle-examples/examples/encodec/main.rs
+++ b/candle-examples/examples/encodec/main.rs
@@ -9,7 +9,7 @@ use candle::{DType, IndexOp, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::encodec::{Config, Model};
 use clap::{Parser, ValueEnum};
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 
 mod audio_io;
 
@@ -46,9 +46,11 @@ fn main() -> Result<()> {
     let device = candle_examples::device(args.cpu)?;
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
-        None => Api::new()?
-            .model("facebook/encodec_24khz".to_string())
-            .get("model.safetensors")?,
+        None => HFClientSync::new()?
+            .model("", "facebook/encodec_24khz")
+            .download_file()
+            .filename("model.safetensors")
+            .send()?,
     };
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DType::F32, &device)? };
     let config = Config::default();

--- a/candle-examples/examples/encodec/main.rs
+++ b/candle-examples/examples/encodec/main.rs
@@ -47,7 +47,7 @@ fn main() -> Result<()> {
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
         None => HFClientSync::new()?
-            .model("", "facebook/encodec_24khz")
+            .model("facebook", "encodec_24khz")
             .download_file()
             .filename("model.safetensors")
             .send()?,

--- a/candle-examples/examples/eva2/main.rs
+++ b/candle-examples/examples/eva2/main.rs
@@ -55,9 +55,11 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("vincent-espitalier/candle-eva2".into());
-            api.get("eva02_base_patch14_448.mim_in22k_ft_in22k_in1k_adapted.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "vincent-espitalier/candle-eva2");
+            api.download_file()
+                .filename("eva02_base_patch14_448.mim_in22k_ft_in22k_in1k_adapted.safetensors")
+                .send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/eva2/main.rs
+++ b/candle-examples/examples/eva2/main.rs
@@ -56,7 +56,7 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "vincent-espitalier/candle-eva2");
+            let api = api.model("vincent-espitalier", "candle-eva2");
             api.download_file()
                 .filename("eva02_base_patch14_448.mim_in22k_ft_in22k_in1k_adapted.safetensors")
                 .send()?

--- a/candle-examples/examples/falcon/main.rs
+++ b/candle-examples/examples/falcon/main.rs
@@ -159,7 +159,8 @@ fn main() -> Result<()> {
     let device = candle_examples::device(args.cpu)?;
     let start = std::time::Instant::now();
     let api = HFClientSync::new()?;
-    let repo = api.model("", &args.model_id);
+    let (owner, name) = args.model_id.split_once('/').unwrap_or(("", args.model_id.as_str()));
+    let repo = api.model(owner, name);
     let revision = args.revision;
     let tokenizer_filename = repo
         .download_file()

--- a/candle-examples/examples/falcon/main.rs
+++ b/candle-examples/examples/falcon/main.rs
@@ -11,7 +11,7 @@ use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 use candle_transformers::models::falcon::{Config, Falcon};
@@ -158,13 +158,14 @@ fn main() -> Result<()> {
 
     let device = candle_examples::device(args.cpu)?;
     let start = std::time::Instant::now();
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id,
-        RepoType::Model,
-        args.revision,
-    ));
-    let tokenizer_filename = repo.get("tokenizer.json")?;
+    let api = HFClientSync::new()?;
+    let repo = api.model("", &args.model_id);
+    let revision = args.revision;
+    let tokenizer_filename = repo
+        .download_file()
+        .filename("tokenizer.json")
+        .revision(revision.clone())
+        .send()?;
     let filenames = candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?;
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;

--- a/candle-examples/examples/fastvit/main.rs
+++ b/candle-examples/examples/fastvit/main.rs
@@ -75,9 +75,9 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", &model_name);
+            api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/fastvit/main.rs
+++ b/candle-examples/examples/fastvit/main.rs
@@ -76,7 +76,8 @@ pub fn main() -> anyhow::Result<()> {
         None => {
             let model_name = args.which.model_filename();
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", &model_name);
+            let (owner, name) = model_name.split_once('/').unwrap_or(("", model_name.as_str()));
+            let api = api.model(owner, name);
             api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),

--- a/candle-examples/examples/flux/main.rs
+++ b/candle-examples/examples/flux/main.rs
@@ -88,11 +88,12 @@ fn run(args: Args) -> Result<()> {
 
     let api = hf_hub::HFClientSync::new()?;
     let bf_repo = {
-        let name = match model {
+        let id = match model {
             Model::Dev => "black-forest-labs/FLUX.1-dev",
             Model::Schnell => "black-forest-labs/FLUX.1-schnell",
         };
-        api.model("", name)
+        let (owner, name) = id.split_once('/').unwrap_or(("", id));
+        api.model(owner, name)
     };
     let device = candle_examples::device(cpu)?;
     if let Some(seed) = args.seed {
@@ -102,7 +103,7 @@ fn run(args: Args) -> Result<()> {
     let img = match decode_only {
         None => {
             let t5_emb = {
-                let repo = api.model("", "google/t5-v1_1-xxl");
+                let repo = api.model("google", "t5-v1_1-xxl");
                 let model_file = repo
                     .download_file()
                     .filename("model.safetensors")
@@ -119,7 +120,7 @@ fn run(args: Args) -> Result<()> {
                 let config: t5::Config = serde_json::from_str(&config)?;
                 let mut model = t5::T5EncoderModel::load(vb, &config)?;
                 let tokenizer_filename = api
-                    .model("", "lmz/mt5-tokenizers")
+                    .model("lmz", "mt5-tokenizers")
                     .download_file()
                     .filename("t5-v1_1-xxl.tokenizer.json")
                     .send()?;
@@ -136,7 +137,7 @@ fn run(args: Args) -> Result<()> {
             };
             println!("T5\n{t5_emb}");
             let clip_emb = {
-                let repo = api.model("", "openai/clip-vit-large-patch14");
+                let repo = api.model("openai", "clip-vit-large-patch14");
                 let model_file = repo
                     .download_file()
                     .filename("model.safetensors")
@@ -198,7 +199,7 @@ fn run(args: Args) -> Result<()> {
                 if quantized {
                     let model_file = match model {
                         Model::Schnell => api
-                            .model("", "lmz/candle-flux")
+                            .model("lmz", "candle-flux")
                             .download_file()
                             .filename("flux1-schnell.gguf")
                             .send()?,

--- a/candle-examples/examples/flux/main.rs
+++ b/candle-examples/examples/flux/main.rs
@@ -86,13 +86,13 @@ fn run(args: Args) -> Result<()> {
         None
     };
 
-    let api = hf_hub::api::sync::Api::new()?;
+    let api = hf_hub::HFClientSync::new()?;
     let bf_repo = {
         let name = match model {
             Model::Dev => "black-forest-labs/FLUX.1-dev",
             Model::Schnell => "black-forest-labs/FLUX.1-schnell",
         };
-        api.repo(hf_hub::Repo::model(name.to_string()))
+        api.model("", name)
     };
     let device = candle_examples::device(cpu)?;
     if let Some(seed) = args.seed {
@@ -102,21 +102,27 @@ fn run(args: Args) -> Result<()> {
     let img = match decode_only {
         None => {
             let t5_emb = {
-                let repo = api.repo(hf_hub::Repo::with_revision(
-                    "google/t5-v1_1-xxl".to_string(),
-                    hf_hub::RepoType::Model,
-                    "refs/pr/2".to_string(),
-                ));
-                let model_file = repo.get("model.safetensors")?;
+                let repo = api.model("", "google/t5-v1_1-xxl");
+                let model_file = repo
+                    .download_file()
+                    .filename("model.safetensors")
+                    .revision("refs/pr/2")
+                    .send()?;
                 let vb =
                     unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], dtype, &device)? };
-                let config_filename = repo.get("config.json")?;
+                let config_filename = repo
+                    .download_file()
+                    .filename("config.json")
+                    .revision("refs/pr/2")
+                    .send()?;
                 let config = std::fs::read_to_string(config_filename)?;
                 let config: t5::Config = serde_json::from_str(&config)?;
                 let mut model = t5::T5EncoderModel::load(vb, &config)?;
                 let tokenizer_filename = api
-                    .model("lmz/mt5-tokenizers".to_string())
-                    .get("t5-v1_1-xxl.tokenizer.json")?;
+                    .model("", "lmz/mt5-tokenizers")
+                    .download_file()
+                    .filename("t5-v1_1-xxl.tokenizer.json")
+                    .send()?;
                 let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
                 let mut tokens = tokenizer
                     .encode(prompt.as_str(), true)
@@ -130,10 +136,11 @@ fn run(args: Args) -> Result<()> {
             };
             println!("T5\n{t5_emb}");
             let clip_emb = {
-                let repo = api.repo(hf_hub::Repo::model(
-                    "openai/clip-vit-large-patch14".to_string(),
-                ));
-                let model_file = repo.get("model.safetensors")?;
+                let repo = api.model("", "openai/clip-vit-large-patch14");
+                let model_file = repo
+                    .download_file()
+                    .filename("model.safetensors")
+                    .send()?;
                 let vb =
                     unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], dtype, &device)? };
                 // https://huggingface.co/openai/clip-vit-large-patch14/blob/main/config.json
@@ -150,7 +157,10 @@ fn run(args: Args) -> Result<()> {
                 };
                 let model =
                     clip::text_model::ClipTextTransformer::new(vb.pp("text_model"), &config)?;
-                let tokenizer_filename = repo.get("tokenizer.json")?;
+                let tokenizer_filename = repo
+                    .download_file()
+                    .filename("tokenizer.json")
+                    .send()?;
                 let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
                 let tokens = tokenizer
                     .encode(prompt.as_str(), true)
@@ -188,8 +198,10 @@ fn run(args: Args) -> Result<()> {
                 if quantized {
                     let model_file = match model {
                         Model::Schnell => api
-                            .repo(hf_hub::Repo::model("lmz/candle-flux".to_string()))
-                            .get("flux1-schnell.gguf")?,
+                            .model("", "lmz/candle-flux")
+                            .download_file()
+                            .filename("flux1-schnell.gguf")
+                            .send()?,
                         Model::Dev => todo!(),
                     };
                     let vb = candle_transformers::quantized_var_builder::VarBuilder::from_gguf(
@@ -210,8 +222,14 @@ fn run(args: Args) -> Result<()> {
                     .to_dtype(dtype)?
                 } else {
                     let model_file = match model {
-                        Model::Schnell => bf_repo.get("flux1-schnell.safetensors")?,
-                        Model::Dev => bf_repo.get("flux1-dev.safetensors")?,
+                        Model::Schnell => bf_repo
+                            .download_file()
+                            .filename("flux1-schnell.safetensors")
+                            .send()?,
+                        Model::Dev => bf_repo
+                            .download_file()
+                            .filename("flux1-dev.safetensors")
+                            .send()?,
                     };
                     let vb = unsafe {
                         VarBuilder::from_mmaped_safetensors(&[model_file], dtype, &device)?
@@ -239,7 +257,10 @@ fn run(args: Args) -> Result<()> {
     println!("latent img\n{img}");
 
     let img = {
-        let model_file = bf_repo.get("ae.safetensors")?;
+        let model_file = bf_repo
+            .download_file()
+            .filename("ae.safetensors")
+            .send()?;
         let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], dtype, &device)? };
         let cfg = match model {
             Model::Dev => flux::autoencoder::Config::dev(),

--- a/candle-examples/examples/gemma/main.rs
+++ b/candle-examples/examples/gemma/main.rs
@@ -15,7 +15,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -266,7 +266,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => match args.which {
@@ -288,18 +288,23 @@ fn main() -> Result<()> {
             Which::InstructV3_1B => "google/gemma-3-1b-it".to_string(),
         },
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let repo = api.model("", &model_id);
+    let revision = args.revision;
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.clone())
+            .send()?,
     };
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.clone())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -307,7 +312,11 @@ fn main() -> Result<()> {
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
         None => match args.which {
-            Which::BaseV3_1B | Which::InstructV3_1B => vec![repo.get("model.safetensors")?],
+            Which::BaseV3_1B | Which::InstructV3_1B => vec![repo
+                .download_file()
+                .filename("model.safetensors")
+                .revision(revision.clone())
+                .send()?],
             _ => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
         },
     };

--- a/candle-examples/examples/gemma/main.rs
+++ b/candle-examples/examples/gemma/main.rs
@@ -288,7 +288,8 @@ fn main() -> Result<()> {
             Which::InstructV3_1B => "google/gemma-3-1b-it".to_string(),
         },
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let revision = args.revision;
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),

--- a/candle-examples/examples/gemma4/main.rs
+++ b/candle-examples/examples/gemma4/main.rs
@@ -245,7 +245,8 @@ fn main() -> Result<()> {
         .model_id
         .clone()
         .unwrap_or_else(|| "google/gemma-4-E4B-it".to_string());
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let revision = args.revision;
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),

--- a/candle-examples/examples/gemma4/main.rs
+++ b/candle-examples/examples/gemma4/main.rs
@@ -17,7 +17,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 #[allow(clippy::large_enum_variant)]
@@ -240,19 +240,20 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = args
         .model_id
         .clone()
         .unwrap_or_else(|| "google/gemma-4-E4B-it".to_string());
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let repo = api.model("", &model_id);
+    let revision = args.revision;
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.clone())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -262,7 +263,11 @@ fn main() -> Result<()> {
         None => {
             match candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json") {
                 Ok(files) => files,
-                Err(_) => vec![repo.get("model.safetensors")?],
+                Err(_) => vec![repo
+                    .download_file()
+                    .filename("model.safetensors")
+                    .revision(revision.clone())
+                    .send()?],
             }
         }
     };
@@ -282,7 +287,11 @@ fn main() -> Result<()> {
         let config: Gemma4Config = match args.config_file {
             Some(config_file) => serde_json::from_slice(&std::fs::read(config_file)?)?,
             None => {
-                let config_file = repo.get("config.json")?;
+                let config_file = repo
+                    .download_file()
+                    .filename("config.json")
+                    .revision(revision.clone())
+                    .send()?;
                 serde_json::from_slice(&std::fs::read(config_file)?)?
             }
         };
@@ -292,7 +301,11 @@ fn main() -> Result<()> {
         let mut config: Gemma4TextConfig = match args.config_file {
             Some(config_file) => serde_json::from_slice(&std::fs::read(config_file)?)?,
             None => {
-                let config_file = repo.get("config.json")?;
+                let config_file = repo
+                    .download_file()
+                    .filename("config.json")
+                    .revision(revision.clone())
+                    .send()?;
                 // For text-only, try to parse the text_config sub-object
                 let raw: serde_json::Value = serde_json::from_slice(&std::fs::read(config_file)?)?;
                 if let Some(text_cfg) = raw.get("text_config") {

--- a/candle-examples/examples/gguf-tokenizer.rs
+++ b/candle-examples/examples/gguf-tokenizer.rs
@@ -87,8 +87,9 @@ fn resolve_model_path(model: &str, revision: Option<String>) -> Result<PathBuf> 
     let filename = parts[2..].join("/");
 
     let api = HFClientSync::new()?;
+    let (owner, name) = repo_id.split_once('/').unwrap_or(("", repo_id.as_str()));
     let path = api
-        .model("", &repo_id)
+        .model(owner, name)
         .download_file()
         .filename(filename)
         .revision(revision.unwrap_or_else(|| "main".to_string()))

--- a/candle-examples/examples/gguf-tokenizer.rs
+++ b/candle-examples/examples/gguf-tokenizer.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use candle::quantized::gguf_file;
 use candle::quantized::tokenizer::TokenizerFromGguf;
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 #[derive(Parser, Debug)]
@@ -86,12 +86,12 @@ fn resolve_model_path(model: &str, revision: Option<String>) -> Result<PathBuf> 
     let repo_id = format!("{}/{}", parts[0], parts[1]);
     let filename = parts[2..].join("/");
 
-    let api = Api::new()?;
-    let repo = Repo::with_revision(
-        repo_id,
-        RepoType::Model,
-        revision.unwrap_or_else(|| "main".to_string()),
-    );
-    let path = api.repo(repo).get(&filename)?;
+    let api = HFClientSync::new()?;
+    let path = api
+        .model("", &repo_id)
+        .download_file()
+        .filename(filename)
+        .revision(revision.unwrap_or_else(|| "main".to_string()))
+        .send()?;
     Ok(path)
 }

--- a/candle-examples/examples/glm4/main.rs
+++ b/candle-examples/examples/glm4/main.rs
@@ -5,7 +5,6 @@ use candle_transformers::models::glm4::{Config as ConfigOld, EosTokenId, Model a
 use candle_transformers::models::glm4_new::{Config as ConfigNew, ModelForCausalLM as ModelNew};
 
 use clap::Parser;
-use hf_hub::{Repo, RepoType};
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -214,12 +213,13 @@ fn main() -> anyhow::Result<()> {
 
     let start = std::time::Instant::now();
     let api = match args.cache_path.as_ref() {
-        None => hf_hub::api::sync::Api::new()?,
-        Some(path) => {
-            hf_hub::api::sync::ApiBuilder::from_cache(hf_hub::Cache::new(path.to_string().into()))
+        None => hf_hub::HFClientSync::new()?,
+        Some(path) => hf_hub::HFClientSync::from_inner(
+            hf_hub::HFClient::builder()
+                .cache_dir(std::path::PathBuf::from(path.to_string()))
                 .build()
-                .map_err(anyhow::Error::msg)?
-        }
+                .map_err(anyhow::Error::msg)?,
+        )?,
     };
 
     let model_id = match args.model_id.as_ref() {
@@ -233,16 +233,24 @@ fn main() -> anyhow::Result<()> {
         Some(rev) => rev.to_string(),
         None => "main".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match (args.weight_path.as_ref(), args.tokenizer.as_ref()) {
         (Some(_), Some(file)) => std::path::PathBuf::from(file),
         (None, Some(file)) => std::path::PathBuf::from(file),
         (Some(path), None) => std::path::Path::new(path).join("tokenizer.json"),
-        (None, None) => repo.get("tokenizer.json")?,
+        (None, None) => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.clone())
+            .send()?,
     };
     let config_filename = match &args.weight_path {
         Some(path) => std::path::Path::new(path).join("config.json"),
-        _ => repo.get("config.json")?,
+        _ => repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.clone())
+            .send()?,
     };
 
     let filenames = match &args.weight_path {

--- a/candle-examples/examples/glm4/main.rs
+++ b/candle-examples/examples/glm4/main.rs
@@ -233,7 +233,8 @@ fn main() -> anyhow::Result<()> {
         Some(rev) => rev.to_string(),
         None => "main".to_string(),
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match (args.weight_path.as_ref(), args.tokenizer.as_ref()) {
         (Some(_), Some(file)) => std::path::PathBuf::from(file),
         (None, Some(file)) => std::path::PathBuf::from(file),

--- a/candle-examples/examples/granite/main.rs
+++ b/candle-examples/examples/granite/main.rs
@@ -121,7 +121,8 @@ fn main() -> Result<()> {
         });
         println!("loading the model weights from {model_id}");
         let revision = args.revision.unwrap_or("main".to_string());
-        let api = api.model("", &model_id);
+        let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+        let api = api.model(owner, name);
 
         let tokenizer_filename = api
             .download_file()

--- a/candle-examples/examples/granite/main.rs
+++ b/candle-examples/examples/granite/main.rs
@@ -12,7 +12,7 @@ use clap::{Parser, ValueEnum};
 use candle::{DType, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use std::io::Write;
 
 use candle_transformers::models::granite as model;
@@ -115,16 +115,24 @@ fn main() -> Result<()> {
         None => DType::F16,
     };
     let (granite, tokenizer_filename, mut cache, config) = {
-        let api = Api::new()?;
+        let api = HFClientSync::new()?;
         let model_id = args.model_id.unwrap_or_else(|| match args.model_type {
             GraniteModel::Granite7bInstruct => "ibm-granite/granite-7b-instruct".to_string(),
         });
         println!("loading the model weights from {model_id}");
         let revision = args.revision.unwrap_or("main".to_string());
-        let api = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+        let api = api.model("", &model_id);
 
-        let tokenizer_filename = api.get("tokenizer.json")?;
-        let config_filename = api.get("config.json")?;
+        let tokenizer_filename = api
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.clone())
+            .send()?;
+        let config_filename = api
+            .download_file()
+            .filename("config.json")
+            .revision(revision.clone())
+            .send()?;
         let config: GraniteConfig = serde_json::from_slice(&std::fs::read(config_filename)?)?;
         let config = config.into_config(args.use_flash_attn);
 

--- a/candle-examples/examples/granitemoehybrid/main.rs
+++ b/candle-examples/examples/granitemoehybrid/main.rs
@@ -153,7 +153,8 @@ fn main() -> Result<()> {
         } else {
             let api = HFClientSync::new()?;
             let revision = args.revision.clone().unwrap_or_else(|| "main".to_string());
-            let repo = api.model("", &model_id);
+            let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+            let repo = api.model(owner, name);
 
             let tokenizer_filename = repo
                 .download_file()

--- a/candle-examples/examples/granitemoehybrid/main.rs
+++ b/candle-examples/examples/granitemoehybrid/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
 use candle_transformers::models::granitemoehybrid as model;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use model::{GraniteMoeHybrid, GraniteMoeHybridCache, GraniteMoeHybridConfig};
 
 use std::{io::Write, path::Path};
@@ -151,12 +151,20 @@ fn main() -> Result<()> {
                 config,
             )
         } else {
-            let api = Api::new()?;
+            let api = HFClientSync::new()?;
             let revision = args.revision.clone().unwrap_or_else(|| "main".to_string());
-            let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+            let repo = api.model("", &model_id);
 
-            let tokenizer_filename = repo.get("tokenizer.json")?;
-            let config_filename = repo.get("config.json")?;
+            let tokenizer_filename = repo
+                .download_file()
+                .filename("tokenizer.json")
+                .revision(revision.clone())
+                .send()?;
+            let config_filename = repo
+                .download_file()
+                .filename("config.json")
+                .revision(revision.clone())
+                .send()?;
             let config: GraniteMoeHybridConfig =
                 serde_json::from_slice(&std::fs::read(config_filename)?)?;
             let config = config.into_config(args.use_flash_attn);

--- a/candle-examples/examples/gte-qwen/main.rs
+++ b/candle-examples/examples/gte-qwen/main.rs
@@ -52,7 +52,8 @@ struct ConfigFiles {
 // Loading the model from the HuggingFace Hub. Network access is required.
 fn load_from_hub(model_id: &str, revision: &str) -> Result<ConfigFiles> {
     let api = HFClientSync::new()?;
-    let repo = api.model("", model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id));
+    let repo = api.model(owner, name);
     Ok(ConfigFiles {
         config: repo
             .download_file()

--- a/candle-examples/examples/gte-qwen/main.rs
+++ b/candle-examples/examples/gte-qwen/main.rs
@@ -11,7 +11,7 @@ use candle_transformers::models::qwen2::{Config, Model};
 
 use candle::{DType, Tensor};
 use candle_nn::VarBuilder;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{
     utils::padding::{PaddingDirection, PaddingParams, PaddingStrategy},
     Tokenizer,
@@ -51,15 +51,19 @@ struct ConfigFiles {
 
 // Loading the model from the HuggingFace Hub. Network access is required.
 fn load_from_hub(model_id: &str, revision: &str) -> Result<ConfigFiles> {
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        model_id.to_string(),
-        RepoType::Model,
-        revision.to_string(),
-    ));
+    let api = HFClientSync::new()?;
+    let repo = api.model("", model_id);
     Ok(ConfigFiles {
-        config: repo.get("config.json")?,
-        tokenizer: repo.get("tokenizer.json")?,
+        config: repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.to_string())
+            .send()?,
+        tokenizer: repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.to_string())
+            .send()?,
         weights: candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
     })
 }

--- a/candle-examples/examples/helium/main.rs
+++ b/candle-examples/examples/helium/main.rs
@@ -16,7 +16,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 #[derive(Debug, Clone)]
@@ -272,7 +272,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => {
@@ -283,21 +283,26 @@ fn main() -> Result<()> {
             name.to_string()
         }
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let repo = api.model("", &model_id);
+    let revision = args.revision;
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.clone())
+            .send()?,
     };
     let filenames = match args.weights {
         Some(files) => files
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => vec![repo.get("model.safetensors")?],
+        None => vec![repo
+            .download_file()
+            .filename("model.safetensors")
+            .revision(revision.clone())
+            .send()?],
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
@@ -305,7 +310,11 @@ fn main() -> Result<()> {
     let start = std::time::Instant::now();
     let config_file = match args.config {
         Some(config_file) => std::path::PathBuf::from(config_file),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.clone())
+            .send()?,
     };
     let config = match args.which {
         Which::V1Preview => Config::Preview(serde_json::from_slice(&std::fs::read(config_file)?)?),

--- a/candle-examples/examples/helium/main.rs
+++ b/candle-examples/examples/helium/main.rs
@@ -283,7 +283,8 @@ fn main() -> Result<()> {
             name.to_string()
         }
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let revision = args.revision;
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),

--- a/candle-examples/examples/hiera/main.rs
+++ b/candle-examples/examples/hiera/main.rs
@@ -72,9 +72,9 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", &model_name);
+            api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/hiera/main.rs
+++ b/candle-examples/examples/hiera/main.rs
@@ -73,7 +73,8 @@ pub fn main() -> anyhow::Result<()> {
         None => {
             let model_name = args.which.model_filename();
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", &model_name);
+            let (owner, name) = model_name.split_once('/').unwrap_or(("", model_name.as_str()));
+            let api = api.model(owner, name);
             api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),

--- a/candle-examples/examples/jina-bert/main.rs
+++ b/candle-examples/examples/jina-bert/main.rs
@@ -46,7 +46,7 @@ struct Args {
 
 impl Args {
     fn build_model_and_tokenizer(&self) -> anyhow::Result<(BertModel, tokenizers::Tokenizer)> {
-        use hf_hub::{api::sync::Api, Repo, RepoType};
+        use hf_hub::HFClientSync;
         let model_name = match self.model.as_ref() {
             Some(model) => model.to_string(),
             None => "jinaai/jina-embeddings-v2-base-en".to_string(),
@@ -54,15 +54,19 @@ impl Args {
 
         let model = match &self.model_file {
             Some(model_file) => std::path::PathBuf::from(model_file),
-            None => Api::new()?
-                .repo(Repo::new(model_name.to_string(), RepoType::Model))
-                .get("model.safetensors")?,
+            None => HFClientSync::new()?
+                .model("", &model_name)
+                .download_file()
+                .filename("model.safetensors")
+                .send()?,
         };
         let tokenizer = match &self.tokenizer {
             Some(file) => std::path::PathBuf::from(file),
-            None => Api::new()?
-                .repo(Repo::new(model_name.to_string(), RepoType::Model))
-                .get("tokenizer.json")?,
+            None => HFClientSync::new()?
+                .model("", &model_name)
+                .download_file()
+                .filename("tokenizer.json")
+                .send()?,
         };
         let device = candle_examples::device(self.cpu)?;
         let tokenizer = tokenizers::Tokenizer::from_file(tokenizer).map_err(E::msg)?;

--- a/candle-examples/examples/jina-bert/main.rs
+++ b/candle-examples/examples/jina-bert/main.rs
@@ -51,11 +51,12 @@ impl Args {
             Some(model) => model.to_string(),
             None => "jinaai/jina-embeddings-v2-base-en".to_string(),
         };
+        let (owner, name) = model_name.split_once('/').unwrap_or(("", model_name.as_str()));
 
         let model = match &self.model_file {
             Some(model_file) => std::path::PathBuf::from(model_file),
             None => HFClientSync::new()?
-                .model("", &model_name)
+                .model(owner, name)
                 .download_file()
                 .filename("model.safetensors")
                 .send()?,
@@ -63,7 +64,7 @@ impl Args {
         let tokenizer = match &self.tokenizer {
             Some(file) => std::path::PathBuf::from(file),
             None => HFClientSync::new()?
-                .model("", &model_name)
+                .model(owner, name)
                 .download_file()
                 .filename("tokenizer.json")
                 .send()?,

--- a/candle-examples/examples/llama/main.rs
+++ b/candle-examples/examples/llama/main.rs
@@ -18,7 +18,7 @@ use clap::{Parser, ValueEnum};
 use candle::{DType, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use std::io::Write;
 
 use candle_transformers::models::llama as model;
@@ -145,7 +145,7 @@ fn main() -> Result<()> {
         None => DType::F16,
     };
     let (llama, tokenizer_filename, mut cache, config) = {
-        let api = Api::new()?;
+        let api = HFClientSync::new()?;
         let model_id = args.model_id.unwrap_or_else(|| {
             let str = match args.which {
                 Which::V1 => "Narsil/amall-7b",
@@ -171,10 +171,10 @@ fn main() -> Result<()> {
         });
         println!("loading the model weights from {model_id}");
         let revision = args.revision.unwrap_or("main".to_string());
-        let api = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+        let api = api.model("", &model_id);
 
-        let tokenizer_filename = api.get("tokenizer.json")?;
-        let config_filename = api.get("config.json")?;
+        let tokenizer_filename = api.download_file().filename("tokenizer.json").revision(&revision).send()?;
+        let config_filename = api.download_file().filename("config.json").revision(&revision).send()?;
         let config: LlamaConfig = serde_json::from_slice(&std::fs::read(config_filename)?)?;
         let config = config.into_config(args.use_flash_attn);
 
@@ -199,7 +199,7 @@ fn main() -> Result<()> {
             | Which::V32_1b
             | Which::V32_1bInstruct
             | Which::TinyLlama1_1BChat => {
-                vec![api.get("model.safetensors")?]
+                vec![api.download_file().filename("model.safetensors").revision(&revision).send()?]
             }
         };
         let cache = model::Cache::new(!args.no_kv_cache, dtype, &config, &device)?;

--- a/candle-examples/examples/llama/main.rs
+++ b/candle-examples/examples/llama/main.rs
@@ -171,7 +171,8 @@ fn main() -> Result<()> {
         });
         println!("loading the model weights from {model_id}");
         let revision = args.revision.unwrap_or("main".to_string());
-        let api = api.model("", &model_id);
+        let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+        let api = api.model(owner, name);
 
         let tokenizer_filename = api.download_file().filename("tokenizer.json").revision(&revision).send()?;
         let config_filename = api.download_file().filename("config.json").revision(&revision).send()?;

--- a/candle-examples/examples/llama2-c/main.rs
+++ b/candle-examples/examples/llama2-c/main.rs
@@ -125,7 +125,7 @@ impl Args {
             Some(config) => std::path::PathBuf::from(config),
             None => {
                 let api = hf_hub::HFClientSync::new()?;
-                let api = api.model("", "hf-internal-testing/llama-tokenizer");
+                let api = api.model("hf-internal-testing", "llama-tokenizer");
                 api.download_file().filename("tokenizer.json").send()?
             }
         };
@@ -176,7 +176,8 @@ fn run_eval(args: &EvaluationCmd, common_args: &Args) -> Result<()> {
         None => {
             let api = hf_hub::HFClientSync::new()?;
             println!("loading the model weights from {}", args.model_id);
-            let api = api.model("", &args.model_id);
+            let (owner, name) = args.model_id.split_once('/').unwrap_or(("", args.model_id.as_str()));
+            let api = api.model(owner, name);
             api.download_file().filename(&args.which_model).send()?
         }
     };
@@ -196,7 +197,8 @@ fn run_eval(args: &EvaluationCmd, common_args: &Args) -> Result<()> {
             let api = hf_hub::HFClientSync::new()?;
             let model_id = "roneneldan/TinyStories"; // TODO: Make this configurable.
             println!("loading the evaluation dataset from {}", model_id);
-            let api = api.dataset("", model_id);
+            let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id));
+            let api = api.dataset(owner, name);
             let dataset_path = api.download_file().filename("TinyStories-valid.txt").send()?;
             let file = std::fs::File::open(dataset_path)?;
             let file = std::io::BufReader::new(file);
@@ -248,7 +250,8 @@ fn run_inference(args: &InferenceCmd, common_args: &Args) -> Result<()> {
         None => {
             let api = hf_hub::HFClientSync::new()?;
             println!("loading the model weights from {}", args.model_id);
-            let api = api.model("", &args.model_id);
+            let (owner, name) = args.model_id.split_once('/').unwrap_or(("", args.model_id.as_str()));
+            let api = api.model(owner, name);
             api.download_file().filename(&args.which_model).send()?
         }
     };

--- a/candle-examples/examples/llama2-c/main.rs
+++ b/candle-examples/examples/llama2-c/main.rs
@@ -124,9 +124,9 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
-                let api = api.model("hf-internal-testing/llama-tokenizer".to_string());
-                api.get("tokenizer.json")?
+                let api = hf_hub::HFClientSync::new()?;
+                let api = api.model("", "hf-internal-testing/llama-tokenizer");
+                api.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(E::msg)
@@ -174,10 +174,10 @@ fn run_eval(args: &EvaluationCmd, common_args: &Args) -> Result<()> {
     let config_path = match &args.config {
         Some(config) => std::path::PathBuf::from(config),
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
+            let api = hf_hub::HFClientSync::new()?;
             println!("loading the model weights from {}", args.model_id);
-            let api = api.model(args.model_id.clone());
-            api.get(&args.which_model)?
+            let api = api.model("", &args.model_id);
+            api.download_file().filename(&args.which_model).send()?
         }
     };
 
@@ -193,11 +193,11 @@ fn run_eval(args: &EvaluationCmd, common_args: &Args) -> Result<()> {
 
     let tokens = match &args.pretokenized_dir {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
+            let api = hf_hub::HFClientSync::new()?;
             let model_id = "roneneldan/TinyStories"; // TODO: Make this configurable.
             println!("loading the evaluation dataset from {}", model_id);
-            let api = api.dataset(model_id.to_string());
-            let dataset_path = api.get("TinyStories-valid.txt")?;
+            let api = api.dataset("", model_id);
+            let dataset_path = api.download_file().filename("TinyStories-valid.txt").send()?;
             let file = std::fs::File::open(dataset_path)?;
             let file = std::io::BufReader::new(file);
             let mut tokens = vec![];
@@ -246,10 +246,10 @@ fn run_inference(args: &InferenceCmd, common_args: &Args) -> Result<()> {
     let config_path = match &args.config {
         Some(config) => std::path::PathBuf::from(config),
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
+            let api = hf_hub::HFClientSync::new()?;
             println!("loading the model weights from {}", args.model_id);
-            let api = api.model(args.model_id.clone());
-            api.get(&args.which_model)?
+            let api = api.model("", &args.model_id);
+            api.download_file().filename(&args.which_model).send()?
         }
     };
 

--- a/candle-examples/examples/llama_multiprocess/main.rs
+++ b/candle-examples/examples/llama_multiprocess/main.rs
@@ -17,7 +17,7 @@ use candle_transformers::generation::LogitsProcessor;
 use candle_transformers::models::llama::LlamaEosToks;
 use cudarc::driver::safe::CudaDevice;
 use cudarc::nccl::safe::{Comm, Id};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use std::io::Write;
 use std::rc::Rc;
 
@@ -105,7 +105,7 @@ fn main() -> Result<()> {
         bail!("comm file {comm_file:?} already exists, please remove it first")
     }
 
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model) => model,
         None => match args.which {
@@ -117,10 +117,10 @@ fn main() -> Result<()> {
     };
     println!("loading the model weights from {model_id}");
     let revision = args.revision.unwrap_or("main".to_string());
-    let api = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
-    let config_filename = api.get("config.json")?;
+    let api = api.model("", &model_id);
+    let config_filename = api.download_file().filename("config.json").revision(&revision).send()?;
     let config: Config = serde_json::from_slice(&std::fs::read(config_filename)?)?;
-    let tokenizer_filename = api.get("tokenizer.json")?;
+    let tokenizer_filename = api.download_file().filename("tokenizer.json").revision(&revision).send()?;
     let filenames = candle_examples::hub_load_safetensors(&api, "model.safetensors.index.json")?;
 
     let rank = match args.rank {

--- a/candle-examples/examples/llama_multiprocess/main.rs
+++ b/candle-examples/examples/llama_multiprocess/main.rs
@@ -117,7 +117,8 @@ fn main() -> Result<()> {
     };
     println!("loading the model weights from {model_id}");
     let revision = args.revision.unwrap_or("main".to_string());
-    let api = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let api = api.model(owner, name);
     let config_filename = api.download_file().filename("config.json").revision(&revision).send()?;
     let config: Config = serde_json::from_slice(&std::fs::read(config_filename)?)?;
     let tokenizer_filename = api.download_file().filename("tokenizer.json").revision(&revision).send()?;

--- a/candle-examples/examples/llava/image_processor.rs
+++ b/candle-examples/examples/llava/image_processor.rs
@@ -74,7 +74,8 @@ fn default_image_std() -> Vec<f32> {
 impl ImageProcessor {
     pub fn from_pretrained(clip_id: &str) -> Result<Self> {
         let api = HFClientSync::new().map_err(|e| candle::Error::Msg(e.to_string()))?;
-        let api = api.model("", clip_id);
+        let (owner, name) = clip_id.split_once('/').unwrap_or(("", clip_id));
+        let api = api.model(owner, name);
         let config_filename = api
             .download_file()
             .filename("preprocessor_config.json")

--- a/candle-examples/examples/llava/image_processor.rs
+++ b/candle-examples/examples/llava/image_processor.rs
@@ -5,7 +5,7 @@ use candle_transformers::models::llava::{
     config::{HFPreProcessorConfig, LLaVAConfig},
     utils::select_best_resolution,
 };
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use image::{imageops::overlay, DynamicImage, GenericImageView, Rgb, RgbImage};
 use serde::{Deserialize, Serialize};
 
@@ -73,10 +73,12 @@ fn default_image_std() -> Vec<f32> {
 
 impl ImageProcessor {
     pub fn from_pretrained(clip_id: &str) -> Result<Self> {
-        let api = Api::new().map_err(|e| candle::Error::Msg(e.to_string()))?;
-        let api = api.model(clip_id.to_string());
+        let api = HFClientSync::new().map_err(|e| candle::Error::Msg(e.to_string()))?;
+        let api = api.model("", clip_id);
         let config_filename = api
-            .get("preprocessor_config.json")
+            .download_file()
+            .filename("preprocessor_config.json")
+            .send()
             .map_err(|e| candle::Error::Msg(e.to_string()))?;
         let image_processor =
             serde_json::from_slice(&std::fs::read(config_filename).map_err(candle::Error::Io)?)

--- a/candle-examples/examples/llava/main.rs
+++ b/candle-examples/examples/llava/main.rs
@@ -15,7 +15,7 @@ use candle_transformers::models::llava::{config::LLaVAConfig, LLaVA};
 use clap::Parser;
 use constants::*;
 use conversation::Conversation;
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use image_processor::{process_image, ImageProcessor};
 use std::io::Write;
 use tokenizers::Tokenizer;
@@ -150,21 +150,21 @@ fn main() -> Result<()> {
     let mut args = Args::parse();
     let device = candle_examples::device(args.cpu)?;
     println!("Start loading model");
-    let api = Api::new()?;
-    let api = api.model(args.model_path.clone());
+    let api = HFClientSync::new()?;
+    let api = api.model("", &args.model_path);
     let (llava_config, tokenizer, clip_vision_config, image_processor) = if args.hf {
-        let config_filename = api.get("config.json")?;
+        let config_filename = api.download_file().filename("config.json").send()?;
         let hf_llava_config: HFLLaVAConfig =
             serde_json::from_slice(&std::fs::read(config_filename)?)?;
-        let generation_config_filename = api.get("generation_config.json")?;
+        let generation_config_filename = api.download_file().filename("generation_config.json").send()?;
         let generation_config: HFGenerationConfig =
             serde_json::from_slice(&std::fs::read(generation_config_filename)?)?;
-        let preprocessor_config_filename = api.get("preprocessor_config.json")?;
+        let preprocessor_config_filename = api.download_file().filename("preprocessor_config.json").send()?;
         let preprocessor_config: HFPreProcessorConfig =
             serde_json::from_slice(&std::fs::read(preprocessor_config_filename)?)?;
         let llava_config =
             hf_llava_config.to_llava_config(&generation_config, &preprocessor_config);
-        let tokenizer_filename = api.get("tokenizer.json")?;
+        let tokenizer_filename = api.download_file().filename("tokenizer.json").send()?;
         let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
         let clip_vision_config = hf_llava_config.to_clip_vision_config();
         (
@@ -174,7 +174,7 @@ fn main() -> Result<()> {
             ImageProcessor::from_hf_preprocessor_config(&preprocessor_config),
         )
     } else {
-        let config_filename = api.get("config.json")?;
+        let config_filename = api.download_file().filename("config.json").send()?;
         let llava_config: LLaVAConfig = serde_json::from_slice(&std::fs::read(config_filename)?)?;
         let tokenizer = Tokenizer::from_file(&args.tokenizer_path)
             .map_err(|e| E::msg(format!("Error loading {}: {}", &args.tokenizer_path, e)))?;

--- a/candle-examples/examples/llava/main.rs
+++ b/candle-examples/examples/llava/main.rs
@@ -151,7 +151,8 @@ fn main() -> Result<()> {
     let device = candle_examples::device(args.cpu)?;
     println!("Start loading model");
     let api = HFClientSync::new()?;
-    let api = api.model("", &args.model_path);
+    let (owner, name) = args.model_path.split_once('/').unwrap_or(("", args.model_path.as_str()));
+    let api = api.model(owner, name);
     let (llava_config, tokenizer, clip_vision_config, image_processor) = if args.hf {
         let config_filename = api.download_file().filename("config.json").send()?;
         let hf_llava_config: HFLLaVAConfig =

--- a/candle-examples/examples/mamba-minimal/main.rs
+++ b/candle-examples/examples/mamba-minimal/main.rs
@@ -14,7 +14,7 @@ use candle::{DType, Device, Module, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -235,23 +235,21 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id
-            .unwrap_or_else(|| args.which.model_id().to_string()),
-        RepoType::Model,
-        args.revision
-            .unwrap_or_else(|| args.which.revision().to_string()),
-    ));
+    let api = HFClientSync::new()?;
+    let model_id = args.model_id
+        .unwrap_or_else(|| args.which.model_id().to_string());
+    let revision = args.revision
+        .unwrap_or_else(|| args.which.revision().to_string());
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .model("EleutherAI/gpt-neox-20b".to_string())
-            .get("tokenizer.json")?,
+            .model("", "EleutherAI/gpt-neox-20b")
+            .download_file().filename("tokenizer.json").send()?,
     };
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo.download_file().filename("config.json").revision(&revision).send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -259,7 +257,7 @@ fn main() -> Result<()> {
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
         None => {
-            vec![repo.get("model.safetensors")?]
+            vec![repo.download_file().filename("model.safetensors").revision(&revision).send()?]
         }
     };
     println!("retrieved the files in {:?}", start.elapsed());

--- a/candle-examples/examples/mamba-minimal/main.rs
+++ b/candle-examples/examples/mamba-minimal/main.rs
@@ -240,11 +240,12 @@ fn main() -> Result<()> {
         .unwrap_or_else(|| args.which.model_id().to_string());
     let revision = args.revision
         .unwrap_or_else(|| args.which.revision().to_string());
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .model("", "EleutherAI/gpt-neox-20b")
+            .model("EleutherAI", "gpt-neox-20b")
             .download_file().filename("tokenizer.json").send()?,
     };
     let config_filename = match args.config_file {

--- a/candle-examples/examples/mamba/main.rs
+++ b/candle-examples/examples/mamba/main.rs
@@ -256,11 +256,12 @@ fn main() -> Result<()> {
         .unwrap_or_else(|| args.which.model_id().to_string());
     let revision = args.revision
         .unwrap_or_else(|| args.which.revision().to_string());
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .model("", "EleutherAI/gpt-neox-20b")
+            .model("EleutherAI", "gpt-neox-20b")
             .download_file().filename("tokenizer.json").send()?,
     };
     let config_filename = match args.config_file {

--- a/candle-examples/examples/mamba/main.rs
+++ b/candle-examples/examples/mamba/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -251,23 +251,21 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id
-            .unwrap_or_else(|| args.which.model_id().to_string()),
-        RepoType::Model,
-        args.revision
-            .unwrap_or_else(|| args.which.revision().to_string()),
-    ));
+    let api = HFClientSync::new()?;
+    let model_id = args.model_id
+        .unwrap_or_else(|| args.which.model_id().to_string());
+    let revision = args.revision
+        .unwrap_or_else(|| args.which.revision().to_string());
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .model("EleutherAI/gpt-neox-20b".to_string())
-            .get("tokenizer.json")?,
+            .model("", "EleutherAI/gpt-neox-20b")
+            .download_file().filename("tokenizer.json").send()?,
     };
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo.download_file().filename("config.json").revision(&revision).send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -275,7 +273,7 @@ fn main() -> Result<()> {
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
         None => {
-            vec![repo.get("model.safetensors")?]
+            vec![repo.download_file().filename("model.safetensors").revision(&revision).send()?]
         }
     };
     println!("retrieved the files in {:?}", start.elapsed());

--- a/candle-examples/examples/mamba2/main.rs
+++ b/candle-examples/examples/mamba2/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -272,18 +272,18 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = args
         .model_id
         .unwrap_or_else(|| args.which.model_id().to_string());
-    let repo = api.repo(Repo::new(model_id.clone(), RepoType::Model));
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").send()?,
     };
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo.download_file().filename("config.json").send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -291,7 +291,7 @@ fn main() -> Result<()> {
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
         None => {
-            vec![repo.get("model.safetensors")?]
+            vec![repo.download_file().filename("model.safetensors").send()?]
         }
     };
     println!("retrieved the files in {:?}", start.elapsed());

--- a/candle-examples/examples/mamba2/main.rs
+++ b/candle-examples/examples/mamba2/main.rs
@@ -276,7 +276,8 @@ fn main() -> Result<()> {
     let model_id = args
         .model_id
         .unwrap_or_else(|| args.which.model_id().to_string());
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => repo.download_file().filename("tokenizer.json").send()?,

--- a/candle-examples/examples/marian-mt/main.rs
+++ b/candle-examples/examples/marian-mt/main.rs
@@ -91,6 +91,9 @@ pub fn main() -> anyhow::Result<()> {
         | LanguagePair::EnFr
         | LanguagePair::EnRu => "KeighBee/candle-marian",
     };
+    let (tokenizer_default_owner, tokenizer_default_name) = tokenizer_default_repo
+        .split_once('/')
+        .unwrap_or(("", tokenizer_default_repo));
     let tokenizer = {
         let tokenizer = match args.tokenizer {
             Some(tokenizer) => std::path::PathBuf::from(tokenizer),
@@ -108,7 +111,7 @@ pub fn main() -> anyhow::Result<()> {
                     }
                 };
                 HFClientSync::new()?
-                    .model("", tokenizer_default_repo)
+                    .model(tokenizer_default_owner, tokenizer_default_name)
                     .download_file().filename(filename).send()?
             }
         };
@@ -132,7 +135,7 @@ pub fn main() -> anyhow::Result<()> {
                     }
                 };
                 HFClientSync::new()?
-                    .model("", tokenizer_default_repo)
+                    .model(tokenizer_default_owner, tokenizer_default_name)
                     .download_file().filename(filename).send()?
             }
         };
@@ -179,7 +182,8 @@ pub fn main() -> anyhow::Result<()> {
                         anyhow::bail!("big is not supported for language pair {lp:?}")
                     }
                 };
-                let repo = api.model("", model_name);
+                let (owner, name) = model_name.split_once('/').unwrap_or(("", model_name));
+                let repo = api.model(owner, name);
                 repo.download_file()
                     .filename("model.safetensors")
                     .maybe_revision(revision)

--- a/candle-examples/examples/marian-mt/main.rs
+++ b/candle-examples/examples/marian-mt/main.rs
@@ -70,7 +70,7 @@ struct Args {
 }
 
 pub fn main() -> anyhow::Result<()> {
-    use hf_hub::api::sync::Api;
+    use hf_hub::HFClientSync;
     let args = Args::parse();
 
     let config = match (args.which, args.language_pair) {
@@ -107,9 +107,9 @@ pub fn main() -> anyhow::Result<()> {
                         anyhow::bail!("big is not supported for language pair {lp:?}")
                     }
                 };
-                Api::new()?
-                    .model(tokenizer_default_repo.to_string())
-                    .get(filename)?
+                HFClientSync::new()?
+                    .model("", tokenizer_default_repo)
+                    .download_file().filename(filename).send()?
             }
         };
         Tokenizer::from_file(&tokenizer).map_err(E::msg)?
@@ -131,9 +131,9 @@ pub fn main() -> anyhow::Result<()> {
                         anyhow::bail!("big is not supported for language pair {lp:?}")
                     }
                 };
-                Api::new()?
-                    .model(tokenizer_default_repo.to_string())
-                    .get(filename)?
+                HFClientSync::new()?
+                    .model("", tokenizer_default_repo)
+                    .download_file().filename(filename).send()?
             }
         };
         Tokenizer::from_file(&tokenizer).map_err(E::msg)?
@@ -145,46 +145,45 @@ pub fn main() -> anyhow::Result<()> {
         let model = match args.model {
             Some(model) => std::path::PathBuf::from(model),
             None => {
-                let api = Api::new()?;
-                let api = match (args.which, args.language_pair) {
-                    (Which::Base, LanguagePair::FrEn) => api.repo(hf_hub::Repo::with_revision(
-                        "Helsinki-NLP/opus-mt-fr-en".to_string(),
-                        hf_hub::RepoType::Model,
-                        "refs/pr/4".to_string(),
-                    )),
-                    (Which::Big, LanguagePair::FrEn) => {
-                        api.model("Helsinki-NLP/opus-mt-tc-big-fr-en".to_string())
-                    }
-                    (Which::Base, LanguagePair::EnZh) => api.repo(hf_hub::Repo::with_revision(
-                        "Helsinki-NLP/opus-mt-en-zh".to_string(),
-                        hf_hub::RepoType::Model,
-                        "refs/pr/13".to_string(),
-                    )),
-                    (Which::Base, LanguagePair::EnHi) => api.repo(hf_hub::Repo::with_revision(
-                        "Helsinki-NLP/opus-mt-en-hi".to_string(),
-                        hf_hub::RepoType::Model,
-                        "refs/pr/3".to_string(),
-                    )),
-                    (Which::Base, LanguagePair::EnEs) => api.repo(hf_hub::Repo::with_revision(
-                        "Helsinki-NLP/opus-mt-en-es".to_string(),
-                        hf_hub::RepoType::Model,
-                        "refs/pr/4".to_string(),
-                    )),
-                    (Which::Base, LanguagePair::EnFr) => api.repo(hf_hub::Repo::with_revision(
-                        "Helsinki-NLP/opus-mt-en-fr".to_string(),
-                        hf_hub::RepoType::Model,
-                        "refs/pr/9".to_string(),
-                    )),
-                    (Which::Base, LanguagePair::EnRu) => api.repo(hf_hub::Repo::with_revision(
-                        "Helsinki-NLP/opus-mt-en-ru".to_string(),
-                        hf_hub::RepoType::Model,
-                        "refs/pr/7".to_string(),
-                    )),
+                let api = HFClientSync::new()?;
+                let (model_name, revision): (&str, Option<String>) = match (args.which, args.language_pair) {
+                    (Which::Base, LanguagePair::FrEn) => (
+                        "Helsinki-NLP/opus-mt-fr-en",
+                        Some("refs/pr/4".to_string()),
+                    ),
+                    (Which::Big, LanguagePair::FrEn) => (
+                        "Helsinki-NLP/opus-mt-tc-big-fr-en",
+                        None,
+                    ),
+                    (Which::Base, LanguagePair::EnZh) => (
+                        "Helsinki-NLP/opus-mt-en-zh",
+                        Some("refs/pr/13".to_string()),
+                    ),
+                    (Which::Base, LanguagePair::EnHi) => (
+                        "Helsinki-NLP/opus-mt-en-hi",
+                        Some("refs/pr/3".to_string()),
+                    ),
+                    (Which::Base, LanguagePair::EnEs) => (
+                        "Helsinki-NLP/opus-mt-en-es",
+                        Some("refs/pr/4".to_string()),
+                    ),
+                    (Which::Base, LanguagePair::EnFr) => (
+                        "Helsinki-NLP/opus-mt-en-fr",
+                        Some("refs/pr/9".to_string()),
+                    ),
+                    (Which::Base, LanguagePair::EnRu) => (
+                        "Helsinki-NLP/opus-mt-en-ru",
+                        Some("refs/pr/7".to_string()),
+                    ),
                     (Which::Big, lp) => {
                         anyhow::bail!("big is not supported for language pair {lp:?}")
                     }
                 };
-                api.get("model.safetensors")?
+                let repo = api.model("", model_name);
+                repo.download_file()
+                    .filename("model.safetensors")
+                    .maybe_revision(revision)
+                    .send()?
             }
         };
         unsafe { VarBuilder::from_mmaped_safetensors(&[&model], DType::F32, &device)? }

--- a/candle-examples/examples/metavoice/main.rs
+++ b/candle-examples/examples/metavoice/main.rs
@@ -110,7 +110,7 @@ fn main() -> Result<()> {
     );
     let device = candle_examples::device(args.cpu)?;
     let api = HFClientSync::new()?;
-    let repo = api.model("", "lmz/candle-metavoice");
+    let repo = api.model("lmz", "candle-metavoice");
     let first_stage_meta = match &args.first_stage_meta {
         Some(w) => std::path::PathBuf::from(w),
         None => repo.download_file().filename("first_stage.meta.json").send()?,
@@ -133,7 +133,7 @@ fn main() -> Result<()> {
     let encodec_weights = match args.encodec_weights {
         Some(w) => std::path::PathBuf::from(w),
         None => HFClientSync::new()?
-            .model("", "facebook/encodec_24khz")
+            .model("facebook", "encodec_24khz")
             .download_file().filename("model.safetensors").send()?,
     };
     let dtype = match args.dtype {

--- a/candle-examples/examples/metavoice/main.rs
+++ b/candle-examples/examples/metavoice/main.rs
@@ -15,7 +15,7 @@ use candle_transformers::models::quantized_metavoice::transformer as qtransforme
 
 use candle::{DType, IndexOp, Tensor};
 use candle_nn::VarBuilder;
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use rand::{distr::Distribution, SeedableRng};
 
 pub const ENCODEC_NTOKENS: u32 = 1024;
@@ -109,11 +109,11 @@ fn main() -> Result<()> {
         candle::utils::with_f16c()
     );
     let device = candle_examples::device(args.cpu)?;
-    let api = Api::new()?;
-    let repo = api.model("lmz/candle-metavoice".to_string());
+    let api = HFClientSync::new()?;
+    let repo = api.model("", "lmz/candle-metavoice");
     let first_stage_meta = match &args.first_stage_meta {
         Some(w) => std::path::PathBuf::from(w),
-        None => repo.get("first_stage.meta.json")?,
+        None => repo.download_file().filename("first_stage.meta.json").send()?,
     };
     let first_stage_meta: serde_json::Value =
         serde_json::from_reader(&std::fs::File::open(first_stage_meta)?)?;
@@ -128,13 +128,13 @@ fn main() -> Result<()> {
 
     let second_stage_weights = match &args.second_stage_weights {
         Some(w) => std::path::PathBuf::from(w),
-        None => repo.get("second_stage.safetensors")?,
+        None => repo.download_file().filename("second_stage.safetensors").send()?,
     };
     let encodec_weights = match args.encodec_weights {
         Some(w) => std::path::PathBuf::from(w),
-        None => Api::new()?
-            .model("facebook/encodec_24khz".to_string())
-            .get("model.safetensors")?,
+        None => HFClientSync::new()?
+            .model("", "facebook/encodec_24khz")
+            .download_file().filename("model.safetensors").send()?,
     };
     let dtype = match args.dtype {
         ArgDType::F32 => DType::F32,
@@ -146,7 +146,7 @@ fn main() -> Result<()> {
     let mut first_stage_model = if args.quantized {
         let filename = match &args.first_stage_weights {
             Some(w) => std::path::PathBuf::from(w),
-            None => repo.get("first_stage_q4k.gguf")?,
+            None => repo.download_file().filename("first_stage_q4k.gguf").send()?,
         };
         let vb =
             candle_transformers::quantized_var_builder::VarBuilder::from_gguf(filename, &device)?;
@@ -155,7 +155,7 @@ fn main() -> Result<()> {
     } else {
         let first_stage_weights = match &args.first_stage_weights {
             Some(w) => std::path::PathBuf::from(w),
-            None => repo.get("first_stage.safetensors")?,
+            None => repo.download_file().filename("first_stage.safetensors").send()?,
         };
         let first_stage_vb =
             unsafe { VarBuilder::from_mmaped_safetensors(&[first_stage_weights], dtype, &device)? };
@@ -184,7 +184,7 @@ fn main() -> Result<()> {
     println!("{tokens:?}");
     let spk_emb_file = match &args.spk_emb {
         Some(w) => std::path::PathBuf::from(w),
-        None => repo.get("spk_emb.safetensors")?,
+        None => repo.download_file().filename("spk_emb.safetensors").send()?,
     };
     let spk_emb = candle::safetensors::load(&spk_emb_file, &candle::Device::Cpu)?;
     let spk_emb = match spk_emb.get("spk_emb") {

--- a/candle-examples/examples/mimi/main.rs
+++ b/candle-examples/examples/mimi/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
         None => HFClientSync::new()?
-            .model("", "kyutai/mimi")
+            .model("kyutai", "mimi")
             .download_file().filename("model.safetensors").send()?,
     };
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DType::F32, &device)? };

--- a/candle-examples/examples/mimi/main.rs
+++ b/candle-examples/examples/mimi/main.rs
@@ -9,7 +9,7 @@ use candle::{DType, IndexOp, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::mimi::{Config, Model};
 use clap::{Parser, ValueEnum};
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 
 mod audio_io;
 
@@ -51,9 +51,9 @@ fn main() -> Result<()> {
     let device = candle_examples::device(args.cpu)?;
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
-        None => Api::new()?
-            .model("kyutai/mimi".to_string())
-            .get("model.safetensors")?,
+        None => HFClientSync::new()?
+            .model("", "kyutai/mimi")
+            .download_file().filename("model.safetensors").send()?,
     };
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DType::F32, &device)? };
     let config = Config::v0_1(None);

--- a/candle-examples/examples/mistral/main.rs
+++ b/candle-examples/examples/mistral/main.rs
@@ -14,7 +14,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -257,7 +257,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => {
@@ -280,14 +280,11 @@ fn main() -> Result<()> {
             }
         }
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision;
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -296,7 +293,7 @@ fn main() -> Result<()> {
             .collect::<Vec<_>>(),
         None => {
             if args.quantized {
-                vec![repo.get("model-q4k.gguf")?]
+                vec![repo.download_file().filename("model-q4k.gguf").revision(&revision).send()?]
             } else {
                 candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?
             }
@@ -312,7 +309,7 @@ fn main() -> Result<()> {
             if args.quantized {
                 Config::config_7b_v0_1(args.use_flash_attn)
             } else {
-                let config_file = repo.get("config.json")?;
+                let config_file = repo.download_file().filename("config.json").revision(&revision).send()?;
                 serde_json::from_slice(&std::fs::read(config_file)?)?
             }
         }

--- a/candle-examples/examples/mistral/main.rs
+++ b/candle-examples/examples/mistral/main.rs
@@ -281,7 +281,8 @@ fn main() -> Result<()> {
         }
     };
     let revision = args.revision;
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,

--- a/candle-examples/examples/mixtral/main.rs
+++ b/candle-examples/examples/mixtral/main.rs
@@ -196,7 +196,8 @@ fn main() -> Result<()> {
     let start = std::time::Instant::now();
     let api = HFClientSync::new()?;
     let revision = args.revision;
-    let repo = api.model("", &args.model_id);
+    let (owner, name) = args.model_id.split_once('/').unwrap_or(("", args.model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,

--- a/candle-examples/examples/mixtral/main.rs
+++ b/candle-examples/examples/mixtral/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -194,15 +194,12 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let api = HFClientSync::new()?;
+    let revision = args.revision;
+    let repo = api.model("", &args.model_id);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files

--- a/candle-examples/examples/mobileclip/main.rs
+++ b/candle-examples/examples/mobileclip/main.rs
@@ -77,14 +77,14 @@ pub fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     let model_name = args.which.model_name();
-    let api = hf_hub::api::sync::Api::new()?;
-    let api = api.model(model_name);
+    let api = hf_hub::HFClientSync::new()?;
+    let api = api.model("", &model_name);
     let model_file = if args.use_pth {
-        api.get("open_clip_pytorch_model.bin")?
+        api.download_file().filename("open_clip_pytorch_model.bin").send()?
     } else {
-        api.get("open_clip_model.safetensors")?
+        api.download_file().filename("open_clip_model.safetensors").send()?
     };
-    let tokenizer = api.get("tokenizer.json")?;
+    let tokenizer = api.download_file().filename("tokenizer.json").send()?;
     let tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;
     let config = &args.which.config();
     let device = candle_examples::device(args.cpu)?;

--- a/candle-examples/examples/mobileclip/main.rs
+++ b/candle-examples/examples/mobileclip/main.rs
@@ -78,7 +78,8 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_name = args.which.model_name();
     let api = hf_hub::HFClientSync::new()?;
-    let api = api.model("", &model_name);
+    let (owner, name) = model_name.split_once('/').unwrap_or(("", model_name.as_str()));
+    let api = api.model(owner, name);
     let model_file = if args.use_pth {
         api.download_file().filename("open_clip_pytorch_model.bin").send()?
     } else {

--- a/candle-examples/examples/mobilenetv4/main.rs
+++ b/candle-examples/examples/mobilenetv4/main.rs
@@ -81,7 +81,8 @@ pub fn main() -> anyhow::Result<()> {
         None => {
             let model_name = args.which.model_filename();
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", &model_name);
+            let (owner, name) = model_name.split_once('/').unwrap_or(("", model_name.as_str()));
+            let api = api.model(owner, name);
             api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),

--- a/candle-examples/examples/mobilenetv4/main.rs
+++ b/candle-examples/examples/mobilenetv4/main.rs
@@ -80,9 +80,9 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", &model_name);
+            api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/mobileone/main.rs
+++ b/candle-examples/examples/mobileone/main.rs
@@ -69,9 +69,9 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", &model_name);
+            api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/mobileone/main.rs
+++ b/candle-examples/examples/mobileone/main.rs
@@ -70,7 +70,8 @@ pub fn main() -> anyhow::Result<()> {
         None => {
             let model_name = args.which.model_filename();
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", &model_name);
+            let (owner, name) = model_name.split_once('/').unwrap_or(("", model_name.as_str()));
+            let api = api.model(owner, name);
             api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),

--- a/candle-examples/examples/modernbert/main.rs
+++ b/candle-examples/examples/modernbert/main.rs
@@ -5,7 +5,7 @@ use candle::{Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::modernbert;
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingParams, Tokenizer};
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -53,7 +53,7 @@ struct Args {
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => match args.model {
@@ -61,27 +61,24 @@ fn main() -> Result<()> {
             Model::ModernBertLarge => "answerdotai/ModernBERT-large".to_string(),
         },
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision;
+    let repo = api.model("", &model_id);
 
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
 
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo.download_file().filename("config.json").revision(&revision).send()?,
     };
 
     let weights_filename = match args.weight_files {
         Some(files) => PathBuf::from(files),
-        None => match repo.get("model.safetensors") {
+        None => match repo.download_file().filename("model.safetensors").revision(&revision).send() {
             Ok(safetensors) => safetensors,
-            Err(_) => match repo.get("pytorch_model.bin") {
+            Err(_) => match repo.download_file().filename("pytorch_model.bin").revision(&revision).send() {
                 Ok(pytorch_model) => pytorch_model,
                 Err(e) => {
                     anyhow::bail!("Model weights not found. The weights should either be a `model.safetensors` or `pytorch_model.bin` file.  Error: {e}")

--- a/candle-examples/examples/modernbert/main.rs
+++ b/candle-examples/examples/modernbert/main.rs
@@ -62,7 +62,8 @@ fn main() -> Result<()> {
         },
     };
     let revision = args.revision;
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
 
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),

--- a/candle-examples/examples/moondream/main.rs
+++ b/candle-examples/examples/moondream/main.rs
@@ -270,7 +270,8 @@ async fn main() -> anyhow::Result<()> {
         (None, Some(r)) => r.to_string(),
         (None, None) => "main".to_string(),
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let model_file = match args.model_file {
         Some(m) => m.into(),
         None => {

--- a/candle-examples/examples/moondream/main.rs
+++ b/candle-examples/examples/moondream/main.rs
@@ -251,7 +251,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = hf_hub::api::tokio::Api::new()?;
+    let api = hf_hub::HFClient::new()?;
     let (model_id, revision) = match args.model_id {
         Some(model_id) => (model_id.to_string(), None),
         None => {
@@ -270,24 +270,20 @@ async fn main() -> anyhow::Result<()> {
         (None, Some(r)) => r.to_string(),
         (None, None) => "main".to_string(),
     };
-    let repo = api.repo(hf_hub::Repo::with_revision(
-        model_id,
-        hf_hub::RepoType::Model,
-        revision,
-    ));
+    let repo = api.model("", &model_id);
     let model_file = match args.model_file {
         Some(m) => m.into(),
         None => {
             if args.quantized {
-                repo.get("model-q4_0.gguf").await?
+                repo.download_file().filename("model-q4_0.gguf").revision(&revision).send().await?
             } else {
-                repo.get("model.safetensors").await?
+                repo.download_file().filename("model.safetensors").revision(&revision).send().await?
             }
         }
     };
     let tokenizer = match args.tokenizer_file {
         Some(m) => m.into(),
-        None => repo.get("tokenizer.json").await?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send().await?,
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;

--- a/candle-examples/examples/musicgen/main.rs
+++ b/candle-examples/examples/musicgen/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
     let tokenizer = match args.tokenizer {
         Some(tokenizer) => std::path::PathBuf::from(tokenizer),
         None => HFClientSync::new()?
-            .model("", "facebook/musicgen-small")
+            .model("facebook", "musicgen-small")
             .download_file().filename("tokenizer.json").send()?,
     };
     let mut tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;
@@ -64,7 +64,7 @@ fn main() -> Result<()> {
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
         None => HFClientSync::new()?
-            .model("", "facebook/musicgen-small")
+            .model("facebook", "musicgen-small")
             .download_file().filename("model.safetensors").revision("refs/pr/13").send()?,
     };
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DTYPE, &device)? };

--- a/candle-examples/examples/musicgen/main.rs
+++ b/candle-examples/examples/musicgen/main.rs
@@ -18,7 +18,7 @@ use anyhow::{Error as E, Result};
 use candle::{DType, Tensor};
 use candle_nn::VarBuilder;
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 
 const DTYPE: DType = DType::F32;
 
@@ -51,9 +51,9 @@ fn main() -> Result<()> {
     let device = candle_examples::device(args.cpu)?;
     let tokenizer = match args.tokenizer {
         Some(tokenizer) => std::path::PathBuf::from(tokenizer),
-        None => Api::new()?
-            .model("facebook/musicgen-small".to_string())
-            .get("tokenizer.json")?,
+        None => HFClientSync::new()?
+            .model("", "facebook/musicgen-small")
+            .download_file().filename("tokenizer.json").send()?,
     };
     let mut tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;
     let tokenizer = tokenizer
@@ -63,13 +63,9 @@ fn main() -> Result<()> {
 
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
-        None => Api::new()?
-            .repo(Repo::with_revision(
-                "facebook/musicgen-small".to_string(),
-                RepoType::Model,
-                "refs/pr/13".to_string(),
-            ))
-            .get("model.safetensors")?,
+        None => HFClientSync::new()?
+            .model("", "facebook/musicgen-small")
+            .download_file().filename("model.safetensors").revision("refs/pr/13").send()?,
     };
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DTYPE, &device)? };
     let config = GenConfig::small();

--- a/candle-examples/examples/nomic-bert/main.rs
+++ b/candle-examples/examples/nomic-bert/main.rs
@@ -61,7 +61,8 @@ fn main() -> Result<()> {
     let revision = args.revision;
     let (config_filename, tokenizer_filename, weights_filename) = {
         let api = HFClientSync::new()?;
-        let api = api.model("", &args.model_id);
+        let (owner, name) = args.model_id.split_once('/').unwrap_or(("", args.model_id.as_str()));
+        let api = api.model(owner, name);
         let config = api.download_file().filename("config.json").revision(&revision).send()?;
         let tokenizer = api.download_file().filename("tokenizer.json").revision(&revision).send()?;
         let weights = api.download_file().filename("model.safetensors").revision(&revision).send()?;

--- a/candle-examples/examples/nomic-bert/main.rs
+++ b/candle-examples/examples/nomic-bert/main.rs
@@ -10,7 +10,7 @@ use anyhow::{bail, Error as E, Result};
 use candle::{DType, Tensor};
 use candle_nn::VarBuilder;
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingParams, Tokenizer};
 
 #[derive(Parser, Debug)]
@@ -58,13 +58,13 @@ fn main() -> Result<()> {
     };
 
     let device = candle_examples::device(args.cpu)?;
-    let repo = Repo::with_revision(args.model_id.clone(), RepoType::Model, args.revision);
+    let revision = args.revision;
     let (config_filename, tokenizer_filename, weights_filename) = {
-        let api = Api::new()?;
-        let api = api.repo(repo);
-        let config = api.get("config.json")?;
-        let tokenizer = api.get("tokenizer.json")?;
-        let weights = api.get("model.safetensors")?;
+        let api = HFClientSync::new()?;
+        let api = api.model("", &args.model_id);
+        let config = api.download_file().filename("config.json").revision(&revision).send()?;
+        let tokenizer = api.download_file().filename("tokenizer.json").revision(&revision).send()?;
+        let weights = api.download_file().filename("model.safetensors").revision(&revision).send()?;
         (config, tokenizer, weights)
     };
 

--- a/candle-examples/examples/nvembed_v2/main.rs
+++ b/candle-examples/examples/nvembed_v2/main.rs
@@ -50,7 +50,8 @@ impl Args {
         };
 
         let api = HFClientSync::new()?;
-        let repo = api.model("", &model_name);
+        let (owner, name) = model_name.split_once('/').unwrap_or(("", model_name.as_str()));
+        let repo = api.model(owner, name);
 
         let model_files = match &self.model_files {
             Some(files) => files

--- a/candle-examples/examples/nvembed_v2/main.rs
+++ b/candle-examples/examples/nvembed_v2/main.rs
@@ -9,7 +9,7 @@ use candle::{DType, IndexOp, Shape, Tensor, D};
 use candle_nn::VarBuilder;
 use candle_transformers::models::nvembed_v2::model::Model;
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingDirection, PaddingParams, Tokenizer, TruncationParams};
 
 #[derive(Parser, Debug)]
@@ -49,8 +49,8 @@ impl Args {
             None => "nvidia/NV-Embed-v2".to_string(),
         };
 
-        let api = Api::new()?;
-        let repo = api.repo(Repo::new(model_name.to_string(), RepoType::Model));
+        let api = HFClientSync::new()?;
+        let repo = api.model("", &model_name);
 
         let model_files = match &self.model_files {
             Some(files) => files
@@ -62,7 +62,7 @@ impl Args {
 
         let tokenizer_file = match &self.tokenizer {
             Some(file) => std::path::PathBuf::from(file),
-            None => repo.get("tokenizer.json")?,
+            None => repo.download_file().filename("tokenizer.json").send()?,
         };
 
         let device = candle_examples::device(self.cpu)?;

--- a/candle-examples/examples/olmo/main.rs
+++ b/candle-examples/examples/olmo/main.rs
@@ -14,7 +14,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -217,7 +217,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => match args.model {
@@ -229,14 +229,11 @@ fn main() -> Result<()> {
         },
     };
 
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision;
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -245,13 +242,13 @@ fn main() -> Result<()> {
             .collect::<Vec<_>>(),
         None => match args.model {
             Which::W1b | Which::V2W1b => {
-                vec![repo.get("model.safetensors")?]
+                vec![repo.download_file().filename("model.safetensors").revision(&revision).send()?]
             }
             _ => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
         },
     };
 
-    let config_filename = repo.get("config.json")?;
+    let config_filename = repo.download_file().filename("config.json").revision(&revision).send()?;
     println!("retrieved the files in {:?}", start.elapsed());
 
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;

--- a/candle-examples/examples/olmo/main.rs
+++ b/candle-examples/examples/olmo/main.rs
@@ -230,7 +230,8 @@ fn main() -> Result<()> {
     };
 
     let revision = args.revision;
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,

--- a/candle-examples/examples/onnx-llm/main.rs
+++ b/candle-examples/examples/onnx-llm/main.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use candle::{DType, Tensor};
 use candle_transformers::generation::{LogitsProcessor, Sampling};
 use clap::{Parser, ValueEnum};
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use serde::Deserialize;
 use std::io::Write;
 use tokenizers::Tokenizer;
@@ -69,15 +69,15 @@ pub fn main() -> Result<()> {
         Which::SmolLM135M => ("HuggingFaceTB/SmolLM-135M", "HuggingFaceTB/SmolLM-135M"),
     };
 
-    let api = Api::new()?;
-    let model_repo = api.model(model_id.to_string());
-    let tokenizer_repo = api.model(tokenizer_id.to_string());
+    let api = HFClientSync::new()?;
+    let model_repo = api.model("", model_id);
+    let tokenizer_repo = api.model("", tokenizer_id);
 
-    let model_path = model_repo.get("onnx/model.onnx")?;
-    let config_file = model_repo.get("config.json")?;
+    let model_path = model_repo.download_file().filename("onnx/model.onnx").send()?;
+    let config_file = model_repo.download_file().filename("config.json").send()?;
     let config: Config = serde_json::from_reader(std::fs::File::open(config_file)?)?;
 
-    let tokenizer_path = tokenizer_repo.get("tokenizer.json")?;
+    let tokenizer_path = tokenizer_repo.download_file().filename("tokenizer.json").send()?;
     let tokenizer = Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)?;
 
     let tokens_u32 = tokenizer

--- a/candle-examples/examples/onnx-llm/main.rs
+++ b/candle-examples/examples/onnx-llm/main.rs
@@ -70,8 +70,10 @@ pub fn main() -> Result<()> {
     };
 
     let api = HFClientSync::new()?;
-    let model_repo = api.model("", model_id);
-    let tokenizer_repo = api.model("", tokenizer_id);
+    let (model_owner, model_name) = model_id.split_once('/').unwrap_or(("", model_id));
+    let model_repo = api.model(model_owner, model_name);
+    let (tokenizer_owner, tokenizer_name) = tokenizer_id.split_once('/').unwrap_or(("", tokenizer_id));
+    let tokenizer_repo = api.model(tokenizer_owner, tokenizer_name);
 
     let model_path = model_repo.download_file().filename("onnx/model.onnx").send()?;
     let config_file = model_repo.download_file().filename("config.json").send()?;

--- a/candle-examples/examples/onnx/main.rs
+++ b/candle-examples/examples/onnx/main.rs
@@ -52,15 +52,15 @@ pub fn main() -> anyhow::Result<()> {
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
         None => match args.which {
-            Which::SqueezeNet => hf_hub::api::sync::Api::new()?
-                .model("lmz/candle-onnx".into())
-                .get("squeezenet1.1-7.onnx")?,
-            Which::EfficientNet => hf_hub::api::sync::Api::new()?
-                .model("onnx/EfficientNet-Lite4".into())
-                .get("efficientnet-lite4-11.onnx")?,
-            Which::EsrGan => hf_hub::api::sync::Api::new()?
-                .model("qualcomm/Real-ESRGAN-x4plus".into())
-                .get("Real-ESRGAN-x4plus.onnx")?,
+            Which::SqueezeNet => hf_hub::HFClientSync::new()?
+                .model("", "lmz/candle-onnx")
+                .download_file().filename("squeezenet1.1-7.onnx").send()?,
+            Which::EfficientNet => hf_hub::HFClientSync::new()?
+                .model("", "onnx/EfficientNet-Lite4")
+                .download_file().filename("efficientnet-lite4-11.onnx").send()?,
+            Which::EsrGan => hf_hub::HFClientSync::new()?
+                .model("", "qualcomm/Real-ESRGAN-x4plus")
+                .download_file().filename("Real-ESRGAN-x4plus.onnx").send()?,
         },
     };
 

--- a/candle-examples/examples/onnx/main.rs
+++ b/candle-examples/examples/onnx/main.rs
@@ -53,13 +53,13 @@ pub fn main() -> anyhow::Result<()> {
         Some(model) => std::path::PathBuf::from(model),
         None => match args.which {
             Which::SqueezeNet => hf_hub::HFClientSync::new()?
-                .model("", "lmz/candle-onnx")
+                .model("lmz", "candle-onnx")
                 .download_file().filename("squeezenet1.1-7.onnx").send()?,
             Which::EfficientNet => hf_hub::HFClientSync::new()?
-                .model("", "onnx/EfficientNet-Lite4")
+                .model("onnx", "EfficientNet-Lite4")
                 .download_file().filename("efficientnet-lite4-11.onnx").send()?,
             Which::EsrGan => hf_hub::HFClientSync::new()?
-                .model("", "qualcomm/Real-ESRGAN-x4plus")
+                .model("qualcomm", "Real-ESRGAN-x4plus")
                 .download_file().filename("Real-ESRGAN-x4plus.onnx").send()?,
         },
     };

--- a/candle-examples/examples/orpheus/main.rs
+++ b/candle-examples/examples/orpheus/main.rs
@@ -159,10 +159,10 @@ struct Model {
 
 fn load_snac(device: &Device) -> Result<SnacModel> {
     let api = hf_hub::HFClientSync::new()?;
-    let m = api.model("", "hubertsiuzdak/snac_24khz");
+    let m = api.model("hubertsiuzdak", "snac_24khz");
     let config = m.download_file().filename("config.json").send()?;
     let config: SnacConfig = serde_json::from_reader(std::fs::File::open(config)?)?;
-    let m = api.model("", "lmz/candle-snac");
+    let m = api.model("lmz", "candle-snac");
     let model = m.download_file().filename("snac_24khz.safetensors").send()?;
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DType::F32, device)? };
     let model = SnacModel::new(&config, vb)?;
@@ -183,7 +183,8 @@ impl Model {
             Some(r) => r,
             None => "main".to_string(),
         };
-        let repo = api.model("", &model_id);
+        let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+        let repo = api.model(owner, name);
         let model_files = match args.model_file {
             Some(m) => vec![m.into()],
             None => match args.which {

--- a/candle-examples/examples/orpheus/main.rs
+++ b/candle-examples/examples/orpheus/main.rs
@@ -158,12 +158,12 @@ struct Model {
 }
 
 fn load_snac(device: &Device) -> Result<SnacModel> {
-    let api = hf_hub::api::sync::Api::new()?;
-    let m = api.model("hubertsiuzdak/snac_24khz".to_string());
-    let config = m.get("config.json")?;
+    let api = hf_hub::HFClientSync::new()?;
+    let m = api.model("", "hubertsiuzdak/snac_24khz");
+    let config = m.download_file().filename("config.json").send()?;
     let config: SnacConfig = serde_json::from_reader(std::fs::File::open(config)?)?;
-    let m = api.model("lmz/candle-snac".to_string());
-    let model = m.get("snac_24khz.safetensors")?;
+    let m = api.model("", "lmz/candle-snac");
+    let model = m.download_file().filename("snac_24khz.safetensors").send()?;
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DType::F32, device)? };
     let model = SnacModel::new(&config, vb)?;
     Ok(model)
@@ -172,7 +172,7 @@ fn load_snac(device: &Device) -> Result<SnacModel> {
 impl Model {
     fn load(args: Args) -> Result<Self> {
         let start = std::time::Instant::now();
-        let api = hf_hub::api::sync::Api::new()?;
+        let api = hf_hub::HFClientSync::new()?;
         let model_id = match args.model_id {
             Some(model_id) => model_id.to_string(),
             None => match args.which {
@@ -183,11 +183,7 @@ impl Model {
             Some(r) => r,
             None => "main".to_string(),
         };
-        let repo = api.repo(hf_hub::Repo::with_revision(
-            model_id,
-            hf_hub::RepoType::Model,
-            revision,
-        ));
+        let repo = api.model("", &model_id);
         let model_files = match args.model_file {
             Some(m) => vec![m.into()],
             None => match args.which {
@@ -198,11 +194,11 @@ impl Model {
         };
         let config = match args.config_file {
             Some(m) => m.into(),
-            None => repo.get("config.json")?,
+            None => repo.download_file().filename("config.json").revision(&revision).send()?,
         };
         let tokenizer = match args.tokenizer_file {
             Some(m) => m.into(),
-            None => repo.get("tokenizer.json")?,
+            None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
         };
         println!("retrieved the files in {:?}", start.elapsed());
         let tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;

--- a/candle-examples/examples/paddleocr-vl/main.rs
+++ b/candle-examples/examples/paddleocr-vl/main.rs
@@ -598,7 +598,8 @@ fn main() -> Result<()> {
     println!("Loading model from {}...", args.model_id);
     let api = hf_hub::HFClientSync::new()?;
     let revision = args.revision.clone();
-    let repo = api.model("", &args.model_id);
+    let (owner, name) = args.model_id.split_once('/').unwrap_or(("", args.model_id.as_str()));
+    let repo = api.model(owner, name);
 
     // Load config
     let config_file = repo.download_file().filename("config.json").revision(&revision).send()?;

--- a/candle-examples/examples/paddleocr-vl/main.rs
+++ b/candle-examples/examples/paddleocr-vl/main.rs
@@ -596,15 +596,12 @@ fn main() -> Result<()> {
 
     // Load model from HuggingFace
     println!("Loading model from {}...", args.model_id);
-    let api = hf_hub::api::sync::Api::new()?;
-    let repo = api.repo(hf_hub::Repo::with_revision(
-        args.model_id.clone(),
-        hf_hub::RepoType::Model,
-        args.revision.clone(),
-    ));
+    let api = hf_hub::HFClientSync::new()?;
+    let revision = args.revision.clone();
+    let repo = api.model("", &args.model_id);
 
     // Load config
-    let config_file = repo.get("config.json")?;
+    let config_file = repo.download_file().filename("config.json").revision(&revision).send()?;
     let config: Config = serde_json::from_str(&std::fs::read_to_string(&config_file)?)?;
     println!(
         "Vision: {}L {}H, Text: {}L {}H (GQA: {}KV)",
@@ -616,13 +613,13 @@ fn main() -> Result<()> {
     );
 
     // Load tokenizer
-    let tokenizer_file = repo.get("tokenizer.json")?;
+    let tokenizer_file = repo.download_file().filename("tokenizer.json").revision(&revision).send()?;
     let tokenizer = Tokenizer::from_file(&tokenizer_file).map_err(E::msg)?;
 
     // Load model weights
-    let model_file = match repo.get("model.safetensors") {
+    let model_file = match repo.download_file().filename("model.safetensors").revision(&revision).send() {
         Ok(f) => f,
-        Err(_) => repo.get("pytorch_model.bin")?,
+        Err(_) => repo.download_file().filename("pytorch_model.bin").revision(&revision).send()?,
     };
 
     println!("Loading weights from {:?}...", model_file);

--- a/candle-examples/examples/paligemma/main.rs
+++ b/candle-examples/examples/paligemma/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -218,19 +218,16 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => "google/paligemma-3b-mix-224".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision;
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files

--- a/candle-examples/examples/paligemma/main.rs
+++ b/candle-examples/examples/paligemma/main.rs
@@ -224,7 +224,8 @@ fn main() -> Result<()> {
         None => "google/paligemma-3b-mix-224".to_string(),
     };
     let revision = args.revision;
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,

--- a/candle-examples/examples/parler-tts/main.rs
+++ b/candle-examples/examples/parler-tts/main.rs
@@ -125,7 +125,7 @@ fn main() -> anyhow::Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = hf_hub::api::sync::Api::new()?;
+    let api = hf_hub::HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id.to_string(),
         None => match args.which {
@@ -137,15 +137,11 @@ fn main() -> anyhow::Result<()> {
         Some(r) => r,
         None => "main".to_string(),
     };
-    let repo = api.repo(hf_hub::Repo::with_revision(
-        model_id,
-        hf_hub::RepoType::Model,
-        revision,
-    ));
+    let repo = api.model("", &model_id);
     let model_files = match args.model_file {
         Some(m) => vec![m.into()],
         None => match args.which {
-            Which::MiniV1 => vec![repo.get("model.safetensors")?],
+            Which::MiniV1 => vec![repo.download_file().filename("model.safetensors").revision(&revision).send()?],
             Which::LargeV1 => {
                 candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?
             }
@@ -153,11 +149,11 @@ fn main() -> anyhow::Result<()> {
     };
     let config = match args.config_file {
         Some(m) => m.into(),
-        None => repo.get("config.json")?,
+        None => repo.download_file().filename("config.json").revision(&revision).send()?,
     };
     let tokenizer = match args.tokenizer_file {
         Some(m) => m.into(),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;

--- a/candle-examples/examples/parler-tts/main.rs
+++ b/candle-examples/examples/parler-tts/main.rs
@@ -137,7 +137,8 @@ fn main() -> anyhow::Result<()> {
         Some(r) => r,
         None => "main".to_string(),
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let model_files = match args.model_file {
         Some(m) => vec![m.into()],
         None => match args.which {

--- a/candle-examples/examples/phi/main.rs
+++ b/candle-examples/examples/phi/main.rs
@@ -291,7 +291,8 @@ fn main() -> Result<()> {
             }
         }
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
         None => match args.model {

--- a/candle-examples/examples/phi/main.rs
+++ b/candle-examples/examples/phi/main.rs
@@ -16,7 +16,7 @@ use candle_transformers::models::quantized_mixformer::MixFormerSequentialForCaus
 use candle::{DType, Device, IndexOp, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -250,7 +250,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id.to_string(),
         None => {
@@ -291,7 +291,7 @@ fn main() -> Result<()> {
             }
         }
     };
-    let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
         None => match args.model {
@@ -301,9 +301,9 @@ fn main() -> Result<()> {
             | WhichModel::V2Old
             | WhichModel::V3
             | WhichModel::V3Medium
-            | WhichModel::V4Mini => repo.get("tokenizer.json")?,
+            | WhichModel::V4Mini => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
             WhichModel::PuffinPhiV2 | WhichModel::PhiHermes => {
-                repo.get("tokenizer-puffin-phi-v2.json")?
+                repo.download_file().filename("tokenizer-puffin-phi-v2.json").revision(&revision).send()?
             }
         },
     };
@@ -312,18 +312,18 @@ fn main() -> Result<()> {
         None => {
             if args.quantized {
                 match args.model {
-                    WhichModel::V1 => vec![repo.get("model-v1-q4k.gguf")?],
-                    WhichModel::V1_5 => vec![repo.get("model-q4k.gguf")?],
-                    WhichModel::V2 | WhichModel::V2Old => vec![repo.get("model-v2-q4k.gguf")?],
-                    WhichModel::PuffinPhiV2 => vec![repo.get("model-puffin-phi-v2-q4k.gguf")?],
-                    WhichModel::PhiHermes => vec![repo.get("model-phi-hermes-1_3B-q4k.gguf")?],
+                    WhichModel::V1 => vec![repo.download_file().filename("model-v1-q4k.gguf").revision(&revision).send()?],
+                    WhichModel::V1_5 => vec![repo.download_file().filename("model-q4k.gguf").revision(&revision).send()?],
+                    WhichModel::V2 | WhichModel::V2Old => vec![repo.download_file().filename("model-v2-q4k.gguf").revision(&revision).send()?],
+                    WhichModel::PuffinPhiV2 => vec![repo.download_file().filename("model-puffin-phi-v2-q4k.gguf").revision(&revision).send()?],
+                    WhichModel::PhiHermes => vec![repo.download_file().filename("model-phi-hermes-1_3B-q4k.gguf").revision(&revision).send()?],
                     WhichModel::V3 | WhichModel::V3Medium | WhichModel::V4Mini => anyhow::bail!(
                         "use the quantized or quantized-phi examples for quantized phi-v3"
                     ),
                 }
             } else {
                 match args.model {
-                    WhichModel::V1 | WhichModel::V1_5 => vec![repo.get("model.safetensors")?],
+                    WhichModel::V1 | WhichModel::V1_5 => vec![repo.download_file().filename("model.safetensors").revision(&revision).send()?],
                     WhichModel::V2
                     | WhichModel::V2Old
                     | WhichModel::V3
@@ -332,8 +332,8 @@ fn main() -> Result<()> {
                         &repo,
                         "model.safetensors.index.json",
                     )?,
-                    WhichModel::PuffinPhiV2 => vec![repo.get("model-puffin-phi-v2.safetensors")?],
-                    WhichModel::PhiHermes => vec![repo.get("model-phi-hermes-1_3B.safetensors")?],
+                    WhichModel::PuffinPhiV2 => vec![repo.download_file().filename("model-puffin-phi-v2.safetensors").revision(&revision).send()?],
+                    WhichModel::PhiHermes => vec![repo.download_file().filename("model-phi-hermes-1_3B.safetensors").revision(&revision).send()?],
                 }
             }
         }
@@ -381,14 +381,14 @@ fn main() -> Result<()> {
         let vb = unsafe { VarBuilder::from_mmaped_safetensors(&filenames, dtype, &device)? };
         match args.model {
             WhichModel::V1 | WhichModel::V1_5 | WhichModel::V2 => {
-                let config_filename = repo.get("config.json")?;
+                let config_filename = repo.download_file().filename("config.json").revision(&revision).send()?;
                 let config = std::fs::read_to_string(config_filename)?;
                 let config: PhiConfig = serde_json::from_str(&config)?;
                 let phi = Phi::new(&config, vb)?;
                 Model::Phi(phi)
             }
             WhichModel::V3 | WhichModel::V3Medium | WhichModel::V4Mini => {
-                let config_filename = repo.get("config.json")?;
+                let config_filename = repo.download_file().filename("config.json").revision(&revision).send()?;
                 let config = std::fs::read_to_string(config_filename)?;
                 let config: Phi3Config = serde_json::from_str(&config)?;
                 let phi3 = Phi3::new(&config, vb)?;

--- a/candle-examples/examples/pixtral/main.rs
+++ b/candle-examples/examples/pixtral/main.rs
@@ -251,7 +251,8 @@ fn main() -> Result<()> {
         None => "mistral-community/pixtral-12b".to_string(),
     };
     let revision = args.revision;
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,

--- a/candle-examples/examples/pixtral/main.rs
+++ b/candle-examples/examples/pixtral/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Module, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -245,19 +245,16 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => "mistral-community/pixtral-12b".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision;
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -277,7 +274,7 @@ fn main() -> Result<()> {
     let config: Config = match args.config_file {
         Some(config_file) => serde_json::from_slice(&std::fs::read(config_file)?)?,
         None => {
-            let config_file = repo.get("config.json")?;
+            let config_file = repo.download_file().filename("config.json").revision(&revision).send()?;
             serde_json::from_slice(&std::fs::read(config_file)?)?
         }
     };

--- a/candle-examples/examples/quantized-gemma/main.rs
+++ b/candle-examples/examples/quantized-gemma/main.rs
@@ -93,7 +93,8 @@ impl Args {
                 let api = hf_hub::HFClientSync::new()?;
                 let repo = "google/gemma-3-4b-it";
                 println!("DEBUG: Downloading tokenizer from {repo}");
-                let api = api.model("", repo);
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                let api = api.model(owner, name);
                 api.download_file().filename("tokenizer.json").send()?
             }
         };
@@ -114,7 +115,8 @@ impl Args {
                     ),
                 };
                 let api = hf_hub::HFClientSync::new()?;
-                api.model("", repo)
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                api.model(owner, name)
                     .download_file()
                     .filename(filename)
                     .revision("main")

--- a/candle-examples/examples/quantized-gemma/main.rs
+++ b/candle-examples/examples/quantized-gemma/main.rs
@@ -90,11 +90,11 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
+                let api = hf_hub::HFClientSync::new()?;
                 let repo = "google/gemma-3-4b-it";
                 println!("DEBUG: Downloading tokenizer from {repo}");
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let api = api.model("", repo);
+                api.download_file().filename("tokenizer.json").send()?
             }
         };
         println!("DEBUG: Loading tokenizer from {tokenizer_path:?}");
@@ -113,13 +113,12 @@ impl Args {
                         "gemma-3-4b-it-q4_0.gguf",
                     ),
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    "main".to_string(),
-                ))
-                .get(filename)?
+                let api = hf_hub::HFClientSync::new()?;
+                api.model("", repo)
+                    .download_file()
+                    .filename(filename)
+                    .revision("main")
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/quantized-glm4/main.rs
+++ b/candle-examples/examples/quantized-glm4/main.rs
@@ -96,15 +96,15 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
+                let api = hf_hub::HFClientSync::new()?;
                 let repo = match self.which {
                     Which::Q2k9b => "THUDM/GLM-4-9B-0414",
                     Which::Q2k32b => "THUDM/GLM-4-32B-0414",
                     Which::Q4k9b => "THUDM/GLM-4-9B-0414",
                     Which::Q4k32b => "THUDM/GLM-4-32B-0414",
                 };
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let api = api.model("", repo);
+                api.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
@@ -136,13 +136,12 @@ impl Args {
                         "main",
                     ),
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    revision.to_string(),
-                ))
-                .get(filename)?
+                let api = hf_hub::HFClientSync::new()?;
+                api.model("", repo)
+                    .download_file()
+                    .filename(filename)
+                    .revision(revision)
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/quantized-glm4/main.rs
+++ b/candle-examples/examples/quantized-glm4/main.rs
@@ -103,7 +103,8 @@ impl Args {
                     Which::Q4k9b => "THUDM/GLM-4-9B-0414",
                     Which::Q4k32b => "THUDM/GLM-4-32B-0414",
                 };
-                let api = api.model("", repo);
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                let api = api.model(owner, name);
                 api.download_file().filename("tokenizer.json").send()?
             }
         };
@@ -137,7 +138,8 @@ impl Args {
                     ),
                 };
                 let api = hf_hub::HFClientSync::new()?;
-                api.model("", repo)
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                api.model(owner, name)
                     .download_file()
                     .filename(filename)
                     .revision(revision)

--- a/candle-examples/examples/quantized-lfm2/main.rs
+++ b/candle-examples/examples/quantized-lfm2/main.rs
@@ -110,14 +110,13 @@ impl Args {
             Which::Lfm2_2_6BQ4KM => ("LiquidAI/LFM2-2.6B-GGUF", "LFM2-2.6B-Q4_K_M.gguf"),
             Which::Lfm2_2_6BQ8_0 => ("LiquidAI/LFM2-2.6B-GGUF", "LFM2-2.6B-Q8_0.gguf"),
         };
-        let api = hf_hub::api::sync::Api::new()?;
-        api.repo(hf_hub::Repo::with_revision(
-            repo.to_string(),
-            hf_hub::RepoType::Model,
-            self.revision.clone(),
-        ))
-        .get(filename)
-        .map_err(Into::into)
+        let api = hf_hub::HFClientSync::new()?;
+        api.model("", repo)
+            .download_file()
+            .filename(filename)
+            .revision(self.revision.clone())
+            .send()
+            .map_err(Into::into)
     }
 
     fn tokenizer(&self, model_path: &Path) -> Result<Tokenizer> {
@@ -136,14 +135,13 @@ impl Args {
             Which::Lfm2_350MQ4KM | Which::Lfm2_350MQ8_0 => "LiquidAI/LFM2-350M",
             Which::Lfm2_2_6BQ4KM | Which::Lfm2_2_6BQ8_0 => "LiquidAI/LFM2-2.6B",
         };
-        let api = hf_hub::api::sync::Api::new()?;
+        let api = hf_hub::HFClientSync::new()?;
         let tokenizer_path = api
-            .repo(hf_hub::Repo::with_revision(
-                tokenizer_repo.to_string(),
-                hf_hub::RepoType::Model,
-                self.revision.clone(),
-            ))
-            .get("tokenizer.json")?;
+            .model("", tokenizer_repo)
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(self.revision.clone())
+            .send()?;
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
     }
 }

--- a/candle-examples/examples/quantized-lfm2/main.rs
+++ b/candle-examples/examples/quantized-lfm2/main.rs
@@ -111,7 +111,8 @@ impl Args {
             Which::Lfm2_2_6BQ8_0 => ("LiquidAI/LFM2-2.6B-GGUF", "LFM2-2.6B-Q8_0.gguf"),
         };
         let api = hf_hub::HFClientSync::new()?;
-        api.model("", repo)
+        let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+        api.model(owner, name)
             .download_file()
             .filename(filename)
             .revision(self.revision.clone())
@@ -136,8 +137,9 @@ impl Args {
             Which::Lfm2_2_6BQ4KM | Which::Lfm2_2_6BQ8_0 => "LiquidAI/LFM2-2.6B",
         };
         let api = hf_hub::HFClientSync::new()?;
+        let (owner, name) = tokenizer_repo.split_once('/').unwrap_or(("", tokenizer_repo));
         let tokenizer_path = api
-            .model("", tokenizer_repo)
+            .model(owner, name)
             .download_file()
             .filename("tokenizer.json")
             .revision(self.revision.clone())

--- a/candle-examples/examples/quantized-phi/main.rs
+++ b/candle-examples/examples/quantized-phi/main.rs
@@ -102,14 +102,14 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
+                let api = hf_hub::HFClientSync::new()?;
                 let repo = match self.which {
                     Which::Phi2 => "microsoft/phi-2",
                     Which::Phi3 | Which::Phi3b => "microsoft/Phi-3-mini-4k-instruct",
                     Which::Phi4 => "microsoft/phi-4",
                 };
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let api = api.model("", repo);
+                api.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
@@ -133,13 +133,12 @@ impl Args {
                     ),
                     Which::Phi4 => ("microsoft/phi-4-gguf", "phi-4-q4.gguf", "main"),
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    revision.to_string(),
-                ))
-                .get(filename)?
+                let api = hf_hub::HFClientSync::new()?;
+                api.model("", repo)
+                    .download_file()
+                    .filename(filename)
+                    .revision(revision)
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/quantized-phi/main.rs
+++ b/candle-examples/examples/quantized-phi/main.rs
@@ -108,7 +108,8 @@ impl Args {
                     Which::Phi3 | Which::Phi3b => "microsoft/Phi-3-mini-4k-instruct",
                     Which::Phi4 => "microsoft/phi-4",
                 };
-                let api = api.model("", repo);
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                let api = api.model(owner, name);
                 api.download_file().filename("tokenizer.json").send()?
             }
         };
@@ -134,7 +135,8 @@ impl Args {
                     Which::Phi4 => ("microsoft/phi-4-gguf", "phi-4-q4.gguf", "main"),
                 };
                 let api = hf_hub::HFClientSync::new()?;
-                api.model("", repo)
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                api.model(owner, name)
                     .download_file()
                     .filename(filename)
                     .revision(revision)

--- a/candle-examples/examples/quantized-qwen2-instruct/main.rs
+++ b/candle-examples/examples/quantized-qwen2-instruct/main.rs
@@ -98,7 +98,7 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
+                let api = hf_hub::HFClientSync::new()?;
                 let repo = match self.which {
                     Which::W2_0_5b => "Qwen/Qwen2-0.5B-Instruct",
                     Which::W2_1_5b => "Qwen/Qwen2-1.5B-Instruct",
@@ -106,8 +106,8 @@ impl Args {
                     Which::W2_72b => "Qwen/Qwen2-72B-Instruct",
                     Which::DeepseekR1Qwen7B => "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
                 };
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let api = api.model("", repo);
+                api.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
@@ -144,13 +144,12 @@ impl Args {
                         "main",
                     ),
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    revision.to_string(),
-                ))
-                .get(filename)?
+                let api = hf_hub::HFClientSync::new()?;
+                api.model("", repo)
+                    .download_file()
+                    .filename(filename)
+                    .revision(revision)
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/quantized-qwen2-instruct/main.rs
+++ b/candle-examples/examples/quantized-qwen2-instruct/main.rs
@@ -106,7 +106,8 @@ impl Args {
                     Which::W2_72b => "Qwen/Qwen2-72B-Instruct",
                     Which::DeepseekR1Qwen7B => "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
                 };
-                let api = api.model("", repo);
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                let api = api.model(owner, name);
                 api.download_file().filename("tokenizer.json").send()?
             }
         };
@@ -145,7 +146,8 @@ impl Args {
                     ),
                 };
                 let api = hf_hub::HFClientSync::new()?;
-                api.model("", repo)
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                api.model(owner, name)
                     .download_file()
                     .filename(filename)
                     .revision(revision)

--- a/candle-examples/examples/quantized-qwen3-moe/main.rs
+++ b/candle-examples/examples/quantized-qwen3-moe/main.rs
@@ -109,7 +109,8 @@ impl Args {
             None => {
                 let api = hf_hub::HFClientSync::new()?;
                 let repo = "Qwen/Qwen3-30B-A3B-Instruct-2507";
-                let api = api.model("", repo);
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                let api = api.model(owner, name);
                 api.download_file().filename("tokenizer.json").send()?
             }
         };
@@ -164,7 +165,8 @@ impl Args {
                     ),
                 };
                 let api = hf_hub::HFClientSync::new()?;
-                api.model("", repo)
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                api.model(owner, name)
                     .download_file()
                     .filename(filename)
                     .revision(revision)

--- a/candle-examples/examples/quantized-qwen3-moe/main.rs
+++ b/candle-examples/examples/quantized-qwen3-moe/main.rs
@@ -107,10 +107,10 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
+                let api = hf_hub::HFClientSync::new()?;
                 let repo = "Qwen/Qwen3-30B-A3B-Instruct-2507";
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let api = api.model("", repo);
+                api.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
@@ -163,13 +163,12 @@ impl Args {
                         "main",
                     ),
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    revision.to_string(),
-                ))
-                .get(filename)?
+                let api = hf_hub::HFClientSync::new()?;
+                api.model("", repo)
+                    .download_file()
+                    .filename(filename)
+                    .revision(revision)
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/quantized-qwen3/main.rs
+++ b/candle-examples/examples/quantized-qwen3/main.rs
@@ -112,7 +112,8 @@ impl Args {
                     Which::W3_14b => "Qwen/Qwen3-14B",
                     Which::W3_32b => "Qwen/Qwen3-32B",
                 };
-                let api = api.model("", repo);
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                let api = api.model(owner, name);
                 api.download_file().filename("tokenizer.json").send()?
             }
         };
@@ -135,7 +136,8 @@ impl Args {
                     Which::W3_32b => ("unsloth/Qwen3-32B-GGUF", "Qwen3-32B-Q4_K_M.gguf", "main"),
                 };
                 let api = hf_hub::HFClientSync::new()?;
-                api.model("", repo)
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                api.model(owner, name)
                     .download_file()
                     .filename(filename)
                     .revision(revision)

--- a/candle-examples/examples/quantized-qwen3/main.rs
+++ b/candle-examples/examples/quantized-qwen3/main.rs
@@ -102,7 +102,7 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
+                let api = hf_hub::HFClientSync::new()?;
                 let repo = match self.which {
                     Which::W3_0_6b => "Qwen/Qwen3-0.6B",
                     Which::W3_0_6b8_0 => "Qwen/Qwen3-0.6B",
@@ -112,8 +112,8 @@ impl Args {
                     Which::W3_14b => "Qwen/Qwen3-14B",
                     Which::W3_32b => "Qwen/Qwen3-32B",
                 };
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let api = api.model("", repo);
+                api.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
@@ -134,13 +134,12 @@ impl Args {
                     Which::W3_14b => ("unsloth/Qwen3-14B-GGUF", "Qwen3-14B-Q4_K_M.gguf", "main"),
                     Which::W3_32b => ("unsloth/Qwen3-32B-GGUF", "Qwen3-32B-Q4_K_M.gguf", "main"),
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    revision.to_string(),
-                ))
-                .get(filename)?
+                let api = hf_hub::HFClientSync::new()?;
+                api.model("", repo)
+                    .download_file()
+                    .filename(filename)
+                    .revision(revision)
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/quantized-t5/main.rs
+++ b/candle-examples/examples/quantized-t5/main.rs
@@ -92,7 +92,8 @@ impl T5ModelBuilder {
         };
 
         let api = HFClientSync::new()?;
-        let api = api.model("", &model_id);
+        let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+        let api = api.model(owner, name);
         let config_filename = match &args.config_file {
             Some(filename) => Self::get_local_or_remote_file(filename, &api, &revision)?,
             None => match args.which {

--- a/candle-examples/examples/quantized-t5/main.rs
+++ b/candle-examples/examples/quantized-t5/main.rs
@@ -12,7 +12,7 @@ use anyhow::{Error as E, Result};
 use candle::{Device, Tensor};
 use candle_transformers::generation::LogitsProcessor;
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, api::sync::ApiRepo, Repo, RepoType};
+use hf_hub::{HFClientSync, HFRepositorySync, RepoTypeModel};
 use tokenizers::Tokenizer;
 
 #[derive(Clone, Debug, Copy, ValueEnum)]
@@ -91,30 +91,29 @@ impl T5ModelBuilder {
             (None, None) => (default_model, "main".to_string()),
         };
 
-        let repo = Repo::with_revision(model_id, RepoType::Model, revision);
-        let api = Api::new()?;
-        let api = api.repo(repo);
+        let api = HFClientSync::new()?;
+        let api = api.model("", &model_id);
         let config_filename = match &args.config_file {
-            Some(filename) => Self::get_local_or_remote_file(filename, &api)?,
+            Some(filename) => Self::get_local_or_remote_file(filename, &api, &revision)?,
             None => match args.which {
-                Which::T5Small => api.get("config.json")?,
-                Which::FlanT5Small => api.get("config-flan-t5-small.json")?,
-                Which::FlanT5Base => api.get("config-flan-t5-base.json")?,
-                Which::FlanT5Large => api.get("config-flan-t5-large.json")?,
-                Which::FlanT5Xl => api.get("config-flan-t5-xl.json")?,
-                Which::FlanT5Xxl => api.get("config-flan-t5-xxl.json")?,
+                Which::T5Small => api.download_file().filename("config.json").revision(&revision).send()?,
+                Which::FlanT5Small => api.download_file().filename("config-flan-t5-small.json").revision(&revision).send()?,
+                Which::FlanT5Base => api.download_file().filename("config-flan-t5-base.json").revision(&revision).send()?,
+                Which::FlanT5Large => api.download_file().filename("config-flan-t5-large.json").revision(&revision).send()?,
+                Which::FlanT5Xl => api.download_file().filename("config-flan-t5-xl.json").revision(&revision).send()?,
+                Which::FlanT5Xxl => api.download_file().filename("config-flan-t5-xxl.json").revision(&revision).send()?,
             },
         };
-        let tokenizer_filename = api.get("tokenizer.json")?;
+        let tokenizer_filename = api.download_file().filename("tokenizer.json").revision(&revision).send()?;
         let weights_filename = match &args.weight_file {
-            Some(filename) => Self::get_local_or_remote_file(filename, &api)?,
+            Some(filename) => Self::get_local_or_remote_file(filename, &api, &revision)?,
             None => match args.which {
-                Which::T5Small => api.get("model.gguf")?,
-                Which::FlanT5Small => api.get("model-flan-t5-small.gguf")?,
-                Which::FlanT5Base => api.get("model-flan-t5-base.gguf")?,
-                Which::FlanT5Large => api.get("model-flan-t5-large.gguf")?,
-                Which::FlanT5Xl => api.get("model-flan-t5-xl.gguf")?,
-                Which::FlanT5Xxl => api.get("model-flan-t5-xxl.gguf")?,
+                Which::T5Small => api.download_file().filename("model.gguf").revision(&revision).send()?,
+                Which::FlanT5Small => api.download_file().filename("model-flan-t5-small.gguf").revision(&revision).send()?,
+                Which::FlanT5Base => api.download_file().filename("model-flan-t5-base.gguf").revision(&revision).send()?,
+                Which::FlanT5Large => api.download_file().filename("model-flan-t5-large.gguf").revision(&revision).send()?,
+                Which::FlanT5Xl => api.download_file().filename("model-flan-t5-xl.gguf").revision(&revision).send()?,
+                Which::FlanT5Xxl => api.download_file().filename("model-flan-t5-xxl.gguf").revision(&revision).send()?,
             },
         };
         let config = std::fs::read_to_string(config_filename)?;
@@ -137,12 +136,12 @@ impl T5ModelBuilder {
         Ok(t5::T5ForConditionalGeneration::load(vb, &self.config)?)
     }
 
-    fn get_local_or_remote_file(filename: &str, api: &ApiRepo) -> Result<PathBuf> {
+    fn get_local_or_remote_file(filename: &str, api: &HFRepositorySync<RepoTypeModel>, revision: &str) -> Result<PathBuf> {
         let local_filename = std::path::PathBuf::from(filename);
         if local_filename.exists() {
             Ok(local_filename)
         } else {
-            Ok(api.get(filename)?)
+            Ok(api.download_file().filename(filename).revision(revision).send()?)
         }
     }
 }

--- a/candle-examples/examples/quantized/main.rs
+++ b/candle-examples/examples/quantized/main.rs
@@ -309,10 +309,10 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
+                let api = hf_hub::HFClientSync::new()?;
                 let repo = self.which.tokenizer_repo();
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let api = api.model("", repo);
+                api.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
@@ -408,13 +408,12 @@ impl Args {
                 } else {
                     "main"
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    revision.to_string(),
-                ))
-                .get(filename)?
+                let api = hf_hub::HFClientSync::new()?;
+                api.model("", repo)
+                    .download_file()
+                    .filename(filename)
+                    .revision(revision)
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/quantized/main.rs
+++ b/candle-examples/examples/quantized/main.rs
@@ -311,7 +311,8 @@ impl Args {
             None => {
                 let api = hf_hub::HFClientSync::new()?;
                 let repo = self.which.tokenizer_repo();
-                let api = api.model("", repo);
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                let api = api.model(owner, name);
                 api.download_file().filename("tokenizer.json").send()?
             }
         };
@@ -409,7 +410,8 @@ impl Args {
                     "main"
                 };
                 let api = hf_hub::HFClientSync::new()?;
-                api.model("", repo)
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                api.model(owner, name)
                     .download_file()
                     .filename(filename)
                     .revision(revision)

--- a/candle-examples/examples/qwen/main.rs
+++ b/candle-examples/examples/qwen/main.rs
@@ -311,7 +311,8 @@ fn main() -> Result<()> {
             format!("Qwen/Qwen{version}-{size}")
         }
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let revision = args.revision.clone();
 
     let tokenizer_filename = match (args.weight_path.as_ref(), args.tokenizer_file.as_ref()) {

--- a/candle-examples/examples/qwen/main.rs
+++ b/candle-examples/examples/qwen/main.rs
@@ -16,7 +16,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -284,7 +284,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let use_chat_template = args.should_use_chat_template();
     let thinking = args.thinking;
     let model_id = match args.model_id {
@@ -311,21 +311,18 @@ fn main() -> Result<()> {
             format!("Qwen/Qwen{version}-{size}")
         }
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let repo = api.model("", &model_id);
+    let revision = args.revision.clone();
 
     let tokenizer_filename = match (args.weight_path.as_ref(), args.tokenizer_file.as_ref()) {
         (Some(_), Some(file)) => std::path::PathBuf::from(file),
         (None, Some(file)) => std::path::PathBuf::from(file),
         (Some(path), None) => std::path::Path::new(path).join("tokenizer.json"),
-        (None, None) => repo.get("tokenizer.json")?,
+        (None, None) => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
     let config_file = match &args.weight_path {
         Some(path) => std::path::Path::new(path).join("config.json"),
-        _ => repo.get("config.json")?,
+        _ => repo.download_file().filename("config.json").revision(&revision).send()?,
     };
 
     let filenames = match args.weight_path {
@@ -345,7 +342,7 @@ fn main() -> Result<()> {
             | WhichModel::W2_1_5b
             | WhichModel::W1_8b
             | WhichModel::W3_0_6b => {
-                vec![repo.get("model.safetensors")?]
+                vec![repo.download_file().filename("model.safetensors").revision(&revision).send()?]
             }
             WhichModel::W4b
             | WhichModel::W7b

--- a/candle-examples/examples/recurrent-gemma/main.rs
+++ b/candle-examples/examples/recurrent-gemma/main.rs
@@ -14,7 +14,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -242,7 +242,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => match args.which {
@@ -250,18 +250,15 @@ fn main() -> Result<()> {
             Which::Instruct2B => "google/recurrentgemma-2b-it".to_string(),
         },
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision.clone();
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo.download_file().filename("config.json").revision(&revision).send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -274,7 +271,7 @@ fn main() -> Result<()> {
                     Which::Base2B => "recurrent-gemma-2b-q4k.gguf",
                     Which::Instruct2B => "recurrent-gemma-7b-q4k.gguf",
                 };
-                let filename = api.model("lmz/candle-gemma".to_string()).get(filename)?;
+                let filename = api.model("", "lmz/candle-gemma").download_file().filename(filename).send()?;
                 vec![filename]
             } else {
                 candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?

--- a/candle-examples/examples/recurrent-gemma/main.rs
+++ b/candle-examples/examples/recurrent-gemma/main.rs
@@ -251,7 +251,8 @@ fn main() -> Result<()> {
         },
     };
     let revision = args.revision.clone();
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
@@ -271,7 +272,7 @@ fn main() -> Result<()> {
                     Which::Base2B => "recurrent-gemma-2b-q4k.gguf",
                     Which::Instruct2B => "recurrent-gemma-7b-q4k.gguf",
                 };
-                let filename = api.model("", "lmz/candle-gemma").download_file().filename(filename).send()?;
+                let filename = api.model("lmz", "candle-gemma").download_file().filename(filename).send()?;
                 vec![filename]
             } else {
                 candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?

--- a/candle-examples/examples/replit-code/main.rs
+++ b/candle-examples/examples/replit-code/main.rs
@@ -217,7 +217,8 @@ fn main() -> Result<()> {
         Some(rev) => rev.to_string(),
         None => "main".to_string(),
     };
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
         None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,

--- a/candle-examples/examples/replit-code/main.rs
+++ b/candle-examples/examples/replit-code/main.rs
@@ -13,7 +13,7 @@ use candle_transformers::models::quantized_mpt::Model as Q;
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -208,7 +208,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id.to_string(),
         None => "lmz/candle-replit-code".to_string(),
@@ -217,18 +217,18 @@ fn main() -> Result<()> {
         Some(rev) => rev.to_string(),
         None => "main".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
     let filename = match args.weight_file {
         Some(weight_file) => std::path::PathBuf::from(weight_file),
         None => {
             if args.quantized {
-                repo.get("model-replit-code-v1_5-q4k.gguf")?
+                repo.download_file().filename("model-replit-code-v1_5-q4k.gguf").revision(&revision).send()?
             } else {
-                repo.get("model.safetensors")?
+                repo.download_file().filename("model.safetensors").revision(&revision).send()?
             }
         }
     };

--- a/candle-examples/examples/repvgg/main.rs
+++ b/candle-examples/examples/repvgg/main.rs
@@ -84,9 +84,9 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", &model_name);
+            api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/repvgg/main.rs
+++ b/candle-examples/examples/repvgg/main.rs
@@ -85,7 +85,8 @@ pub fn main() -> anyhow::Result<()> {
         None => {
             let model_name = args.which.model_filename();
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", &model_name);
+            let (owner, repo_name) = model_name.split_once('/').unwrap_or(("", model_name.as_str()));
+            let api = api.model(owner, repo_name);
             api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),

--- a/candle-examples/examples/resnet/main.rs
+++ b/candle-examples/examples/resnet/main.rs
@@ -50,8 +50,8 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("lmz/candle-resnet".into());
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "lmz/candle-resnet");
             let filename = match args.which {
                 Which::Resnet18 => "resnet18.safetensors",
                 Which::Resnet34 => "resnet34.safetensors",
@@ -59,7 +59,7 @@ pub fn main() -> anyhow::Result<()> {
                 Which::Resnet101 => "resnet101.safetensors",
                 Which::Resnet152 => "resnet152.safetensors",
             };
-            api.get(filename)?
+            api.download_file().filename(filename).send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/resnet/main.rs
+++ b/candle-examples/examples/resnet/main.rs
@@ -51,7 +51,7 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "lmz/candle-resnet");
+            let api = api.model("lmz", "candle-resnet");
             let filename = match args.which {
                 Which::Resnet18 => "resnet18.safetensors",
                 Which::Resnet34 => "resnet34.safetensors",

--- a/candle-examples/examples/rwkv/main.rs
+++ b/candle-examples/examples/rwkv/main.rs
@@ -627,11 +627,12 @@ fn main() -> Result<()> {
         .unwrap_or_else(|| args.which.model_id().to_string());
     let revision = args.revision
         .unwrap_or_else(|| args.which.revision().to_string());
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .model("", "lmz/candle-rwkv")
+            .model("lmz", "candle-rwkv")
             .download_file()
             .filename("rwkv_vocab_v20230424.json")
             .send()?,
@@ -653,17 +654,17 @@ fn main() -> Result<()> {
                 }
                 vec![match args.which {
                     Which::World1b5 => api
-                        .model("", "lmz/candle-rwkv")
+                        .model("lmz", "candle-rwkv")
                         .download_file()
                         .filename("world1b5-q4k.gguf")
                         .send()?,
                     Which::World3b => api
-                        .model("", "lmz/candle-rwkv")
+                        .model("lmz", "candle-rwkv")
                         .download_file()
                         .filename("world3b-q4k.gguf")
                         .send()?,
                     Which::Eagle7b => api
-                        .model("", "lmz/candle-rwkv")
+                        .model("lmz", "candle-rwkv")
                         .download_file()
                         .filename("eagle7b-q4k.gguf")
                         .send()?,

--- a/candle-examples/examples/rwkv/main.rs
+++ b/candle-examples/examples/rwkv/main.rs
@@ -18,7 +18,7 @@ use candle_transformers::models::rwkv_v7::{
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 
 const EOS_TOKEN_ID: u32 = 261;
 
@@ -622,24 +622,24 @@ fn main() -> Result<()> {
         }
     }
 
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id
-            .unwrap_or_else(|| args.which.model_id().to_string()),
-        RepoType::Model,
-        args.revision
-            .unwrap_or_else(|| args.which.revision().to_string()),
-    ));
+    let api = HFClientSync::new()?;
+    let model_id = args.model_id
+        .unwrap_or_else(|| args.which.model_id().to_string());
+    let revision = args.revision
+        .unwrap_or_else(|| args.which.revision().to_string());
+    let repo = api.model("", &model_id);
     let tokenizer = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
         None => api
-            .model("lmz/candle-rwkv".to_string())
-            .get("rwkv_vocab_v20230424.json")?,
+            .model("", "lmz/candle-rwkv")
+            .download_file()
+            .filename("rwkv_vocab_v20230424.json")
+            .send()?,
     };
     let config_filename = match (&args.config_file, args.which.is_v7()) {
         (Some(file), _) => Some(std::path::PathBuf::from(file)),
         (None, true) => None, // v7 models use built-in config, no config.json needed
-        (None, false) => Some(repo.get("config.json")?),
+        (None, false) => Some(repo.download_file().filename("config.json").revision(&revision).send()?),
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -653,46 +653,52 @@ fn main() -> Result<()> {
                 }
                 vec![match args.which {
                     Which::World1b5 => api
-                        .model("lmz/candle-rwkv".to_string())
-                        .get("world1b5-q4k.gguf")?,
+                        .model("", "lmz/candle-rwkv")
+                        .download_file()
+                        .filename("world1b5-q4k.gguf")
+                        .send()?,
                     Which::World3b => api
-                        .model("lmz/candle-rwkv".to_string())
-                        .get("world3b-q4k.gguf")?,
+                        .model("", "lmz/candle-rwkv")
+                        .download_file()
+                        .filename("world3b-q4k.gguf")
+                        .send()?,
                     Which::Eagle7b => api
-                        .model("lmz/candle-rwkv".to_string())
-                        .get("eagle7b-q4k.gguf")?,
-                    Which::World6_1b6 => repo.get("rwkv-6-world-1b6-q4k.gguf")?,
+                        .model("", "lmz/candle-rwkv")
+                        .download_file()
+                        .filename("eagle7b-q4k.gguf")
+                        .send()?,
+                    Which::World6_1b6 => repo.download_file().filename("rwkv-6-world-1b6-q4k.gguf").revision(&revision).send()?,
                     _ => unreachable!(),
                 }]
             } else {
                 vec![match args.which {
                     Which::World1b5 | Which::World3b | Which::Eagle7b => {
-                        repo.get("model.safetensors")?
+                        repo.download_file().filename("model.safetensors").revision(&revision).send()?
                     }
-                    Which::World6_1b6 => repo.get("rwkv-6-world-1b6.safetensors")?,
+                    Which::World6_1b6 => repo.download_file().filename("rwkv-6-world-1b6.safetensors").revision(&revision).send()?,
                     Which::Rwkv7G1d0_1b => {
-                        repo.get("rwkv7-g1d-0.1b-20260129-ctx8192.safetensors")?
+                        repo.download_file().filename("rwkv7-g1d-0.1b-20260129-ctx8192.safetensors").revision(&revision).send()?
                     }
                     Which::Rwkv7G1d0_4b => {
-                        repo.get("rwkv7-g1d-0.4b-20260210-ctx8192.safetensors")?
+                        repo.download_file().filename("rwkv7-g1d-0.4b-20260210-ctx8192.safetensors").revision(&revision).send()?
                     }
                     Which::Rwkv7G1d1_5b => {
-                        repo.get("rwkv7-g1d-1.5b-20260212-ctx8192.safetensors")?
+                        repo.download_file().filename("rwkv7-g1d-1.5b-20260212-ctx8192.safetensors").revision(&revision).send()?
                     }
                     Which::Rwkv7G1d2_9b => {
-                        repo.get("rwkv7-g1d-2.9b-20260131-ctx8192.safetensors")?
+                        repo.download_file().filename("rwkv7-g1d-2.9b-20260131-ctx8192.safetensors").revision(&revision).send()?
                     }
                     Which::Rwkv7G1d7_2b => {
-                        repo.get("rwkv7-g1d-7.2b-20260131-ctx8192.safetensors")?
+                        repo.download_file().filename("rwkv7-g1d-7.2b-20260131-ctx8192.safetensors").revision(&revision).send()?
                     }
                     Which::Rwkv7G1d13_3b => {
-                        repo.get("rwkv7-g1d-13.3b-20260131-ctx8192.safetensors")?
+                        repo.download_file().filename("rwkv7-g1d-13.3b-20260131-ctx8192.safetensors").revision(&revision).send()?
                     }
                     Which::Rwkv7aG1d0_1b => {
-                        repo.get("rwkv7a-g1d-0.1b-20260212-ctx8192.safetensors")?
+                        repo.download_file().filename("rwkv7a-g1d-0.1b-20260212-ctx8192.safetensors").revision(&revision).send()?
                     }
                     Which::Rwkv7bG1b0_1b => {
-                        repo.get("rwkv7b-g1b-0.1b-20250822-ctx4096.safetensors")?
+                        repo.download_file().filename("rwkv7b-g1b-0.1b-20250822-ctx4096.safetensors").revision(&revision).send()?
                     }
                 }]
             }

--- a/candle-examples/examples/segformer/main.rs
+++ b/candle-examples/examples/segformer/main.rs
@@ -61,13 +61,13 @@ fn get_vb_and_config(
     device: &Device,
 ) -> anyhow::Result<(VarBuilder<'_>, Config)> {
     println!("loading model {model_name} via huggingface hub");
-    let api = hf_hub::api::sync::Api::new()?;
-    let api = api.model(model_name.clone());
-    let model_file = api.get("model.safetensors")?;
+    let api = hf_hub::HFClientSync::new()?;
+    let api = api.model("", &model_name);
+    let model_file = api.download_file().filename("model.safetensors").send()?;
     println!("model {model_name} downloaded and loaded");
     let vb =
         unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], candle::DType::F32, device)? };
-    let config = std::fs::read_to_string(api.get("config.json")?)?;
+    let config = std::fs::read_to_string(api.download_file().filename("config.json").send()?)?;
     let config: Config = serde_json::from_str(&config)?;
     println!("{config:?}");
     Ok((vb, config))

--- a/candle-examples/examples/segformer/main.rs
+++ b/candle-examples/examples/segformer/main.rs
@@ -62,7 +62,8 @@ fn get_vb_and_config(
 ) -> anyhow::Result<(VarBuilder<'_>, Config)> {
     println!("loading model {model_name} via huggingface hub");
     let api = hf_hub::HFClientSync::new()?;
-    let api = api.model("", &model_name);
+    let (owner, repo_name) = model_name.split_once('/').unwrap_or(("", model_name.as_str()));
+    let api = api.model(owner, repo_name);
     let model_file = api.download_file().filename("model.safetensors").send()?;
     println!("model {model_name} downloaded and loaded");
     let vb =

--- a/candle-examples/examples/segment-anything/main.rs
+++ b/candle-examples/examples/segment-anything/main.rs
@@ -75,7 +75,7 @@ pub fn main() -> anyhow::Result<()> {
         Some(model) => std::path::PathBuf::from(model),
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "lmz/candle-sam");
+            let api = api.model("lmz", "candle-sam");
             let filename = if args.use_tiny {
                 "mobile_sam-tiny-vitt.safetensors"
             } else {

--- a/candle-examples/examples/segment-anything/main.rs
+++ b/candle-examples/examples/segment-anything/main.rs
@@ -74,14 +74,14 @@ pub fn main() -> anyhow::Result<()> {
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("lmz/candle-sam".to_string());
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "lmz/candle-sam");
             let filename = if args.use_tiny {
                 "mobile_sam-tiny-vitt.safetensors"
             } else {
                 "sam_vit_b_01ec64.safetensors"
             };
-            api.get(filename)?
+            api.download_file().filename(filename).send()?
         }
     };
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DType::F32, &device)? };

--- a/candle-examples/examples/siglip/main.rs
+++ b/candle-examples/examples/siglip/main.rs
@@ -110,17 +110,17 @@ pub fn main() -> anyhow::Result<()> {
     };
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(hf_repo.to_string());
-            api.get("model.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", hf_repo);
+            api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };
     let config_file = match args.config {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(hf_repo.to_string());
-            api.get("config.json")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", hf_repo);
+            api.download_file().filename("config.json").send()?
         }
         Some(config) => config.into(),
     };
@@ -168,9 +168,9 @@ pub fn main() -> anyhow::Result<()> {
 pub fn get_tokenizer(hf_repo: &str, tokenizer: Option<String>) -> anyhow::Result<Tokenizer> {
     let tokenizer = match tokenizer {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(hf_repo.to_string());
-            api.get("tokenizer.json")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", hf_repo);
+            api.download_file().filename("tokenizer.json").send()?
         }
         Some(file) => file.into(),
     };

--- a/candle-examples/examples/siglip/main.rs
+++ b/candle-examples/examples/siglip/main.rs
@@ -108,10 +108,11 @@ pub fn main() -> anyhow::Result<()> {
             Which::V2LargePatch16_512 => "google/siglip2-large-patch16-512",
         },
     };
+    let (hf_owner, hf_name) = hf_repo.split_once('/').unwrap_or(("", hf_repo));
     let model_file = match args.model {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", hf_repo);
+            let api = api.model(hf_owner, hf_name);
             api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
@@ -119,7 +120,7 @@ pub fn main() -> anyhow::Result<()> {
     let config_file = match args.config {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", hf_repo);
+            let api = api.model(hf_owner, hf_name);
             api.download_file().filename("config.json").send()?
         }
         Some(config) => config.into(),
@@ -169,7 +170,8 @@ pub fn get_tokenizer(hf_repo: &str, tokenizer: Option<String>) -> anyhow::Result
     let tokenizer = match tokenizer {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", hf_repo);
+            let (owner, name) = hf_repo.split_once('/').unwrap_or(("", hf_repo));
+            let api = api.model(owner, name);
             api.download_file().filename("tokenizer.json").send()?
         }
         Some(file) => file.into(),

--- a/candle-examples/examples/silero-vad/main.rs
+++ b/candle-examples/examples/silero-vad/main.rs
@@ -124,9 +124,11 @@ fn main() -> Result<()> {
     let model_id = match &args.model_id {
         Some(model_id) => std::path::PathBuf::from(model_id),
         None => match args.which {
-            Which::Silero => hf_hub::api::sync::Api::new()?
-                .model("onnx-community/silero-vad".into())
-                .get("onnx/model.onnx")?,
+            Which::Silero => hf_hub::HFClientSync::new()?
+                .model("", "onnx-community/silero-vad")
+                .download_file()
+                .filename("onnx/model.onnx")
+                .send()?,
             // TODO: candle-onnx doesn't support Int8 dtype
             // Which::SileroQuantized => hf_hub::api::sync::Api::new()?
             //     .model("onnx-community/silero-vad".into())

--- a/candle-examples/examples/silero-vad/main.rs
+++ b/candle-examples/examples/silero-vad/main.rs
@@ -125,7 +125,7 @@ fn main() -> Result<()> {
         Some(model_id) => std::path::PathBuf::from(model_id),
         None => match args.which {
             Which::Silero => hf_hub::HFClientSync::new()?
-                .model("", "onnx-community/silero-vad")
+                .model("onnx-community", "silero-vad")
                 .download_file()
                 .filename("onnx/model.onnx")
                 .send()?,

--- a/candle-examples/examples/smollm3/main.rs
+++ b/candle-examples/examples/smollm3/main.rs
@@ -228,7 +228,7 @@ impl Args {
             Some(path) => std::path::PathBuf::from(path),
             None => {
                 let api = HFClientSync::new()?;
-                let api = api.model("", "HuggingFaceTB/SmolLM3-3B");
+                let api = api.model("HuggingFaceTB", "SmolLM3-3B");
                 api.download_file().filename("tokenizer.json").send()?
             }
         };
@@ -255,7 +255,8 @@ fn load_quantized_model(args: &Args, device: &Device) -> Result<SmolLM3Model> {
                 repo_id,
                 args.quantization.size_gb()
             );
-            api.model("", repo_id)
+            let (owner, name) = repo_id.split_once('/').unwrap_or(("", repo_id));
+            api.model(owner, name)
                 .download_file()
                 .filename(filename)
                 .send()?
@@ -275,7 +276,8 @@ fn load_full_model(args: &Args, device: &Device) -> Result<SmolLM3Model> {
     };
 
     println!("Loading full model from: {}", model_id);
-    let repo = api.model("", model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id));
+    let repo = api.model(owner, name);
 
     let filenames = match &args.model_path {
         Some(path) => vec![std::path::PathBuf::from(path)],

--- a/candle-examples/examples/smollm3/main.rs
+++ b/candle-examples/examples/smollm3/main.rs
@@ -14,7 +14,7 @@ use candle_examples::token_output_stream::TokenOutputStream;
 
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 // Import both model implementations
@@ -227,9 +227,9 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(path) => std::path::PathBuf::from(path),
             None => {
-                let api = Api::new()?;
-                let api = api.model("HuggingFaceTB/SmolLM3-3B".to_string());
-                api.get("tokenizer.json")?
+                let api = HFClientSync::new()?;
+                let api = api.model("", "HuggingFaceTB/SmolLM3-3B");
+                api.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(E::msg)
@@ -248,19 +248,17 @@ fn load_quantized_model(args: &Args, device: &Device) -> Result<SmolLM3Model> {
         None => {
             let filename = args.quantization.filename_unsloth();
             let repo_id = "unsloth/SmolLM3-3B-GGUF";
-            let api = Api::new()?;
+            let api = HFClientSync::new()?;
             println!(
                 "Downloading {} from {} (~{:.2}GB)...",
                 filename,
                 repo_id,
                 args.quantization.size_gb()
             );
-            api.repo(Repo::with_revision(
-                repo_id.to_string(),
-                RepoType::Model,
-                "main".to_string(),
-            ))
-            .get(filename)?
+            api.model("", repo_id)
+                .download_file()
+                .filename(filename)
+                .send()?
         }
     };
 
@@ -270,25 +268,21 @@ fn load_quantized_model(args: &Args, device: &Device) -> Result<SmolLM3Model> {
 }
 
 fn load_full_model(args: &Args, device: &Device) -> Result<SmolLM3Model> {
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match args.model {
         WhichModel::W3b => "HuggingFaceTB/SmolLM3-3B",
         WhichModel::W3bBase => "HuggingFaceTB/SmolLM3-3B-Base",
     };
 
     println!("Loading full model from: {}", model_id);
-    let repo = api.repo(Repo::with_revision(
-        model_id.to_string(),
-        RepoType::Model,
-        "main".to_string(),
-    ));
+    let repo = api.model("", model_id);
 
     let filenames = match &args.model_path {
         Some(path) => vec![std::path::PathBuf::from(path)],
         None => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
     };
 
-    let config_file = repo.get("config.json")?;
+    let config_file = repo.download_file().filename("config.json").send()?;
     let config: Config = serde_json::from_slice(&std::fs::read(config_file)?)?;
 
     let dtype = match args.dtype.as_str() {

--- a/candle-examples/examples/snac/main.rs
+++ b/candle-examples/examples/snac/main.rs
@@ -91,17 +91,21 @@ fn main() -> Result<()> {
     let model_sample_rate = args.which.sample_rate();
     let config = match args.config {
         Some(c) => std::path::PathBuf::from(c),
-        None => HFClientSync::new()?
-            .model("", args.which.config_repo())
-            .download_file()
-            .filename("config.json")
-            .send()?,
+        None => {
+            let config_repo = args.which.config_repo();
+            let (owner, name) = config_repo.split_once('/').unwrap_or(("", config_repo));
+            HFClientSync::new()?
+                .model(owner, name)
+                .download_file()
+                .filename("config.json")
+                .send()?
+        }
     };
     let config: Config = serde_json::from_slice(&std::fs::read(config)?)?;
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
         None => HFClientSync::new()?
-            .model("", "lmz/candle-snac")
+            .model("lmz", "candle-snac")
             .download_file()
             .filename(args.which.model_file())
             .send()?,

--- a/candle-examples/examples/snac/main.rs
+++ b/candle-examples/examples/snac/main.rs
@@ -9,7 +9,7 @@ use candle::{DType, IndexOp, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::snac::{Config, Model};
 use clap::{Parser, ValueEnum};
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 
 mod audio_io;
 
@@ -91,16 +91,20 @@ fn main() -> Result<()> {
     let model_sample_rate = args.which.sample_rate();
     let config = match args.config {
         Some(c) => std::path::PathBuf::from(c),
-        None => Api::new()?
-            .model(args.which.config_repo().to_string())
-            .get("config.json")?,
+        None => HFClientSync::new()?
+            .model("", args.which.config_repo())
+            .download_file()
+            .filename("config.json")
+            .send()?,
     };
     let config: Config = serde_json::from_slice(&std::fs::read(config)?)?;
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
-        None => Api::new()?
-            .model("lmz/candle-snac".to_string())
-            .get(args.which.model_file())?,
+        None => HFClientSync::new()?
+            .model("", "lmz/candle-snac")
+            .download_file()
+            .filename(args.which.model_file())
+            .send()?,
     };
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DType::F32, &device)? };
     let model = Model::new(&config, vb)?;

--- a/candle-examples/examples/splade/main.rs
+++ b/candle-examples/examples/splade/main.rs
@@ -5,7 +5,7 @@ use candle::Tensor;
 use candle_nn::VarBuilder;
 use candle_transformers::models::bert::{self, BertForMaskedLM, Config};
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingParams, Tokenizer};
 
 #[derive(Parser, Debug)]
@@ -45,32 +45,29 @@ struct Args {
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => "prithivida/Splade_PP_en_v1".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision.clone();
+    let repo = api.model("", &model_id);
 
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
 
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo.download_file().filename("config.json").revision(&revision).send()?,
     };
 
     let weights_filename = match args.weight_files {
         Some(files) => PathBuf::from(files),
-        None => match repo.get("model.safetensors") {
+        None => match repo.download_file().filename("model.safetensors").revision(&revision).send() {
             Ok(safetensors) => safetensors,
-            Err(_) => match repo.get("pytorch_model.bin") {
+            Err(_) => match repo.download_file().filename("pytorch_model.bin").revision(&revision).send() {
                 Ok(pytorch_model) => pytorch_model,
                 Err(e) => {
                     return Err(anyhow::Error::msg(format!("Model weights not found. The weights should either be a `model.safetensors` or `pytorch_model.bin` file.  Error: {e}")));

--- a/candle-examples/examples/splade/main.rs
+++ b/candle-examples/examples/splade/main.rs
@@ -51,7 +51,8 @@ fn main() -> Result<()> {
         None => "prithivida/Splade_PP_en_v1".to_string(),
     };
     let revision = args.revision.clone();
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
 
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),

--- a/candle-examples/examples/stable-diffusion-3/clip.rs
+++ b/candle-examples/examples/stable-diffusion-3/clip.rs
@@ -19,9 +19,11 @@ impl ClipWithTokenizer {
         max_position_embeddings: usize,
     ) -> Result<Self> {
         let clip = stable_diffusion::clip::ClipTextTransformer::new(vb, &config)?;
-        let path_buf = hf_hub::api::sync::Api::new()?
-            .model(tokenizer_path.to_string())
-            .get("tokenizer.json")?;
+        let path_buf = hf_hub::HFClientSync::new()?
+            .model("", tokenizer_path)
+            .download_file()
+            .filename("tokenizer.json")
+            .send()?;
         let tokenizer = Tokenizer::from_file(path_buf.to_str().ok_or(E::msg(
             "Failed to serialize huggingface PathBuf of CLIP tokenizer",
         ))?)
@@ -82,20 +84,18 @@ struct T5WithTokenizer {
 
 impl T5WithTokenizer {
     fn new(vb: candle_nn::VarBuilder, max_position_embeddings: usize) -> Result<Self> {
-        let api = hf_hub::api::sync::Api::new()?;
-        let repo = api.repo(hf_hub::Repo::with_revision(
-            "google/t5-v1_1-xxl".to_string(),
-            hf_hub::RepoType::Model,
-            "refs/pr/2".to_string(),
-        ));
-        let config_filename = repo.get("config.json")?;
+        let api = hf_hub::HFClientSync::new()?;
+        let repo = api.model("", "google/t5-v1_1-xxl");
+        let config_filename = repo.download_file().filename("config.json").revision("refs/pr/2").send()?;
         let config = std::fs::read_to_string(config_filename)?;
         let config: t5::Config = serde_json::from_str(&config)?;
         let model = t5::T5EncoderModel::load(vb, &config)?;
 
         let tokenizer_filename = api
-            .model("lmz/mt5-tokenizers".to_string())
-            .get("t5-v1_1-xxl.tokenizer.json")?;
+            .model("", "lmz/mt5-tokenizers")
+            .download_file()
+            .filename("t5-v1_1-xxl.tokenizer.json")
+            .send()?;
 
         let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
         Ok(Self {

--- a/candle-examples/examples/stable-diffusion-3/clip.rs
+++ b/candle-examples/examples/stable-diffusion-3/clip.rs
@@ -19,8 +19,9 @@ impl ClipWithTokenizer {
         max_position_embeddings: usize,
     ) -> Result<Self> {
         let clip = stable_diffusion::clip::ClipTextTransformer::new(vb, &config)?;
+        let (owner, name) = tokenizer_path.split_once('/').unwrap_or(("", tokenizer_path));
         let path_buf = hf_hub::HFClientSync::new()?
-            .model("", tokenizer_path)
+            .model(owner, name)
             .download_file()
             .filename("tokenizer.json")
             .send()?;
@@ -85,14 +86,14 @@ struct T5WithTokenizer {
 impl T5WithTokenizer {
     fn new(vb: candle_nn::VarBuilder, max_position_embeddings: usize) -> Result<Self> {
         let api = hf_hub::HFClientSync::new()?;
-        let repo = api.model("", "google/t5-v1_1-xxl");
+        let repo = api.model("google", "t5-v1_1-xxl");
         let config_filename = repo.download_file().filename("config.json").revision("refs/pr/2").send()?;
         let config = std::fs::read_to_string(config_filename)?;
         let config: t5::Config = serde_json::from_str(&config)?;
         let model = t5::T5EncoderModel::load(vb, &config)?;
 
         let tokenizer_filename = api
-            .model("", "lmz/mt5-tokenizers")
+            .model("lmz", "mt5-tokenizers")
             .download_file()
             .filename("t5-v1_1-xxl.tokenizer.json")
             .send()?;

--- a/candle-examples/examples/stable-diffusion-3/main.rs
+++ b/candle-examples/examples/stable-diffusion-3/main.rs
@@ -137,7 +137,7 @@ fn main() -> Result<()> {
     };
     let cfg_scale = cfg_scale.unwrap_or(default_cfg_scale);
 
-    let api = hf_hub::api::sync::Api::new()?;
+    let api = hf_hub::HFClientSync::new()?;
     let (mmdit_config, mut triple, vb) = if which.is_3_5() {
         let sai_repo_for_text_encoders = {
             let name = match which {
@@ -156,7 +156,7 @@ fn main() -> Result<()> {
                 Which::V3_5Medium => "stabilityai/stable-diffusion-3.5-large",
                 Which::V3Medium => unreachable!(),
             };
-            api.repo(hf_hub::Repo::model(name.to_string()))
+            api.model("", name)
         };
         let sai_repo_for_mmdit = {
             let name = match which {
@@ -165,11 +165,11 @@ fn main() -> Result<()> {
                 Which::V3_5Medium => "stabilityai/stable-diffusion-3.5-medium",
                 Which::V3Medium => unreachable!(),
             };
-            api.repo(hf_hub::Repo::model(name.to_string()))
+            api.model("", name)
         };
-        let clip_g_file = sai_repo_for_text_encoders.get("text_encoders/clip_g.safetensors")?;
-        let clip_l_file = sai_repo_for_text_encoders.get("text_encoders/clip_l.safetensors")?;
-        let t5xxl_file = sai_repo_for_text_encoders.get("text_encoders/t5xxl_fp16.safetensors")?;
+        let clip_g_file = sai_repo_for_text_encoders.download_file().filename("text_encoders/clip_g.safetensors").send()?;
+        let clip_l_file = sai_repo_for_text_encoders.download_file().filename("text_encoders/clip_l.safetensors").send()?;
+        let t5xxl_file = sai_repo_for_text_encoders.download_file().filename("text_encoders/t5xxl_fp16.safetensors").send()?;
         let model_file = {
             let model_file = match which {
                 Which::V3_5Large => "sd3.5_large.safetensors",
@@ -177,7 +177,7 @@ fn main() -> Result<()> {
                 Which::V3_5Medium => "sd3.5_medium.safetensors",
                 Which::V3Medium => unreachable!(),
             };
-            sai_repo_for_mmdit.get(model_file)?
+            sai_repo_for_mmdit.download_file().filename(model_file).send()?
         };
         let triple = StableDiffusion3TripleClipWithTokenizer::new_split(
             &clip_g_file,
@@ -197,9 +197,9 @@ fn main() -> Result<()> {
     } else {
         let sai_repo = {
             let name = "stabilityai/stable-diffusion-3-medium";
-            api.repo(hf_hub::Repo::model(name.to_string()))
+            api.model("", name)
         };
-        let model_file = sai_repo.get("sd3_medium_incl_clips_t5xxlfp16.safetensors")?;
+        let model_file = sai_repo.download_file().filename("sd3_medium_incl_clips_t5xxlfp16.safetensors").send()?;
         let vb = unsafe {
             candle_nn::VarBuilder::from_mmaped_safetensors(&[&model_file], DType::F16, &device)?
         };

--- a/candle-examples/examples/stable-diffusion-3/main.rs
+++ b/candle-examples/examples/stable-diffusion-3/main.rs
@@ -156,7 +156,8 @@ fn main() -> Result<()> {
                 Which::V3_5Medium => "stabilityai/stable-diffusion-3.5-large",
                 Which::V3Medium => unreachable!(),
             };
-            api.model("", name)
+            let (owner, repo_name) = name.split_once('/').unwrap_or(("", name));
+            api.model(owner, repo_name)
         };
         let sai_repo_for_mmdit = {
             let name = match which {
@@ -165,7 +166,8 @@ fn main() -> Result<()> {
                 Which::V3_5Medium => "stabilityai/stable-diffusion-3.5-medium",
                 Which::V3Medium => unreachable!(),
             };
-            api.model("", name)
+            let (owner, repo_name) = name.split_once('/').unwrap_or(("", name));
+            api.model(owner, repo_name)
         };
         let clip_g_file = sai_repo_for_text_encoders.download_file().filename("text_encoders/clip_g.safetensors").send()?;
         let clip_l_file = sai_repo_for_text_encoders.download_file().filename("text_encoders/clip_l.safetensors").send()?;
@@ -197,7 +199,8 @@ fn main() -> Result<()> {
     } else {
         let sai_repo = {
             let name = "stabilityai/stable-diffusion-3-medium";
-            api.model("", name)
+            let (owner, repo_name) = name.split_once('/').unwrap_or(("", name));
+            api.model(owner, repo_name)
         };
         let model_file = sai_repo.download_file().filename("sd3_medium_incl_clips_t5xxlfp16.safetensors").send()?;
         let vb = unsafe {

--- a/candle-examples/examples/stable-diffusion/main.rs
+++ b/candle-examples/examples/stable-diffusion/main.rs
@@ -280,7 +280,8 @@ impl ModelFile {
                         }
                     }
                 };
-                let filename = HFClientSync::new()?.model("", repo).download_file().filename(path).send()?;
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                let filename = HFClientSync::new()?.model(owner, name).download_file().filename(path).send()?;
                 Ok(filename)
             }
         }

--- a/candle-examples/examples/stable-diffusion/main.rs
+++ b/candle-examples/examples/stable-diffusion/main.rs
@@ -236,7 +236,7 @@ impl ModelFile {
         version: StableDiffusionVersion,
         use_f16: bool,
     ) -> Result<std::path::PathBuf> {
-        use hf_hub::api::sync::Api;
+        use hf_hub::HFClientSync;
         match filename {
             Some(filename) => Ok(std::path::PathBuf::from(filename)),
             None => {
@@ -280,7 +280,7 @@ impl ModelFile {
                         }
                     }
                 };
-                let filename = Api::new()?.model(repo.to_string()).get(path)?;
+                let filename = HFClientSync::new()?.model("", repo).download_file().filename(path).send()?;
                 Ok(filename)
             }
         }

--- a/candle-examples/examples/stable-lm/main.rs
+++ b/candle-examples/examples/stable-lm/main.rs
@@ -14,7 +14,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -219,7 +219,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => match args.which {
@@ -232,14 +232,11 @@ fn main() -> Result<()> {
         },
     };
 
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision.clone();
+    let repo = api.model("", &model_id);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -247,24 +244,28 @@ fn main() -> Result<()> {
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
         None => match (args.which, args.quantized) {
-            (Which::V1Orig | Which::V1, true) => vec![repo.get("model-q4k.gguf")?],
+            (Which::V1Orig | Which::V1, true) => vec![repo.download_file().filename("model-q4k.gguf").revision(&revision).send()?],
             (Which::V2, true) => {
                 let gguf = api
-                    .model("lmz/candle-stablelm".to_string())
-                    .get("stablelm-2-1_6b-q4k.gguf")?;
+                    .model("", "lmz/candle-stablelm")
+                    .download_file()
+                    .filename("stablelm-2-1_6b-q4k.gguf")
+                    .send()?;
                 vec![gguf]
             }
             (Which::V2Zephyr, true) => {
                 let gguf = api
-                    .model("lmz/candle-stablelm".to_string())
-                    .get("stablelm-2-zephyr-1_6b-q4k.gguf")?;
+                    .model("", "lmz/candle-stablelm")
+                    .download_file()
+                    .filename("stablelm-2-zephyr-1_6b-q4k.gguf")
+                    .send()?;
                 vec![gguf]
             }
             (Which::V1Zephyr | Which::Code, true) => {
                 anyhow::bail!("Quantized {:?} variant not supported.", args.which)
             }
             (Which::V1Orig | Which::V1 | Which::V1Zephyr | Which::V2 | Which::V2Zephyr, false) => {
-                vec![repo.get("model.safetensors")?]
+                vec![repo.download_file().filename("model.safetensors").revision(&revision).send()?]
             }
             (Which::Code, false) => {
                 candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?
@@ -279,7 +280,7 @@ fn main() -> Result<()> {
     let config = match args.which {
         Which::V1Orig => Config::stablelm_3b_4e1t(args.use_flash_attn),
         Which::V1 | Which::V1Zephyr | Which::V2 | Which::V2Zephyr | Which::Code => {
-            let config_filename = repo.get("config.json")?;
+            let config_filename = repo.download_file().filename("config.json").revision(&revision).send()?;
             let config = std::fs::read_to_string(config_filename)?;
             let mut config: Config = serde_json::from_str(&config)?;
             config.set_use_flash_attn(args.use_flash_attn);

--- a/candle-examples/examples/stable-lm/main.rs
+++ b/candle-examples/examples/stable-lm/main.rs
@@ -233,7 +233,8 @@ fn main() -> Result<()> {
     };
 
     let revision = args.revision.clone();
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
@@ -247,7 +248,7 @@ fn main() -> Result<()> {
             (Which::V1Orig | Which::V1, true) => vec![repo.download_file().filename("model-q4k.gguf").revision(&revision).send()?],
             (Which::V2, true) => {
                 let gguf = api
-                    .model("", "lmz/candle-stablelm")
+                    .model("lmz", "candle-stablelm")
                     .download_file()
                     .filename("stablelm-2-1_6b-q4k.gguf")
                     .send()?;
@@ -255,7 +256,7 @@ fn main() -> Result<()> {
             }
             (Which::V2Zephyr, true) => {
                 let gguf = api
-                    .model("", "lmz/candle-stablelm")
+                    .model("lmz", "candle-stablelm")
                     .download_file()
                     .filename("stablelm-2-zephyr-1_6b-q4k.gguf")
                     .send()?;

--- a/candle-examples/examples/starcoder2/main.rs
+++ b/candle-examples/examples/starcoder2/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -197,30 +197,27 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => "bigcode/starcoder2-3b".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision.clone();
+    let repo = api.model("", &model_id);
     let config_file = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo.download_file().filename("config.json").revision(&revision).send()?,
     };
     let tokenizer_file = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => vec![repo.get("model.safetensors")?],
+        None => vec![repo.download_file().filename("model.safetensors").revision(&revision).send()?],
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_file).map_err(E::msg)?;

--- a/candle-examples/examples/starcoder2/main.rs
+++ b/candle-examples/examples/starcoder2/main.rs
@@ -203,7 +203,8 @@ fn main() -> Result<()> {
         None => "bigcode/starcoder2-3b".to_string(),
     };
     let revision = args.revision.clone();
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
     let config_file = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
         None => repo.download_file().filename("config.json").revision(&revision).send()?,

--- a/candle-examples/examples/stella-en-v5/main.rs
+++ b/candle-examples/examples/stella-en-v5/main.rs
@@ -15,7 +15,7 @@ use candle_transformers::models::stella_en_v5::{
 
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use hf_hub::{api::sync::Api, Repo};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingDirection, PaddingParams, PaddingStrategy, Tokenizer};
 
 struct Embedding {
@@ -313,7 +313,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let embed_dim = match args.embed_dim {
         Some(d) => d,
         None => EmbedDim::Dim1024,
@@ -330,10 +330,10 @@ fn main() -> Result<()> {
         ),
     };
 
-    let repo = api.repo(Repo::model(repo.to_string()));
+    let repo = api.model("", repo);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").send()?,
     };
 
     // Note, if you are providing `weight_files`, ensure that the `--embed_dim` dimensions provided matches the weights
@@ -344,7 +344,7 @@ fn main() -> Result<()> {
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
         None => {
-            vec![repo.get("model.safetensors")?]
+            vec![repo.download_file().filename("model.safetensors").send()?]
         }
     };
 
@@ -355,7 +355,7 @@ fn main() -> Result<()> {
             .collect::<Vec<_>>(),
         None => {
             let head_w_path = format!("{}/model.safetensors", embed_dim.embed_dim_default_dir());
-            vec![repo.get(&head_w_path)?]
+            vec![repo.download_file().filename(head_w_path).send()?]
         }
     };
 

--- a/candle-examples/examples/stella-en-v5/main.rs
+++ b/candle-examples/examples/stella-en-v5/main.rs
@@ -330,7 +330,8 @@ fn main() -> Result<()> {
         ),
     };
 
-    let repo = api.model("", repo);
+    let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => repo.download_file().filename("tokenizer.json").send()?,

--- a/candle-examples/examples/t5/main.rs
+++ b/candle-examples/examples/t5/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 const DTYPE: DType = DType::F32;
@@ -124,25 +124,30 @@ impl T5ModelBuilder {
             (None, None) => (default_model, default_revision),
         };
 
-        let repo = Repo::with_revision(model_id.clone(), RepoType::Model, revision);
-        let api = Api::new()?;
-        let repo = api.repo(repo);
+        let api = HFClientSync::new()?;
+        let repo = api.model("", &model_id);
         let config_filename = match &args.config_file {
-            None => repo.get("config.json")?,
+            None => repo.download_file().filename("config.json").revision(&revision).send()?,
             Some(f) => f.into(),
         };
         let tokenizer_filename = match &args.tokenizer_file {
             None => match args.which {
                 Which::Mt5Base => api
-                    .model("lmz/mt5-tokenizers".into())
-                    .get("mt5-base.tokenizer.json")?,
+                    .model("", "lmz/mt5-tokenizers")
+                    .download_file()
+                    .filename("mt5-base.tokenizer.json")
+                    .send()?,
                 Which::Mt5Small => api
-                    .model("lmz/mt5-tokenizers".into())
-                    .get("mt5-small.tokenizer.json")?,
+                    .model("", "lmz/mt5-tokenizers")
+                    .download_file()
+                    .filename("mt5-small.tokenizer.json")
+                    .send()?,
                 Which::Mt5Large => api
-                    .model("lmz/mt5-tokenizers".into())
-                    .get("mt5-large.tokenizer.json")?,
-                _ => repo.get("tokenizer.json")?,
+                    .model("", "lmz/mt5-tokenizers")
+                    .download_file()
+                    .filename("mt5-large.tokenizer.json")
+                    .send()?,
+                _ => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
             },
             Some(f) => f.into(),
         };
@@ -152,7 +157,7 @@ impl T5ModelBuilder {
                 if model_id == "google/flan-t5-xxl" || model_id == "google/flan-ul2" {
                     candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?
                 } else {
-                    vec![repo.get("model.safetensors")?]
+                    vec![repo.download_file().filename("model.safetensors").revision(&revision).send()?]
                 }
             }
         };

--- a/candle-examples/examples/t5/main.rs
+++ b/candle-examples/examples/t5/main.rs
@@ -125,7 +125,8 @@ impl T5ModelBuilder {
         };
 
         let api = HFClientSync::new()?;
-        let repo = api.model("", &model_id);
+        let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+        let repo = api.model(owner, name);
         let config_filename = match &args.config_file {
             None => repo.download_file().filename("config.json").revision(&revision).send()?,
             Some(f) => f.into(),
@@ -133,17 +134,17 @@ impl T5ModelBuilder {
         let tokenizer_filename = match &args.tokenizer_file {
             None => match args.which {
                 Which::Mt5Base => api
-                    .model("", "lmz/mt5-tokenizers")
+                    .model("lmz", "mt5-tokenizers")
                     .download_file()
                     .filename("mt5-base.tokenizer.json")
                     .send()?,
                 Which::Mt5Small => api
-                    .model("", "lmz/mt5-tokenizers")
+                    .model("lmz", "mt5-tokenizers")
                     .download_file()
                     .filename("mt5-small.tokenizer.json")
                     .send()?,
                 Which::Mt5Large => api
-                    .model("", "lmz/mt5-tokenizers")
+                    .model("lmz", "mt5-tokenizers")
                     .download_file()
                     .filename("mt5-large.tokenizer.json")
                     .send()?,

--- a/candle-examples/examples/trocr/main.rs
+++ b/candle-examples/examples/trocr/main.rs
@@ -71,7 +71,7 @@ pub fn main() -> anyhow::Result<()> {
     let mut tokenizer_dec = {
         let tokenizer_file = match args.tokenizer {
             None => api
-                .model("", "ToluClassics/candle-trocr-tokenizer")
+                .model("ToluClassics", "candle-trocr-tokenizer")
                 .download_file()
                 .filename("tokenizer.json")
                 .send()?,
@@ -87,7 +87,8 @@ pub fn main() -> anyhow::Result<()> {
             Some(model) => std::path::PathBuf::from(model),
             None => {
                 let (repo, branch) = args.which.repo_and_branch_name();
-                api.model("", repo)
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                api.model(owner, name)
                     .download_file()
                     .filename("model.safetensors")
                     .revision(branch)
@@ -100,8 +101,9 @@ pub fn main() -> anyhow::Result<()> {
 
     let (encoder_config, decoder_config) = {
         let (repo, branch) = args.which.repo_and_branch_name();
+        let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
         let config_filename = api
-            .model("", repo)
+            .model(owner, name)
             .download_file()
             .filename("config.json")
             .revision(branch)

--- a/candle-examples/examples/trocr/main.rs
+++ b/candle-examples/examples/trocr/main.rs
@@ -66,13 +66,15 @@ struct Args {
 
 pub fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    let api = hf_hub::api::sync::Api::new()?;
+    let api = hf_hub::HFClientSync::new()?;
 
     let mut tokenizer_dec = {
         let tokenizer_file = match args.tokenizer {
             None => api
-                .model(String::from("ToluClassics/candle-trocr-tokenizer"))
-                .get("tokenizer.json")?,
+                .model("", "ToluClassics/candle-trocr-tokenizer")
+                .download_file()
+                .filename("tokenizer.json")
+                .send()?,
             Some(tokenizer) => std::path::PathBuf::from(tokenizer),
         };
         let tokenizer = Tokenizer::from_file(&tokenizer_file).map_err(E::msg)?;
@@ -85,12 +87,11 @@ pub fn main() -> anyhow::Result<()> {
             Some(model) => std::path::PathBuf::from(model),
             None => {
                 let (repo, branch) = args.which.repo_and_branch_name();
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    branch.to_string(),
-                ))
-                .get("model.safetensors")?
+                api.model("", repo)
+                    .download_file()
+                    .filename("model.safetensors")
+                    .revision(branch)
+                    .send()?
             }
         };
         println!("model: {model:?}");
@@ -100,12 +101,11 @@ pub fn main() -> anyhow::Result<()> {
     let (encoder_config, decoder_config) = {
         let (repo, branch) = args.which.repo_and_branch_name();
         let config_filename = api
-            .repo(hf_hub::Repo::with_revision(
-                repo.to_string(),
-                hf_hub::RepoType::Model,
-                branch.to_string(),
-            ))
-            .get("config.json")?;
+            .model("", repo)
+            .download_file()
+            .filename("config.json")
+            .revision(branch)
+            .send()?;
         let config: Config = serde_json::from_reader(std::fs::File::open(config_filename)?)?;
         (config.encoder, config.decoder)
     };

--- a/candle-examples/examples/vgg/main.rs
+++ b/candle-examples/examples/vgg/main.rs
@@ -43,7 +43,8 @@ pub fn main() -> anyhow::Result<()> {
         Which::Vgg16 => "timm/vgg16.tv_in1k",
         Which::Vgg19 => "timm/vgg19.tv_in1k",
     };
-    let api = api.model("", repo);
+    let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+    let api = api.model(owner, name);
     let filename = "model.safetensors";
     let model_file = api.download_file().filename(filename).send()?;
 

--- a/candle-examples/examples/vgg/main.rs
+++ b/candle-examples/examples/vgg/main.rs
@@ -37,15 +37,15 @@ pub fn main() -> anyhow::Result<()> {
 
     println!("loaded image {image:?}");
 
-    let api = hf_hub::api::sync::Api::new()?;
+    let api = hf_hub::HFClientSync::new()?;
     let repo = match args.which {
         Which::Vgg13 => "timm/vgg13.tv_in1k",
         Which::Vgg16 => "timm/vgg16.tv_in1k",
         Which::Vgg19 => "timm/vgg19.tv_in1k",
     };
-    let api = api.model(repo.into());
+    let api = api.model("", repo);
     let filename = "model.safetensors";
-    let model_file = api.get(filename)?;
+    let model_file = api.download_file().filename(filename).send()?;
 
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], DType::F32, &device)? };
     let model = match args.which {

--- a/candle-examples/examples/vit/main.rs
+++ b/candle-examples/examples/vit/main.rs
@@ -33,9 +33,9 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("google/vit-base-patch16-224".into());
-            api.get("model.safetensors")?
+            let api = hf_hub::HFClientSync::new()?;
+            let api = api.model("", "google/vit-base-patch16-224");
+            api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/vit/main.rs
+++ b/candle-examples/examples/vit/main.rs
@@ -34,7 +34,7 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let api = hf_hub::HFClientSync::new()?;
-            let api = api.model("", "google/vit-base-patch16-224");
+            let api = api.model("google", "vit-base-patch16-224");
             api.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),

--- a/candle-examples/examples/voxtral/download.rs
+++ b/candle-examples/examples/voxtral/download.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 
 /// # Errors
 ///
@@ -13,14 +13,10 @@ use hf_hub::{api::sync::Api, Repo, RepoType};
 pub fn model_files(model_id: &str) -> Result<((PathBuf, Vec<PathBuf>), PathBuf)> {
     let revision = "main";
 
-    let api = Api::new().unwrap();
-    let repo = api.repo(Repo::with_revision(
-        model_id.to_string(),
-        RepoType::Model,
-        revision.to_string(),
-    ));
+    let api = HFClientSync::new().unwrap();
+    let repo = api.model("", model_id);
 
-    let config = repo.get("config.json")?;
+    let config = repo.download_file().filename("config.json").revision(revision).send()?;
 
     // Download model files - look for safetensors
     let mut model_files = Vec::new();
@@ -56,7 +52,7 @@ pub fn model_files(model_id: &str) -> Result<((PathBuf, Vec<PathBuf>), PathBuf)>
 
     println!("Downloading safetensors files...");
     for filename in &safetensors_files {
-        if let Ok(file) = repo.get(filename) {
+        if let Ok(file) = repo.download_file().filename(*filename).revision(revision).send() {
             println!("{} downloaded", filename);
             model_files.push(file);
         }
@@ -68,8 +64,8 @@ pub fn model_files(model_id: &str) -> Result<((PathBuf, Vec<PathBuf>), PathBuf)>
 
     // Download tokenizer
     let tokenizer_file = repo
-        .get("tekken.json")
-        .or_else(|_| repo.get("tokenizer/tokenizer.json"))?;
+        .download_file().filename("tekken.json").revision(revision).send()
+        .or_else(|_| repo.download_file().filename("tokenizer/tokenizer.json").revision(revision).send())?;
 
     Ok(((config, model_files), tokenizer_file))
 }

--- a/candle-examples/examples/voxtral/download.rs
+++ b/candle-examples/examples/voxtral/download.rs
@@ -14,7 +14,8 @@ pub fn model_files(model_id: &str) -> Result<((PathBuf, Vec<PathBuf>), PathBuf)>
     let revision = "main";
 
     let api = HFClientSync::new().unwrap();
-    let repo = api.model("", model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id));
+    let repo = api.model(owner, name);
 
     let config = repo.download_file().filename("config.json").revision(revision).send()?;
 

--- a/candle-examples/examples/voxtral/main.rs
+++ b/candle-examples/examples/voxtral/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use model::VoxtralModel;
 
 mod download;
@@ -46,18 +46,18 @@ fn main() -> Result<()> {
 
     println!("Model loaded successfully on device: {:?}", model.device());
 
-    let api = Api::new()?;
-    let dataset = api.dataset("Narsil/candle-examples".to_string());
+    let api = HFClientSync::new()?;
+    let dataset = api.dataset("", "Narsil/candle-examples");
 
     let audio_file = if let Some(input) = args.input {
         if let Some(sample) = input.strip_prefix("sample:") {
-            dataset.get(&format!("samples_{sample}.wav"))?
+            dataset.download_file().filename(format!("samples_{sample}.wav")).send()?
         } else {
             std::path::PathBuf::from(input)
         }
     } else {
         println!("No audio file submitted: Downloading https://huggingface.co/datasets/Narsil/candle_demo/blob/main/samples_jfk.wav");
-        dataset.get("samples_jfk.wav")?
+        dataset.download_file().filename("samples_jfk.wav").send()?
     };
 
     let (audio_data, sample_rate) =

--- a/candle-examples/examples/voxtral/main.rs
+++ b/candle-examples/examples/voxtral/main.rs
@@ -47,7 +47,7 @@ fn main() -> Result<()> {
     println!("Model loaded successfully on device: {:?}", model.device());
 
     let api = HFClientSync::new()?;
-    let dataset = api.dataset("", "Narsil/candle-examples");
+    let dataset = api.dataset("Narsil", "candle-examples");
 
     let audio_file = if let Some(input) = args.input {
         if let Some(sample) = input.strip_prefix("sample:") {

--- a/candle-examples/examples/whisper-microphone/main.rs
+++ b/candle-examples/examples/whisper-microphone/main.rs
@@ -515,7 +515,8 @@ pub fn main() -> Result<()> {
 
     let (config_filename, tokenizer_filename, weights_filename) = {
         let api = HFClientSync::new()?;
-        let repo = api.model("", &model_id);
+        let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+        let repo = api.model(owner, name);
         let (config, tokenizer, model) = if args.quantized {
             let ext = match args.model {
                 WhichModel::TinyEn => "tiny-en",

--- a/candle-examples/examples/whisper-microphone/main.rs
+++ b/candle-examples/examples/whisper-microphone/main.rs
@@ -8,7 +8,7 @@ use anyhow::{Error as E, Result};
 use candle::{Device, IndexOp, Tensor};
 use candle_nn::{ops::softmax, VarBuilder};
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use rand::{distr::Distribution, SeedableRng};
 use tokenizers::Tokenizer;
 
@@ -514,8 +514,8 @@ pub fn main() -> Result<()> {
     };
 
     let (config_filename, tokenizer_filename, weights_filename) = {
-        let api = Api::new()?;
-        let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+        let api = HFClientSync::new()?;
+        let repo = api.model("", &model_id);
         let (config, tokenizer, model) = if args.quantized {
             let ext = match args.model {
                 WhichModel::TinyEn => "tiny-en",
@@ -523,14 +523,14 @@ pub fn main() -> Result<()> {
                 _ => unimplemented!("no quantized support for {:?}", args.model),
             };
             (
-                repo.get(&format!("config-{ext}.json"))?,
-                repo.get(&format!("tokenizer-{ext}.json"))?,
-                repo.get(&format!("model-{ext}-q80.gguf"))?,
+                repo.download_file().filename(format!("config-{ext}.json")).revision(&revision).send()?,
+                repo.download_file().filename(format!("tokenizer-{ext}.json")).revision(&revision).send()?,
+                repo.download_file().filename(format!("model-{ext}-q80.gguf")).revision(&revision).send()?,
             )
         } else {
-            let config = repo.get("config.json")?;
-            let tokenizer = repo.get("tokenizer.json")?;
-            let model = repo.get("model.safetensors")?;
+            let config = repo.download_file().filename("config.json").revision(&revision).send()?;
+            let tokenizer = repo.download_file().filename("tokenizer.json").revision(&revision).send()?;
+            let model = repo.download_file().filename("model.safetensors").revision(&revision).send()?;
             (config, tokenizer, model)
         };
         (config, tokenizer, model)

--- a/candle-examples/examples/whisper/main.rs
+++ b/candle-examples/examples/whisper/main.rs
@@ -16,7 +16,7 @@ use candle_nn::{
     VarBuilder,
 };
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use rand::distr::weighted::WeightedIndex;
 use rand::distr::Distribution;
 use rand::SeedableRng;
@@ -675,18 +675,18 @@ fn main() -> Result<()> {
     };
 
     let (config_filename, tokenizer_filename, weights_filename, input) = {
-        let api = Api::new()?;
-        let dataset = api.dataset("Narsil/candle-examples".to_string());
-        let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+        let api = HFClientSync::new()?;
+        let dataset = api.dataset("", "Narsil/candle-examples");
+        let repo = api.model("", &model_id);
         let sample = if let Some(input) = args.input {
             if let Some(sample) = input.strip_prefix("sample:") {
-                dataset.get(&format!("samples_{sample}.wav"))?
+                dataset.download_file().filename(format!("samples_{sample}.wav")).send()?
             } else {
                 std::path::PathBuf::from(input)
             }
         } else {
             println!("No audio file submitted: Downloading https://huggingface.co/datasets/Narsil/candle_demo/blob/main/samples_jfk.wav");
-            dataset.get("samples_jfk.wav")?
+            dataset.download_file().filename("samples_jfk.wav").send()?
         };
         let (config, tokenizer, model) = if args.quantized {
             let ext = match args.model {
@@ -695,14 +695,14 @@ fn main() -> Result<()> {
                 _ => unimplemented!("no quantized support for {:?}", args.model),
             };
             (
-                repo.get(&format!("config-{ext}.json"))?,
-                repo.get(&format!("tokenizer-{ext}.json"))?,
-                repo.get(&format!("model-{ext}-q80.gguf"))?,
+                repo.download_file().filename(format!("config-{ext}.json")).revision(&revision).send()?,
+                repo.download_file().filename(format!("tokenizer-{ext}.json")).revision(&revision).send()?,
+                repo.download_file().filename(format!("model-{ext}-q80.gguf")).revision(&revision).send()?,
             )
         } else {
-            let config = repo.get("config.json")?;
-            let tokenizer = repo.get("tokenizer.json")?;
-            let model = repo.get("model.safetensors")?;
+            let config = repo.download_file().filename("config.json").revision(&revision).send()?;
+            let tokenizer = repo.download_file().filename("tokenizer.json").revision(&revision).send()?;
+            let model = repo.download_file().filename("model.safetensors").revision(&revision).send()?;
             (config, tokenizer, model)
         };
         (config, tokenizer, model, sample)

--- a/candle-examples/examples/whisper/main.rs
+++ b/candle-examples/examples/whisper/main.rs
@@ -676,8 +676,9 @@ fn main() -> Result<()> {
 
     let (config_filename, tokenizer_filename, weights_filename, input) = {
         let api = HFClientSync::new()?;
-        let dataset = api.dataset("", "Narsil/candle-examples");
-        let repo = api.model("", &model_id);
+        let dataset = api.dataset("Narsil", "candle-examples");
+        let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+        let repo = api.model(owner, name);
         let sample = if let Some(input) = args.input {
             if let Some(sample) = input.strip_prefix("sample:") {
                 dataset.download_file().filename(format!("samples_{sample}.wav")).send()?

--- a/candle-examples/examples/wuerstchen/main.rs
+++ b/candle-examples/examples/wuerstchen/main.rs
@@ -100,7 +100,7 @@ enum ModelFile {
 
 impl ModelFile {
     fn get(&self, filename: Option<String>) -> Result<std::path::PathBuf> {
-        use hf_hub::api::sync::Api;
+        use hf_hub::HFClientSync;
         match filename {
             Some(filename) => Ok(std::path::PathBuf::from(filename)),
             None => {
@@ -115,7 +115,7 @@ impl ModelFile {
                     Self::VqGan => (repo_main, "vqgan/diffusion_pytorch_model.safetensors"),
                     Self::Prior => (repo_prior, "prior/diffusion_pytorch_model.safetensors"),
                 };
-                let filename = Api::new()?.model(repo.to_string()).get(path)?;
+                let filename = HFClientSync::new()?.model("", repo).download_file().filename(path).send()?;
                 Ok(filename)
             }
         }

--- a/candle-examples/examples/wuerstchen/main.rs
+++ b/candle-examples/examples/wuerstchen/main.rs
@@ -115,7 +115,8 @@ impl ModelFile {
                     Self::VqGan => (repo_main, "vqgan/diffusion_pytorch_model.safetensors"),
                     Self::Prior => (repo_prior, "prior/diffusion_pytorch_model.safetensors"),
                 };
-                let filename = HFClientSync::new()?.model("", repo).download_file().filename(path).send()?;
+                let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
+                let filename = HFClientSync::new()?.model(owner, name).download_file().filename(path).send()?;
                 Ok(filename)
             }
         }

--- a/candle-examples/examples/xlm-roberta/main.rs
+++ b/candle-examples/examples/xlm-roberta/main.rs
@@ -95,7 +95,8 @@ fn main() -> Result<()> {
         },
     };
     let revision = args.revision.clone();
-    let repo = api.model("", &model_id);
+    let (owner, name) = model_id.split_once('/').unwrap_or(("", model_id.as_str()));
+    let repo = api.model(owner, name);
 
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),

--- a/candle-examples/examples/xlm-roberta/main.rs
+++ b/candle-examples/examples/xlm-roberta/main.rs
@@ -8,7 +8,7 @@ use candle_transformers::models::xlm_roberta::{
     Config, XLMRobertaForMaskedLM, XLMRobertaForSequenceClassification,
 };
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingParams, Tokenizer};
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -71,7 +71,7 @@ struct Args {
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    let api = Api::new()?;
+    let api = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => match args.task {
@@ -94,27 +94,24 @@ fn main() -> Result<()> {
             },
         },
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision.clone();
+    let repo = api.model("", &model_id);
 
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
 
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo.download_file().filename("config.json").revision(&revision).send()?,
     };
 
     let weights_filename = match args.weight_files {
         Some(files) => PathBuf::from(files),
-        None => match repo.get("model.safetensors") {
+        None => match repo.download_file().filename("model.safetensors").revision(&revision).send() {
             Ok(safetensors) => safetensors,
-            Err(_) => match repo.get("pytorch_model.bin") {
+            Err(_) => match repo.download_file().filename("pytorch_model.bin").revision(&revision).send() {
                 Ok(pytorch_model) => pytorch_model,
                 Err(e) => {
                     return Err(anyhow::Error::msg(format!("Model weights not found. The weights should either be a `model.safetensors` or `pytorch_model.bin` file.  Error: {e}")));

--- a/candle-examples/examples/yi/main.rs
+++ b/candle-examples/examples/yi/main.rs
@@ -206,7 +206,8 @@ fn main() -> Result<()> {
     let start = std::time::Instant::now();
     let api = HFClientSync::new()?;
     let revision = args.revision.clone();
-    let repo = api.model("", &args.model_id);
+    let (owner, name) = args.model_id.split_once('/').unwrap_or(("", args.model_id.as_str()));
+    let repo = api.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
         None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,

--- a/candle-examples/examples/yi/main.rs
+++ b/candle-examples/examples/yi/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, ValueEnum)]
@@ -204,15 +204,12 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let api = HFClientSync::new()?;
+    let revision = args.revision.clone();
+    let repo = api.model("", &args.model_id);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").revision(&revision).send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files

--- a/candle-examples/examples/yolo-v3/main.rs
+++ b/candle-examples/examples/yolo-v3/main.rs
@@ -121,9 +121,9 @@ impl Args {
         let path = match &self.config {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
-                let api = api.model("lmz/candle-yolo-v3".to_string());
-                api.get("yolo-v3.cfg")?
+                let api = hf_hub::HFClientSync::new()?;
+                let api = api.model("", "lmz/candle-yolo-v3");
+                api.download_file().filename("yolo-v3.cfg").send()?
             }
         };
         Ok(path)
@@ -133,9 +133,9 @@ impl Args {
         let path = match &self.model {
             Some(model) => std::path::PathBuf::from(model),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
-                let api = api.model("lmz/candle-yolo-v3".to_string());
-                api.get("yolo-v3.safetensors")?
+                let api = hf_hub::HFClientSync::new()?;
+                let api = api.model("", "lmz/candle-yolo-v3");
+                api.download_file().filename("yolo-v3.safetensors").send()?
             }
         };
         Ok(path)

--- a/candle-examples/examples/yolo-v3/main.rs
+++ b/candle-examples/examples/yolo-v3/main.rs
@@ -122,7 +122,7 @@ impl Args {
             Some(config) => std::path::PathBuf::from(config),
             None => {
                 let api = hf_hub::HFClientSync::new()?;
-                let api = api.model("", "lmz/candle-yolo-v3");
+                let api = api.model("lmz", "candle-yolo-v3");
                 api.download_file().filename("yolo-v3.cfg").send()?
             }
         };
@@ -134,7 +134,7 @@ impl Args {
             Some(model) => std::path::PathBuf::from(model),
             None => {
                 let api = hf_hub::HFClientSync::new()?;
-                let api = api.model("", "lmz/candle-yolo-v3");
+                let api = api.model("lmz", "candle-yolo-v3");
                 api.download_file().filename("yolo-v3.safetensors").send()?
             }
         };

--- a/candle-examples/examples/yolo-v8/main.rs
+++ b/candle-examples/examples/yolo-v8/main.rs
@@ -297,7 +297,7 @@ impl Args {
             Some(model) => std::path::PathBuf::from(model),
             None => {
                 let api = hf_hub::HFClientSync::new()?;
-                let api = api.model("", "lmz/candle-yolo-v8");
+                let api = api.model("lmz", "candle-yolo-v8");
                 let size = match self.which {
                     Which::N => "n",
                     Which::S => "s",

--- a/candle-examples/examples/yolo-v8/main.rs
+++ b/candle-examples/examples/yolo-v8/main.rs
@@ -296,8 +296,8 @@ impl Args {
         let path = match &self.model {
             Some(model) => std::path::PathBuf::from(model),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
-                let api = api.model("lmz/candle-yolo-v8".to_string());
+                let api = hf_hub::HFClientSync::new()?;
+                let api = api.model("", "lmz/candle-yolo-v8");
                 let size = match self.which {
                     Which::N => "n",
                     Which::S => "s",
@@ -309,7 +309,7 @@ impl Args {
                     YoloTask::Pose => "-pose",
                     YoloTask::Detect => "",
                 };
-                api.get(&format!("yolov8{size}{task}.safetensors"))?
+                api.download_file().filename(format!("yolov8{size}{task}.safetensors")).send()?
             }
         };
         Ok(path)

--- a/candle-examples/examples/z_image/main.rs
+++ b/candle-examples/examples/z_image/main.rs
@@ -155,7 +155,9 @@ fn run(args: Args) -> Result<()> {
 
     // Resolve model: use provided path or download from HuggingFace
     let api = HFClientSync::new()?;
-    let repo = api.model("", args.model.repo());
+    let repo_id = args.model.repo();
+    let (owner, name) = repo_id.split_once('/').unwrap_or(("", repo_id));
+    let repo = api.model(owner, name);
     let use_local = args.model_path.is_some();
     let model_path = args.model_path.map(std::path::PathBuf::from);
 

--- a/candle-examples/examples/z_image/main.rs
+++ b/candle-examples/examples/z_image/main.rs
@@ -41,7 +41,7 @@ use candle_transformers::models::z_image::{
     ZImageTextEncoder, ZImageTransformer2DModel,
 };
 use clap::Parser;
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 /// Z-Image scheduler constants
@@ -154,8 +154,8 @@ fn run(args: Args) -> Result<()> {
     let dtype = device.bf16_default_to_f32();
 
     // Resolve model: use provided path or download from HuggingFace
-    let api = Api::new()?;
-    let repo = api.model(args.model.repo().to_string());
+    let api = HFClientSync::new()?;
+    let repo = api.model("", args.model.repo());
     let use_local = args.model_path.is_some();
     let model_path = args.model_path.map(std::path::PathBuf::from);
 
@@ -180,7 +180,7 @@ fn run(args: Args) -> Result<()> {
             .join("tokenizer")
             .join("tokenizer.json")
     } else {
-        repo.get("tokenizer/tokenizer.json")?
+        repo.download_file().filename("tokenizer/tokenizer.json").send()?
     };
     let tokenizer = Tokenizer::from_file(&tokenizer_path).map_err(E::msg)?;
 
@@ -193,7 +193,7 @@ fn run(args: Args) -> Result<()> {
             .join("text_encoder")
             .join("config.json")
     } else {
-        repo.get("text_encoder/config.json")?
+        repo.download_file().filename("text_encoder/config.json").send()?
     };
     let text_encoder_cfg: TextEncoderConfig = if text_encoder_config_path.exists() {
         serde_json::from_reader(std::fs::File::open(&text_encoder_config_path)?)?
@@ -215,7 +215,7 @@ fn run(args: Args) -> Result<()> {
                 .collect()
         } else {
             (1..=3)
-                .map(|i| repo.get(&format!("text_encoder/model-{:05}-of-00003.safetensors", i)))
+                .map(|i| repo.download_file().filename(format!("text_encoder/model-{:05}-of-00003.safetensors", i)).send())
                 .filter_map(|r| r.ok())
                 .collect()
         };
@@ -239,7 +239,7 @@ fn run(args: Args) -> Result<()> {
             .join("transformer")
             .join("config.json")
     } else {
-        repo.get("transformer/config.json")?
+        repo.download_file().filename("transformer/config.json").send()?
     };
     let transformer_cfg: Config = if transformer_config_path.exists() {
         serde_json::from_reader(std::fs::File::open(&transformer_config_path)?)?
@@ -265,10 +265,10 @@ fn run(args: Args) -> Result<()> {
         } else {
             (1..=3)
                 .map(|i| {
-                    repo.get(&format!(
+                    repo.download_file().filename(format!(
                         "transformer/diffusion_pytorch_model-{:05}-of-00003.safetensors",
                         i
-                    ))
+                    )).send()
                 })
                 .filter_map(|r| r.ok())
                 .collect()
@@ -289,7 +289,7 @@ fn run(args: Args) -> Result<()> {
     let vae_config_path = if use_local {
         model_path.as_ref().unwrap().join("vae").join("config.json")
     } else {
-        repo.get("vae/config.json")?
+        repo.download_file().filename("vae/config.json").send()?
     };
     let vae_cfg: VaeConfig = if vae_config_path.exists() {
         serde_json::from_reader(std::fs::File::open(&vae_config_path)?)?
@@ -308,7 +308,7 @@ fn run(args: Args) -> Result<()> {
         }
         path
     } else {
-        repo.get("vae/diffusion_pytorch_model.safetensors")?
+        repo.download_file().filename("vae/diffusion_pytorch_model.safetensors").send()?
     };
 
     let vae_weights = unsafe {

--- a/candle-examples/src/lib.rs
+++ b/candle-examples/src/lib.rs
@@ -123,10 +123,14 @@ pub fn save_image_resize<P: AsRef<std::path::Path>>(
 
 /// Loads the safetensors files for a model from the hub based on a json index file.
 pub fn hub_load_safetensors(
-    repo: &hf_hub::api::sync::ApiRepo,
+    repo: &hf_hub::HFRepositorySync<hf_hub::RepoTypeModel>,
     json_file: &str,
 ) -> Result<Vec<std::path::PathBuf>> {
-    let json_file = repo.get(json_file).map_err(candle::Error::wrap)?;
+    let json_file = repo
+        .download_file()
+        .filename(json_file)
+        .send()
+        .map_err(candle::Error::wrap)?;
     let json_file = std::fs::File::open(json_file)?;
     let json: serde_json::Value =
         serde_json::from_reader(&json_file).map_err(candle::Error::wrap)?;
@@ -143,7 +147,12 @@ pub fn hub_load_safetensors(
     }
     let safetensors_files = safetensors_files
         .iter()
-        .map(|v| repo.get(v).map_err(candle::Error::wrap))
+        .map(|v| {
+            repo.download_file()
+                .filename(v)
+                .send()
+                .map_err(candle::Error::wrap)
+        })
         .collect::<Result<Vec<_>>>()?;
     Ok(safetensors_files)
 }

--- a/candle-wasm-examples/yolo/Cargo.toml
+++ b/candle-wasm-examples/yolo/Cargo.toml
@@ -35,7 +35,7 @@ yew-agent = "0.2.0"
 yew = { version = "0.20.0", features = ["csr"] }
 
 [dependencies.web-sys]
-version = "=0.3.70"
+version = "0.3.70"
 features = [
   'Blob',
   'CanvasRenderingContext2d',


### PR DESCRIPTION
## Summary

- Bump `hf-hub` from `0.4.1` to `1.0.0-rc.1` workspace-wide. The 1.0 release is a complete API redesign: `api::sync::Api` / `api::tokio::Api` are gone, replaced by `HFClient` (async) and `HFClientSync` (gated by the new `blocking` feature). Repository handles are typed (`HFRepository<RepoTypeModel>`) and downloads go through a builder where revision is per-call rather than baked into a `Repo` value.
- Switch `candle-datasets`, `candle-book`, and `candle-examples` from `features = ["tokio"]` to `features = ["blocking"]` (which exposes both the sync and async handles).
- Migrate ~110 files across `candle-datasets`, `candle-book`, and `candle-examples` to the new API.
- Relax `web-sys = "=0.3.70"` to `"0.3.70"` in `candle-wasm-examples/yolo/Cargo.toml` so `hf-xet` (a new transitive dependency of `hf-hub`) can resolve its `^0.3.77` requirement.

## Migration patterns applied

| Old | New |
|---|---|
| `Api::new()?` | `HFClientSync::new()?` / `HFClient::new()?` |
| `api.repo(Repo::with_revision(name, RepoType::Model, rev))` | `client.model(\"\", &name)`, with `.revision(rev)` per call |
| `repo.get(file)?` | `repo.download_file().filename(file).send()?` |
| `repo.info()?.siblings` | `repo.info().send()?.siblings.unwrap_or_default()` |
| `ApiBuilder::from_cache(Cache::new(path))` | `HFClientSync::from_inner(HFClient::builder().cache_dir(path).build()?)?` |
| `ApiError` / `ApiRepo` | `HFError` / `HFRepositorySync<RepoTypeModel>` |

The empty-owner trick (`client.model(\"\", \"openai-community/gpt2\")`) is used throughout to avoid splitting full repo IDs into owner/name parts — `HFRepository::repo_path()` returns just the name when owner is empty, producing the same URL as the old `Repo::model(\"openai-community/gpt2\".to_string())`.

## Behavior caveat

In the new API, revision is per-call rather than stored on the repo. For sites that called `hub_load_safetensors(&repo, ...)` after constructing a repo with `Repo::with_revision`, the shared helper does not thread the revision through (it didn't before either, but it is now visible). If revision-aware shard loading is needed, the helper signature would need a new `revision` parameter — left as a follow-up.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo check -p candle-examples --examples` passes
- [x] `cargo check -p candle-examples --example mnist-training --features candle-datasets` passes
- [x] `cargo check -p candle-examples --example llama2-c --features candle-datasets` passes
- [x] `cargo check -p candle-examples --example whisper --features symphonia` passes
- [ ] Run an end-to-end example that actually downloads (e.g. `cargo run --example bert`) before merging
- [ ] Verify CI passes

## Notes

- `candle-examples/src/audio.rs` fails to compile when rubato-pulling features (`microphone`, `encodec`, `mimi`, `snac`) are enabled because `rubato::FftFixedInOut` is missing from the resolved version of `rubato`. This is unrelated to the hf-hub upgrade — `git diff` confirms `audio.rs` was untouched on this branch — and worth filing separately.
- The PR is marked draft pending end-to-end runtime verification and feedback on whether 1.0.0-rc.1 (a release candidate) is too early to ship versus waiting for stable 1.0.0.