### PR TITLE
feat(distilbert): make Config fields public, consistent with DistilBertConfig

### DIFF
--- a/candle-transformers/src/models/distilbert.rs
+++ b/candle-transformers/src/models/distilbert.rs
@@ -58,18 +58,18 @@ pub enum PositionEmbeddingType {
 pub struct Config {
     pub vocab_size: usize,
     pub dim: usize,
-    n_layers: usize,
-    n_heads: usize,
-    hidden_dim: usize,
-    activation: HiddenAct,
-    max_position_embeddings: usize,
-    initializer_range: f64,
+    pub n_layers: usize,
+    pub n_heads: usize,
+    pub hidden_dim: usize,
+    pub activation: HiddenAct,
+    pub max_position_embeddings: usize,
+    pub initializer_range: f64,
     pub pad_token_id: usize,
     #[serde(default)]
-    position_embedding_type: PositionEmbeddingType,
+    pub position_embedding_type: PositionEmbeddingType,
     #[serde(default)]
-    use_cache: bool,
-    model_type: Option<String>,
+    pub use_cache: bool,
+    pub model_type: Option<String>,
 }
 
 impl Default for Config {
@@ -77,7 +77,7 @@ impl Default for Config {
         Self {
             vocab_size: 30522,
             dim: 768,
-            n_layers: 12,
+            n_layers: 6,
             n_heads: 12,
             hidden_dim: 3072,
             activation: HiddenAct::Gelu,


### PR DESCRIPTION
Currently, most fields in distilbert::Config are private, which prevents users from constructing or mutating configs programmatically without going through JSON deserialization.

This is inconsistent with BertConfig in candle-transformers/src/models/bert.rs, where all fields are pub.

Changes:
- Make all Config fields `pub` in distilbert.rs
- No functional changes, no breaking changes to existing deserialization

Also fixes Default impl: n_layers was incorrectly set to 12 (BERT-sized). Actual distilbert-base-uncased uses n_layers: 6, per the official HuggingFace config.json.