### PR TITLE
conv: avoid O(groups) kernel launches for depthwise conv1d/conv2d

### DIFF
--- a/candle-core/src/conv.rs
+++ b/candle-core/src/conv.rs
@@ -193,17 +193,9 @@ impl Tensor {
         if groups == 1 {
             self.conv1d_single_group(kernel, &params)
         } else if c_in_k == 1 && c_out == c_in && groups == c_in && stride == 1 && dilation == 1 {
-            // Depthwise conv1d (groups == in_channels, unit stride/dilation, no channel
-            // multiplier). The per-group decomposition below launches O(groups) tiny kernels
-            // (plus a `cat`), dominated by launch overhead on CUDA — see issue #3389, where
-            // depthwise conv layers were 54% of total inference time on an RTX 5090 because of
-            // ~6000 kernel launches for `groups=2048, k=3`. Depthwise conv is just a per-channel
-            // weighted sum over the kernel window, expressible as `k_size` slices each scaled by a
-            // per-channel scalar and accumulated: a fixed number of elementwise kernels (~2*k_size)
-            // regardless of the channel count, numerically equivalent to the existing kernels (up
-            // to floating-point summation order, just like the CPU/CUDA backends already differ).
-            // The stride/dilation==1 guard is only because candle has no strided-narrow primitive
-            // yet; other strides keep the old per-group path.
+            // Depthwise fast path: the per-group decomposition below launches O(groups) tiny
+            // kernels, which dominates runtime on CUDA (issue #3389). Restricted to unit
+            // stride/dilation as there is no strided-narrow primitive yet.
             self.conv1d_depthwise(kernel, &params)
         } else {
             let blocks = self.chunk(groups, 1)?;
@@ -217,22 +209,21 @@ impl Tensor {
         }
     }
 
-    // Depthwise 1D convolution (stride == dilation == 1) with elementwise ops only, no per-group
-    // loop. `self`: (b_size, c, l_in); `kernel`: (c, 1, k_size); out: (b_size, c, l_out).
+    // Depthwise 1D conv as a per-channel weighted sum of k_size shifted slices, elementwise only.
+    // `self`: (b_size, c, l_in); `kernel`: (c, 1, k_size); out: (b_size, c, l_out).
     fn conv1d_depthwise(&self, kernel: &Self, params: &ParamsConv1D) -> Result<Self> {
         let (b_size, c, _l_in) = self.dims3()?;
         let l_out = params.l_out();
-        // (b_size, c, l_in + 2*padding)
         let padded = if params.padding == 0 {
             self.clone()
         } else {
             self.pad_with_zeros(2, params.padding, params.padding)?
         };
-        // (c, 1, k_size) -> (1, c, k_size) so it broadcasts over the batch dimension.
+        // (c, 1, k_size) -> (1, c, k_size) to broadcast over the batch dimension.
         let kernel = kernel.reshape((c, params.k_size))?.unsqueeze(0)?;
         let mut out: Option<Tensor> = None;
         for k in 0..params.k_size {
-            // out[b, c, t] += padded[b, c, t + k] * kernel[c, k]   (stride == dilation == 1)
+            // out[b, c, t] += padded[b, c, t + k] * kernel[c, k]
             let slice = padded.narrow(2, k, l_out)?; // (b_size, c, l_out)
             let w_k = kernel.narrow(2, k, 1)?; // (1, c, 1)
             let term = slice.broadcast_mul(&w_k)?;
@@ -243,7 +234,7 @@ impl Tensor {
         }
         match out {
             Some(out) => Ok(out),
-            // k_size == 0 is rejected upstream by the kernel-shape checks; be defensive anyway.
+            // k_size == 0 is rejected upstream; handled defensively.
             None => Tensor::zeros((b_size, c, l_out), self.dtype(), self.device()),
         }
     }
@@ -373,9 +364,7 @@ impl Tensor {
         if groups == 1 {
             self.conv2d_single_group(kernel, &params)
         } else if c_in_k == 1 && c_out == c_in && groups == c_in && stride == 1 && dilation == 1 {
-            // Depthwise conv2d — see `conv1d_with_algo` for the rationale (issue #3389).
-            // `k_h * k_w` slices, each scaled by a per-channel scalar and accumulated: a fixed
-            // number of elementwise kernels independent of the channel count.
+            // Depthwise fast path, see `conv1d_with_algo` (issue #3389).
             self.conv2d_depthwise(kernel, &params)
         } else {
             let blocks = self.chunk(groups, 1)?;
@@ -389,7 +378,7 @@ impl Tensor {
         }
     }
 
-    // Depthwise 2D convolution (stride == dilation == 1) implemented with elementwise ops only.
+    // Depthwise 2D conv, the 2D analogue of `conv1d_depthwise`.
     // `self`: (b, c, h, w); `kernel`: (c, 1, k_h, k_w); out: (b, c, out_h, out_w).
     fn conv2d_depthwise(&self, kernel: &Self, params: &ParamsConv2D) -> Result<Self> {
         let (b_size, c, _i_h, _i_w) = self.dims4()?;

--- a/candle-core/src/conv.rs
+++ b/candle-core/src/conv.rs
@@ -128,6 +128,18 @@ impl ParamsConvTranspose2D {
     }
 }
 
+// The depthwise fast path trades `3 * groups` tiny launches for `2 * taps - 1` full-output
+// ones, so it only pays while the per-group path is launch-bound. Both limits are measured.
+const DEPTHWISE_LAUNCH_MARGIN_NUM: usize = 3;
+const DEPTHWISE_LAUNCH_MARGIN_DEN: usize = 2;
+const DEPTHWISE_MAX_GROUP_WORK: usize = 1 << 20;
+
+fn depthwise_fast_path_wins(groups: usize, taps: usize, group_work: usize) -> bool {
+    let per_group_launches = 3 * groups * DEPTHWISE_LAUNCH_MARGIN_DEN;
+    let fast_path_launches = (2 * taps - 1) * DEPTHWISE_LAUNCH_MARGIN_NUM;
+    per_group_launches >= fast_path_launches && group_work <= DEPTHWISE_MAX_GROUP_WORK
+}
+
 impl Tensor {
     fn conv1d_single_group(&self, kernel: &Self, params: &ParamsConv1D) -> Result<Self> {
         let storage =
@@ -192,7 +204,14 @@ impl Tensor {
         };
         if groups == 1 {
             self.conv1d_single_group(kernel, &params)
-        } else if c_in_k == 1 && c_out == c_in && groups == c_in && stride == 1 && dilation == 1 {
+        } else if c_in_k == 1
+            && c_out == c_in
+            && groups == c_in
+            && stride == 1
+            && dilation == 1
+            && self.device().is_cuda()
+            && depthwise_fast_path_wins(groups, k_size, b_size * params.l_out() * k_size)
+        {
             // Depthwise fast path: the per-group decomposition below launches O(groups) tiny
             // kernels, which dominates runtime on CUDA (issue #3389). Restricted to unit
             // stride/dilation as there is no strided-narrow primitive yet.
@@ -363,7 +382,18 @@ impl Tensor {
         };
         if groups == 1 {
             self.conv2d_single_group(kernel, &params)
-        } else if c_in_k == 1 && c_out == c_in && groups == c_in && stride == 1 && dilation == 1 {
+        } else if c_in_k == 1
+            && c_out == c_in
+            && groups == c_in
+            && stride == 1
+            && dilation == 1
+            && self.device().is_cuda()
+            && depthwise_fast_path_wins(
+                groups,
+                k_h * k_w,
+                b_size * params.out_h() * params.out_w() * k_h * k_w,
+            )
+        {
             // Depthwise fast path, see `conv1d_with_algo` (issue #3389).
             self.conv2d_depthwise(kernel, &params)
         } else {

--- a/candle-core/src/conv.rs
+++ b/candle-core/src/conv.rs
@@ -192,6 +192,19 @@ impl Tensor {
         };
         if groups == 1 {
             self.conv1d_single_group(kernel, &params)
+        } else if c_in_k == 1 && c_out == c_in && groups == c_in && stride == 1 && dilation == 1 {
+            // Depthwise conv1d (groups == in_channels, unit stride/dilation, no channel
+            // multiplier). The per-group decomposition below launches O(groups) tiny kernels
+            // (plus a `cat`), dominated by launch overhead on CUDA — see issue #3389, where
+            // depthwise conv layers were 54% of total inference time on an RTX 5090 because of
+            // ~6000 kernel launches for `groups=2048, k=3`. Depthwise conv is just a per-channel
+            // weighted sum over the kernel window, expressible as `k_size` slices each scaled by a
+            // per-channel scalar and accumulated: a fixed number of elementwise kernels (~2*k_size)
+            // regardless of the channel count, numerically equivalent to the existing kernels (up
+            // to floating-point summation order, just like the CPU/CUDA backends already differ).
+            // The stride/dilation==1 guard is only because candle has no strided-narrow primitive
+            // yet; other strides keep the old per-group path.
+            self.conv1d_depthwise(kernel, &params)
         } else {
             let blocks = self.chunk(groups, 1)?;
             let kernel = kernel.chunk(groups, 0)?;
@@ -201,6 +214,37 @@ impl Tensor {
                 .map(|(block, kernel)| block.conv1d_single_group(kernel, &params))
                 .collect::<Result<Vec<_>>>()?;
             Tensor::cat(&blocks, 1)
+        }
+    }
+
+    // Depthwise 1D convolution (stride == dilation == 1) with elementwise ops only, no per-group
+    // loop. `self`: (b_size, c, l_in); `kernel`: (c, 1, k_size); out: (b_size, c, l_out).
+    fn conv1d_depthwise(&self, kernel: &Self, params: &ParamsConv1D) -> Result<Self> {
+        let (b_size, c, _l_in) = self.dims3()?;
+        let l_out = params.l_out();
+        // (b_size, c, l_in + 2*padding)
+        let padded = if params.padding == 0 {
+            self.clone()
+        } else {
+            self.pad_with_zeros(2, params.padding, params.padding)?
+        };
+        // (c, 1, k_size) -> (1, c, k_size) so it broadcasts over the batch dimension.
+        let kernel = kernel.reshape((c, params.k_size))?.unsqueeze(0)?;
+        let mut out: Option<Tensor> = None;
+        for k in 0..params.k_size {
+            // out[b, c, t] += padded[b, c, t + k] * kernel[c, k]   (stride == dilation == 1)
+            let slice = padded.narrow(2, k, l_out)?; // (b_size, c, l_out)
+            let w_k = kernel.narrow(2, k, 1)?; // (1, c, 1)
+            let term = slice.broadcast_mul(&w_k)?;
+            out = Some(match out {
+                None => term,
+                Some(acc) => (acc + term)?,
+            });
+        }
+        match out {
+            Some(out) => Ok(out),
+            // k_size == 0 is rejected upstream by the kernel-shape checks; be defensive anyway.
+            None => Tensor::zeros((b_size, c, l_out), self.dtype(), self.device()),
         }
     }
 
@@ -328,6 +372,11 @@ impl Tensor {
         };
         if groups == 1 {
             self.conv2d_single_group(kernel, &params)
+        } else if c_in_k == 1 && c_out == c_in && groups == c_in && stride == 1 && dilation == 1 {
+            // Depthwise conv2d — see `conv1d_with_algo` for the rationale (issue #3389).
+            // `k_h * k_w` slices, each scaled by a per-channel scalar and accumulated: a fixed
+            // number of elementwise kernels independent of the channel count.
+            self.conv2d_depthwise(kernel, &params)
         } else {
             let blocks = self.chunk(groups, 1)?;
             let kernel = kernel.chunk(groups, 0)?;
@@ -337,6 +386,38 @@ impl Tensor {
                 .map(|(block, kernel)| block.conv2d_single_group(kernel, &params))
                 .collect::<Result<Vec<_>>>()?;
             Tensor::cat(&blocks, 1)
+        }
+    }
+
+    // Depthwise 2D convolution (stride == dilation == 1) implemented with elementwise ops only.
+    // `self`: (b, c, h, w); `kernel`: (c, 1, k_h, k_w); out: (b, c, out_h, out_w).
+    fn conv2d_depthwise(&self, kernel: &Self, params: &ParamsConv2D) -> Result<Self> {
+        let (b_size, c, _i_h, _i_w) = self.dims4()?;
+        let (out_h, out_w) = (params.out_h(), params.out_w());
+        let padded = if params.padding == 0 {
+            self.clone()
+        } else {
+            self.pad_with_zeros(2, params.padding, params.padding)?
+                .pad_with_zeros(3, params.padding, params.padding)?
+        };
+        // (c, 1, k_h, k_w) -> (1, c, k_h, k_w) to broadcast over the batch dimension.
+        let kernel = kernel.reshape((c, params.k_h, params.k_w))?.unsqueeze(0)?;
+        let mut out: Option<Tensor> = None;
+        for kh in 0..params.k_h {
+            for kw in 0..params.k_w {
+                // out[b, c, i, j] += padded[b, c, i + kh, j + kw] * kernel[c, kh, kw]
+                let slice = padded.narrow(2, kh, out_h)?.narrow(3, kw, out_w)?; // (b, c, out_h, out_w)
+                let w = kernel.narrow(2, kh, 1)?.narrow(3, kw, 1)?; // (1, c, 1, 1)
+                let term = slice.broadcast_mul(&w)?;
+                out = Some(match out {
+                    None => term,
+                    Some(acc) => (acc + term)?,
+                });
+            }
+        }
+        match out {
+            Some(out) => Ok(out),
+            None => Tensor::zeros((b_size, c, out_h, out_w), self.dtype(), self.device()),
         }
     }
 

--- a/candle-core/tests/conv_tests.rs
+++ b/candle-core/tests/conv_tests.rs
@@ -970,3 +970,76 @@ test_device!(
     conv2d_c_eq_h_eq_w_gpu,
     conv2d_c_eq_h_eq_w_metal
 );
+
+// Depthwise convolutions (groups == in_channels). The fast depthwise path
+// (groups == c_in, c_in_k == 1, stride == dilation == 1) is exercised here and
+// cross-checked against an *independent* code path: building the equivalent
+// block-diagonal dense weight (c_out, c_in, k...) and running a plain
+// `groups == 1` convolution (the im2col / cuDNN path). They must agree up to
+// floating-point summation order.
+fn conv1d_depthwise(dev: &Device) -> Result<()> {
+    let (b, c, l, k) = (2usize, 6usize, 13usize, 3usize);
+    let t = Tensor::randn(0f32, 1f32, (b, c, l), dev)?;
+    // Depthwise weight: (c_out=c, c_in_k=1, k).
+    let w = Tensor::randn(0f32, 1f32, (c, 1, k), dev)?;
+    // Equivalent block-diagonal dense weight (c_out=c, c_in=c, k), zero off the diagonal:
+    // w (c,1,k) -> (c,k,1); eye (c,c) -> (c,1,c); product -> (c,k,c) -> transpose -> (c,c,k).
+    let dense = {
+        let eye = Tensor::eye(c, t.dtype(), dev)?.unsqueeze(1)?; // (c, 1, c)
+        let wk = w.reshape((c, k))?.unsqueeze(2)?; // (c, k, 1)
+        wk.broadcast_mul(&eye)?.transpose(1, 2)?.contiguous()? // (c, c, k)
+    };
+    for &padding in &[0usize, 1usize] {
+        let l_out = l + 2 * padding - (k - 1);
+        let fast = t.conv1d(&w, padding, 1, 1, c)?;
+        assert_eq!(fast.dims(), &[b, c, l_out]);
+        let reference = t.conv1d(&dense, padding, 1, 1, 1)?;
+        let diff: f32 = (fast - reference)?
+            .abs()?
+            .flatten_all()?
+            .max(0)?
+            .to_scalar()?;
+        assert!(diff < 1e-4, "depthwise conv1d mismatch: {diff}");
+    }
+    Ok(())
+}
+
+fn conv2d_depthwise(dev: &Device) -> Result<()> {
+    let (b, c, h, w_, k) = (2usize, 5usize, 5usize, 7usize, 3usize);
+    let t = Tensor::randn(0f32, 1f32, (b, c, h, w_), dev)?;
+    // Depthwise weight: (c_out=c, c_in_k=1, k, k).
+    let weight = Tensor::randn(0f32, 1f32, (c, 1, k, k), dev)?;
+    // Equivalent block-diagonal dense weight (c_out=c, c_in=c, k, k), zero off the diagonal.
+    let dense = {
+        let eye = Tensor::eye(c, t.dtype(), dev)?.reshape((c, c, 1, 1))?;
+        let wk = weight.reshape((c, 1, k, k))?;
+        wk.broadcast_mul(&eye)?.contiguous()? // (c, c, k, k)
+    };
+    for &padding in &[0usize, 1usize] {
+        let oh = h + 2 * padding - (k - 1);
+        let ow = w_ + 2 * padding - (k - 1);
+        let fast = t.conv2d(&weight, padding, 1, 1, c)?;
+        assert_eq!(fast.dims(), &[b, c, oh, ow]);
+        let reference = t.conv2d(&dense, padding, 1, 1, 1)?;
+        let diff: f32 = (fast - reference)?
+            .abs()?
+            .flatten_all()?
+            .max(0)?
+            .to_scalar()?;
+        assert!(diff < 1e-4, "depthwise conv2d mismatch: {diff}");
+    }
+    Ok(())
+}
+
+test_device!(
+    conv1d_depthwise,
+    conv1d_depthwise_cpu,
+    conv1d_depthwise_gpu,
+    conv1d_depthwise_metal
+);
+test_device!(
+    conv2d_depthwise,
+    conv2d_depthwise_cpu,
+    conv2d_depthwise_gpu,
+    conv2d_depthwise_metal
+);

--- a/candle-core/tests/conv_tests.rs
+++ b/candle-core/tests/conv_tests.rs
@@ -971,19 +971,14 @@ test_device!(
     conv2d_c_eq_h_eq_w_metal
 );
 
-// Depthwise convolutions (groups == in_channels). The fast depthwise path
-// (groups == c_in, c_in_k == 1, stride == dilation == 1) is exercised here and
-// cross-checked against an *independent* code path: building the equivalent
-// block-diagonal dense weight (c_out, c_in, k...) and running a plain
-// `groups == 1` convolution (the im2col / cuDNN path). They must agree up to
+// Cross-checks the depthwise fast path against an independent reference: the equivalent
+// block-diagonal dense weight run through the `groups == 1` path. They must agree up to
 // floating-point summation order.
 fn conv1d_depthwise(dev: &Device) -> Result<()> {
     let (b, c, l, k) = (2usize, 6usize, 13usize, 3usize);
     let t = Tensor::randn(0f32, 1f32, (b, c, l), dev)?;
-    // Depthwise weight: (c_out=c, c_in_k=1, k).
     let w = Tensor::randn(0f32, 1f32, (c, 1, k), dev)?;
-    // Equivalent block-diagonal dense weight (c_out=c, c_in=c, k), zero off the diagonal:
-    // w (c,1,k) -> (c,k,1); eye (c,c) -> (c,1,c); product -> (c,k,c) -> transpose -> (c,c,k).
+    // Block-diagonal dense weight (c, c, k), zero off the diagonal.
     let dense = {
         let eye = Tensor::eye(c, t.dtype(), dev)?.unsqueeze(1)?; // (c, 1, c)
         let wk = w.reshape((c, k))?.unsqueeze(2)?; // (c, k, 1)
@@ -1007,9 +1002,8 @@ fn conv1d_depthwise(dev: &Device) -> Result<()> {
 fn conv2d_depthwise(dev: &Device) -> Result<()> {
     let (b, c, h, w_, k) = (2usize, 5usize, 5usize, 7usize, 3usize);
     let t = Tensor::randn(0f32, 1f32, (b, c, h, w_), dev)?;
-    // Depthwise weight: (c_out=c, c_in_k=1, k, k).
     let weight = Tensor::randn(0f32, 1f32, (c, 1, k, k), dev)?;
-    // Equivalent block-diagonal dense weight (c_out=c, c_in=c, k, k), zero off the diagonal.
+    // Block-diagonal dense weight (c, c, k, k), zero off the diagonal.
     let dense = {
         let eye = Tensor::eye(c, t.dtype(), dev)?.reshape((c, c, 1, 1))?;
         let wk = weight.reshape((c, 1, k, k))?;

--- a/candle-core/tests/conv_tests.rs
+++ b/candle-core/tests/conv_tests.rs
@@ -1000,7 +1000,8 @@ fn conv1d_depthwise(dev: &Device) -> Result<()> {
 }
 
 fn conv2d_depthwise(dev: &Device) -> Result<()> {
-    let (b, c, h, w_, k) = (2usize, 5usize, 5usize, 7usize, 3usize);
+    // c is above the fast path's groups threshold so CUDA still exercises it here.
+    let (b, c, h, w_, k) = (2usize, 16usize, 5usize, 7usize, 3usize);
     let t = Tensor::randn(0f32, 1f32, (b, c, h, w_), dev)?;
     let weight = Tensor::randn(0f32, 1f32, (c, 1, k, k), dev)?;
     // Block-diagonal dense weight (c, c, k, k), zero off the diagonal.


### PR DESCRIPTION
Fixes the depthwise part of #3389.

## Problem

`Tensor::conv1d` / `conv2d` with `groups > 1` decompose into `groups` separate single-group convolutions plus a `cat`. For depthwise convolution (`groups == in_channels`) that's O(groups) tiny kernel launches — `groups = 2048, k = 3` → thousands of CUDA launches whose host/driver overhead dwarfs the trivial per-channel work. #3389 reports depthwise conv layers at ~54% of total inference time on an RTX 5090 (~33 ms/layer) vs `<0.1 ms` for a hand-written expansion.

## Change

For the common depthwise case (`groups == c_in`, `c_in_k == 1` — no channel multiplier, unit stride/dilation) compute the convolution directly as a sum of `k` slices each scaled by a per-channel scalar:

```
out[b, c, ..] = Σ_k  input[b, c, ..+k] · weight[c, k]
```

That's a fixed number of elementwise kernels (~2k) regardless of channel count, numerically equivalent to the existing backends (up to float summation order — the CPU/CUDA paths already differ from each other to that degree). It's pure `Tensor`-level code, so it benefits every backend (CPU / CUDA / Metal) and stays differentiable. All other `groups > 1` cases keep the existing per-group path unchanged.

The `stride == dilation == 1` guard is only because there's no strided-narrow primitive yet; that regime is the dominant one (MobileNet/EfficientNet 3×3, LFM2 / Mamba conv) and covers the case in the issue. The *general* grouped-conv case (`c_in_k > 1`, ResNeXt-style) needs a separate fix — passing `groups` through to `cudnnSetConvolutionGroupCount`, a batched-GEMM rewrite, or a fused grouped kernel — discussed in #3389.

## Tests / validation

Adds `conv1d_depthwise` / `conv2d_depthwise` tests that cross-check the fast path against an independent code path (the equivalent block-diagonal dense weight run through `groups == 1`).

- CPU: `cargo test -p candle-core --test conv_tests` 10/10, `cargo test -p candle-nn` green, `cargo clippy -p candle-core --tests` 0 warnings, `cargo fmt --check` clean.
- **GPU, validated on an RTX PRO 6000 (Blackwell, CUDA 12.9):** `cargo test -p candle-core --features cuda --test conv_tests` — 20/20 pass, incl. the new `conv1d_depthwise_gpu` / `conv2d_depthwise_gpu`. Microbench, depthwise conv1d `(1, 2048, 21) × (2048, 1, 3)` `groups=2048`, 100 iters after warmup: **31971 µs/call → 23 µs/call (≈1390×)**; `cuLaunchKernel` count per call (via `nsys`): **~4096 → ~5**.
- `--features cuda,cudnn` has a pre-existing exact-equality assertion failure in the *non*-depthwise `conv1d_gpu` test (cuDNN picks a different algorithm with ~1e-3 different rounding) — unrelated to this change; all depthwise tests pass under cuDNN too.

+154/−0, 2 files.


## Update (70bf01e): gating the fast path to the shapes where it wins

The original version of this PR gated only on `c_in_k == 1`, `c_out == c_in`, `groups == c_in`, `stride == 1`, `dilation == 1`. That is not sufficient. Sweeping 113 depthwise shapes across conv1d and conv2d on an RTX PRO 6000 Blackwell Workstation (CUDA 13.0, driver 580.142) found 26 of them *slower* than the per-group path, by up to 1.9x, for three separate reasons:

1. No kernel-size term. The fast path issues `2*taps - 1` full-output launches against the per-group path's `3 * groups` tiny ones, so it loses whenever groups do not exceed the tap count. C=16, 64x64, k=11: 0.253 to 1.035 ms, 4.1x slower.
2. A second regime the launch count cannot see. The fast path moves roughly 2x the data im2col does, so it is a launch-overhead workaround rather than a cheaper algorithm. Once per-group work is large enough that the per-group path is no longer launch-bound, that extra traffic dominates at any group count. N=64, C=256, 128x128, k=3 has a launch ratio of 45x and is still 1.59x slower.
3. The gate was device-agnostic, so CPU took the fast path too. conv1d C=256, L=4096, k=15 on CPU: 12.80 to 25.76 ms, 2.01x slower.

The gate now also requires a launch ratio above 1.5, per-group work at or below `1 << 20` elements, and CUDA:

```rust
fn depthwise_fast_path_wins(groups: usize, taps: usize, group_work: usize) -> bool {
    let per_group_launches = 3 * groups * DEPTHWISE_LAUNCH_MARGIN_DEN;
    let fast_path_launches = (2 * taps - 1) * DEPTHWISE_LAUNCH_MARGIN_NUM;
    per_group_launches >= fast_path_launches && group_work <= DEPTHWISE_MAX_GROUP_WORK
}
```

`taps` is `k_size` for conv1d and `k_h * k_w` for conv2d; the 1d launch count is `2*k - 1` rather than the 2d formula, confirmed under `nsys` (1536 old-path launches per call at C=512, exactly `3 * groups`).

Both constants were set by measurement. The launch margin of 1.5 was chosen by building 1.5 and 2.0 and sweeping all 113 shapes through each: neither regresses anything, and 1.5 recovers 7 shapes worth 1.31x to 8.8x, while sitting 1.25x above the highest launch ratio at which any regression was measured. The group-work cap sits 1.56x below the lowest group-work at which one was, with probes on both sides of it.

### Headline shapes

ms per call, before / ungated / gated:

| shape | before | ungated | gated | path |
| --- | ---: | ---: | ---: | --- |
| C=11200 32x32 k=3 (SANA-1.6B Mix-FFN) | 183.82 | 1.901 | 1.900 | fast |
| N=32 C=256 56x56 k=3 | 6.193 | 4.838 | 4.837 | fast |
| C=64 64x64 k=3 | 0.985 | 0.107 | 0.107 | fast |
| C=32 128x128 k=7 | 0.601 | 0.612 | 0.601 | fallback |
| C=16 64x64 k=11 | 0.253 | 1.035 | 0.253 | fallback |

At the SANA shape `nsys` attributes the old cost as expected: 33,600 launches per conv2d call (11,200 each of im2col, gemvx, copy2d) totalling 48.8 ms of kernel time inside a 184 ms wall call, so about 74% of wall time has no kernel resident at all. The gated fast path is 23 kernels per call and is GPU-bound.

### Gate boundary

A sweep that steps over the point where the gate opens proves little, so the boundary was measured directly: for each of conv2d k=3, 5, 7, 11 and conv1d k=15, 127, the first group count the predicate admits, the counts above it, and the last one it rejects. conv2d at 64x64 N=1, conv1d at L=4096 N=1:

| shape | launch ratio | before | ungated | gated | path |
| --- | ---: | ---: | ---: | ---: | --- |
| 2d k=3 g=8 | 1.412 | 0.1272 | 0.1008 | 0.1265 | fallback |
| 2d k=3 g=9 | 1.588 | 0.1424 | 0.1008 | 0.0998 | fast |
| 2d k=5 g=24 | 1.469 | 0.3805 | 0.2362 | 0.3754 | fallback |
| 2d k=5 g=25 | 1.531 | 0.3961 | 0.2371 | 0.2355 | fast |
| 2d k=7 g=48 | 1.485 | 0.7579 | 0.4507 | 0.7551 | fallback |
| 2d k=7 g=49 | 1.515 | 0.7699 | 0.4485 | 0.4481 | fast |
| 2d k=11 g=120 | 1.494 | 1.9064 | 1.4986 | 1.9107 | fallback |
| 2d k=11 g=121 | 1.506 | 1.9264 | 1.4985 | 1.4989 | fast |
| 1d k=15 g=14 | 1.448 | 0.2958 | 0.1337 | 0.2959 | fallback |
| 1d k=15 g=15 | 1.552 | 0.3191 | 0.1346 | 0.1352 | fast |
| 1d k=127 g=126 | 1.494 | 13.2026 | 1.5310 | 13.2019 | fallback |
| 1d k=127 g=127 | 1.506 | 13.3212 | 1.5335 | 1.5331 | fast |

Every first-admitted shape is 1.29x to 8.70x faster than the per-group path rather than marginally equal, and the transition is a step rather than a drift: at k=11 the gated time drops from 1.91 to 1.50 ms between g=120 and g=121 while the per-group path rises smoothly across the same pair.

### Validation

No shape in the set is slower than the per-group path. The worst gated/before ratio across all 113 is 1.0085, on a fallback shape running byte-identical code to the old path, and four repeats fully overlap. All 26 previously regressing shapes now match within 0.3%.

Path selection was proven rather than inferred: for every shape the gated build's output dump is byte-identical to the ungated build on exactly those taking the fast path, and byte-identical to the pre-PR build on exactly those falling back, agreeing with the predicate on all 133 measured shapes with zero mismatches. Every run was repeated and byte-compared against itself; all deterministic. Methodology throughout: release mode, per-call device synchronization, 5 warmup iterations discarded, seeded host-side inputs hashed to confirm both builds see byte-identical data.

`cargo test -p candle-core --features cuda --test conv_tests` passes 20/20. Note that the PR's own `conv2d_depthwise` test used `c = 5`, which fails the new launch-margin term, so the fast path would have silently lost its only test coverage; `c` is bumped to 16 to keep it covered.

### Known limits

`DEPTHWISE_MAX_GROUP_WORK` stands in for launch overhead times bandwidth and is calibrated on one GPU, so the true crossover moves with hardware; the launch-margin term should be far more portable, since both paths pay the same launch cost in that regime. The gate also forfeits real wins, 26 shapes worth, the largest being conv1d at large kernel size (k=127, c=84 is an 8.05x win blocked at ratio 1.00) where im2col1d amplifies memory k-fold and the launch-count model under-predicts the fast path; recovering those needs a 1d-specific predicate with its own calibration. Metal keeps the per-group path because it was not measured. Outputs on fast-path shapes differ from the per-group path by at most 9.54e-7, exactly 2^-20 and about 2 ULP at that magnitude, the same order as candle's own cudnn versus non-cudnn conv2d spread on this input; fallback shapes are bit-identical. All measurements are f32, forward pass only, single otherwise-idle GPU, one machine.
