### PR TITLE
[Metal] Improved inter-encoder sync and gemv

### DIFF
--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -172,8 +172,6 @@ impl MetalDevice {
             .wait_until_completed()
             .map_err(MetalError::from)?;
 
-        // Drop unused buffers only after all in-flight CBs are confirmed complete.
-        // With commandBufferWithUnretainedReferences, buffers must stay alive until GPU is done.
         self.drop_unused_buffers()?;
         Ok(())
     }

--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -4,14 +4,13 @@ use crate::{DType, Result};
 use candle_metal_kernels::metal::ComputePipeline;
 use candle_metal_kernels::{
     metal::{
-        BlitCommandEncoder, Buffer, BufferMap, Commands, ComputeCommandEncoder, Device,
-        MTLResourceOptions,
+        BlitCommandsGuard, Buffer, BufferMap, Commands, CommandsGuard, Device, MTLResourceOptions,
+        ResidencySet,
     },
     Kernels,
 };
 use objc2_foundation::NSURL;
 use objc2_metal::{MTLCaptureDescriptor, MTLCaptureDestination, MTLCaptureManager};
-
 use std::path::Path;
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -39,7 +38,7 @@ pub struct MetalDevice {
     /// Raw metal device: <https://developer.apple.com/documentation/metal/mtldevice?language=objc>
     pub(crate) device: Device,
 
-    pub(crate) commands: Arc<RwLock<Commands>>,
+    pub(crate) commands: Arc<Commands>,
 
     /// Simple allocator struct.
     /// The buffers are stored in size buckets since ML tends to use similar shapes over and over.
@@ -67,19 +66,21 @@ pub struct MetalDevice {
     pub(crate) seed: Arc<Mutex<Buffer>>,
     /// Last seed value set on this device.
     pub(crate) seed_value: Arc<RwLock<u64>>,
+    /// Residency set registered on the command queue.
+    pub(crate) residency_set: Arc<ResidencySet>,
 }
 
 // Resource options used for creating buffers. Shared storage mode allows both CPU and GPU to access the buffer.
-pub const RESOURCE_OPTIONS: MTLResourceOptions =
-    objc2_metal::MTLResourceOptions(MTLResourceOptions::StorageModeShared.bits());
-//| MTLResourceOptions::HazardTrackingModeUntracked.bits(),
-//);
-
+pub const RESOURCE_OPTIONS: MTLResourceOptions = objc2_metal::MTLResourceOptions(
+    MTLResourceOptions::StorageModeShared.0 | MTLResourceOptions::HazardTrackingModeUntracked.0,
+);
 // Resource options used for `new_private_buffer`. This uses `private` where supported.
 #[cfg(target_os = "ios")]
-pub const PRIVATE_RESOURCE_OPTIONS: MTLResourceOptions = MTLResourceOptions::StorageModeShared;
+pub const PRIVATE_RESOURCE_OPTIONS: MTLResourceOptions = RESOURCE_OPTIONS;
 #[cfg(not(target_os = "ios"))]
-pub const PRIVATE_RESOURCE_OPTIONS: MTLResourceOptions = MTLResourceOptions::StorageModePrivate;
+pub const PRIVATE_RESOURCE_OPTIONS: MTLResourceOptions = objc2_metal::MTLResourceOptions(
+    MTLResourceOptions::StorageModePrivate.0 | MTLResourceOptions::HazardTrackingModeUntracked.0,
+);
 
 impl std::fmt::Debug for MetalDevice {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -130,37 +131,50 @@ impl MetalDevice {
     fn drop_unused_buffers(&self) -> Result<()> {
         let mut buffers = self.buffers.write().map_err(MetalError::from)?;
         for subbuffers in buffers.values_mut() {
-            let newbuffers = subbuffers
-                .iter()
-                .filter(|s| Arc::strong_count(*s) > 1)
-                .map(Arc::clone)
-                .collect();
-            *subbuffers = newbuffers;
+            subbuffers.retain(|s| {
+                if Arc::strong_count(s) == 1 {
+                    self.residency_set.remove(s);
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        let mut private_buffers = self.private_buffers.write().map_err(MetalError::from)?;
+        for subbuffers in private_buffers.values_mut() {
+            subbuffers.retain(|s| {
+                if Arc::strong_count(s) == 1 {
+                    self.residency_set.remove(s);
+                    false
+                } else {
+                    true
+                }
+            });
         }
         Ok(())
     }
 
-    pub fn command_encoder(&self) -> Result<ComputeCommandEncoder> {
-        let commands = self.commands.write().map_err(MetalError::from)?;
-        let (flush, command_encoder) = commands.command_encoder().map_err(MetalError::from)?;
-        if flush {
-            self.drop_unused_buffers()?
-        }
+    pub fn command_encoder<'a>(&'a self) -> Result<CommandsGuard<'a>> {
+        let command_encoder = self.commands.command_encoder().map_err(MetalError::from)?;
         Ok(command_encoder)
     }
 
-    pub fn blit_command_encoder(&self) -> Result<BlitCommandEncoder> {
-        let commands = self.commands.write().map_err(MetalError::from)?;
-        let (flush, command_encoder) = commands.blit_command_encoder().map_err(MetalError::from)?;
-        if flush {
-            self.drop_unused_buffers()?
-        }
+    pub fn blit_command_encoder(&self) -> Result<BlitCommandsGuard<'_>> {
+        let command_encoder = self
+            .commands
+            .blit_command_encoder()
+            .map_err(MetalError::from)?;
         Ok(command_encoder)
     }
 
     pub fn wait_until_completed(&self) -> Result<()> {
-        let commands = self.commands.write().map_err(MetalError::from)?;
-        commands.wait_until_completed().map_err(MetalError::from)?;
+        self.commands
+            .wait_until_completed()
+            .map_err(MetalError::from)?;
+
+        // Drop unused buffers only after all in-flight CBs are confirmed complete.
+        // With commandBufferWithUnretainedReferences, buffers must stay alive until GPU is done.
+        self.drop_unused_buffers()?;
         Ok(())
     }
 
@@ -195,6 +209,7 @@ impl MetalDevice {
             .new_buffer(size, PRIVATE_RESOURCE_OPTIONS)
             .map_err(MetalError::from)?;
         let new_buffer = Arc::new(new_buffer);
+        self.residency_set.insert(&new_buffer);
         subbuffers.push(new_buffer.clone());
         Ok(new_buffer)
     }
@@ -213,7 +228,9 @@ impl MetalDevice {
             .device
             .new_buffer(size, PRIVATE_RESOURCE_OPTIONS)
             .map_err(MetalError::from)?;
-        Ok(Arc::new(buffer))
+        let buffer = Arc::new(buffer);
+        self.residency_set.insert(&buffer);
+        Ok(buffer)
     }
 
     /// Creates a new buffer from data.
@@ -231,16 +248,32 @@ impl MetalDevice {
         let subbuffers = buffers.entry(size).or_insert(vec![]);
 
         let new_buffer = Arc::new(new_buffer);
+        self.residency_set.insert(&new_buffer);
         subbuffers.push(new_buffer.clone());
         Ok(new_buffer)
     }
 
     pub fn allocate_zeros(&self, size_in_bytes: usize) -> Result<Arc<Buffer>> {
         let buffer = self.allocate_buffer(size_in_bytes)?;
-        let blit = self.blit_command_encoder()?;
+        let mut blit = self.blit_command_encoder()?;
         blit.set_label("zeros");
         blit.fill_buffer(&buffer, (0, buffer.length()), 0);
-        blit.end_encoding();
+        /*
+        // Alternative impl
+        if size_in_bytes > 0 {
+            let encoder = self.command_encoder()?;
+            call_const_fill(
+                &self.device,
+                &encoder,
+                &self.kernels,
+                "fill_u8",
+                size_in_bytes,
+                &buffer,
+                0u8,
+            )
+            .map_err(crate::Error::wrap)?;
+        }
+        */
         Ok(buffer)
     }
 
@@ -259,6 +292,7 @@ impl MetalDevice {
             .new_buffer(size, RESOURCE_OPTIONS)
             .map_err(MetalError::from)?;
         let new_buffer = Arc::new(new_buffer);
+        self.residency_set.insert(&new_buffer);
         subbuffers.push(new_buffer.clone());
         Ok(new_buffer)
     }

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -5,7 +5,7 @@ use crate::conv::{ParamsConv1D, ParamsConv2D, ParamsConvTranspose1D, ParamsConvT
 use crate::op::{BinaryOpT, CmpOp, ReduceOp, UnaryOpT};
 use crate::{CpuStorage, CpuStorageRef, DType, Error, Layout, Result, Shape};
 use candle_metal_kernels::{
-    metal::{Buffer, Commands, Device},
+    metal::{Buffer, Commands, Device, ResidencySet},
     BufferOffset, CallConvTranspose2dCfg, Kernels, RESOURCE_OPTIONS,
 };
 use objc2_foundation::NSRange;
@@ -1734,13 +1734,12 @@ impl BackendStorage for MetalStorage {
             )
         }
         if src_s == d2 && dst_s == d2 {
-            let blit = self.device.blit_command_encoder()?;
+            let mut blit = self.device.blit_command_encoder()?;
             blit.set_label("copy2d_contiguous");
             let src_offset = src_o * self.dtype.size_in_bytes();
             let length = d1 * d2 * self.dtype.size_in_bytes();
             let dst_offset = dst_o * dst.dtype().size_in_bytes();
             blit.copy_from_buffer(&self.buffer, src_offset, dst.buffer(), dst_offset, length);
-            blit.end_encoding();
         } else {
             let el_count = d1 * d2;
             if el_count == 0 {
@@ -1778,13 +1777,12 @@ impl BackendStorage for MetalStorage {
 
     fn copy_strided_src(&self, dst: &mut Self, dst_offset: usize, src_l: &Layout) -> Result<()> {
         if src_l.is_contiguous() && self.dtype == dst.dtype() {
-            let blit = self.device.blit_command_encoder()?;
+            let mut blit = self.device.blit_command_encoder()?;
             blit.set_label("copy_contiguous");
             let src_offset = src_l.start_offset() * self.dtype.size_in_bytes();
             let length = src_l.shape().elem_count() * self.dtype.size_in_bytes();
             let dst_offset = dst_offset * dst.dtype().size_in_bytes();
             blit.copy_from_buffer(&self.buffer, src_offset, dst.buffer(), dst_offset, length);
-            blit.end_encoding();
         } else {
             let src_shape = src_l.shape();
             let el_count = src_shape.elem_count();
@@ -1911,10 +1909,9 @@ impl MetalStorage {
         let size = self.count * self.dtype.size_in_bytes();
         let buffer = self.device.allocate_buffer(size)?;
         {
-            let blit = self.device.blit_command_encoder()?;
+            let mut blit = self.device.blit_command_encoder()?;
             blit.set_label("blit_to_cpu");
             blit.copy_from_buffer(&self.buffer, 0, &buffer, 0, size);
-            blit.end_encoding();
         }
         self.device.wait_until_completed()?;
         Ok(read_to_vec(&buffer, self.count))
@@ -1928,25 +1925,27 @@ impl BackendDevice for MetalDevice {
         let device = Device::all().swap_remove(ordinal);
         let command_queue = device.new_command_queue().map_err(MetalError::from)?;
         let kernels = Arc::new(Kernels::new());
-        let seed = Arc::new(Mutex::new(
-            device
-                .new_buffer_with_data(
-                    [299792458u64].as_ptr() as *const c_void,
-                    std::mem::size_of::<u64>(),
-                    RESOURCE_OPTIONS,
-                )
-                .map_err(MetalError::from)?,
-        ));
-        let commands = Commands::new(command_queue).map_err(MetalError::from)?;
+        let residency_set = Arc::new(ResidencySet::new(&device));
+        let seed_buf = device
+            .new_buffer_with_data(
+                [299792458u64].as_ptr() as *const c_void,
+                std::mem::size_of::<u64>(),
+                RESOURCE_OPTIONS,
+            )
+            .map_err(MetalError::from)?;
+        residency_set.insert(&seed_buf);
+        let seed = Arc::new(Mutex::new(seed_buf));
+        let commands = Commands::new(command_queue, &residency_set).map_err(MetalError::from)?;
         Ok(Self {
             id: DeviceId::new(),
             device,
-            commands: Arc::new(RwLock::new(commands)),
+            commands: Arc::new(commands),
             buffers: Arc::new(RwLock::new(HashMap::new())),
             private_buffers: Arc::new(RwLock::new(HashMap::new())),
             kernels,
             seed,
             seed_value: Arc::new(RwLock::new(299792458)),
+            residency_set,
         })
     }
 

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -344,7 +344,6 @@ impl QMetalStorage {
             let mut blit = self.device.blit_command_encoder()?;
             blit.set_label("blit_to_cpu");
             blit.copy_from_buffer(&self.buffer, 0, &buffer, 0, self.buffer.length());
-            blit.as_ref().end_encoding();
         }
         self.device.wait_until_completed()?;
         Ok(read_to_vec::<u8>(&buffer, self.storage_size_in_bytes()))

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -37,10 +37,11 @@ impl QMetalStorage {
         use crate::quantized::k_quants::GgmlType;
 
         let buffer = self.device.allocate_buffer(self.buffer.length())?;
-        let blit = self.device.blit_command_encoder()?;
-        blit.set_label("blit_to_cpu");
-        blit.copy_from_buffer(&self.buffer, 0, &buffer, 0, self.buffer.length());
-        blit.end_encoding();
+        {
+            let mut blit = self.device.blit_command_encoder()?;
+            blit.set_label("blit_to_cpu");
+            blit.copy_from_buffer(&self.buffer, 0, &buffer, 0, self.buffer.length());
+        }
         self.device.wait_until_completed()?;
         let mut out = vec![0.0; elem_count];
         let block_len = elem_count / self.dtype.block_size();
@@ -239,7 +240,8 @@ impl QMetalStorage {
             )
             .map_err(MetalError::from)?;
         }
-        let dst_storage = crate::MetalStorage::new(dst, device, dst_shape.elem_count(), DType::F32);
+        let dst_storage =
+            crate::MetalStorage::new(dst, device.clone(), dst_shape.elem_count(), DType::F32);
         Ok((dst_storage, dst_shape))
     }
 
@@ -331,17 +333,18 @@ impl QMetalStorage {
         )
         .map_err(MetalError::from)?;
 
-        let dst_storage = crate::MetalStorage::new(dst, device, dst_shape.elem_count(), DType::F32);
+        let dst_storage =
+            crate::MetalStorage::new(dst, device.clone(), dst_shape.elem_count(), DType::F32);
         Ok((dst_storage, dst_shape))
     }
 
     pub fn data(&self) -> Result<Vec<u8>> {
         let buffer = self.device.allocate_buffer(self.buffer.length())?;
         {
-            let blit = self.device.blit_command_encoder()?;
+            let mut blit = self.device.blit_command_encoder()?;
             blit.set_label("blit_to_cpu");
             blit.copy_from_buffer(&self.buffer, 0, &buffer, 0, self.buffer.length());
-            blit.end_encoding();
+            blit.as_ref().end_encoding();
         }
         self.device.wait_until_completed()?;
         Ok(read_to_vec::<u8>(&buffer, self.storage_size_in_bytes()))

--- a/candle-metal-kernels/Cargo.toml
+++ b/candle-metal-kernels/Cargo.toml
@@ -19,7 +19,8 @@ half = { version = "2.5.0", features = [
 once_cell = "1.21"
 thiserror = "2"
 tracing = "0.1.41"
-objc2-metal = "0.3.2"
+objc2-metal = { version = "0.3.2", features = ["block2"] }
+block2 = { version = ">=0.6.1, <0.8.0", features = ["alloc"], default-features = false }
 objc2 = "0.6.3"
 objc2-foundation = "0.3.2"
 

--- a/candle-metal-kernels/examples/metal_benchmarks.rs
+++ b/candle-metal-kernels/examples/metal_benchmarks.rs
@@ -1,12 +1,11 @@
 use anyhow::Result;
 use candle_metal_kernels::{
-    metal::{create_command_buffer, CommandSemaphore, Device},
+    metal::{Commands, Device, ResidencySet},
     GemmDType, RESOURCE_OPTIONS,
 };
 /// This example contains some simple benchmarks so that it's easy to run them in perf etc.
 use clap::{Parser, Subcommand};
 use half::f16;
-use std::sync::Arc;
 
 fn run_gemm(f32: bool, n: usize) -> Result<()> {
     const WARMUP_ITERS: usize = 2;
@@ -16,7 +15,7 @@ fn run_gemm(f32: bool, n: usize) -> Result<()> {
 
     let (b, m, n, k) = (1, n, n, n);
     let kernels = candle_metal_kernels::Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
+    let residency_set = std::sync::Arc::new(ResidencySet::new(&device));
     let options = RESOURCE_OPTIONS;
 
     let (lhs, rhs) = if f32 {
@@ -66,12 +65,13 @@ fn run_gemm(f32: bool, n: usize) -> Result<()> {
     let mut sum_dt = 0f64;
     let mut iters = 0usize;
     for idx in 0.. {
-        let semaphore = Arc::new(CommandSemaphore::new());
-        let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+        let command_queue = device.new_command_queue().unwrap();
+        let commands = Commands::new(command_queue, &residency_set).unwrap();
+        let encoder = commands.command_encoder().unwrap();
         let start_time = std::time::Instant::now();
         candle_metal_kernels::call_mlx_gemm(
             &device,
-            &command_buffer,
+            &encoder,
             &kernels,
             dtype,
             (b, m, n, k),
@@ -83,8 +83,8 @@ fn run_gemm(f32: bool, n: usize) -> Result<()> {
             &rhs,
             &output,
         )?;
-        command_buffer.commit();
-        command_buffer.wait_until_completed();
+        drop(encoder);
+        commands.wait_until_completed().unwrap();
         let dt = start_time.elapsed().as_secs_f64();
         if idx < WARMUP_ITERS {
             continue;

--- a/candle-metal-kernels/src/kernel.rs
+++ b/candle-metal-kernels/src/kernel.rs
@@ -1,6 +1,6 @@
 use crate::source::{
-    AFFINE, BINARY, CAST, CONV, FILL, INDEXING, MLX_GEMM, MLX_SORT, QUANTIZED, RANDOM, REDUCE,
-    SDPA, SORT, TERNARY, UNARY,
+    AFFINE, BINARY, CAST, CONV, FILL, GEMV, INDEXING, MLX_GEMM, MLX_SORT, QUANTIZED, RANDOM,
+    REDUCE, SDPA, SORT, TERNARY, UNARY,
 };
 use crate::utils::get_env_bool;
 use crate::{
@@ -91,6 +91,7 @@ impl Kernels {
             Source::Conv => CONV,
             Source::Fill => FILL,
             Source::Gemm => MLX_GEMM,
+            Source::Gemv => GEMV,
             Source::Indexing => INDEXING,
             Source::MlxSort => MLX_SORT,
             Source::Quantized => QUANTIZED,

--- a/candle-metal-kernels/src/kernels/mlx_gemm.rs
+++ b/candle-metal-kernels/src/kernels/mlx_gemm.rs
@@ -1,5 +1,5 @@
 use crate::metal::{Buffer, ComputeCommandEncoder, Device, MetalDeviceType};
-use crate::utils::EncoderProvider;
+use crate::utils::{EncoderProvider, Input};
 use crate::{
     set_params, ConstantValues, EncoderParam, Kernels, MetalKernelError, Output, Source, Value,
 };
@@ -254,6 +254,200 @@ fn should_use_split_k(b: usize, m: usize, n: usize, k: usize) -> bool {
     (tm * tn) <= 32 && tk >= 8
 }
 
+/// M=1 -> gemv_t (vec[K] x mat[K,N] -> vec[N])
+/// N=1 -> gemv   (mat[M,K] x vec[K] -> vec[M])
+#[allow(clippy::too_many_arguments)]
+pub fn call_mlx_gemv(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    dtype: GemmDType,
+    (b, m, n, k): (usize, usize, usize, usize),
+    lhs_stride: &[usize],
+    lhs_offset: usize,
+    lhs_buffer: &Buffer,
+    rhs_stride: &[usize],
+    rhs_offset: usize,
+    rhs_buffer: &Buffer,
+    output: &Buffer,
+) -> Result<(), MetalKernelError> {
+    debug_assert!(m == 1 || n == 1, "call_mlx_gemv requires M=1 or N=1");
+
+    assert!(rhs_stride.len() >= 2);
+    assert!(lhs_stride.len() >= 2);
+
+    // Determine transpose flags from strides (same logic as call_mlx_gemm)
+    let rhs_m1 = rhs_stride[rhs_stride.len() - 1];
+    let rhs_m2 = rhs_stride[rhs_stride.len() - 2];
+    let lhs_m1 = lhs_stride[lhs_stride.len() - 1];
+    let lhs_m2 = lhs_stride[lhs_stride.len() - 2];
+
+    let (lda, a_trans) = if (lhs_m1 == 1 || k == 1) && (lhs_m2 == k || m == 1) {
+        (k as i32, false)
+    } else if (lhs_m1 == m || k == 1) && (lhs_m2 == 1 || m == 1) {
+        (m as i32, true)
+    } else {
+        return Err(MetalKernelError::MatMulNonContiguous {
+            lhs_stride: lhs_stride.to_vec(),
+            rhs_stride: rhs_stride.to_vec(),
+            mnk: (m, n, k),
+        }
+        .bt())?;
+    };
+
+    let (ldb, b_trans) = if (rhs_m1 == 1 || n == 1) && (rhs_m2 == n || k == 1) {
+        (n as i32, false)
+    } else if (rhs_m1 == k || n == 1) && (rhs_m2 == 1 || k == 1) {
+        (k as i32, true)
+    } else {
+        return Err(MetalKernelError::MatMulNonContiguous {
+            lhs_stride: lhs_stride.to_vec(),
+            rhs_stride: rhs_stride.to_vec(),
+            mnk: (m, n, k),
+        }
+        .bt())?;
+    };
+
+    // Figure out if transpose is needed.
+    let is_b_matrix = n != 1;
+    let transpose_mat = if is_b_matrix { !b_trans } else { a_trans };
+    let mat_ld = if is_b_matrix {
+        ldb as usize
+    } else {
+        lda as usize
+    };
+    let in_vec_size = k;
+    let out_vec_size = if is_b_matrix { n } else { m };
+
+    let (mat_buffer, mat_offset, vec_buffer, vec_offset) = if is_b_matrix {
+        (rhs_buffer, rhs_offset, lhs_buffer, lhs_offset)
+    } else {
+        (lhs_buffer, lhs_offset, rhs_buffer, rhs_offset)
+    };
+
+    // Batch strides (elements per batch item)
+    let vec_batch_stride: i64 = if is_b_matrix {
+        if lhs_stride.len() > 2 {
+            lhs_stride[lhs_stride.len() - 3] as i64
+        } else {
+            k as i64
+        }
+    } else {
+        if rhs_stride.len() > 2 {
+            rhs_stride[rhs_stride.len() - 3] as i64
+        } else {
+            k as i64
+        }
+    };
+    // Weight matrix is often 2D (shared across batch) -> stride = 0
+    let mat_batch_stride: i64 = if is_b_matrix {
+        if rhs_stride.len() > 2 {
+            rhs_stride[rhs_stride.len() - 3] as i64
+        } else {
+            0
+        }
+    } else {
+        if lhs_stride.len() > 2 {
+            lhs_stride[lhs_stride.len() - 3] as i64
+        } else {
+            0
+        }
+    };
+
+    // Tile selection
+    let (bm, bn, sm, sn, tm, tn) = if transpose_mat {
+        // gemv_t: vec[K] x mat[K,N_out] -> out[N_out]
+        let (sm, sn) = if in_vec_size >= 8192 && out_vec_size >= 2048 {
+            (4usize, 8usize)
+        } else {
+            (8, 4)
+        };
+        let bn = if out_vec_size >= 2048 {
+            16usize
+        } else if out_vec_size >= 512 {
+            4
+        } else {
+            2
+        };
+        let tn: usize = if out_vec_size < 4 { 1 } else { 4 };
+        (1usize, bn, sm, sn, 4usize, tn)
+    } else {
+        // gemv: mat[M_out,K] x vec[K] -> out[M_out]
+        let (bm, bn, sm, sn): (usize, usize, usize, usize) = if in_vec_size <= 64 {
+            (1, 1, 8, 4)
+        } else if in_vec_size >= 16 * out_vec_size {
+            (1, 8, 1, 32)
+        } else if out_vec_size >= 4096 {
+            (8, 1, 1, 32)
+        } else {
+            (4, 1, 1, 32)
+        };
+        let tm: usize = if out_vec_size < 4 { 1 } else { 4 };
+        (bm, bn, sm, sn, tm, 4usize)
+    };
+
+    let dtype_str = match dtype {
+        GemmDType::F32 => "float32",
+        GemmDType::F16 => "float16",
+        GemmDType::BF16 => "bfloat16",
+    };
+    let kernel_prefix = if transpose_mat { "gemv_t" } else { "gemv" };
+    let name = format!(
+        "{}_{}_bm{}_bn{}_sm{}_sn{}_tm{}_tn{}_nc0_axpby0",
+        kernel_prefix, dtype_str, bm, bn, sm, sn, tm, tn
+    );
+
+    let pipeline = kernels.load_pipeline(device, Source::Gemv, name)?;
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    let batch_shape = [b as i32];
+    let vec_batch_strides = [vec_batch_stride];
+    let mat_batch_strides = [mat_batch_stride];
+    let bias_batch_strides = [0i64];
+
+    set_params!(
+        encoder,
+        (
+            Input::with_offset(mat_buffer, mat_offset),
+            Input::with_offset(vec_buffer, vec_offset),
+            (), // bias
+            Output::new(output),
+            in_vec_size as i32,
+            out_vec_size as i32,
+            mat_ld as i32,
+            1.0f32, // alpha
+            0.0f32, // beta
+            1i32,   // batch_ndim
+            &batch_shape[..],
+            &vec_batch_strides[..],
+            &mat_batch_strides[..],
+            &bias_batch_strides[..],
+            1i32 // bias_stride
+        )
+    );
+
+    let n_out_per_tgp = if transpose_mat {
+        bn * sn * tn
+    } else {
+        bm * sm * tm
+    };
+    let n_tgp = out_vec_size.div_ceil(n_out_per_tgp);
+    let grid_size = MTLSize {
+        width: n_tgp,
+        height: 1,
+        depth: b,
+    };
+    let group_size = MTLSize {
+        width: 32,
+        height: bn,
+        depth: bm,
+    };
+    encoder.dispatch_thread_groups(grid_size, group_size);
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn call_mlx_gemm(
     device: &Device,
@@ -321,6 +515,23 @@ pub fn call_mlx_gemm(
         }
         .bt())?;
     };
+
+    if m == 1 || n == 1 {
+        return call_mlx_gemv(
+            device,
+            ep,
+            kernels,
+            dtype,
+            (b, m, n, k),
+            lhs_stride,
+            lhs_offset,
+            lhs_buffer,
+            rhs_stride,
+            rhs_offset,
+            rhs_buffer,
+            output,
+        );
+    }
 
     // Check for batch collapse optimization (MLX matmul.cpp lines 700-740)
     // When B is broadcasted (2D), collapse batch into M dimension

--- a/candle-metal-kernels/src/kernels/mod.rs
+++ b/candle-metal-kernels/src/kernels/mod.rs
@@ -20,7 +20,7 @@ pub use cast::{call_cast_contiguous, call_cast_strided};
 pub use convolution::*;
 pub use fill::*;
 pub use indexing::*;
-pub use mlx_gemm::{call_mlx_gemm, GemmDType};
+pub use mlx_gemm::{call_mlx_gemm, call_mlx_gemv, GemmDType};
 pub use quantized::{call_quantized_matmul_mm_t, call_quantized_matmul_mv_t, GgmlDType};
 pub use random::*;
 pub use reduce::*;

--- a/candle-metal-kernels/src/kernels/sort.rs
+++ b/candle-metal-kernels/src/kernels/sort.rs
@@ -75,8 +75,8 @@ fn multi_block_sort(
     let mut dev_idxs_1 = device.new_buffer(el_count * 4, RESOURCE_OPTIONS)?;
     let mut block_partitions = device.new_buffer((nrows * (nblocks + 1)) * 4, RESOURCE_OPTIONS)?;
     // Prepare command encoder
-    let encoder = ep.encoder();
-    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    let encoder_guard = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder_guard.as_ref();
     // Do blockwise sort
     {
         let name = format!("sort_mbsort_{dtype_str}_uint32_bn{bn}_tn{tn}");
@@ -92,7 +92,7 @@ fn multi_block_sort(
                 /* stride_sorted_axis */ 1i32,
                 /* nc_dim */ 1i32,
                 /* nc_shape */ nrows as i32,
-                /* nc_str */ ncols as i32
+                /* nc_str */ ncols as i64
             )
         );
         let thread_group_count = MTLSize {

--- a/candle-metal-kernels/src/lib.rs
+++ b/candle-metal-kernels/src/lib.rs
@@ -13,8 +13,8 @@ pub use kernels::{
     unary::*, GemmDType, GgmlDType,
 };
 use metal::{
-    BlitCommandEncoder, Buffer, CommandQueue, ComputeCommandEncoder, ComputePipeline,
-    ConstantValues, Device, Function, Library, MTLResourceOptions, Value,
+    Buffer, CommandQueue, ComputeCommandEncoder, ComputePipeline, ConstantValues, Device, Function,
+    Library, MTLResourceOptions, Value,
 };
 use objc2_metal::{MTLCompileOptions, MTLMathFloatingPointFunctions, MTLMathMode, MTLSize};
 use source::Source;

--- a/candle-metal-kernels/src/lib.rs
+++ b/candle-metal-kernels/src/lib.rs
@@ -21,10 +21,9 @@ use source::Source;
 use utils::{get_block_dims, get_tile_size, linear_split, EncoderParam, EncoderProvider};
 pub use utils::{BufferOffset, Output};
 
-pub const RESOURCE_OPTIONS: MTLResourceOptions =
-    objc2_metal::MTLResourceOptions(MTLResourceOptions::StorageModeShared.bits());
-//| MTLResourceOptions::HazardTrackingModeUntracked.bits(),
-//);
+pub const RESOURCE_OPTIONS: MTLResourceOptions = objc2_metal::MTLResourceOptions(
+    MTLResourceOptions::StorageModeShared.0 | MTLResourceOptions::HazardTrackingModeUntracked.0,
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DType {

--- a/candle-metal-kernels/src/metal/command_buffer.rs
+++ b/candle-metal-kernels/src/metal/command_buffer.rs
@@ -1,92 +1,50 @@
-use crate::{BlitCommandEncoder, ComputeCommandEncoder};
+use super::{BlitCommandEncoder, ComputeCommandEncoder, Device, Fence, PrevCeOutputs};
 use objc2::{rc::Retained, runtime::ProtocolObject};
 use objc2_foundation::NSString;
 use objc2_metal::{MTLCommandBuffer, MTLCommandBufferStatus, MTLDispatchType};
 use std::borrow::Cow;
-use std::sync::{Arc, Condvar, Mutex, MutexGuard};
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum CommandStatus {
-    Available,
-    Encoding,
-    Done,
-}
-
-#[derive(Debug)]
-pub struct CommandSemaphore {
-    pub cond: Condvar,
-    pub status: Mutex<CommandStatus>,
-}
-
-impl CommandSemaphore {
-    pub fn new() -> CommandSemaphore {
-        CommandSemaphore {
-            cond: Condvar::new(),
-            status: Mutex::new(CommandStatus::Available),
-        }
-    }
-
-    pub fn wait_until<F: FnMut(&mut CommandStatus) -> bool>(
-        &self,
-        mut f: F,
-    ) -> MutexGuard<'_, CommandStatus> {
-        self.cond
-            .wait_while(self.status.lock().unwrap(), |s| !f(s))
-            .unwrap()
-    }
-
-    pub fn set_status(&self, status: CommandStatus) {
-        *self.status.lock().unwrap() = status;
-        // We notify the condvar that the value has changed.
-        self.cond.notify_one();
-    }
-
-    pub fn when<T, B: FnMut(&mut CommandStatus) -> bool, F: FnMut() -> T>(
-        &self,
-        b: B,
-        mut f: F,
-        next: Option<CommandStatus>,
-    ) -> T {
-        let mut guard = self.wait_until(b);
-        let v = f();
-        if let Some(status) = next {
-            *guard = status;
-            self.cond.notify_one();
-        }
-        v
-    }
-}
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct CommandBuffer {
     raw: Retained<ProtocolObject<dyn MTLCommandBuffer>>,
-    semaphore: Arc<CommandSemaphore>,
 }
 
 unsafe impl Send for CommandBuffer {}
 unsafe impl Sync for CommandBuffer {}
 
 impl CommandBuffer {
-    pub fn new(
-        raw: Retained<ProtocolObject<dyn MTLCommandBuffer>>,
-        semaphore: Arc<CommandSemaphore>,
-    ) -> Self {
-        Self { raw, semaphore }
+    pub fn new(raw: Retained<ProtocolObject<dyn MTLCommandBuffer>>) -> Self {
+        Self { raw }
     }
 
-    pub fn compute_command_encoder(&self) -> ComputeCommandEncoder {
-        // Concurrent dispatching allows the GPU to reorder independent dispatches.
-        // We prevent read after write using dependency aware barriers in [`ComputeCommandEncoder`].
+    /// Create a compute command encoder with the provided per-encoder fence and global output map.
+    pub fn compute_command_encoder(&self, fence: &Arc<Fence>) -> ComputeCommandEncoder {
         self.as_ref()
             .computeCommandEncoderWithDispatchType(MTLDispatchType::Concurrent)
-            .map(|raw| ComputeCommandEncoder::new(raw, Arc::clone(&self.semaphore)))
+            .map(|raw| ComputeCommandEncoder::new(raw, self.raw.clone(), Arc::clone(fence)))
             .unwrap()
     }
 
-    pub fn blit_command_encoder(&self) -> BlitCommandEncoder {
+    /// Create a compute command encoder with freshly allocated fence and a standalone output map.
+    /// Used by tests and `EncoderProvider` implementations that don't share a global fence map.
+    pub fn compute_command_encoder_no_fence(&self) -> ComputeCommandEncoder {
+        let device = Device::new(self.raw.device());
+        let fence = Arc::new(Fence::new(&device));
+        self.as_ref()
+            .computeCommandEncoderWithDispatchType(MTLDispatchType::Concurrent)
+            .map(|raw| ComputeCommandEncoder::new(raw, self.raw.clone(), fence))
+            .unwrap()
+    }
+
+    pub fn blit_command_encoder(
+        &self,
+        fence: &Arc<Fence>,
+        prev_ce_outputs: &PrevCeOutputs,
+    ) -> BlitCommandEncoder {
         self.as_ref()
             .blitCommandEncoder()
-            .map(|raw| BlitCommandEncoder::new(raw, Arc::clone(&self.semaphore)))
+            .map(|raw| BlitCommandEncoder::new(raw, Arc::clone(fence), Arc::clone(prev_ce_outputs)))
             .unwrap()
     }
 

--- a/candle-metal-kernels/src/metal/commands.rs
+++ b/candle-metal-kernels/src/metal/commands.rs
@@ -110,6 +110,8 @@ pub struct Commands {
     state: Mutex<EntryState>,
     compute_count: AtomicUsize,
     command_queue: CommandQueue,
+    /// The maximum amount of [compute command encoder](https://developer.apple.com/documentation/metal/mtlcomputecommandencoder?language=objc)
+    /// per [command buffer](https://developer.apple.com/documentation/metal/mtlcommandbuffer?language=objc)
     compute_per_buffer: usize,
     device: Device,
     /// Global cross-encoder output map. Maps buffer pointer to the fence of the last encoder

--- a/candle-metal-kernels/src/metal/commands.rs
+++ b/candle-metal-kernels/src/metal/commands.rs
@@ -1,30 +1,93 @@
 use crate::metal::{
-    BlitCommandEncoder, CommandBuffer, CommandSemaphore, CommandStatus, ComputeCommandEncoder,
+    BlitCommandEncoder, Buffer, CommandBuffer, ComputeCommandEncoder, ComputePipeline, Device,
+    Fence, PrevCeOutputs, ResidencySet,
 };
 use crate::MetalKernelError;
+use block2::RcBlock;
 use objc2::{rc::Retained, runtime::ProtocolObject};
-use objc2_metal::{MTLCommandBufferStatus, MTLCommandQueue};
+use objc2_metal::{MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandQueue};
+use std::collections::HashMap;
+use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 // Use Retained when appropriate. Gives us a more elegant way of handling memory (peaks) than autoreleasepool.
 // https://docs.rs/objc2/latest/objc2/rc/struct.Retained.html
 pub type CommandQueue = Retained<ProtocolObject<dyn MTLCommandQueue>>;
 
 const DEFAULT_CANDLE_METAL_COMPUTE_PER_BUFFER: usize = 50;
-const DEFAULT_CANDLE_METAL_COMMAND_POOL_SIZE: usize = 5;
 
-/// Creates a new command buffer from the queue with an attached semaphore for tracking its state.
-pub fn create_command_buffer(
-    command_queue: &CommandQueue,
-    semaphore: Arc<CommandSemaphore>,
-) -> Result<CommandBuffer, MetalKernelError> {
-    command_queue
-        .commandBuffer()
-        .map(|raw| CommandBuffer::new(raw, semaphore))
-        .ok_or(MetalKernelError::FailedToCreateResource(
-            "CommandBuffer".to_string(),
-        ))
+fn create_command_buffer(command_queue: &CommandQueue) -> Result<CommandBuffer, MetalKernelError> {
+    command_queue.commandBuffer().map(CommandBuffer::new).ok_or(
+        MetalKernelError::FailedToCreateResource("CommandBuffer".to_string()),
+    )
+}
+
+/// RAII guard for compute command encoder operations.
+pub struct CommandsGuard<'a> {
+    guard: MutexGuard<'a, EntryState>,
+}
+
+impl AsRef<ComputeCommandEncoder> for CommandsGuard<'_> {
+    fn as_ref(&self) -> &ComputeCommandEncoder {
+        self.guard.current_encoder.as_ref().unwrap()
+    }
+}
+
+impl CommandsGuard<'_> {
+    pub fn set_label(&self, label: &str) {
+        self.as_ref().set_label(label);
+    }
+
+    pub fn set_compute_pipeline_state(&self, pipeline: &ComputePipeline) {
+        self.as_ref().set_compute_pipeline_state(pipeline);
+    }
+}
+
+/// RAII guard for blit command encoder operations.
+pub struct BlitCommandsGuard<'a> {
+    _guard: MutexGuard<'a, EntryState>,
+    state: BlitCommandEncoder,
+}
+
+impl<'a> AsRef<BlitCommandEncoder> for BlitCommandsGuard<'a> {
+    fn as_ref(&self) -> &BlitCommandEncoder {
+        &self.state
+    }
+}
+
+impl<'a> AsMut<BlitCommandEncoder> for BlitCommandsGuard<'a> {
+    fn as_mut(&mut self) -> &mut BlitCommandEncoder {
+        &mut self.state
+    }
+}
+
+impl BlitCommandsGuard<'_> {
+    pub fn set_label(&self, label: &str) {
+        self.as_ref().set_label(label);
+    }
+
+    pub fn copy_from_buffer(
+        &mut self,
+        src_buffer: &Buffer,
+        src_offset: usize,
+        dst_buffer: &Buffer,
+        dst_offset: usize,
+        size: usize,
+    ) {
+        self.as_mut()
+            .copy_from_buffer(src_buffer, src_offset, dst_buffer, dst_offset, size)
+    }
+
+    pub fn fill_buffer(&mut self, buffer: &Buffer, range: (usize, usize), value: u8) {
+        self.as_mut().fill_buffer(buffer, range, value);
+    }
+}
+
+impl Drop for BlitCommandsGuard<'_> {
+    fn drop(&mut self) {
+        self.as_ref().end_encoding();
+    }
 }
 
 struct EntryState {
@@ -33,31 +96,35 @@ struct EntryState {
     current_encoder: Option<ComputeCommandEncoder>,
 }
 
-/// A pool entry containing a command buffer, its usage count, and synchronization primitives.
-/// The `state` mutex guards the current buffer and the in-flight list for coherent updates.
-/// `compute_count` and `semaphore` remain accessible without locking for selection/coordination.
-pub struct CommandBufferEntry {
-    state: Mutex<EntryState>,
-    compute_count: AtomicUsize,
-    semaphore: Arc<CommandSemaphore>,
+impl EntryState {
+    pub fn new(cb: CommandBuffer) -> EntryState {
+        EntryState {
+            current: cb,
+            in_flight: vec![],
+            current_encoder: None,
+        }
+    }
 }
 
 pub struct Commands {
-    /// Maintains a pool of command buffers, allowing
-    /// the pool to balance load across multiple buffers and improve GPU utilization.
-    /// Can be shared across threads safely.
-    pool: Vec<Arc<CommandBufferEntry>>,
-    /// Single command queue for the entire device.
+    state: Mutex<EntryState>,
+    compute_count: AtomicUsize,
     command_queue: CommandQueue,
-    /// The maximum amount of [compute command encoder](https://developer.apple.com/documentation/metal/mtlcomputecommandencoder?language=objc) per [command buffer](https://developer.apple.com/documentation/metal/mtlcommandbuffer?language=objc)
     compute_per_buffer: usize,
+    device: Device,
+    /// Global cross-encoder output map. Maps buffer pointer to the fence of the last encoder
+    /// that wrote it, enabling cross-command-buffer ordering for HazardTrackingModeUntracked.
+    prev_ce_outputs: PrevCeOutputs,
 }
 
 unsafe impl Send for Commands {}
 unsafe impl Sync for Commands {}
 
 impl Commands {
-    pub fn new(command_queue: CommandQueue) -> Result<Self, MetalKernelError> {
+    pub fn new(
+        command_queue: CommandQueue,
+        residency_set: &ResidencySet,
+    ) -> Result<Self, MetalKernelError> {
         let compute_per_buffer = match std::env::var("CANDLE_METAL_COMPUTE_PER_BUFFER") {
             Ok(val) => val
                 .parse()
@@ -65,214 +132,156 @@ impl Commands {
             _ => DEFAULT_CANDLE_METAL_COMPUTE_PER_BUFFER,
         };
 
-        let pool_size = match std::env::var("CANDLE_METAL_COMMAND_POOL_SIZE") {
-            Ok(val) => val
-                .parse()
-                .unwrap_or(DEFAULT_CANDLE_METAL_COMMAND_POOL_SIZE),
-            _ => DEFAULT_CANDLE_METAL_COMMAND_POOL_SIZE,
-        };
+        if let Some(raw) = residency_set.raw() {
+            command_queue.addResidencySet(raw);
+        }
 
-        let pool = (0..pool_size)
-            .map(|_| Self::create_pool_entry(&command_queue))
-            .collect::<Result<Vec<_>, _>>()?;
+        let device = Device::new(command_queue.device());
+        let cb = create_command_buffer(&command_queue)?;
 
         Ok(Self {
-            pool,
+            state: Mutex::new(EntryState::new(cb)),
+            compute_count: AtomicUsize::new(0),
             command_queue,
             compute_per_buffer,
+            device,
+            prev_ce_outputs: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
-    fn create_pool_entry(
-        command_queue: &CommandQueue,
-    ) -> Result<Arc<CommandBufferEntry>, MetalKernelError> {
-        let semaphore = Arc::new(CommandSemaphore::new());
-        let cb = create_command_buffer(command_queue, Arc::clone(&semaphore))?;
+    pub fn command_encoder(&self) -> Result<CommandsGuard<'_>, MetalKernelError> {
+        let mut state_guard = self.state.lock().unwrap();
+        let count = self.compute_count.fetch_add(1, Ordering::Relaxed);
+        let flush = count >= self.compute_per_buffer;
 
-        Ok(Arc::new(CommandBufferEntry {
-            state: Mutex::new(EntryState {
-                current: cb,
-                in_flight: Vec::new(),
-                current_encoder: None,
-            }),
-            compute_count: AtomicUsize::new(0),
-            semaphore,
-        }))
+        if flush {
+            self.commit_swap_locked(&mut state_guard, 1)?;
+        }
+
+        if state_guard.current_encoder.is_none() {
+            let fence = Arc::new(Fence::new(&self.device));
+            let enc = state_guard.current.compute_command_encoder(&fence);
+            // Wait for all prior encoder fences before the first dispatch.
+            // Using HazardTrackingModeUntracked implies that Metal does not automatically flush GPU caches
+            // at encoder or command buffer boundaries.
+            {
+                use std::collections::HashSet;
+                let map = self.prev_ce_outputs.lock().unwrap();
+                let mut seen = HashSet::new();
+                for f in map.values() {
+                    let ptr = Arc::as_ptr(f) as usize;
+                    if seen.insert(ptr) {
+                        enc.wait_for_fence(f);
+                    }
+                }
+            }
+            state_guard.current_encoder = Some(enc);
+        }
+
+        Ok(CommandsGuard { guard: state_guard })
     }
 
-    pub fn command_encoder(&self) -> Result<(bool, ComputeCommandEncoder), MetalKernelError> {
-        let entry = self.select_entry()?;
-        self.finalize_entry(entry)
-    }
+    pub fn blit_command_encoder(&self) -> Result<BlitCommandsGuard<'_>, MetalKernelError> {
+        let mut state_guard = self.state.lock().unwrap();
+        let count = self.compute_count.fetch_add(1, Ordering::Relaxed);
+        let flush = count >= self.compute_per_buffer;
 
-    pub fn blit_command_encoder(&self) -> Result<(bool, BlitCommandEncoder), MetalKernelError> {
-        let entry = self.select_entry()?;
-        self.finalize_blit_entry(entry)
+        if flush {
+            self.commit_swap_locked(&mut state_guard, 1)?;
+        }
+
+        // End compute encoder before starting blit.
+        if let Some(enc) = state_guard.current_encoder.take() {
+            self.end_encoding(enc);
+        }
+
+        let fence = Arc::new(Fence::new(&self.device));
+        let encoder = state_guard
+            .current
+            .blit_command_encoder(&fence, &self.prev_ce_outputs);
+
+        // Wait for all prior encoder fences before any blit commands execute.
+        // Required for HazardTrackingModeUntracked: GPU caches are not auto-flushed.
+        {
+            use std::collections::HashSet;
+            let map = self.prev_ce_outputs.lock().unwrap();
+            let mut seen = HashSet::new();
+            for f in map.values() {
+                let ptr = Arc::as_ptr(f) as usize;
+                if seen.insert(ptr) {
+                    encoder.wait_for_fence(f);
+                }
+            }
+        }
+
+        Ok(BlitCommandsGuard {
+            _guard: state_guard,
+            state: encoder,
+        })
     }
 
     pub fn wait_until_completed(&self) -> Result<(), MetalKernelError> {
         self.flush_and_wait()
     }
 
-    // Selects an entry from the pool using a two-phase strategy:
-    /// 1. Try non-blocking: find any available buffer without waiting
-    /// 2. Fallback: select the least-loaded buffer and wait for availability
-    fn select_entry(&self) -> Result<Arc<CommandBufferEntry>, MetalKernelError> {
-        // Phase 1: Try to find an available buffer without blocking
-        for entry in &self.pool {
-            if let Ok(mut status) = entry.semaphore.status.try_lock() {
-                if matches!(*status, CommandStatus::Available) {
-                    *status = CommandStatus::Encoding;
-                    return Ok(Arc::clone(entry));
-                }
-            }
-        }
-
-        // Phase 2: Select the buffer with the most work and wait for it
-        let entry = self
-            .pool
-            .iter()
-            .max_by_key(|e| e.compute_count.load(Ordering::Acquire))
-            .ok_or(MetalKernelError::FailedToCreateResource(
-                "Command buffer pool is empty".to_string(),
-            ))?;
-
-        let entry = Arc::clone(entry);
-        {
-            let mut guard = entry
-                .semaphore
-                .wait_until(|s| matches!(s, CommandStatus::Available));
-            *guard = CommandStatus::Encoding;
-        }
-
-        Ok(entry)
-    }
-
-    /// Get or create the long lived encoder for this entry, returning a cloned reference.
-    fn finalize_entry(
-        &self,
-        entry: Arc<CommandBufferEntry>,
-    ) -> Result<(bool, ComputeCommandEncoder), MetalKernelError> {
-        let mut state = entry.state.lock()?;
-
-        let count = entry.compute_count.fetch_add(1, Ordering::Relaxed);
-        let flush = count >= self.compute_per_buffer;
-
-        if flush {
-            self.commit_swap_locked(&entry, &mut state, 1)?;
-        }
-
-        // Lazily create the canonical encoder for this command buffer.
-        // Mark it long-lived so Drop won't call endEncoding. Only commit_swap_locked ends this encoder.
-        if state.current_encoder.is_none() {
-            let mut enc = state.current.compute_command_encoder();
-            enc.make_long_lived();
-            state.current_encoder = Some(enc);
-        }
-
-        let encoder_ref = state.current_encoder.as_ref().unwrap().clone_ref();
-        Ok((flush, encoder_ref))
-    }
-
-    fn finalize_blit_entry(
-        &self,
-        entry: Arc<CommandBufferEntry>,
-    ) -> Result<(bool, BlitCommandEncoder), MetalKernelError> {
-        let mut state = entry.state.lock()?;
-
-        let count = entry.compute_count.fetch_add(1, Ordering::Relaxed);
-        let flush = count >= self.compute_per_buffer;
-
-        if flush {
-            self.commit_swap_locked(&entry, &mut state, 1)?;
-        }
-
-        // Blit encoder requires ending the current compute encoder first.
-        // Use end_encoding_silent so the semaphore stays `Encoding` — the blit
-        // encoder is now the active encoder and its end_encoding() will signal `Available`.
-        if let Some(enc) = state.current_encoder.take() {
-            enc.end_encoding_silent();
-        }
-
-        let encoder = state.current.blit_command_encoder();
-        Ok((flush, encoder))
-    }
-
-    /// Flushes all buffers and waits for their completion.
-    /// Commits any pending work on the current buffers, moves them to in-flight,
-    /// then waits on all in-flight buffers including those from prior recycles.
     pub fn flush_and_wait(&self) -> Result<(), MetalKernelError> {
-        for entry in &self.pool {
-            // Wait for any active encoding to finish, then drop the guard immediately.
-            // We must NOT hold the semaphore guard while calling commit_swap_locked, because
-            // commit_swap_locked -> end_encoding -> signal_encoding_ended tries to re-lock it.
+        let to_wait = {
+            let mut state = self.state.lock()?;
+            if self.compute_count.load(Ordering::Acquire) > 0 {
+                self.commit_swap_locked(&mut state, 0)?;
+            }
+            std::mem::take(&mut state.in_flight)
+        };
 
-            let to_wait: Vec<CommandBuffer> = {
-                let mut state = {
-                    let _guard = entry
-                        .semaphore
-                        .wait_until(|s| matches!(s, CommandStatus::Available));
-
-                    entry.state.lock()?
-
-                    // semiphore guard is dropped when state guard is acquired.
-                    // must drop before `commit_swap_locked` as `end_encoding` requires locking the same guard.
-                };
-
-                if entry.compute_count.load(Ordering::Acquire) > 0 {
-                    self.commit_swap_locked(&entry, &mut state, 0)?;
-                }
-
-                // Drain `in_flight` into a local vec to wait without holding the lock.
-                // Replaces `state.in_flight` with an empty vec and returns its previous contents.
-                std::mem::take(&mut state.in_flight)
-            };
-
-            for cb in to_wait {
-                Self::ensure_completed(&cb)?;
+        // Wait only on the last CB. Metal executes CBs in queue order, so all earlier
+        // CBs are guaranteed complete when the last one is. Calling waitUntilCompleted on
+        // each CB individually pays OS notification latency (~1-2ms) N times unnecessarily.
+        if let Some(last) = to_wait.last() {
+            Self::ensure_completed(last)?;
+        }
+        // Check earlier CBs for errors (no need to block — they're already done).
+        for cb in &to_wait[..to_wait.len().saturating_sub(1)] {
+            if cb.status() == MTLCommandBufferStatus::Error {
+                let msg = cb
+                    .error()
+                    .map(|e| e.to_string())
+                    .unwrap_or_else(|| "unknown error".to_string());
+                return Err(MetalKernelError::CommandBufferError(msg));
             }
         }
+
+        self.prev_ce_outputs.lock()?.clear();
 
         Ok(())
     }
 
-    /// Flushes all buffers without waiting for completion.
-    /// Commits any pending work and moves current buffers to in-flight.
     pub fn flush(&self) -> Result<(), MetalKernelError> {
-        for entry in &self.pool {
-            let guard = entry
-                .semaphore
-                .wait_until(|s| matches!(s, CommandStatus::Available));
-
-            let mut state = entry.state.lock()?;
-            drop(guard);
-
-            if entry.compute_count.load(Ordering::Acquire) > 0 {
-                self.commit_swap_locked(&entry, &mut state, 0)?;
-            }
+        let mut state = self.state.lock()?;
+        if self.compute_count.load(Ordering::Acquire) > 0 {
+            self.commit_swap_locked(&mut state, 0)?;
         }
-
         Ok(())
     }
 
-    /// Commit the current command buffer, swap in a fresh one, push the old into `in_flight`,
-    /// and reset `compute_count` to `reset_to`.
     fn commit_swap_locked(
         &self,
-        entry: &CommandBufferEntry,
         state: &mut EntryState,
         reset_to: usize,
     ) -> Result<(), MetalKernelError> {
-        // End the open encoder before committing the command buffer
         if let Some(enc) = state.current_encoder.take() {
-            enc.end_encoding();
+            self.end_encoding(enc);
         }
 
-        state.current.commit();
-        let new_cb = create_command_buffer(&self.command_queue, Arc::clone(&entry.semaphore))?;
+        match state.current.status() {
+            MTLCommandBufferStatus::NotEnqueued | MTLCommandBufferStatus::Enqueued => {
+                state.current.commit();
+            }
+            _ => {}
+        }
+        let new_cb = create_command_buffer(&self.command_queue)?;
         let old_cb = std::mem::replace(&mut state.current, new_cb);
         state.in_flight.push(old_cb);
-        entry.compute_count.store(reset_to, Ordering::Release);
+        self.compute_count.store(reset_to, Ordering::Release);
 
         Ok(())
     }
@@ -299,11 +308,67 @@ impl Commands {
 
         Ok(())
     }
+
+    fn end_encoding(&self, encoder: ComputeCommandEncoder) {
+        use objc2_metal::MTLCommandEncoder as _;
+        use objc2_metal::MTLComputeCommandEncoder as _;
+
+        let (all_inputs, all_outputs) = {
+            let s = encoder.state.lock().unwrap();
+            (s.all_inputs.clone(), s.all_outputs.clone())
+        };
+
+        let mut prev_ce_outputs = self.prev_ce_outputs.lock().unwrap();
+
+        // Wait for any prior encoder that wrote to buffers we're reading (RAW protection).
+        let mut waiting_on = HashMap::new();
+        for input in all_inputs.iter() {
+            if let Some(fence) = prev_ce_outputs.get(input) {
+                if !waiting_on.contains_key(input) {
+                    encoder.wait_for_fence(fence);
+                    waiting_on.insert(input, fence.clone());
+                }
+            }
+        }
+
+        // Register our outputs so subsequent encoders can wait for us.
+        for output in all_outputs.iter() {
+            let _ = prev_ce_outputs.insert(*output, encoder.fence.clone());
+        }
+
+        drop(prev_ce_outputs);
+
+        // Signal this encoder's completion fence and end encoding.
+        encoder.raw.updateFence(encoder.fence.raw());
+
+        // Schedule cleanup of our output entries once the GPU completes.
+        let all_buffers: Vec<usize> = all_outputs.iter().copied().collect();
+        if !all_buffers.is_empty() {
+            let fence_for_cleanup = Arc::clone(&encoder.fence);
+            let map_for_cleanup = Arc::clone(&self.prev_ce_outputs);
+            let block = RcBlock::new(move |_cb: NonNull<ProtocolObject<dyn MTLCommandBuffer>>| {
+                let mut map = map_for_cleanup.lock().unwrap();
+                for &buf in &all_buffers {
+                    if let Some(f) = map.get(&buf) {
+                        if Arc::ptr_eq(f, &fence_for_cleanup) {
+                            map.remove(&buf);
+                        }
+                    }
+                }
+            });
+            unsafe {
+                encoder
+                    .command_buffer
+                    .addCompletedHandler(RcBlock::as_ptr(&block))
+            };
+        }
+
+        encoder.raw.endEncoding();
+    }
 }
 
 impl Drop for Commands {
     fn drop(&mut self) {
-        // TODO: Avoid redundant allocation before drop
         let _ = self.flush();
     }
 }

--- a/candle-metal-kernels/src/metal/commands.rs
+++ b/candle-metal-kernels/src/metal/commands.rs
@@ -315,42 +315,29 @@ impl Commands {
         use objc2_metal::MTLCommandEncoder as _;
         use objc2_metal::MTLComputeCommandEncoder as _;
 
-        let (all_inputs, all_outputs) = {
+        let all_outputs = {
             let s = encoder.state.lock().unwrap();
-            (s.all_inputs.clone(), s.all_outputs.clone())
+            s.all_outputs.clone()
         };
 
-        let mut prev_ce_outputs = self.prev_ce_outputs.lock().unwrap();
-
-        // Wait for any prior encoder that wrote to buffers we're reading (RAW protection).
-        let mut waiting_on = HashMap::new();
-        for input in all_inputs.iter() {
-            if let Some(fence) = prev_ce_outputs.get(input) {
-                if !waiting_on.contains_key(input) {
-                    encoder.wait_for_fence(fence);
-                    waiting_on.insert(input, fence.clone());
-                }
+        {
+            let mut prev_ce_outputs = self.prev_ce_outputs.lock().unwrap();
+            // Register our outputs so subsequent encoders can wait for us.
+            for output in all_outputs.iter() {
+                let _ = prev_ce_outputs.insert(*output, encoder.fence.clone());
             }
         }
-
-        // Register our outputs so subsequent encoders can wait for us.
-        for output in all_outputs.iter() {
-            let _ = prev_ce_outputs.insert(*output, encoder.fence.clone());
-        }
-
-        drop(prev_ce_outputs);
 
         // Signal this encoder's completion fence and end encoding.
         encoder.raw.updateFence(encoder.fence.raw());
 
         // Schedule cleanup of our output entries once the GPU completes.
-        let all_buffers: Vec<usize> = all_outputs.iter().copied().collect();
-        if !all_buffers.is_empty() {
+        if !all_outputs.is_empty() {
             let fence_for_cleanup = Arc::clone(&encoder.fence);
             let map_for_cleanup = Arc::clone(&self.prev_ce_outputs);
             let block = RcBlock::new(move |_cb: NonNull<ProtocolObject<dyn MTLCommandBuffer>>| {
                 let mut map = map_for_cleanup.lock().unwrap();
-                for &buf in &all_buffers {
+                for &buf in &all_outputs {
                     if let Some(f) = map.get(&buf) {
                         if Arc::ptr_eq(f, &fence_for_cleanup) {
                             map.remove(&buf);

--- a/candle-metal-kernels/src/metal/device.rs
+++ b/candle-metal-kernels/src/metal/device.rs
@@ -43,6 +43,10 @@ impl AsRef<ProtocolObject<dyn MTLDevice>> for Device {
 }
 
 impl Device {
+    pub fn new(raw: Retained<ProtocolObject<dyn MTLDevice>>) -> Self {
+        Device { raw }
+    }
+
     pub fn registry_id(&self) -> u64 {
         self.as_ref().registryID()
     }

--- a/candle-metal-kernels/src/metal/encoder.rs
+++ b/candle-metal-kernels/src/metal/encoder.rs
@@ -1,51 +1,62 @@
-use crate::metal::{Buffer, CommandSemaphore, CommandStatus, ComputePipeline};
+use crate::metal::{Buffer, ComputePipeline, Fence};
 use objc2::{rc::Retained, runtime::ProtocolObject};
 use objc2_foundation::{NSRange, NSString};
 use objc2_metal::{
-    MTLBarrierScope, MTLBlitCommandEncoder, MTLCommandEncoder, MTLComputeCommandEncoder, MTLSize,
+    MTLBarrierScope, MTLBlitCommandEncoder, MTLCommandBuffer, MTLCommandEncoder,
+    MTLComputeCommandEncoder, MTLSize,
 };
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     ffi::c_void,
     ptr,
     sync::{Arc, Mutex},
 };
 
-struct EncoderState {
-    /// Buffer ptr values written since the last barrier (RAW/WAW detection).
-    prev_outputs: HashSet<usize>,
-    /// Buffer ptr values written by the current op, promoted to prev_outputs after dispatch.
-    next_outputs: HashSet<usize>,
-    /// Buffer ptr values read since the last barrier (WAR detection).
-    prev_inputs: HashSet<usize>,
-    /// Buffer ptr values read by the current op, promoted to prev_inputs after dispatch.
-    next_inputs: HashSet<usize>,
-    /// Whether a barrier is needed before the next dispatch.
-    needs_barrier: bool,
+/// Shared cross-encoder output map: maps buffer pointer -> fence of the last encoder that wrote it.
+/// Used by subsequent encoders to call waitForFence before reading those buffers.
+pub type PrevCeOutputs = Arc<Mutex<HashMap<usize, Arc<Fence>>>>;
+
+/// Barrier tracking state for one encoder session.
+/// Owned by ComputeCommandEncoder via Arc<Mutex<>> so clones share state.
+pub struct EncoderState {
+    /// Buffer ptrs written since last barrier (RAW/WAW detection).
+    pub prev_outputs: HashSet<usize>,
+    pub next_outputs: HashSet<usize>,
+    /// Buffer ptrs read since last barrier (WAR detection).
+    pub prev_inputs: HashSet<usize>,
+    pub next_inputs: HashSet<usize>,
+    pub needs_barrier: bool,
+    /// All inputs seen this encoder session (cross-encoder fence coordination).
+    pub all_inputs: HashSet<usize>,
+    /// All outputs seen this encoder session (registered in global map at end_encoding).
+    pub all_outputs: HashSet<usize>,
 }
 
 impl EncoderState {
-    fn new() -> Self {
+    pub fn new() -> Self {
         EncoderState {
             prev_outputs: HashSet::new(),
             next_outputs: HashSet::new(),
             prev_inputs: HashSet::new(),
             next_inputs: HashSet::new(),
             needs_barrier: false,
+            all_inputs: HashSet::new(),
+            all_outputs: HashSet::new(),
         }
     }
 }
 
+#[derive(Clone)]
 pub struct ComputeCommandEncoder {
-    raw: Retained<ProtocolObject<dyn MTLComputeCommandEncoder>>,
-    semaphore: Arc<CommandSemaphore>,
-    /// Barrier tracking state, shared between the original encoder and any clone_refs.
-    state: Arc<Mutex<EncoderState>>,
-    /// If true, Drop calls `end_encoding`.
-    end_on_drop: bool,
-    /// Only meaningful when `end_on_drop` is false.
-    /// If true, Drop signals the semaphore `Available` (clone_ref).
-    signal_on_drop: bool,
+    pub(crate) raw: Retained<ProtocolObject<dyn MTLComputeCommandEncoder>>,
+    /// Retained so we can register completion handlers on this CB.
+    pub(crate) command_buffer: Retained<ProtocolObject<dyn MTLCommandBuffer>>,
+    /// Per-encoder-session fence. Updated at end_encoding.
+    pub(crate) fence: Arc<Fence>,
+    /// Hazard tracking state. Arc shared between the canonical encoder in EntryState
+    /// and the clone held by CommandsGuard. Uncontended in practice (CommandsGuard
+    /// holds the outer Commands mutex for the entire kernel dispatch).
+    pub(crate) state: Arc<Mutex<EncoderState>>,
 }
 
 impl AsRef<ComputeCommandEncoder> for ComputeCommandEncoder {
@@ -57,65 +68,19 @@ impl AsRef<ComputeCommandEncoder> for ComputeCommandEncoder {
 impl ComputeCommandEncoder {
     pub fn new(
         raw: Retained<ProtocolObject<dyn MTLComputeCommandEncoder>>,
-        semaphore: Arc<CommandSemaphore>,
+        command_buffer: Retained<ProtocolObject<dyn MTLCommandBuffer>>,
+        fence: Arc<Fence>,
     ) -> ComputeCommandEncoder {
         ComputeCommandEncoder {
             raw,
-            semaphore,
+            command_buffer,
+            fence,
             state: Arc::new(Mutex::new(EncoderState::new())),
-            end_on_drop: true,
-            signal_on_drop: true,
         }
-    }
-
-    /// Convert this encoder into a long lived original encoder.
-    /// Drop becomes a noop. Only explicit end_encoding() calls will signal the semaphore.
-    pub(crate) fn make_long_lived(&mut self) {
-        self.end_on_drop = false;
-        self.signal_on_drop = false;
-    }
-
-    /// Return a non-owning clone that shares barrier tracking state with this encoder.
-    /// Dropping the clone signals the semaphore (`Available`) but does not call metal `endEncoding`.
-    /// Only the original encoder ends the encoding.
-    pub(crate) fn clone_ref(&self) -> ComputeCommandEncoder {
-        ComputeCommandEncoder {
-            raw: self.raw.clone(),
-            semaphore: Arc::clone(&self.semaphore),
-            state: Arc::clone(&self.state),
-            end_on_drop: false,
-            signal_on_drop: true,
-        }
-    }
-
-    pub(crate) fn signal_encoding_ended(&self) {
-        self.semaphore.set_status(CommandStatus::Available);
     }
 
     pub fn set_threadgroup_memory_length(&self, index: usize, length: usize) {
         unsafe { self.raw.setThreadgroupMemoryLength_atIndex(length, index) }
-    }
-
-    /// Insert a memory barrier only when a RAW, WAW, or WAR hazard is detected.
-    ///
-    /// RAW/WAW: input or output buffer ptr was in prev_outputs (written since last barrier).
-    /// WAR: output buffer ptr was in prev_inputs (read since last barrier, now being recycled).
-    ///
-    /// On barrier: replace both prev sets with the current op's sets.
-    /// On no barrier: accumulate both prev sets with the current op's sets.
-    fn auto_barrier(&self) {
-        let mut s = self.state.lock().unwrap();
-        if s.needs_barrier {
-            self.raw.memoryBarrierWithScope(MTLBarrierScope::Buffers);
-            s.needs_barrier = false;
-            s.prev_outputs = std::mem::take(&mut s.next_outputs);
-            s.prev_inputs = std::mem::take(&mut s.next_inputs);
-        } else {
-            let next_out = std::mem::take(&mut s.next_outputs);
-            s.prev_outputs.extend(next_out);
-            let next_in = std::mem::take(&mut s.next_inputs);
-            s.prev_inputs.extend(next_in);
-        }
     }
 
     pub fn dispatch_threads(&self, threads_per_grid: MTLSize, threads_per_threadgroup: MTLSize) {
@@ -136,7 +101,21 @@ impl ComputeCommandEncoder {
         )
     }
 
-    /// Set a buffer as an input. Checks for RAW hazard and tracks the read.
+    fn auto_barrier(&self) {
+        let mut s = self.state.lock().unwrap();
+        if s.needs_barrier {
+            self.raw.memoryBarrierWithScope(MTLBarrierScope::Buffers);
+            s.needs_barrier = false;
+            s.prev_outputs = std::mem::take(&mut s.next_outputs);
+            s.prev_inputs = std::mem::take(&mut s.next_inputs);
+        } else {
+            let next_out = std::mem::take(&mut s.next_outputs);
+            s.prev_outputs.extend(next_out);
+            let next_in = std::mem::take(&mut s.next_inputs);
+            s.prev_inputs.extend(next_in);
+        }
+    }
+
     pub fn set_input_buffer(&self, index: usize, buffer: Option<&Buffer>, offset: usize) {
         if let Some(buf) = buffer {
             let ptr = buf.raw_ptr() as usize;
@@ -145,6 +124,7 @@ impl ComputeCommandEncoder {
                 s.needs_barrier = true;
             }
             s.next_inputs.insert(ptr);
+            s.all_inputs.insert(ptr);
         }
         unsafe {
             self.raw
@@ -152,7 +132,6 @@ impl ComputeCommandEncoder {
         }
     }
 
-    /// Set a buffer as an output. Checks for WAW and WAR hazards, tracks the write.
     pub fn set_output_buffer(&self, index: usize, buffer: Option<&Buffer>, offset: usize) {
         if let Some(buf) = buffer {
             let ptr = buf.raw_ptr() as usize;
@@ -161,6 +140,7 @@ impl ComputeCommandEncoder {
                 s.needs_barrier = true;
             }
             s.next_outputs.insert(ptr);
+            s.all_outputs.insert(ptr);
         }
         unsafe {
             self.raw
@@ -183,22 +163,25 @@ impl ComputeCommandEncoder {
         self.raw.setComputePipelineState(pipeline.as_ref());
     }
 
-    /// Ends the Metal encoding session and resets intra encoder state.
-    /// Signals the semaphore as `Available`.
-    pub fn end_encoding(&self) {
-        use objc2_metal::MTLCommandEncoder as _;
-        self.raw.endEncoding();
-        *self.state.lock().unwrap() = EncoderState::new();
-        self.signal_encoding_ended();
+    /// Insert a memory barrier at buffers scope.
+    pub fn insert_memory_barrier(&self) {
+        self.raw.memoryBarrierWithScope(MTLBarrierScope::Buffers);
     }
 
-    /// End the Metal encoding session without signaling the semaphore.
-    /// Used when the caller will immediately create a new encoder on the same
-    /// command buffer (e.g. blit encoder) and needs the semaphore to stay `Encoding`.
-    pub(crate) fn end_encoding_silent(&self) {
+    /// Wait for a fence before continuing execution.
+    pub fn wait_for_fence(&self, fence: &Fence) {
+        self.raw.waitForFence(fence.raw());
+    }
+
+    /// Update a fence after commands complete.
+    pub fn update_fence(&self, fence: &Fence) {
+        self.raw.updateFence(fence.raw());
+    }
+
+    pub fn end_encoding(&self) {
         use objc2_metal::MTLCommandEncoder as _;
+        self.raw.updateFence(self.fence.raw());
         self.raw.endEncoding();
-        *self.state.lock().unwrap() = EncoderState::new();
     }
 
     pub fn encode_pipeline(&mut self, pipeline: &ComputePipeline) {
@@ -211,21 +194,14 @@ impl ComputeCommandEncoder {
     }
 }
 
-impl Drop for ComputeCommandEncoder {
-    fn drop(&mut self) {
-        if self.end_on_drop {
-            self.end_encoding();
-        } else if self.signal_on_drop {
-            // Clone ref. Release semaphore slot. Encoding continues on original.
-            self.signal_encoding_ended();
-        }
-        // Original encoder means noop. `end_encoding` must be called explicitly.
-    }
-}
-
 pub struct BlitCommandEncoder {
-    raw: Retained<ProtocolObject<dyn MTLBlitCommandEncoder>>,
-    semaphore: Arc<CommandSemaphore>,
+    pub(crate) raw: Retained<ProtocolObject<dyn MTLBlitCommandEncoder>>,
+    /// Per-encoder fence, updated at end_encoding.
+    fence: Arc<Fence>,
+    /// Shared global cross-encoder output map.
+    prev_ce_outputs: PrevCeOutputs,
+    /// Buffer pointers written by this blit encoder (registered in global map at end_encoding).
+    tracked_outputs: Vec<usize>,
 }
 
 impl AsRef<BlitCommandEncoder> for BlitCommandEncoder {
@@ -237,19 +213,41 @@ impl AsRef<BlitCommandEncoder> for BlitCommandEncoder {
 impl BlitCommandEncoder {
     pub fn new(
         raw: Retained<ProtocolObject<dyn MTLBlitCommandEncoder>>,
-        semaphore: Arc<CommandSemaphore>,
+        fence: Arc<Fence>,
+        prev_ce_outputs: PrevCeOutputs,
     ) -> BlitCommandEncoder {
-        BlitCommandEncoder { raw, semaphore }
+        BlitCommandEncoder {
+            raw,
+            fence,
+            prev_ce_outputs,
+            tracked_outputs: Vec::new(),
+        }
     }
 
-    pub(crate) fn signal_encoding_ended(&self) {
-        self.semaphore.set_status(CommandStatus::Available);
+    /// Wait for a fence before continuing execution.
+    pub fn wait_for_fence(&self, fence: &Fence) {
+        self.raw.waitForFence(fence.raw());
+    }
+
+    /// Update a fence after commands complete.
+    pub fn update_fence(&self, fence: &Fence) {
+        self.raw.updateFence(fence.raw());
     }
 
     pub fn end_encoding(&self) {
         use objc2_metal::MTLCommandEncoder as _;
+
+        // Signal this blit encoder's fence after all blit commands complete
+        self.update_fence(&self.fence);
         self.raw.endEncoding();
-        self.signal_encoding_ended();
+
+        // Register outputs so subsequent encoders can wait.
+        {
+            let mut map = self.prev_ce_outputs.lock().unwrap();
+            for &out in &self.tracked_outputs {
+                map.insert(out, Arc::clone(&self.fence));
+            }
+        }
     }
 
     pub fn set_label(&self, label: &str) {
@@ -257,14 +255,28 @@ impl BlitCommandEncoder {
         self.raw.setLabel(Some(&NSString::from_str(label)))
     }
 
+    /// Copy bytes from src to dst. Waits on any fence that wrote to src_buffer to ensure
+    /// correct ordering for HazardTrackingModeUntracked buffers.
     pub fn copy_from_buffer(
-        &self,
+        &mut self,
         src_buffer: &Buffer,
         src_offset: usize,
         dst_buffer: &Buffer,
         dst_offset: usize,
         size: usize,
     ) {
+        let src_ptr = src_buffer.raw_ptr() as usize;
+        let fence_to_wait = {
+            let map = self.prev_ce_outputs.lock().unwrap();
+            map.get(&src_ptr).cloned()
+        };
+        if let Some(fence) = fence_to_wait {
+            use objc2_metal::MTLBlitCommandEncoder as _;
+            self.raw.waitForFence(fence.raw());
+        }
+
+        self.tracked_outputs.push(dst_buffer.raw_ptr() as usize);
+
         unsafe {
             self.raw
                 .copyFromBuffer_sourceOffset_toBuffer_destinationOffset_size(
@@ -277,7 +289,18 @@ impl BlitCommandEncoder {
         }
     }
 
-    pub fn fill_buffer(&self, buffer: &Buffer, range: (usize, usize), value: u8) {
+    pub fn fill_buffer(&mut self, buffer: &Buffer, range: (usize, usize), value: u8) {
+        let ptr = buffer.raw_ptr() as usize;
+        let fence_to_wait = {
+            let map = self.prev_ce_outputs.lock().unwrap();
+            map.get(&ptr).cloned()
+        };
+        if let Some(fence) = fence_to_wait {
+            use objc2_metal::MTLBlitCommandEncoder as _;
+            self.raw.waitForFence(fence.raw());
+        }
+        self.tracked_outputs.push(ptr);
+
         self.raw.fillBuffer_range_value(
             buffer.as_ref(),
             NSRange {

--- a/candle-metal-kernels/src/metal/fence.rs
+++ b/candle-metal-kernels/src/metal/fence.rs
@@ -1,0 +1,30 @@
+use super::Device;
+use objc2::{rc::Retained, runtime::ProtocolObject};
+use objc2_metal::MTLFence;
+
+/// Cross-encoder synchronization primitive for HazardTrackingModeUntracked resources.
+///
+/// memoryBarrierWithScope only works within a single encoder. When transitioning between
+/// encoders (e.g. compute -> blit for to_cpu, blit -> compute for next dispatch), untracked
+/// resources need explicit fence wait/update calls to ensure memory visibility.
+pub struct Fence {
+    raw: Retained<ProtocolObject<dyn MTLFence>>,
+}
+
+unsafe impl Send for Fence {}
+unsafe impl Sync for Fence {}
+
+impl Fence {
+    pub fn new(device: &Device) -> Self {
+        use objc2_metal::MTLDevice as _;
+        let raw = device
+            .as_ref()
+            .newFence()
+            .expect("failed to create MTLFence");
+        Fence { raw }
+    }
+
+    pub fn raw(&self) -> &ProtocolObject<dyn MTLFence> {
+        &self.raw
+    }
+}

--- a/candle-metal-kernels/src/metal/mod.rs
+++ b/candle-metal-kernels/src/metal/mod.rs
@@ -4,7 +4,9 @@ pub mod commands;
 pub mod compute_pipeline;
 pub mod device;
 pub mod encoder;
+pub mod fence;
 pub mod library;
+pub mod residency_set;
 
 pub use buffer::*;
 pub use command_buffer::*;
@@ -12,4 +14,6 @@ pub use commands::*;
 pub use compute_pipeline::*;
 pub use device::*;
 pub use encoder::*;
+pub use fence::*;
 pub use library::*;
+pub use residency_set::*;

--- a/candle-metal-kernels/src/metal/residency_set.rs
+++ b/candle-metal-kernels/src/metal/residency_set.rs
@@ -1,0 +1,56 @@
+use super::{Buffer, Device};
+use objc2::{rc::Retained, runtime::ProtocolObject};
+use objc2_metal::{MTLAllocation, MTLDevice as _, MTLResidencySet, MTLResidencySetDescriptor};
+
+/// Keeps Metal buffers resident in GPU memory, removing the need for `useResource` calls.
+///
+/// Add the set to the command queue once via `MTLCommandQueue::addResidencySet`. Then
+/// register every buffer at allocation time and unregister at free time.
+pub struct ResidencySet {
+    raw: Option<Retained<ProtocolObject<dyn MTLResidencySet>>>,
+}
+
+unsafe impl Send for ResidencySet {}
+unsafe impl Sync for ResidencySet {}
+
+impl ResidencySet {
+    pub fn new(device: &Device) -> Self {
+        let descriptor = MTLResidencySetDescriptor::new();
+        let raw = device
+            .as_ref()
+            .newResidencySetWithDescriptor_error(&descriptor)
+            .ok()
+            .inspect(|set| set.requestResidency());
+        ResidencySet { raw }
+    }
+
+    pub fn raw(&self) -> Option<&ProtocolObject<dyn MTLResidencySet>> {
+        self.raw.as_deref()
+    }
+
+    pub fn insert(&self, buf: &Buffer) {
+        if let Some(set) = &self.raw {
+            set.addAllocation(as_allocation(buf));
+            set.commit();
+        }
+    }
+
+    pub fn remove(&self, buf: &Buffer) {
+        if let Some(set) = &self.raw {
+            set.removeAllocation(as_allocation(buf));
+            set.commit();
+        }
+    }
+}
+
+/// Cast a `&Buffer` to `&ProtocolObject<dyn MTLAllocation>`.
+///
+/// Safe because `MTLBuffer: MTLResource: MTLAllocation`. All `ProtocolObject<P>` are
+/// `repr(C)` thin ObjC pointers — the cast only changes the static protocol marker,
+/// not the pointer value or runtime dispatch.
+fn as_allocation(buf: &Buffer) -> &ProtocolObject<dyn MTLAllocation> {
+    unsafe {
+        &*(buf.as_ref() as *const ProtocolObject<dyn objc2_metal::MTLBuffer>
+            as *const ProtocolObject<dyn MTLAllocation>)
+    }
+}

--- a/candle-metal-kernels/src/metal_src/gemv.metal
+++ b/candle-metal-kernels/src/metal_src/gemv.metal
@@ -1,0 +1,527 @@
+// GEMV kernel adapted from MLX:
+// https://github.com/ml-explore/mlx/blob/main/mlx/backend/metal/kernels/gemv.metal
+// Copyright © 2023-2024 Apple Inc.
+
+#include <metal_simdgroup>
+#include <metal_stdlib>
+
+using namespace metal;
+
+#define MLX_MTL_CONST static constant constexpr const
+#define MLX_MTL_PRAGMA_UNROLL _Pragma("clang loop unroll(full)")
+
+// elem_to_loc for nc=1 batch handling
+template <typename stride_t>
+METAL_FUNC stride_t gemv_elem_to_loc(
+    uint elem,
+    constant const int* shape,
+    constant const stride_t* strides,
+    int ndim) {
+  stride_t loc = 0;
+  for (int i = ndim - 1; i >= 0 && elem > 0; --i) {
+    loc += (elem % shape[i]) * strides[i];
+    elem /= shape[i];
+  }
+  return loc;
+}
+
+template <typename U>
+struct GemvDefaultAccT {
+  using type = float;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+/// Matrix-vector: mat [M_out, K] × vec [K] → out [M_out]
+/// (mat rows = output dimension, mat cols = K)
+///////////////////////////////////////////////////////////////////////////////
+
+template <
+    typename T,
+    const int BM,       // Threadgroup rows (in simdgroups)
+    const int BN,       // Threadgroup cols (in simdgroups)
+    const int SM,       // Simdgroup rows (in threads)
+    const int SN,       // Simdgroup cols (in threads)
+    const int TM,       // Thread rows (in elements)
+    const int TN,       // Thread cols (in elements)
+    const bool kDoAxpby,
+    typename AccT = typename GemvDefaultAccT<T>::type>
+struct GEMVKernel {
+  using acc_type = AccT;
+
+  MLX_MTL_CONST int threadsM = BM * SM;
+  MLX_MTL_CONST int threadsN = BN * SN;
+
+  MLX_MTL_CONST int blockM = threadsM * TM;
+  MLX_MTL_CONST int blockN = threadsN * TN;
+
+  static_assert(SM * SN == 32, "simdgroup must have 32 threads");
+  static_assert(SN == 4 || SN == 8 || SN == 16 || SN == 32,
+                "gemv block must have width 4, 8, 16, or 32");
+
+  MLX_MTL_CONST short tgp_mem_size = BN > 1 ? BN * (blockM + TM) : 0;
+  MLX_MTL_CONST bool needs_tgp_reduction = BN > 1;
+
+  template <typename U = T>
+  static METAL_FUNC void load_unsafe(
+      const device T* src, thread U dst[TN], const int src_offset = 0) {
+    MLX_MTL_PRAGMA_UNROLL
+    for (int tn = 0; tn < TN; tn++) {
+      dst[tn] = static_cast<U>(src[src_offset + tn]);
+    }
+  }
+
+  template <typename U = T>
+  static METAL_FUNC void load_safe(
+      const device T* src,
+      thread U dst[TN],
+      const int src_offset = 0,
+      const int src_size = TN) {
+    if (src_offset + TN <= src_size) {
+      MLX_MTL_PRAGMA_UNROLL
+      for (int tn = 0; tn < TN; tn++) {
+        dst[tn] = static_cast<U>(src[src_offset + tn]);
+      }
+    } else {
+      MLX_MTL_PRAGMA_UNROLL
+      for (int tn = 0; tn < TN; tn++) {
+        dst[tn] = src_offset + tn < src_size
+            ? static_cast<U>(src[src_offset + tn])
+            : U(0);
+      }
+    }
+  }
+
+  static METAL_FUNC void run(
+      const device T* mat,
+      const device T* in_vec,
+      const device T* bias,
+      device T* out_vec,
+      const int in_vec_size,
+      const int out_vec_size,
+      const int matrix_ld,
+      const float alpha,
+      const float beta,
+      const int bias_stride,
+      threadgroup AccT* tgp_memory,
+      uint3 tid,
+      uint3 lid,
+      uint simd_gid,
+      uint simd_lid) {
+    (void)lid;
+
+    thread AccT result[TM] = {0};
+    thread T inter[TN];
+    thread AccT v_coeff[TN];
+
+    const int thrM = SN != 32 ? (int)(simd_lid / SN) : 0;
+    const int thrN = SN != 32 ? (int)(simd_lid % SN) : (int)simd_lid;
+
+    const int sgN = BN != 1 ? (int)(simd_gid % BN) : 0;
+    const int simdM = BN != 1 ? SM * (int)(simd_gid / BN) : (int)(SM * simd_gid);
+    const int simdN = BN != 1 ? SN * (int)(simd_gid % BN) : 0;
+
+    int bm = (simdM + thrM) * TM;
+    int bn = (simdN + thrN) * TN;
+
+    // Block position (output row)
+    int out_row = tid.x * blockM + bm;
+
+    if (out_row >= out_vec_size) return;
+
+    out_row = out_row + TM <= out_vec_size ? out_row : out_vec_size - TM;
+
+    mat += out_row * matrix_ld;
+
+    const int loop_stride = blockN;
+    const int in_size = in_vec_size;
+    const int n_iter = in_size / loop_stride;
+    const int last_iter = loop_stride * n_iter;
+    const int leftover = in_size - last_iter;
+
+    for (int i = 0; i < n_iter; ++i) {
+      load_unsafe<AccT>(in_vec, v_coeff, bn);
+
+      int mat_offset = 0;
+      MLX_MTL_PRAGMA_UNROLL
+      for (int tm = 0; tm < TM; tm++) {
+        load_unsafe(mat, inter, mat_offset + bn);
+        MLX_MTL_PRAGMA_UNROLL
+        for (int tn = 0; tn < TN; tn++) {
+          result[tm] += inter[tn] * v_coeff[tn];
+        }
+        mat_offset += matrix_ld;
+      }
+      bn += blockN;
+    }
+
+    if (leftover > 0) {
+      load_safe<AccT>(in_vec, v_coeff, bn, in_size);
+      MLX_MTL_PRAGMA_UNROLL
+      for (int tm = 0; tm < TM; tm++) {
+        load_safe(&mat[tm * matrix_ld], inter, bn, in_size);
+        MLX_MTL_PRAGMA_UNROLL
+        for (int tn = 0; tn < TN; tn++) {
+          result[tm] += inter[tn] * v_coeff[tn];
+        }
+      }
+    }
+
+    MLX_MTL_PRAGMA_UNROLL
+    for (int tm = 0; tm < TM; tm++) {
+      MLX_MTL_PRAGMA_UNROLL
+      for (ushort sn = (SN / 2); sn >= 1; sn >>= 1) {
+        result[tm] += simd_shuffle_down(result[tm], sn);
+      }
+    }
+
+    if (needs_tgp_reduction) {
+      threadgroup AccT* tgp_results = tgp_memory + sgN * (blockM + TM) + bm;
+      if (thrN == 0) {
+        MLX_MTL_PRAGMA_UNROLL
+        for (int tm = 0; tm < TM; tm++) {
+          tgp_results[tm] = result[tm];
+        }
+        threadgroup_barrier(mem_flags::mem_none);
+        if (sgN == 0) {
+          MLX_MTL_PRAGMA_UNROLL
+          for (int sgn = 1; sgn < BN; sgn++) {
+            MLX_MTL_PRAGMA_UNROLL
+            for (int tm = 0; tm < TM; tm++) {
+              result[tm] += tgp_results[sgn * (blockM + TM) + tm];
+            }
+          }
+        }
+      }
+    }
+
+    if (simdN == 0 && thrN == 0) {
+      MLX_MTL_PRAGMA_UNROLL
+      for (int tm = 0; tm < TM; tm++) {
+        if (kDoAxpby) {
+          out_vec[out_row + tm] =
+              static_cast<T>(alpha) * static_cast<T>(result[tm]) +
+              static_cast<T>(beta) * bias[(out_row + tm) * bias_stride];
+        } else {
+          out_vec[out_row + tm] = static_cast<T>(result[tm]);
+        }
+      }
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+/// Vector-matrix: vec [K] × mat [K, N_out] → out [N_out]
+/// (mat rows = K, mat cols = output dimension)
+///////////////////////////////////////////////////////////////////////////////
+
+template <
+    typename T,
+    const int BM,
+    const int BN,
+    const int SM,
+    const int SN,
+    const int TM,
+    const int TN,
+    const bool kDoAxpby,
+    typename AccT = typename GemvDefaultAccT<T>::type>
+struct GEMVTKernel {
+  using acc_type = AccT;
+
+  MLX_MTL_CONST int threadsM = BM * SM;
+  MLX_MTL_CONST int threadsN = BN * SN;
+
+  MLX_MTL_CONST int blockM = threadsM * TM;
+  MLX_MTL_CONST int blockN = threadsN * TN;
+
+  static_assert(SM * SN == 32, "simdgroup must have 32 threads");
+
+  MLX_MTL_CONST short tgp_mem_size = BM > 1 ? BM * (blockN + TN) : 0;
+  MLX_MTL_CONST bool needs_tgp_reduction = BM > 1;
+
+  static METAL_FUNC void run(
+      const device T* mat,
+      const device T* in_vec,
+      const device T* bias,
+      device T* out_vec,
+      const int in_vec_size,
+      const int out_vec_size,
+      const int marix_ld,
+      const float alpha,
+      const float beta,
+      const int bias_stride,
+      threadgroup AccT* tgp_memory,
+      uint3 tid,
+      uint3 lid,
+      uint simd_gid,
+      uint simd_lid) {
+    (void)lid;
+
+    AccT result[TN] = {0};
+    T inter[TN];
+    AccT v_coeff[TM];
+
+    const int thrM = SN != 32 ? (int)(simd_lid / SN) : 0;
+    const int thrN = SN != 32 ? (int)(simd_lid % SN) : (int)simd_lid;
+
+    const int sgM = BN != 1 ? (int)(simd_gid / BN) : (int)simd_gid;
+    const int sgN = BN != 1 ? (int)(simd_gid % BN) : 0;
+
+    const int simdM = SM * sgM;
+    const int simdN = SN * sgN;
+
+    int cm = (simdM + thrM);
+    int cn = (simdN + thrN);
+
+    int bm = cm * TM;
+    int bn = cn * TN;
+
+    int out_col = tid.x * blockN + bn;
+
+    const int loop_stride = blockM;
+    const int in_size = in_vec_size;
+    const int n_iter = in_size / loop_stride;
+    const int last_iter = loop_stride * n_iter;
+    const int leftover = in_size - last_iter;
+
+    if (out_col < out_vec_size) {
+      out_col = out_col + TN <= out_vec_size ? out_col : out_vec_size - TN;
+
+      for (int i = 0; i < n_iter; ++i) {
+        threadgroup_barrier(mem_flags::mem_none);
+
+        MLX_MTL_PRAGMA_UNROLL
+        for (int tm = 0; tm < TM; tm++) {
+          v_coeff[tm] = static_cast<AccT>(in_vec[bm + tm]);
+        }
+
+        MLX_MTL_PRAGMA_UNROLL
+        for (int tm = 0; tm < TM; tm++) {
+          auto vc = static_cast<AccT>(v_coeff[tm]);
+          MLX_MTL_PRAGMA_UNROLL
+          for (int tn = 0; tn < TN; tn++) {
+            inter[tn] = mat[(bm + tm) * marix_ld + out_col + tn];
+          }
+          MLX_MTL_PRAGMA_UNROLL
+          for (int tn = 0; tn < TN; tn++) {
+            result[tn] += vc * inter[tn];
+          }
+        }
+
+        bm += blockM;
+      }
+
+      if (leftover > 0) {
+        for (int tm = 0; tm < TM && bm + tm < in_vec_size; tm++) {
+          v_coeff[tm] = static_cast<AccT>(in_vec[bm + tm]);
+          MLX_MTL_PRAGMA_UNROLL
+          for (int tn = 0; tn < TN; tn++) {
+            inter[tn] = mat[(bm + tm) * marix_ld + out_col + tn];
+          }
+          MLX_MTL_PRAGMA_UNROLL
+          for (int tn = 0; tn < TN; tn++) {
+            result[tn] += v_coeff[tm] * inter[tn];
+          }
+        }
+      }
+    }
+
+    MLX_MTL_PRAGMA_UNROLL
+    for (int tn = 0; tn < TN; tn++) {
+      MLX_MTL_PRAGMA_UNROLL
+      for (ushort sm = (SM / 2); sm >= 1; sm >>= 1) {
+        result[tn] += simd_shuffle_down(result[tn], SN * sm);
+      }
+    }
+
+    if (needs_tgp_reduction) {
+      threadgroup AccT* tgp_results = tgp_memory + sgM * (blockN + TN) + bn;
+      if (thrM == 0) {
+        MLX_MTL_PRAGMA_UNROLL
+        for (int tn = 0; tn < TN; tn++) {
+          tgp_results[tn] = result[tn];
+        }
+        threadgroup_barrier(mem_flags::mem_none);
+        if (sgM == 0) {
+          MLX_MTL_PRAGMA_UNROLL
+          for (int sgm = 1; sgm < BM; sgm++) {
+            MLX_MTL_PRAGMA_UNROLL
+            for (int tn = 0; tn < TN; tn++) {
+              result[tn] += tgp_results[sgm * (blockN + TN) + tn];
+            }
+          }
+        }
+      }
+    }
+
+    if (cm == 0 && out_col < out_vec_size) {
+      MLX_MTL_PRAGMA_UNROLL
+      for (int j = 0; j < TN; j++) {
+        if (kDoAxpby) {
+          out_vec[out_col + j] =
+              static_cast<T>(alpha) * static_cast<T>(result[j]) +
+              static_cast<T>(beta) * bias[(out_col + j) * bias_stride];
+        } else {
+          out_vec[out_col + j] = static_cast<T>(result[j]);
+        }
+      }
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+/// gemv kernel: mat [M, K] × vec [K] → out [M]
+///////////////////////////////////////////////////////////////////////////////
+
+template <
+    typename T,
+    const int BM, const int BN,
+    const int SM, const int SN,
+    const int TM, const int TN,
+    const bool kDoNCBatch,
+    const bool kDoAxpby>
+[[kernel, max_total_threads_per_threadgroup(BM * BN * 32)]]
+void gemv(
+    const device T* mat [[buffer(0)]],
+    const device T* in_vec [[buffer(1)]],
+    const device T* bias [[buffer(2)]],
+    device T* out_vec [[buffer(3)]],
+    const constant int& in_vec_size [[buffer(4)]],
+    const constant int& out_vec_size [[buffer(5)]],
+    const constant int& matrix_ld [[buffer(6)]],
+    const constant float& alpha [[buffer(7)]],
+    const constant float& beta [[buffer(8)]],
+    const constant int& batch_ndim [[buffer(9)]],
+    const constant int* batch_shape [[buffer(10)]],
+    const constant int64_t* vector_batch_stride [[buffer(11)]],
+    const constant int64_t* matrix_batch_stride [[buffer(12)]],
+    const constant int64_t* bias_batch_stride [[buffer(13)]],
+    const constant int& bias_stride [[buffer(14)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 lid [[thread_position_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  using kernel_t = GEMVKernel<T, BM, BN, SM, SN, TM, TN, kDoAxpby>;
+  threadgroup typename kernel_t::acc_type tgp_memory[kernel_t::tgp_mem_size == 0 ? 1 : kernel_t::tgp_mem_size];
+
+  if (kDoNCBatch) {
+    in_vec += gemv_elem_to_loc(tid.z, batch_shape, vector_batch_stride, batch_ndim);
+    mat    += gemv_elem_to_loc(tid.z, batch_shape, matrix_batch_stride, batch_ndim);
+    if (kDoAxpby)
+      bias += gemv_elem_to_loc(tid.z, batch_shape, bias_batch_stride, batch_ndim);
+  } else {
+    in_vec += tid.z * vector_batch_stride[0];
+    mat    += tid.z * matrix_batch_stride[0];
+    if (kDoAxpby)
+      bias += tid.z * bias_batch_stride[0];
+  }
+  out_vec += tid.z * out_vec_size;
+
+  kernel_t::run(mat, in_vec, bias, out_vec,
+                in_vec_size, out_vec_size, matrix_ld,
+                alpha, beta, bias_stride,
+                kernel_t::tgp_mem_size == 0 ? nullptr : tgp_memory,
+                tid, lid, simd_gid, simd_lid);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// gemv_t kernel: vec [K] × mat [K, N] → out [N]
+///////////////////////////////////////////////////////////////////////////////
+
+template <
+    typename T,
+    const int BM, const int BN,
+    const int SM, const int SN,
+    const int TM, const int TN,
+    const bool kDoNCBatch,
+    const bool kDoAxpby>
+[[kernel, max_total_threads_per_threadgroup(BM * BN * 32)]]
+void gemv_t(
+    const device T* mat [[buffer(0)]],
+    const device T* in_vec [[buffer(1)]],
+    const device T* bias [[buffer(2)]],
+    device T* out_vec [[buffer(3)]],
+    const constant int& in_vec_size [[buffer(4)]],
+    const constant int& out_vec_size [[buffer(5)]],
+    const constant int& matrix_ld [[buffer(6)]],
+    const constant float& alpha [[buffer(7)]],
+    const constant float& beta [[buffer(8)]],
+    const constant int& batch_ndim [[buffer(9)]],
+    const constant int* batch_shape [[buffer(10)]],
+    const constant int64_t* vector_batch_stride [[buffer(11)]],
+    const constant int64_t* matrix_batch_stride [[buffer(12)]],
+    const constant int64_t* bias_batch_stride [[buffer(13)]],
+    const constant int& bias_stride [[buffer(14)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 lid [[thread_position_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  using kernel_t = GEMVTKernel<T, BM, BN, SM, SN, TM, TN, kDoAxpby>;
+  threadgroup typename kernel_t::acc_type tgp_memory[kernel_t::tgp_mem_size == 0 ? 1 : kernel_t::tgp_mem_size];
+
+  if (kDoNCBatch) {
+    in_vec += gemv_elem_to_loc(tid.z, batch_shape, vector_batch_stride, batch_ndim);
+    mat    += gemv_elem_to_loc(tid.z, batch_shape, matrix_batch_stride, batch_ndim);
+    if (kDoAxpby)
+      bias += gemv_elem_to_loc(tid.z, batch_shape, bias_batch_stride, batch_ndim);
+  } else {
+    in_vec += tid.z * vector_batch_stride[0];
+    mat    += tid.z * matrix_batch_stride[0];
+    if (kDoAxpby)
+      bias += tid.z * bias_batch_stride[0];
+  }
+  out_vec += tid.z * out_vec_size;
+
+  kernel_t::run(mat, in_vec, bias, out_vec,
+                in_vec_size, out_vec_size, matrix_ld,
+                alpha, beta, bias_stride,
+                kernel_t::tgp_mem_size == 0 ? nullptr : tgp_memory,
+                tid, lid, simd_gid, simd_lid);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// Instantiations
+///////////////////////////////////////////////////////////////////////////////
+
+// Use decltype-based instantiation (MLX defines.h pattern):
+//   template [[host_name(...)]] [[kernel]] decltype(func<...>) func<...>;
+// This avoids redeclaring parameter attributes, which Metal rejects.
+#define instantiate_gemv_helper(func, nm, itype, bm, bn, sm, sn, tm, tn, nc, axpby) \
+  template [[host_name(                                                               \
+      #func "_" #nm "_bm" #bm "_bn" #bn "_sm" #sm "_sn" #sn                         \
+            "_tm" #tm "_tn" #tn "_nc" #nc "_axpby" #axpby)]]                         \
+  [[kernel]] decltype(func<itype, bm, bn, sm, sn, tm, tn, (bool)nc, (bool)axpby>)   \
+             func<itype, bm, bn, sm, sn, tm, tn, (bool)nc, (bool)axpby>;
+
+#define instantiate_gemv_nc_axpby(func, nm, itype, bm, bn, sm, sn, tm, tn) \
+  instantiate_gemv_helper(func, nm, itype, bm, bn, sm, sn, tm, tn, 0, 0)   \
+  instantiate_gemv_helper(func, nm, itype, bm, bn, sm, sn, tm, tn, 0, 1)   \
+  instantiate_gemv_helper(func, nm, itype, bm, bn, sm, sn, tm, tn, 1, 0)   \
+  instantiate_gemv_helper(func, nm, itype, bm, bn, sm, sn, tm, tn, 1, 1)
+
+// gemv blocks: mat×vec (output size = M)
+// bm=4/8 for large output; bm=1,bn=8 for K-heavy; bm=1,bn=1,sm=8,sn=4 for small K
+#define instantiate_gemv_blocks(nm, itype)                              \
+  instantiate_gemv_nc_axpby(gemv, nm, itype, 1,  8, 1, 32, 4, 4)      \
+  instantiate_gemv_nc_axpby(gemv, nm, itype, 1,  8, 1, 32, 1, 4)      \
+  instantiate_gemv_nc_axpby(gemv, nm, itype, 1,  1, 8,  4, 4, 4)      \
+  instantiate_gemv_nc_axpby(gemv, nm, itype, 1,  1, 8,  4, 1, 4)      \
+  instantiate_gemv_nc_axpby(gemv, nm, itype, 4,  1, 1, 32, 1, 4)      \
+  instantiate_gemv_nc_axpby(gemv, nm, itype, 4,  1, 1, 32, 4, 4)      \
+  instantiate_gemv_nc_axpby(gemv, nm, itype, 8,  1, 1, 32, 4, 4)
+
+// gemv_t blocks: vec×mat (output size = N)
+// bn=2/4/16 for various output sizes; sm/sn tuned for K size
+#define instantiate_gemv_t_blocks(nm, itype)                              \
+  instantiate_gemv_nc_axpby(gemv_t, nm, itype, 1,  2,  8, 4, 4, 1)      \
+  instantiate_gemv_nc_axpby(gemv_t, nm, itype, 1,  2,  8, 4, 4, 4)      \
+  instantiate_gemv_nc_axpby(gemv_t, nm, itype, 1,  4,  8, 4, 4, 4)      \
+  instantiate_gemv_nc_axpby(gemv_t, nm, itype, 1, 16,  8, 4, 4, 4)      \
+  instantiate_gemv_nc_axpby(gemv_t, nm, itype, 1, 16,  4, 8, 4, 4)
+
+instantiate_gemv_blocks(float32, float)
+instantiate_gemv_blocks(float16, half)
+instantiate_gemv_blocks(bfloat16, bfloat)
+
+instantiate_gemv_t_blocks(float32, float)
+instantiate_gemv_t_blocks(float16, half)
+instantiate_gemv_t_blocks(bfloat16, bfloat)

--- a/candle-metal-kernels/src/source.rs
+++ b/candle-metal-kernels/src/source.rs
@@ -4,6 +4,7 @@ pub const CAST: &str = include_str!("metal_src/cast.metal");
 pub const CONV: &str = include_str!("metal_src/conv.metal");
 pub const FILL: &str = include_str!("metal_src/fill.metal");
 pub const INDEXING: &str = include_str!("metal_src/indexing.metal");
+pub const GEMV: &str = include_str!("metal_src/gemv.metal");
 pub const MLX_GEMM: &str = include_str!("metal_src/mlx_gemm.metal");
 pub const MLX_SORT: &str = include_str!("metal_src/mlx_sort.metal");
 pub const QUANTIZED: &str = include_str!("metal_src/quantized.metal");
@@ -22,6 +23,7 @@ pub enum Source {
     Conv,
     Fill,
     Gemm,
+    Gemv,
     Indexing,
     MlxSort,
     Quantized,

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -1,11 +1,17 @@
 use super::*;
-use crate::metal::{create_command_buffer, CommandSemaphore, Commands};
+use crate::metal::{Commands, ResidencySet};
 use core::ffi::c_void;
 use half::{bf16, f16};
 use rand::prelude::SliceRandom;
 use rand::{rng, Rng};
 use std::sync::Arc;
 use std::thread;
+
+fn commands(device: &Device) -> Commands {
+    let queue = device.new_command_queue().unwrap();
+    let residency_set = Arc::new(ResidencySet::new(&device));
+    Commands::new(queue, &residency_set).unwrap()
+}
 
 fn read_to_vec<T: Clone>(buffer: &Buffer, n: usize) -> Vec<T> {
     let ptr = buffer.contents() as *const T;
@@ -43,9 +49,8 @@ fn approx_bf16(v: Vec<bf16>, digits: i32) -> Vec<f32> {
 fn run<T: Clone>(v: &[T], name: unary::contiguous::Kernel) -> Vec<T> {
     let device = device();
     let kernels = Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
     let input = new_buffer(&device, v);
     let input = BufferOffset {
         buffer: &input,
@@ -54,7 +59,7 @@ fn run<T: Clone>(v: &[T], name: unary::contiguous::Kernel) -> Vec<T> {
     let output = new_buffer(&device, v);
     call_unary_contiguous(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         name,
         size_of::<T>(),
@@ -63,17 +68,16 @@ fn run<T: Clone>(v: &[T], name: unary::contiguous::Kernel) -> Vec<T> {
         &output,
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
     read_to_vec(&output, v.len())
 }
 
 fn run_binary<T: Clone, S: ToString>(x: &[T], y: &[T], name: S) -> Vec<T> {
     let device = device();
     let kernels = Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
     let options = RESOURCE_OPTIONS;
     let left = new_buffer(&device, x);
     let right = new_buffer(&device, y);
@@ -82,7 +86,7 @@ fn run_binary<T: Clone, S: ToString>(x: &[T], y: &[T], name: S) -> Vec<T> {
         .unwrap();
     call_binary_contiguous(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         name,
         size_of::<T>(),
@@ -92,8 +96,8 @@ fn run_binary<T: Clone, S: ToString>(x: &[T], y: &[T], name: S) -> Vec<T> {
         &output,
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
     read_to_vec(&output, x.len())
 }
 
@@ -105,9 +109,8 @@ fn run_strided<T: Clone>(
     offset: usize,
 ) -> Vec<T> {
     let device = device();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
     let input = new_buffer(&device, v);
     let input = BufferOffset {
         buffer: &input,
@@ -120,18 +123,11 @@ fn run_strided<T: Clone>(
     };
     let kernels = Kernels::new();
     call_unary_strided(
-        &device,
-        &command_buffer,
-        &kernels,
-        kernel,
-        shape,
-        input,
-        strides,
-        output,
+        &device, &encoder, &kernels, kernel, shape, input, strides, output,
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
     read_to_vec(&output_b, v.len())
 }
 
@@ -320,9 +316,8 @@ fn binary_ops_bf16() {
 fn run_cast<T: Clone, U: Clone>(v: &[T], name: &'static str) -> Vec<U> {
     let device = device();
     let kernels = Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
     let input = new_buffer(&device, v);
     let options = RESOURCE_OPTIONS;
     let size = v.len() * std::mem::size_of::<U>();
@@ -330,7 +325,7 @@ fn run_cast<T: Clone, U: Clone>(v: &[T], name: &'static str) -> Vec<U> {
 
     call_cast_contiguous(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         name,
         size_of::<T>(),
@@ -339,8 +334,8 @@ fn run_cast<T: Clone, U: Clone>(v: &[T], name: &'static str) -> Vec<U> {
         &output,
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
     read_to_vec(&output, v.len())
 }
 
@@ -533,9 +528,8 @@ fn cast_i64() {
 fn run_affine<T: Clone>(v: &[T], mul: f64, add: f64) -> Vec<T> {
     let device = device();
     let kernels = Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
 
     let input = new_buffer(&device, v);
     let output = new_buffer(&device, v);
@@ -544,7 +538,7 @@ fn run_affine<T: Clone>(v: &[T], mul: f64, add: f64) -> Vec<T> {
 
     call_affine(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         "affine_f32",
         size_of::<T>(),
@@ -555,8 +549,8 @@ fn run_affine<T: Clone>(v: &[T], mul: f64, add: f64) -> Vec<T> {
         add as f32,
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
 
     read_to_vec(&output, v.len())
 }
@@ -570,16 +564,15 @@ fn run_affine_strided<T: Clone>(
 ) -> Vec<T> {
     let device = device();
     let kernels = Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
 
     let input = new_buffer(&device, v);
     let output = new_buffer(&device, v);
 
     call_affine_strided(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         "affine_f32_strided",
         shape,
@@ -590,8 +583,8 @@ fn run_affine_strided<T: Clone>(
         add as f32,
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
 
     let len: usize = shape.iter().product();
     read_to_vec(&output, len)
@@ -628,9 +621,8 @@ fn run_mlx_sort<T: Clone>(v: &[T], ncols: usize) -> Vec<u32> {
     let nrows = v.len() / ncols;
     let device = device();
     let kernels = Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
 
     let input = new_buffer(&device, v);
     let indexes = vec![0u32; v.len()];
@@ -638,7 +630,7 @@ fn run_mlx_sort<T: Clone>(v: &[T], ncols: usize) -> Vec<u32> {
 
     call_mlx_arg_sort(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         DType::F32,
         nrows,
@@ -647,8 +639,8 @@ fn run_mlx_sort<T: Clone>(v: &[T], ncols: usize) -> Vec<u32> {
         &output,
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
     read_to_vec(&output, v.len())
 }
 
@@ -823,9 +815,8 @@ fn run_index_select<T: Clone, I: Clone + std::fmt::Debug>(
 ) -> Vec<T> {
     let device = Device::system_default().expect("no device found");
 
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
     let embeddings_buffer = new_buffer(&device, embeddings);
     let ids_buffer = new_buffer(&device, ids);
 
@@ -837,7 +828,7 @@ fn run_index_select<T: Clone, I: Clone + std::fmt::Debug>(
     let kernels = Kernels::new();
     call_index_select(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         name,
         shape,
@@ -852,8 +843,8 @@ fn run_index_select<T: Clone, I: Clone + std::fmt::Debug>(
     )
     .unwrap();
 
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
 
     read_to_vec(&dst_buffer, dst_el)
 }
@@ -868,9 +859,8 @@ fn run_index_select_strided<T: Clone, I: Clone + std::fmt::Debug>(
 ) -> Vec<T> {
     let device = Device::system_default().expect("no device found");
 
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
     let embeddings_buffer = new_buffer(&device, embeddings);
     let ids_buffer = new_buffer(&device, ids);
 
@@ -882,7 +872,7 @@ fn run_index_select_strided<T: Clone, I: Clone + std::fmt::Debug>(
     let kernels = Kernels::new();
     call_index_select(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         name,
         shape,
@@ -897,8 +887,8 @@ fn run_index_select_strided<T: Clone, I: Clone + std::fmt::Debug>(
     )
     .unwrap();
 
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
 
     read_to_vec(&dst_buffer, dst_el)
 }
@@ -923,9 +913,8 @@ fn run_reduce<T, U: Clone>(
 ) -> Vec<U> {
     let device = device();
     let kernels = Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
     let input = new_buffer(&device, v);
 
     let options = RESOURCE_OPTIONS;
@@ -935,7 +924,7 @@ fn run_reduce<T, U: Clone>(
     let shape = vec![in_length];
     match call_reduce_contiguous(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         name,
         &shape,
@@ -949,8 +938,8 @@ fn run_reduce<T, U: Clone>(
             panic!();
         }
     }
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
 
     read_to_vec(&output, out_length)
 }
@@ -958,14 +947,13 @@ fn run_reduce<T, U: Clone>(
 fn run_softmax<T: Clone + std::fmt::Debug>(v: &[T], last_dim: usize, name: &'static str) -> Vec<T> {
     let device = device();
     let kernels = Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
     let input = new_buffer(&device, v);
     let output = new_buffer(&device, v);
     call_last_softmax(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         name,
         v.len(),
@@ -975,8 +963,8 @@ fn run_softmax<T: Clone + std::fmt::Debug>(v: &[T], last_dim: usize, name: &'sta
         &output,
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
 
     read_to_vec(&output, v.len())
 }
@@ -1243,9 +1231,8 @@ fn run_where_cond<I: Clone, T: Clone>(
 ) -> Vec<T> {
     let device = device();
     let kernels = Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
     let options = RESOURCE_OPTIONS;
 
     let length = cond.len();
@@ -1288,7 +1275,7 @@ fn run_where_cond<I: Clone, T: Clone>(
     };
     call_where_cond(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         name,
         size_of::<T>(),
@@ -1305,8 +1292,8 @@ fn run_where_cond<I: Clone, T: Clone>(
         &output,
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
 
     read_to_vec(&output, length)
 }
@@ -1367,9 +1354,8 @@ fn run_mlx_gemm<T: Clone>(
 ) -> Vec<T> {
     let device = device();
     let kernels = Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
     let options = RESOURCE_OPTIONS;
 
     let lhs = device
@@ -1392,7 +1378,7 @@ fn run_mlx_gemm<T: Clone>(
         .unwrap();
     call_mlx_gemm(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         dtype,
         (b, m, n, k),
@@ -1405,8 +1391,8 @@ fn run_mlx_gemm<T: Clone>(
         &output,
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
 
     read_to_vec(&output, length)
 }
@@ -1518,9 +1504,8 @@ fn mlx_gemm() {
 fn run_random<T: Clone>(name: &'static str, seed: u64, length: usize, a: f32, b: f32) -> Vec<T> {
     let device = device();
     let kernels = Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
 
     let options = RESOURCE_OPTIONS;
     let output = device
@@ -1537,33 +1522,17 @@ fn run_random<T: Clone>(name: &'static str, seed: u64, length: usize, a: f32, b:
 
     if name.starts_with("rand_uniform") {
         call_random_uniform(
-            &device,
-            &command_buffer,
-            &kernels,
-            name,
-            a,
-            b,
-            length,
-            &seed,
-            &output,
+            &device, &encoder, &kernels, name, a, b, length, &seed, &output,
         )
         .unwrap();
     } else {
         call_random_normal(
-            &device,
-            &command_buffer,
-            &kernels,
-            name,
-            a,
-            b,
-            length,
-            &seed,
-            &output,
+            &device, &encoder, &kernels, name, a, b, length, &seed, &output,
         )
         .unwrap();
     }
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
 
     read_to_vec(&output, length)
 }
@@ -1650,9 +1619,8 @@ fn run_scatter_add<T: Clone, I: Clone + std::fmt::Debug>(
 ) -> Vec<T> {
     let device = device();
     let kernels = Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
     let options = RESOURCE_OPTIONS;
     let input_buffer = new_buffer(&device, input);
     let ids_buffer = new_buffer(&device, ids);
@@ -1661,7 +1629,7 @@ fn run_scatter_add<T: Clone, I: Clone + std::fmt::Debug>(
         .unwrap();
     call_scatter(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         name,
         shape,
@@ -1672,8 +1640,8 @@ fn run_scatter_add<T: Clone, I: Clone + std::fmt::Debug>(
         BufferOffset::zero_offset(&output),
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
     read_to_vec(&output, input.len())
 }
 
@@ -1756,15 +1724,14 @@ fn run_index_add<T: Clone, I: Clone + std::fmt::Debug>(
 ) -> Vec<T> {
     let device = device();
     let kernels = Kernels::new();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
     let input_buffer = new_buffer(&device, right);
     let output = new_buffer(&device, left);
     let indices_buffer = new_buffer(&device, indices);
     call_index_add(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         name,
         shape,
@@ -1776,8 +1743,8 @@ fn run_index_add<T: Clone, I: Clone + std::fmt::Debug>(
         &output,
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
     read_to_vec(&output, left.len())
 }
 
@@ -1870,9 +1837,8 @@ fn run_pool2d<T: Clone>(
     name: &'static str,
 ) -> Vec<T> {
     let device = device();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
     let out_w = (shape[2] - w_k) / w_stride + 1;
     let out_h = (shape[3] - h_k) / h_stride + 1;
     let dst_el = out_w * out_h * shape[0] * shape[1];
@@ -1880,24 +1846,12 @@ fn run_pool2d<T: Clone>(
     let output = new_buffer(&device, &vec![0.0f32; dst_el]);
     let kernels = Kernels::new();
     call_pool2d(
-        &device,
-        &command_buffer,
-        &kernels,
-        name,
-        shape,
-        strides,
-        out_w,
-        out_h,
-        w_k,
-        h_k,
-        w_stride,
-        h_stride,
-        &input,
-        &output,
+        &device, &encoder, &kernels, name, shape, strides, out_w, out_h, w_k, h_k, w_stride,
+        h_stride, &input, &output,
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
 
     read_to_vec(&output, dst_el)
 }
@@ -2226,9 +2180,8 @@ fn run_conv_transpose1d<T: Clone>(
     name: &'static str,
 ) -> Vec<T> {
     let device = device();
-    let command_queue = device.new_command_queue().unwrap();
-    let semaphore = Arc::new(CommandSemaphore::new());
-    let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
 
     let c_out = kernel_shape[1];
     let k_size = kernel_shape[2];
@@ -2244,7 +2197,7 @@ fn run_conv_transpose1d<T: Clone>(
 
     call_conv_transpose1d(
         &device,
-        &command_buffer,
+        &encoder,
         &kernels,
         name,
         dilation,
@@ -2265,8 +2218,8 @@ fn run_conv_transpose1d<T: Clone>(
         &output,
     )
     .unwrap();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
 
     read_to_vec(&output, dst_el)
 }
@@ -2434,15 +2387,14 @@ fn const_fill() {
     fn constant_fill<T: Clone + EncoderParam>(name: &'static str, len: usize, value: T) -> Vec<T> {
         let dev = device();
         let kernels = Kernels::new();
-        let command_queue = dev.new_command_queue().unwrap();
-        let semaphore = Arc::new(CommandSemaphore::new());
-        let command_buffer = create_command_buffer(&command_queue, semaphore).unwrap();
+        let commands = commands(&dev);
+        let encoder = commands.command_encoder().unwrap();
         let buffer = dev
             .new_buffer(len * std::mem::size_of::<T>(), RESOURCE_OPTIONS)
             .unwrap();
-        call_const_fill(&dev, &command_buffer, &kernels, name, len, &buffer, value).unwrap();
-        command_buffer.commit();
-        command_buffer.wait_until_completed();
+        call_const_fill(&dev, &encoder, &kernels, name, len, &buffer, value).unwrap();
+        drop(encoder);
+        commands.wait_until_completed().unwrap();
         read_to_vec::<T>(&buffer, len)
     }
     fn test<T: Clone + Copy + EncoderParam + PartialEq + std::fmt::Debug, F: FnOnce(f32) -> T>(
@@ -2467,49 +2419,28 @@ fn const_fill() {
 fn commands_creation_and_encoder() {
     let device = Device::system_default().unwrap();
     let queue = device.new_command_queue().unwrap();
-    let commands = Commands::new(queue).unwrap();
+    let residency_set = Arc::new(ResidencySet::new(&device));
+    let commands = Commands::new(queue, &residency_set).unwrap();
 
-    let (_flush, encoder) = commands.command_encoder().unwrap();
+    let encoder = commands.command_encoder().unwrap();
     drop(encoder);
-}
-
-#[test]
-fn commands_rotation_threshold() {
-    std::env::set_var("CANDLE_METAL_COMPUTE_PER_BUFFER", "2");
-
-    let device = Device::system_default().unwrap();
-    let queue = device.new_command_queue().unwrap();
-    let commands = Commands::new(queue).unwrap();
-
-    let mut flush_count = 0;
-    for _ in 0..6 {
-        let (flush, encoder) = commands.command_encoder().unwrap();
-        flush_count += flush as usize;
-        drop(encoder);
-    }
-
-    assert!(flush_count >= 2);
-
-    // Flushes pending work and blocks until all in‑flight command buffers complete.
-    // Ensures completion and surfaces any GPU errors before the test ends.
-    commands.wait_until_completed().unwrap();
 }
 
 #[test]
 fn commands_concurrent_acquisition() {
     std::env::set_var("CANDLE_METAL_COMPUTE_PER_BUFFER", "2");
-    std::env::set_var("CANDLE_METAL_COMMAND_POOL_SIZE", "4");
 
     let device = Device::system_default().unwrap();
     let queue = device.new_command_queue().unwrap();
-    let commands = Arc::new(Commands::new(queue).unwrap());
+    let residency_set = Arc::new(ResidencySet::new(&device));
+    let commands = Arc::new(Commands::new(queue, &residency_set).unwrap());
 
     let mut handles = vec![];
 
     for _ in 0..16 {
         let c = Arc::clone(&commands);
         handles.push(thread::spawn(move || {
-            let (_flush, encoder) = c.command_encoder().unwrap();
+            let encoder = c.command_encoder().unwrap();
             drop(encoder);
         }));
     }

--- a/candle-metal-kernels/src/utils.rs
+++ b/candle-metal-kernels/src/utils.rs
@@ -1,8 +1,27 @@
-use crate::metal::{Buffer, CommandBuffer, ComputeCommandEncoder, ComputePipeline};
+use crate::metal::{Buffer, CommandsGuard, ComputeCommandEncoder, ComputePipeline};
 use crate::MTLSize;
 use std::ffi::OsStr;
 use std::ops::Deref;
 use std::sync::{RwLockReadGuard, RwLockWriteGuard};
+
+pub struct WrappedEncoder<'a> {
+    inner: &'a ComputeCommandEncoder,
+    end_encoding_on_drop: bool,
+}
+
+impl Drop for WrappedEncoder<'_> {
+    fn drop(&mut self) {
+        if self.end_encoding_on_drop {
+            self.inner.end_encoding()
+        }
+    }
+}
+
+impl AsRef<ComputeCommandEncoder> for WrappedEncoder<'_> {
+    fn as_ref(&self) -> &ComputeCommandEncoder {
+        self.inner
+    }
+}
 
 /// Most kernels apply similarly across the tensors
 /// This creates a strategy that uses the maximum amount of threads per threadgroup (capped at the
@@ -156,6 +175,44 @@ impl EncoderParam for () {
     fn set_param(_: &ComputeCommandEncoder, _: usize, _: Self) {}
 }
 
+/// Marks a buffer as a read input in `set_params!` calls, enabling hazard tracking.
+///
+/// # Examples
+/// ```ignore
+/// set_params!(encoder, (length, Input::new(input), output));
+/// ```
+#[derive(Copy, Clone)]
+pub struct Input<'a> {
+    buffer: &'a Buffer,
+    offset: usize,
+}
+
+impl<'a> Input<'a> {
+    #[inline]
+    pub fn new(buffer: &'a Buffer) -> Self {
+        Self { buffer, offset: 0 }
+    }
+
+    #[inline]
+    pub fn with_offset(buffer: &'a Buffer, offset: usize) -> Self {
+        Self { buffer, offset }
+    }
+
+    #[inline]
+    pub fn from_buffer_offset(bo: &'a BufferOffset<'a>) -> Self {
+        Self {
+            buffer: bo.buffer,
+            offset: bo.offset_in_bytes,
+        }
+    }
+}
+
+impl<'a> EncoderParam for Input<'a> {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+        encoder.set_input_buffer(position, Some(data.buffer), data.offset);
+    }
+}
+
 /// Marks a buffer as a write output in `set_params!` calls, enabling hazard tracking.
 ///
 /// Use this wrapper wherever a kernel writes to a buffer so the encoder can detect
@@ -218,35 +275,6 @@ pub trait EncoderProvider {
     fn encoder(&self) -> Self::Encoder<'_>;
 }
 
-pub struct WrappedEncoder<'a> {
-    inner: &'a ComputeCommandEncoder,
-    end_encoding_on_drop: bool,
-}
-
-impl Drop for WrappedEncoder<'_> {
-    fn drop(&mut self) {
-        if self.end_encoding_on_drop {
-            self.inner.end_encoding()
-        }
-    }
-}
-
-impl AsRef<ComputeCommandEncoder> for WrappedEncoder<'_> {
-    fn as_ref(&self) -> &ComputeCommandEncoder {
-        self.inner
-    }
-}
-
-impl EncoderProvider for &CommandBuffer {
-    type Encoder<'a>
-        = ComputeCommandEncoder
-    where
-        Self: 'a;
-    fn encoder(&self) -> Self::Encoder<'_> {
-        self.compute_command_encoder()
-    }
-}
-
 impl EncoderProvider for &ComputeCommandEncoder {
     type Encoder<'a>
         = WrappedEncoder<'a>
@@ -257,6 +285,16 @@ impl EncoderProvider for &ComputeCommandEncoder {
             inner: self,
             end_encoding_on_drop: false,
         }
+    }
+}
+
+impl EncoderProvider for &CommandsGuard<'_> {
+    type Encoder<'a>
+        = &'a CommandsGuard<'a>
+    where
+        Self: 'a;
+    fn encoder(&self) -> Self::Encoder<'_> {
+        self
     }
 }
 


### PR DESCRIPTION
Changes include
* Use mutex guard wrapper instead of semaphore the guard access to compute/blit encoders.
* Switch to untracked mlt buffers and manual synchronization between encoders.
* Track dependencies between commands on buffers using `Input` and `Output`, which we can use to only wait for the minimum amount of required fences. If two encoders have no depencies between them they run in parallel. This is inter-encoder parallellism, while #3511 addressed intra-encoder parallelism.
* Add residency set for buffers, so that we no longer have to remember `useResource` at (for example) kernel call sites.
* Add mlx's `gemv` and `gemv_t` kernels.


With this and the previous PR I'm seing ~2-2.5x faster tok/s for several non-quantized models, while quantized models get ~20% boost to tok/s.

| model  | old | new |
|-------|-----|------------|
| Llama-3.2-1B | 55 tok/s  | 131 tok/s   |
| Qwen3-0.6B-Q4_K_M    | 170.5 tok/s  | 211.96 tok/s |
