### PR TITLE
Add clear_kv_cache to quantized_llama and quantized_qwen2

### DIFF
--- a/candle-transformers/src/models/quantized_llama.rs
+++ b/candle-transformers/src/models/quantized_llama.rs
@@ -555,6 +555,16 @@ impl ModelWeights {
         }
     }
 
+    /// Clear the KV cache across all layers.
+    ///
+    /// Call this between independent conversations to free cached attention
+    /// state without recreating the model.
+    pub fn clear_kv_cache(&mut self) {
+        for layer in self.layers.iter_mut() {
+            layer.kv_cache = None;
+        }
+    }
+
     pub fn forward(&mut self, x: &Tensor, index_pos: usize) -> Result<Tensor> {
         let (_b_sz, seq_len) = x.dims2()?;
         let mask = if seq_len == 1 {

--- a/candle-transformers/src/models/quantized_qwen2.rs
+++ b/candle-transformers/src/models/quantized_qwen2.rs
@@ -304,6 +304,16 @@ impl ModelWeights {
         }
     }
 
+    /// Clear the KV cache across all layers.
+    ///
+    /// Call this between independent conversations to free cached attention
+    /// state without recreating the model.
+    pub fn clear_kv_cache(&mut self) {
+        for layer in self.layers.iter_mut() {
+            layer.kv_cache = None;
+        }
+    }
+
     pub fn forward(&mut self, x: &Tensor, index_pos: usize) -> Result<Tensor> {
         let (_b_sz, seq_len) = x.dims2()?;
         let mask = if seq_len == 1 {


### PR DESCRIPTION
## Summary

Adds `clear_kv_cache(&mut self)` to `ModelWeights` in both
`candle-transformers/src/models/quantized_llama.rs` and
`candle-transformers/src/models/quantized_qwen2.rs`, mirroring the
existing implementations in `qwen3.rs`, `gemma3.rs`, `phi.rs`,
`smollm3.rs`, and several others.

```rust
pub fn clear_kv_cache(&mut self) {
    for layer in self.layers.iter_mut() {
        layer.kv_cache = None;
    }
}
```

## Motivation

Callers reusing a quantized model across independent conversations
currently have no way to drop cached attention state. Their non-quantized
counterparts already expose this method; this brings the two quantized
variants to parity.

## Test plan

- [x] `cargo fmt`
- [x] `cargo build -p candle-transformers --lib`
- [x] `cargo clippy -p candle-transformers --lib -- -D warnings`