### PR TITLE
qwen2: build RoPE cos/sin tables in fp32 (fixes long-context divergence)

### DIFF
--- a/candle-transformers/src/models/qwen2.rs
+++ b/candle-transformers/src/models/qwen2.rs
@@ -52,14 +52,27 @@ impl RotaryEmbedding {
             .map(|i| 1f32 / cfg.rope_theta.powf(i as f64 / dim as f64) as f32)
             .collect();
         let inv_freq_len = inv_freq.len();
-        let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?.to_dtype(dtype)?;
+        // Compute the cos/sin tables in fp32, then cast to `dtype`
+        // only at the end. Casting `inv_freq` and `t` to bf16 *before*
+        // the matmul loses precision for `position * inv_freq` at
+        // long-context positions: bf16's 7-bit mantissa cannot
+        // represent integer positions above ~256 precisely, so for
+        // `position = 15000+` the angle rounds to neighbouring
+        // representable values, and `cos()` / `sin()` of those
+        // rounded angles diverge wildly from the true cosines (e.g.
+        // `cos(15962) ≈ -0.547` vs `cos(15968) ≈ -0.882` — both
+        // representable bf16 neighbours of 15962). HuggingFace's
+        // Python reference forces fp32 here via
+        // `torch.autocast(enabled=False)` + explicit `.float()`;
+        // candle's own `qwen3_vl/text.rs` already does the same.
+        let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?;
         let t = Tensor::arange(0u32, max_seq_len as u32, dev)?
-            .to_dtype(dtype)?
+            .to_dtype(DType::F32)?
             .reshape((max_seq_len, 1))?;
         let freqs = t.matmul(&inv_freq)?;
         Ok(Self {
-            sin: freqs.sin()?,
-            cos: freqs.cos()?,
+            sin: freqs.sin()?.to_dtype(dtype)?,
+            cos: freqs.cos()?.to_dtype(dtype)?,
         })
     }
 


### PR DESCRIPTION
## Summary

`RotaryEmbedding::new` in `candle-transformers/src/models/qwen2.rs`
casts `inv_freq` and the position vector `t` to `dtype` (typically
bf16) *before* the matmul, then computes `.sin()` / `.cos()` on the
bf16 result. At long-context positions, bf16's 7-bit mantissa
cannot represent integer positions above ~256 exactly, so the
trig outputs become noise rather than trigonometric values.

Concretely: position 15962 rounds to neighbouring bf16 values 15936
or 15968 (16-step granularity at this magnitude). For low-frequency
dims where `inv_freq[0] = 1.0`, the angle becomes the rounded
position, and `cos(15962) ≈ -0.547` vs `cos(15968) ≈ -0.882` are
essentially uncorrelated.

## Fix

Keep `inv_freq` and `t` in fp32, do the matmul + trig in fp32,
cast to `dtype` only at the output. This mirrors:

- HuggingFace `transformers`' `Qwen2_5_VLRotaryEmbedding.forward`
  (uses `torch.autocast(enabled=False)` + `.float()` to force fp32);
- candle's own `candle-transformers/src/models/qwen3_vl/text.rs::RotaryEmbedding::new`
  (already does this correctly).

5-line diff.

## Evidence

Discovered via layer-by-layer bisection on Jina Embeddings V4
(Qwen2.5-VL backbone). Using a 1000-sample stratified cosine
harness against `transformers` + `flash_attn 2.8.3` on cuda:0 bf16:

| Stratum (~tokens) | P95 before | P95 after |
|---|---:|---:|
| retrieval.query (~50–500B) | 0.9996 | 0.9996 |
| retrieval.passage (~200–2kB) | 0.9970 | 0.9997 |
| text-matching | 0.9995 | 0.9995 |
| code | 0.9959 | 0.9990 |
| matryoshka | 0.9995 | 0.9996 |
| **long-context (~16k tokens)** | **0.7705** | **0.9999** |

Long-context min cosine: 0.7032 → 0.9994. Per-position max-abs
diff at post-RoPE Q on a 15962-token input: 38.0 → 0.25.

## Refs

- Closes the long-context divergence portion of #3515 (the FA bump
  there is structurally fine but is correctness-neutral on
  long-context — see [diagnostic update](https://github.com/huggingface/candle/issues/3515#issuecomment-4399608908)).
- Related to #2814 (Qwen2.5-VL support) — see [comment with diagnostic data](https://github.com/huggingface/candle/issues/2814#issuecomment-4399725147).
  Anyone running Qwen2-family or Qwen2.5-VL at long context goes
  through this code path and has the same latent bug.

## Scope note

A grep for the same `.to_dtype(dtype)?` pre-matmul pattern in
`candle-transformers/src/models/` finds it in gemma.rs, olmo.rs,
olmo2.rs, chatglm.rs, phi3.rs, mixtral.rs, falcon.rs,
recurrent_gemma.rs, glm4.rs, and a few others. This PR is
deliberately scoped to qwen2.rs — that's the model I have direct
empirical evidence for. Happy to do follow-ups for the others if
maintainers want a coordinated sweep, or leave them for separate
PRs.

## Note on M-RoPE

Qwen2.5-VL uses M-RoPE, not standard RoPE. For text-only inputs
M-RoPE degenerates mathematically to standard RoPE (the
section-split is no-op when all three position grids are
identical), so the bug above propagates to any text-only
Qwen2.5-VL forward that builds on candle's qwen2 RoPE — even if
the model itself isn't qwen2.