### PR TITLE
feat: Add CPU Conv3d support

### DIFF
--- a/candle-core/src/backend.rs
+++ b/candle-core/src/backend.rs
@@ -57,6 +57,36 @@ pub trait BackendStorage: Sized {
         _params: &crate::conv::ParamsConv2D,
     ) -> Result<Self>;
 
+    fn conv3d(
+        &self,
+        _l: &Layout,
+        _kernel: &Self,
+        _kernel_l: &Layout,
+        _params: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        crate::bail!("conv3d is not implemented for this backend")
+    }
+
+    fn conv3d_backward_input(
+        &self,
+        _l: &Layout,
+        _kernel: &Self,
+        _kernel_l: &Layout,
+        _params: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        crate::bail!("conv3d backward input is not implemented for this backend")
+    }
+
+    fn conv3d_backward_weight(
+        &self,
+        _l: &Layout,
+        _grad: &Self,
+        _grad_l: &Layout,
+        _params: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        crate::bail!("conv3d backward weight is not implemented for this backend")
+    }
+
     fn conv_transpose2d(
         &self,
         _l: &Layout,

--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -80,6 +80,11 @@ impl Tensor {
                         kernel: rhs,
                         ..
                     }
+                    | Op::Conv3D {
+                        arg: lhs,
+                        kernel: rhs,
+                        ..
+                    }
                     | Op::ConvTranspose2D {
                         arg: lhs,
                         kernel: rhs,
@@ -309,6 +314,43 @@ impl Tensor {
                         } else {
                             grad_kernel
                         };
+                        *sum_grad = sum_grad.add(&grad_kernel)?;
+                    }
+                    Op::Conv3D {
+                        arg,
+                        kernel,
+                        padding,
+                        stride,
+                        dilation,
+                    } => {
+                        let (b_size, c_in, i_d, i_h, i_w) = arg.dims5()?;
+                        let (c_out, c_in_k, k_d, k_h, k_w) = kernel.dims5()?;
+                        if c_in != c_in_k {
+                            crate::bail!(
+                                "conv3d backward in_channel mismatch between input ({c_in}) and kernel ({c_in_k})"
+                            )
+                        }
+                        let params = crate::conv::ParamsConv3D {
+                            b_size,
+                            i_d,
+                            i_h,
+                            i_w,
+                            k_d,
+                            k_h,
+                            k_w,
+                            c_out,
+                            c_in,
+                            padding: *padding,
+                            stride: *stride,
+                            dilation: *dilation,
+                        };
+
+                        let grad_arg = grad.conv3d_backward_input(kernel, &params)?;
+                        let sum_grad = grads.or_insert(arg)?;
+                        *sum_grad = sum_grad.add(&grad_arg)?;
+
+                        let grad_kernel = arg.conv3d_backward_weight(&grad, &params)?;
+                        let sum_grad = grads.or_insert(kernel)?;
                         *sum_grad = sum_grad.add(&grad_kernel)?;
                     }
                     Op::ConvTranspose1D { .. } => Err(Error::BackwardNotSupported {

--- a/candle-core/src/conv.rs
+++ b/candle-core/src/conv.rs
@@ -1,4 +1,4 @@
-//! 1D and 2D Convolutions
+//! 1D, 2D and 3D Convolutions
 //!
 use crate::{op::BackpropOp, op::Op, Error, Result, Tensor};
 
@@ -94,6 +94,99 @@ impl ParamsConv2D {
 
     pub(crate) fn out_dims(&self) -> Vec<usize> {
         vec![self.b_size, self.c_out, self.out_h(), self.out_w()]
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParamsConv3D {
+    pub(crate) b_size: usize,
+    pub(crate) i_d: usize,
+    pub(crate) i_h: usize,
+    pub(crate) i_w: usize,
+    pub(crate) k_d: usize,
+    pub(crate) k_h: usize,
+    pub(crate) k_w: usize,
+    pub(crate) c_out: usize,
+    pub(crate) c_in: usize,
+    pub(crate) padding: [usize; 3],
+    pub(crate) stride: [usize; 3],
+    pub(crate) dilation: [usize; 3],
+}
+
+impl ParamsConv3D {
+    fn out_dim(
+        input: usize,
+        kernel: usize,
+        padding: usize,
+        stride: usize,
+        dilation: usize,
+    ) -> Result<usize> {
+        if kernel == 0 {
+            crate::bail!("conv3d kernel dimensions must be non-zero")
+        }
+        if stride == 0 {
+            crate::bail!("conv3d stride dimensions must be non-zero")
+        }
+        if dilation == 0 {
+            crate::bail!("conv3d dilation dimensions must be non-zero")
+        }
+        let padded = input
+            .checked_add(
+                padding
+                    .checked_mul(2)
+                    .ok_or_else(|| Error::Msg("conv3d padding overflow".into()).bt())?,
+            )
+            .ok_or_else(|| Error::Msg("conv3d input size overflow".into()).bt())?;
+        let effective_kernel = dilation
+            .checked_mul(kernel - 1)
+            .and_then(|v| v.checked_add(1))
+            .ok_or_else(|| Error::Msg("conv3d effective kernel size overflow".into()).bt())?;
+        if padded < effective_kernel {
+            crate::bail!(
+                "conv3d padded input size {padded} is smaller than effective kernel size {effective_kernel}"
+            )
+        }
+        Ok((padded - effective_kernel) / stride + 1)
+    }
+
+    pub(crate) fn out_d(&self) -> Result<usize> {
+        Self::out_dim(
+            self.i_d,
+            self.k_d,
+            self.padding[0],
+            self.stride[0],
+            self.dilation[0],
+        )
+    }
+
+    pub(crate) fn out_h(&self) -> Result<usize> {
+        Self::out_dim(
+            self.i_h,
+            self.k_h,
+            self.padding[1],
+            self.stride[1],
+            self.dilation[1],
+        )
+    }
+
+    pub(crate) fn out_w(&self) -> Result<usize> {
+        Self::out_dim(
+            self.i_w,
+            self.k_w,
+            self.padding[2],
+            self.stride[2],
+            self.dilation[2],
+        )
+    }
+
+    pub(crate) fn out_dims(&self) -> Result<Vec<usize>> {
+        Ok(vec![
+            self.b_size,
+            self.c_out,
+            self.out_d()?,
+            self.out_h()?,
+            self.out_w()?,
+        ])
     }
 }
 
@@ -338,6 +431,127 @@ impl Tensor {
                 .collect::<Result<Vec<_>>>()?;
             Tensor::cat(&blocks, 1)
         }
+    }
+
+    fn conv3d_single_group(&self, kernel: &Self, params: &ParamsConv3D) -> Result<Self> {
+        let storage =
+            self.storage()
+                .conv3d(self.layout(), &kernel.storage(), kernel.layout(), params)?;
+        let op = BackpropOp::new2(self, kernel, |arg, kernel| Op::Conv3D {
+            arg,
+            kernel,
+            padding: params.padding,
+            stride: params.stride,
+            dilation: params.dilation,
+        });
+        let out_dims = params.out_dims()?;
+        Ok(crate::tensor::from_storage(storage, out_dims, op, false))
+    }
+
+    /// Applies a 3D convolution over the input tensor.
+    pub fn conv3d(
+        &self,
+        kernel: &Self,
+        padding: [usize; 3],
+        stride: [usize; 3],
+        dilation: [usize; 3],
+        groups: usize,
+    ) -> Result<Self> {
+        if groups == 0 {
+            crate::bail!("conv3d groups must be non-zero")
+        }
+        let (b_size, c_in, i_d, i_h, i_w) = self.dims5()?;
+        let (c_out, c_in_k, k_d, k_h, k_w) = kernel.dims5()?;
+        let expected_c_in = c_in_k
+            .checked_mul(groups)
+            .ok_or_else(|| Error::Msg("conv3d channel count overflow".into()).bt())?;
+        if c_in != expected_c_in {
+            crate::bail!(
+                "in_channel mismatch between input ({c_in}, groups {groups}) and kernel ({c_in_k})"
+            )
+        }
+        if c_out % groups != 0 {
+            crate::bail!("out_channel {c_out} is not divisible by the number of groups {groups}")
+        }
+        let params = ParamsConv3D {
+            b_size,
+            i_d,
+            i_h,
+            i_w,
+            k_d,
+            k_h,
+            k_w,
+            c_out: c_out / groups,
+            c_in: c_in / groups,
+            padding,
+            stride,
+            dilation,
+        };
+        params.out_dims()?;
+        if groups == 1 {
+            self.conv3d_single_group(kernel, &params)
+        } else {
+            let blocks = self.chunk(groups, 1)?;
+            let kernel = kernel.chunk(groups, 0)?;
+            let blocks = blocks
+                .iter()
+                .zip(&kernel)
+                .map(|(block, kernel)| block.conv3d_single_group(kernel, &params))
+                .collect::<Result<Vec<_>>>()?;
+            Tensor::cat(&blocks, 1)
+        }
+    }
+
+    pub(crate) fn conv3d_backward_input(
+        &self,
+        kernel: &Self,
+        params: &ParamsConv3D,
+    ) -> Result<Self> {
+        let storage = self.storage().conv3d_backward_input(
+            self.layout(),
+            &kernel.storage(),
+            kernel.layout(),
+            params,
+        )?;
+        let dims = vec![
+            params.b_size,
+            params.c_in,
+            params.i_d,
+            params.i_h,
+            params.i_w,
+        ];
+        Ok(crate::tensor::from_storage(
+            storage,
+            dims,
+            BackpropOp::none(),
+            false,
+        ))
+    }
+
+    pub(crate) fn conv3d_backward_weight(
+        &self,
+        grad: &Self,
+        params: &ParamsConv3D,
+    ) -> Result<Self> {
+        let storage = self.storage().conv3d_backward_weight(
+            self.layout(),
+            &grad.storage(),
+            grad.layout(),
+            params,
+        )?;
+        let dims = vec![
+            params.c_out,
+            params.c_in,
+            params.k_d,
+            params.k_h,
+            params.k_w,
+        ];
+        Ok(crate::tensor::from_storage(
+            storage,
+            dims,
+            BackpropOp::none(),
+            false,
+        ))
     }
 
     /// Applies a 2D transposed convolution over the input tensor.

--- a/candle-core/src/cpu_backend/conv3d.rs
+++ b/candle-core/src/cpu_backend/conv3d.rs
@@ -1,0 +1,694 @@
+use std::borrow::Cow;
+
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+use crate::{
+    conv::ParamsConv3D,
+    cpu_backend::{Map2, MatMul},
+    shape::dims5,
+    DType, Layout, Result, WithDType,
+};
+
+pub(super) struct Conv3D<'a>(pub(super) &'a ParamsConv3D);
+pub(super) struct Conv3DBackwardInput<'a>(pub(super) &'a ParamsConv3D);
+pub(super) struct Conv3DBackwardWeight<'a>(pub(super) &'a ParamsConv3D);
+
+#[allow(dead_code)]
+enum Conv3dImpl {
+    TiledIm2Col,
+    Direct,
+}
+
+// Unlike conv2d, there is intentionally no full-im2col Conv3d variant here.
+// The full 3D im2col buffer can become very large, so the default general
+// implementation materializes one output tile at a time.
+const DEFAULT_CONV3D_IMPL: Conv3dImpl = Conv3dImpl::TiledIm2Col;
+const CONV3D_TILE_SIZE: usize = 256;
+
+fn src_index(
+    out: usize,
+    kernel: usize,
+    stride: usize,
+    dilation: usize,
+    padding: usize,
+    input: usize,
+) -> Option<usize> {
+    let src = out * stride + kernel * dilation;
+    if src < padding {
+        None
+    } else {
+        let src = src - padding;
+        (src < input).then_some(src)
+    }
+}
+
+impl Map2 for Conv3D<'_> {
+    const OP: &'static str = "conv3d";
+
+    fn f<T: WithDType + num_traits::Num + Copy + 'static>(
+        &self,
+        inp: &[T],
+        inp_l: &Layout,
+        k: &[T],
+        k_l: &Layout,
+    ) -> Result<Vec<T>> {
+        let p = self.0;
+        // The generic CPU MatMul path currently supports F16/F32/F64 here.
+        // Keep direct Conv3d as a fallback so dtypes such as BF16 still work.
+        if !matches!(T::DTYPE, DType::F16 | DType::F32 | DType::F64) {
+            return conv3d_direct(p, inp, inp_l, k, k_l);
+        }
+        if p.k_d == 1
+            && p.k_h == 1
+            && p.k_w == 1
+            && p.stride == [1, 1, 1]
+            && p.padding == [0, 0, 0]
+            && p.dilation == [1, 1, 1]
+        {
+            return conv3d_1x1(p, inp, inp_l, k, k_l);
+        }
+
+        match DEFAULT_CONV3D_IMPL {
+            Conv3dImpl::TiledIm2Col => conv3d_tiled(p, inp, inp_l, k, k_l),
+            Conv3dImpl::Direct => conv3d_direct(p, inp, inp_l, k, k_l),
+        }
+    }
+}
+
+fn conv3d_1x1<T: WithDType + num_traits::Num + Copy + 'static>(
+    p: &ParamsConv3D,
+    inp: &[T],
+    inp_l: &Layout,
+    k: &[T],
+    k_l: &Layout,
+) -> Result<Vec<T>> {
+    let inp = &inp[inp_l.start_offset()..];
+    let (inp_s0, inp_s1, inp_s2, inp_s3, inp_s4) = dims5(inp_l.stride())?;
+    let k = &k[k_l.start_offset()..];
+    let (k_s0, k_s1, _k_s2, _k_s3, _k_s4) = dims5(k_l.stride())?;
+    let spatial_size = p.i_d * p.i_h * p.i_w;
+    let dst = vec![T::zero(); p.b_size * p.c_out * spatial_size];
+    let k_reshaped: Cow<[T]> = if k_s0 == p.c_in && k_s1 == 1 {
+        Cow::Borrowed(&k[..p.c_out * p.c_in])
+    } else {
+        let mut k_reshaped = Vec::with_capacity(p.c_out * p.c_in);
+        for dst_c_idx in 0..p.c_out {
+            for src_c_idx in 0..p.c_in {
+                let k_idx = dst_c_idx * k_s0 + src_c_idx * k_s1;
+                k_reshaped.push(k[k_idx]);
+            }
+        }
+        Cow::Owned(k_reshaped)
+    };
+    let k_layout = Layout::contiguous((p.c_out, p.c_in));
+
+    (0..p.b_size).into_par_iter().try_for_each(|b_idx| {
+        let mut inp_reshaped = Vec::with_capacity(p.c_in * spatial_size);
+        for c_idx in 0..p.c_in {
+            for d_idx in 0..p.i_d {
+                for h_idx in 0..p.i_h {
+                    for w_idx in 0..p.i_w {
+                        let inp_idx = b_idx * inp_s0
+                            + c_idx * inp_s1
+                            + d_idx * inp_s2
+                            + h_idx * inp_s3
+                            + w_idx * inp_s4;
+                        inp_reshaped.push(inp[inp_idx]);
+                    }
+                }
+            }
+        }
+        let inp_layout = Layout::contiguous((p.c_in, spatial_size));
+        let result = MatMul((1, p.c_out, spatial_size, p.c_in)).f(
+            &k_reshaped,
+            &k_layout,
+            &inp_reshaped,
+            &inp_layout,
+        )?;
+        let out_offset = b_idx * p.c_out * spatial_size;
+        for (idx, value) in result.iter().enumerate() {
+            unsafe {
+                let ptr = dst.as_ptr().add(out_offset + idx) as *mut T;
+                *ptr = *value;
+            }
+        }
+        Ok::<(), crate::Error>(())
+    })?;
+
+    Ok(dst)
+}
+
+fn conv3d_tiled<T: WithDType + num_traits::Num + Copy + 'static>(
+    p: &ParamsConv3D,
+    inp: &[T],
+    inp_l: &Layout,
+    k: &[T],
+    k_l: &Layout,
+) -> Result<Vec<T>> {
+    let inp = &inp[inp_l.start_offset()..];
+    let (inp_s0, inp_s1, inp_s2, inp_s3, inp_s4) = dims5(inp_l.stride())?;
+    let k = &k[k_l.start_offset()..];
+    let (k_s0, k_s1, k_s2, k_s3, k_s4) = dims5(k_l.stride())?;
+    let (out_d, out_h, out_w) = (p.out_d()?, p.out_h()?, p.out_w()?);
+
+    let dst = vec![T::zero(); p.b_size * p.c_out * out_d * out_h * out_w];
+
+    let cont_s0 = p.i_d * p.i_h * p.i_w * p.c_in;
+    let cont_s1 = p.i_h * p.i_w * p.c_in;
+    let cont_s2 = p.i_w * p.c_in;
+    let cont_s3 = p.c_in;
+    let mut inp_cont = vec![T::zero(); p.b_size * p.c_in * p.i_d * p.i_h * p.i_w];
+    for b_idx in 0..p.b_size {
+        for d_idx in 0..p.i_d {
+            for h_idx in 0..p.i_h {
+                for w_idx in 0..p.i_w {
+                    for c_idx in 0..p.c_in {
+                        let src_idx = b_idx * inp_s0
+                            + c_idx * inp_s1
+                            + d_idx * inp_s2
+                            + h_idx * inp_s3
+                            + w_idx * inp_s4;
+                        let dst_idx = b_idx * cont_s0
+                            + d_idx * cont_s1
+                            + h_idx * cont_s2
+                            + w_idx * cont_s3
+                            + c_idx;
+                        inp_cont[dst_idx] = inp[src_idx]
+                    }
+                }
+            }
+        }
+    }
+
+    // Flatten weights from [c_out, c_in, k_d, k_h, k_w] into
+    // [c_out, k_d * k_h * k_w * c_in] for GEMM.
+    let k_size = p.c_in * p.k_d * p.k_h * p.k_w;
+    let mut k_flat = Vec::with_capacity(p.c_out * k_size);
+    for dst_c_idx in 0..p.c_out {
+        for kd in 0..p.k_d {
+            for kh in 0..p.k_h {
+                for kw in 0..p.k_w {
+                    for src_c_idx in 0..p.c_in {
+                        let k_idx =
+                            dst_c_idx * k_s0 + src_c_idx * k_s1 + kd * k_s2 + kh * k_s3 + kw * k_s4;
+                        k_flat.push(k[k_idx]);
+                    }
+                }
+            }
+        }
+    }
+    let k_layout = Layout::contiguous((p.c_out, k_size));
+    let total_out_pixels = out_d * out_h * out_w;
+
+    (0..p.b_size).into_par_iter().try_for_each(|b_idx| {
+        let inp_offset = b_idx * cont_s0;
+        let out_batch_offset = b_idx * p.c_out * total_out_pixels;
+        let num_tiles = total_out_pixels.div_ceil(CONV3D_TILE_SIZE);
+        (0..num_tiles).into_par_iter().try_for_each(|tile_idx| {
+            let tile_start = tile_idx * CONV3D_TILE_SIZE;
+            let tile_end = (tile_start + CONV3D_TILE_SIZE).min(total_out_pixels);
+            let tile_size = tile_end - tile_start;
+            // Tile layout is [k_size, tile_size], where each column is one
+            // flattened 3D receptive field.
+            let mut col_tile = vec![T::zero(); k_size * tile_size];
+
+            for (local_idx, out_idx) in (tile_start..tile_end).enumerate() {
+                let dst_d = out_idx / (out_h * out_w);
+                let dst_h = (out_idx / out_w) % out_h;
+                let dst_w = out_idx % out_w;
+                for kd in 0..p.k_d {
+                    let Some(src_d) =
+                        src_index(dst_d, kd, p.stride[0], p.dilation[0], p.padding[0], p.i_d)
+                    else {
+                        continue;
+                    };
+                    for kh in 0..p.k_h {
+                        let Some(src_h) =
+                            src_index(dst_h, kh, p.stride[1], p.dilation[1], p.padding[1], p.i_h)
+                        else {
+                            continue;
+                        };
+                        for kw in 0..p.k_w {
+                            let Some(src_w) = src_index(
+                                dst_w,
+                                kw,
+                                p.stride[2],
+                                p.dilation[2],
+                                p.padding[2],
+                                p.i_w,
+                            ) else {
+                                continue;
+                            };
+                            let patch_offset =
+                                (((kd * p.k_h + kh) * p.k_w + kw) * p.c_in) * tile_size + local_idx;
+                            let inp_idx =
+                                inp_offset + src_d * cont_s1 + src_h * cont_s2 + src_w * cont_s3;
+                            for src_c_idx in 0..p.c_in {
+                                col_tile[patch_offset + src_c_idx * tile_size] =
+                                    inp_cont[inp_idx + src_c_idx];
+                            }
+                        }
+                    }
+                }
+            }
+
+            let col_layout = Layout::contiguous((k_size, tile_size));
+            let result = MatMul((1, p.c_out, tile_size, k_size)).f(
+                &k_flat,
+                &k_layout,
+                &col_tile,
+                &col_layout,
+            )?;
+
+            for (local_idx, out_idx) in (tile_start..tile_end).enumerate() {
+                for dst_c_idx in 0..p.c_out {
+                    let dst_idx = out_batch_offset + dst_c_idx * total_out_pixels + out_idx;
+                    let result_idx = dst_c_idx * tile_size + local_idx;
+                    unsafe {
+                        let ptr = dst.as_ptr().add(dst_idx) as *mut T;
+                        *ptr = result[result_idx];
+                    }
+                }
+            }
+            Ok::<(), crate::Error>(())
+        })
+    })?;
+
+    Ok(dst)
+}
+
+fn conv3d_direct<T: WithDType + num_traits::Num + Copy + 'static>(
+    p: &ParamsConv3D,
+    inp: &[T],
+    inp_l: &Layout,
+    k: &[T],
+    k_l: &Layout,
+) -> Result<Vec<T>> {
+    let inp = &inp[inp_l.start_offset()..];
+    let k = &k[k_l.start_offset()..];
+    let (inp_s0, inp_s1, inp_s2, inp_s3, inp_s4) = dims5(inp_l.stride())?;
+    let (k_s0, k_s1, k_s2, k_s3, k_s4) = dims5(k_l.stride())?;
+    let (out_d, out_h, out_w) = (p.out_d()?, p.out_h()?, p.out_w()?);
+
+    let mut dst = vec![T::zero(); p.b_size * p.c_out * out_d * out_h * out_w];
+    for b_idx in 0..p.b_size {
+        for dst_c_idx in 0..p.c_out {
+            for dst_d in 0..out_d {
+                for dst_h in 0..out_h {
+                    for dst_w in 0..out_w {
+                        let mut acc = T::zero();
+                        for src_c_idx in 0..p.c_in {
+                            for kd in 0..p.k_d {
+                                let Some(src_d) = src_index(
+                                    dst_d,
+                                    kd,
+                                    p.stride[0],
+                                    p.dilation[0],
+                                    p.padding[0],
+                                    p.i_d,
+                                ) else {
+                                    continue;
+                                };
+                                for kh in 0..p.k_h {
+                                    let Some(src_h) = src_index(
+                                        dst_h,
+                                        kh,
+                                        p.stride[1],
+                                        p.dilation[1],
+                                        p.padding[1],
+                                        p.i_h,
+                                    ) else {
+                                        continue;
+                                    };
+                                    for kw in 0..p.k_w {
+                                        let Some(src_w) = src_index(
+                                            dst_w,
+                                            kw,
+                                            p.stride[2],
+                                            p.dilation[2],
+                                            p.padding[2],
+                                            p.i_w,
+                                        ) else {
+                                            continue;
+                                        };
+                                        let inp_idx = b_idx * inp_s0
+                                            + src_c_idx * inp_s1
+                                            + src_d * inp_s2
+                                            + src_h * inp_s3
+                                            + src_w * inp_s4;
+                                        let k_idx = dst_c_idx * k_s0
+                                            + src_c_idx * k_s1
+                                            + kd * k_s2
+                                            + kh * k_s3
+                                            + kw * k_s4;
+                                        acc += inp[inp_idx] * k[k_idx];
+                                    }
+                                }
+                            }
+                        }
+                        let dst_idx = ((((b_idx * p.c_out + dst_c_idx) * out_d + dst_d) * out_h
+                            + dst_h)
+                            * out_w)
+                            + dst_w;
+                        dst[dst_idx] = acc;
+                    }
+                }
+            }
+        }
+    }
+    Ok(dst)
+}
+
+impl Map2 for Conv3DBackwardInput<'_> {
+    const OP: &'static str = "conv3d-backward-input";
+
+    fn f<T: WithDType>(
+        &self,
+        grad: &[T],
+        grad_l: &Layout,
+        k: &[T],
+        k_l: &Layout,
+    ) -> Result<Vec<T>> {
+        // Keep grad-input direct for now. A fast variant needs col2im-style
+        // scatter-add with overlapping writes, which is a separate optimization.
+        let p = self.0;
+        let grad = &grad[grad_l.start_offset()..];
+        let k = &k[k_l.start_offset()..];
+        let (grad_s0, grad_s1, grad_s2, grad_s3, grad_s4) = dims5(grad_l.stride())?;
+        let (k_s0, k_s1, k_s2, k_s3, k_s4) = dims5(k_l.stride())?;
+        let (out_d, out_h, out_w) = (p.out_d()?, p.out_h()?, p.out_w()?);
+
+        let mut dst = vec![T::zero(); p.b_size * p.c_in * p.i_d * p.i_h * p.i_w];
+        for b_idx in 0..p.b_size {
+            for dst_c_idx in 0..p.c_out {
+                for dst_d in 0..out_d {
+                    for dst_h in 0..out_h {
+                        for dst_w in 0..out_w {
+                            let grad_idx = b_idx * grad_s0
+                                + dst_c_idx * grad_s1
+                                + dst_d * grad_s2
+                                + dst_h * grad_s3
+                                + dst_w * grad_s4;
+                            let grad_value = grad[grad_idx];
+                            for src_c_idx in 0..p.c_in {
+                                for kd in 0..p.k_d {
+                                    let Some(src_d) = src_index(
+                                        dst_d,
+                                        kd,
+                                        p.stride[0],
+                                        p.dilation[0],
+                                        p.padding[0],
+                                        p.i_d,
+                                    ) else {
+                                        continue;
+                                    };
+                                    for kh in 0..p.k_h {
+                                        let Some(src_h) = src_index(
+                                            dst_h,
+                                            kh,
+                                            p.stride[1],
+                                            p.dilation[1],
+                                            p.padding[1],
+                                            p.i_h,
+                                        ) else {
+                                            continue;
+                                        };
+                                        for kw in 0..p.k_w {
+                                            let Some(src_w) = src_index(
+                                                dst_w,
+                                                kw,
+                                                p.stride[2],
+                                                p.dilation[2],
+                                                p.padding[2],
+                                                p.i_w,
+                                            ) else {
+                                                continue;
+                                            };
+                                            let k_idx = dst_c_idx * k_s0
+                                                + src_c_idx * k_s1
+                                                + kd * k_s2
+                                                + kh * k_s3
+                                                + kw * k_s4;
+                                            let dst_idx =
+                                                ((((b_idx * p.c_in + src_c_idx) * p.i_d + src_d)
+                                                    * p.i_h
+                                                    + src_h)
+                                                    * p.i_w)
+                                                    + src_w;
+                                            dst[dst_idx] += grad_value * k[k_idx];
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(dst)
+    }
+}
+
+impl Map2 for Conv3DBackwardWeight<'_> {
+    const OP: &'static str = "conv3d-backward-weight";
+
+    fn f<T: WithDType + num_traits::Num + Copy + 'static>(
+        &self,
+        inp: &[T],
+        inp_l: &Layout,
+        grad: &[T],
+        grad_l: &Layout,
+    ) -> Result<Vec<T>> {
+        let p = self.0;
+        // Reuse the tiled im2col + MatMul strategy for supported dtypes, but
+        // preserve the direct path for BF16 and other dtypes.
+        if matches!(T::DTYPE, DType::F16 | DType::F32 | DType::F64) {
+            conv3d_backward_weight_tiled(p, inp, inp_l, grad, grad_l)
+        } else {
+            conv3d_backward_weight_direct(p, inp, inp_l, grad, grad_l)
+        }
+    }
+}
+
+fn conv3d_backward_weight_tiled<T: WithDType + num_traits::Num + Copy + 'static>(
+    p: &ParamsConv3D,
+    inp: &[T],
+    inp_l: &Layout,
+    grad: &[T],
+    grad_l: &Layout,
+) -> Result<Vec<T>> {
+    let inp = &inp[inp_l.start_offset()..];
+    let grad = &grad[grad_l.start_offset()..];
+    let (inp_s0, inp_s1, inp_s2, inp_s3, inp_s4) = dims5(inp_l.stride())?;
+    let (grad_s0, grad_s1, grad_s2, grad_s3, grad_s4) = dims5(grad_l.stride())?;
+    let (out_d, out_h, out_w) = (p.out_d()?, p.out_h()?, p.out_w()?);
+    let total_out_pixels = out_d * out_h * out_w;
+    let k_size = p.c_in * p.k_d * p.k_h * p.k_w;
+
+    let cont_s0 = p.i_d * p.i_h * p.i_w * p.c_in;
+    let cont_s1 = p.i_h * p.i_w * p.c_in;
+    let cont_s2 = p.i_w * p.c_in;
+    let cont_s3 = p.c_in;
+    let mut inp_cont = vec![T::zero(); p.b_size * p.c_in * p.i_d * p.i_h * p.i_w];
+    for b_idx in 0..p.b_size {
+        for d_idx in 0..p.i_d {
+            for h_idx in 0..p.i_h {
+                for w_idx in 0..p.i_w {
+                    for c_idx in 0..p.c_in {
+                        let src_idx = b_idx * inp_s0
+                            + c_idx * inp_s1
+                            + d_idx * inp_s2
+                            + h_idx * inp_s3
+                            + w_idx * inp_s4;
+                        let dst_idx = b_idx * cont_s0
+                            + d_idx * cont_s1
+                            + h_idx * cont_s2
+                            + w_idx * cont_s3
+                            + c_idx;
+                        inp_cont[dst_idx] = inp[src_idx]
+                    }
+                }
+            }
+        }
+    }
+
+    let mut dst = vec![T::zero(); p.c_out * k_size];
+    let num_tiles = total_out_pixels.div_ceil(CONV3D_TILE_SIZE);
+    for b_idx in 0..p.b_size {
+        let inp_offset = b_idx * cont_s0;
+        for tile_idx in 0..num_tiles {
+            let tile_start = tile_idx * CONV3D_TILE_SIZE;
+            let tile_end = (tile_start + CONV3D_TILE_SIZE).min(total_out_pixels);
+            let tile_size = tile_end - tile_start;
+            // grad_tile is [c_out, tile_size], col_tile is [k_size, tile_size].
+            // Their product gives one tile contribution to flattened weights.
+            let mut col_tile = vec![T::zero(); k_size * tile_size];
+            let mut grad_tile = vec![T::zero(); p.c_out * tile_size];
+
+            for (local_idx, out_idx) in (tile_start..tile_end).enumerate() {
+                let dst_d = out_idx / (out_h * out_w);
+                let dst_h = (out_idx / out_w) % out_h;
+                let dst_w = out_idx % out_w;
+
+                for dst_c_idx in 0..p.c_out {
+                    let grad_idx = b_idx * grad_s0
+                        + dst_c_idx * grad_s1
+                        + dst_d * grad_s2
+                        + dst_h * grad_s3
+                        + dst_w * grad_s4;
+                    grad_tile[dst_c_idx * tile_size + local_idx] = grad[grad_idx];
+                }
+
+                for kd in 0..p.k_d {
+                    let Some(src_d) =
+                        src_index(dst_d, kd, p.stride[0], p.dilation[0], p.padding[0], p.i_d)
+                    else {
+                        continue;
+                    };
+                    for kh in 0..p.k_h {
+                        let Some(src_h) =
+                            src_index(dst_h, kh, p.stride[1], p.dilation[1], p.padding[1], p.i_h)
+                        else {
+                            continue;
+                        };
+                        for kw in 0..p.k_w {
+                            let Some(src_w) = src_index(
+                                dst_w,
+                                kw,
+                                p.stride[2],
+                                p.dilation[2],
+                                p.padding[2],
+                                p.i_w,
+                            ) else {
+                                continue;
+                            };
+                            let patch_offset =
+                                (((kd * p.k_h + kh) * p.k_w + kw) * p.c_in) * tile_size + local_idx;
+                            let inp_idx =
+                                inp_offset + src_d * cont_s1 + src_h * cont_s2 + src_w * cont_s3;
+                            for src_c_idx in 0..p.c_in {
+                                col_tile[patch_offset + src_c_idx * tile_size] =
+                                    inp_cont[inp_idx + src_c_idx];
+                            }
+                        }
+                    }
+                }
+            }
+
+            let grad_layout = Layout::contiguous((p.c_out, tile_size));
+            let col_layout = Layout::contiguous((k_size, tile_size)).transpose(0, 1)?;
+            let result = MatMul((1, p.c_out, k_size, tile_size)).f(
+                &grad_tile,
+                &grad_layout,
+                &col_tile,
+                &col_layout,
+            )?;
+            for (idx, value) in result.iter().enumerate() {
+                dst[idx] += *value;
+            }
+        }
+    }
+
+    let mut dst_weight = vec![T::zero(); p.c_out * k_size];
+    for dst_c_idx in 0..p.c_out {
+        for kd in 0..p.k_d {
+            for kh in 0..p.k_h {
+                for kw in 0..p.k_w {
+                    for src_c_idx in 0..p.c_in {
+                        let flat_idx = dst_c_idx * k_size
+                            + (((kd * p.k_h + kh) * p.k_w + kw) * p.c_in)
+                            + src_c_idx;
+                        let weight_idx =
+                            ((((dst_c_idx * p.c_in + src_c_idx) * p.k_d + kd) * p.k_h + kh)
+                                * p.k_w)
+                                + kw;
+                        dst_weight[weight_idx] = dst[flat_idx];
+                    }
+                }
+            }
+        }
+    }
+    Ok(dst_weight)
+}
+
+fn conv3d_backward_weight_direct<T: WithDType>(
+    p: &ParamsConv3D,
+    inp: &[T],
+    inp_l: &Layout,
+    grad: &[T],
+    grad_l: &Layout,
+) -> Result<Vec<T>> {
+    let inp = &inp[inp_l.start_offset()..];
+    let grad = &grad[grad_l.start_offset()..];
+    let (inp_s0, inp_s1, inp_s2, inp_s3, inp_s4) = dims5(inp_l.stride())?;
+    let (grad_s0, grad_s1, grad_s2, grad_s3, grad_s4) = dims5(grad_l.stride())?;
+    let (out_d, out_h, out_w) = (p.out_d()?, p.out_h()?, p.out_w()?);
+
+    let mut dst = vec![T::zero(); p.c_out * p.c_in * p.k_d * p.k_h * p.k_w];
+    for dst_c_idx in 0..p.c_out {
+        for src_c_idx in 0..p.c_in {
+            for kd in 0..p.k_d {
+                for kh in 0..p.k_h {
+                    for kw in 0..p.k_w {
+                        let mut acc = T::zero();
+                        for b_idx in 0..p.b_size {
+                            for dst_d in 0..out_d {
+                                let Some(src_d) = src_index(
+                                    dst_d,
+                                    kd,
+                                    p.stride[0],
+                                    p.dilation[0],
+                                    p.padding[0],
+                                    p.i_d,
+                                ) else {
+                                    continue;
+                                };
+                                for dst_h in 0..out_h {
+                                    let Some(src_h) = src_index(
+                                        dst_h,
+                                        kh,
+                                        p.stride[1],
+                                        p.dilation[1],
+                                        p.padding[1],
+                                        p.i_h,
+                                    ) else {
+                                        continue;
+                                    };
+                                    for dst_w in 0..out_w {
+                                        let Some(src_w) = src_index(
+                                            dst_w,
+                                            kw,
+                                            p.stride[2],
+                                            p.dilation[2],
+                                            p.padding[2],
+                                            p.i_w,
+                                        ) else {
+                                            continue;
+                                        };
+                                        let inp_idx = b_idx * inp_s0
+                                            + src_c_idx * inp_s1
+                                            + src_d * inp_s2
+                                            + src_h * inp_s3
+                                            + src_w * inp_s4;
+                                        let grad_idx = b_idx * grad_s0
+                                            + dst_c_idx * grad_s1
+                                            + dst_d * grad_s2
+                                            + dst_h * grad_s3
+                                            + dst_w * grad_s4;
+                                        acc += inp[inp_idx] * grad[grad_idx];
+                                    }
+                                }
+                            }
+                        }
+                        let dst_idx = ((((dst_c_idx * p.c_in + src_c_idx) * p.k_d + kd) * p.k_h
+                            + kh)
+                            * p.k_w)
+                            + kw;
+                        dst[dst_idx] = acc;
+                    }
+                }
+            }
+        }
+    }
+    Ok(dst)
+}

--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -12,6 +12,8 @@ pub use utils::{
 };
 mod conv2d;
 use conv2d::Conv2D;
+mod conv3d;
+use conv3d::{Conv3D, Conv3DBackwardInput, Conv3DBackwardWeight};
 
 const USE_IM2COL_CONV1D: bool = true;
 const USE_COL2IM_CONV1D_TR: bool = true;
@@ -2859,6 +2861,36 @@ impl BackendStorage for CpuStorage {
         params: &crate::conv::ParamsConv2D,
     ) -> Result<Self> {
         Conv2D(params).map(self, l, kernel, kernel_l)
+    }
+
+    fn conv3d(
+        &self,
+        l: &Layout,
+        kernel: &Self,
+        kernel_l: &Layout,
+        params: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        Conv3D(params).map(self, l, kernel, kernel_l)
+    }
+
+    fn conv3d_backward_input(
+        &self,
+        l: &Layout,
+        kernel: &Self,
+        kernel_l: &Layout,
+        params: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        Conv3DBackwardInput(params).map(self, l, kernel, kernel_l)
+    }
+
+    fn conv3d_backward_weight(
+        &self,
+        l: &Layout,
+        grad: &Self,
+        grad_l: &Layout,
+        params: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        Conv3DBackwardWeight(params).map(self, l, grad, grad_l)
     }
 
     fn conv_transpose2d(

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -116,6 +116,15 @@ pub enum Op {
     },
 
     #[allow(dead_code)]
+    Conv3D {
+        arg: Tensor,
+        kernel: Tensor,
+        padding: [usize; 3],
+        stride: [usize; 3],
+        dilation: [usize; 3],
+    },
+
+    #[allow(dead_code)]
     ConvTranspose2D {
         arg: Tensor,
         kernel: Tensor,

--- a/candle-core/src/storage.rs
+++ b/candle-core/src/storage.rs
@@ -461,6 +461,99 @@ impl Storage {
         }
     }
 
+    pub(crate) fn conv3d(
+        &self,
+        l: &Layout,
+        kernel: &Self,
+        kernel_l: &Layout,
+        params: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        self.same_device(kernel, "conv3d")?;
+        self.same_dtype(kernel, "conv3d")?;
+        match (self, &kernel) {
+            (Storage::Cpu(inp), Storage::Cpu(kernel)) => {
+                let s = inp.conv3d(l, kernel, kernel_l, params)?;
+                Ok(Self::Cpu(s))
+            }
+            (Storage::Cuda(inp), Storage::Cuda(kernel)) => {
+                let s = inp.conv3d(l, kernel, kernel_l, params)?;
+                Ok(Self::Cuda(s))
+            }
+            (Storage::Metal(inp), Storage::Metal(kernel)) => {
+                let s = inp.conv3d(l, kernel, kernel_l, params)?;
+                Ok(Self::Metal(s))
+            }
+            (lhs, rhs) => Err(Error::DeviceMismatchBinaryOp {
+                lhs: lhs.device().location(),
+                rhs: rhs.device().location(),
+                op: "conv3d",
+            }
+            .bt()),
+        }
+    }
+
+    pub(crate) fn conv3d_backward_input(
+        &self,
+        l: &Layout,
+        kernel: &Self,
+        kernel_l: &Layout,
+        params: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        self.same_device(kernel, "conv3d-backward-input")?;
+        self.same_dtype(kernel, "conv3d-backward-input")?;
+        match (self, &kernel) {
+            (Storage::Cpu(grad), Storage::Cpu(kernel)) => {
+                let s = grad.conv3d_backward_input(l, kernel, kernel_l, params)?;
+                Ok(Self::Cpu(s))
+            }
+            (Storage::Cuda(grad), Storage::Cuda(kernel)) => {
+                let s = grad.conv3d_backward_input(l, kernel, kernel_l, params)?;
+                Ok(Self::Cuda(s))
+            }
+            (Storage::Metal(grad), Storage::Metal(kernel)) => {
+                let s = grad.conv3d_backward_input(l, kernel, kernel_l, params)?;
+                Ok(Self::Metal(s))
+            }
+            (lhs, rhs) => Err(Error::DeviceMismatchBinaryOp {
+                lhs: lhs.device().location(),
+                rhs: rhs.device().location(),
+                op: "conv3d-backward-input",
+            }
+            .bt()),
+        }
+    }
+
+    pub(crate) fn conv3d_backward_weight(
+        &self,
+        l: &Layout,
+        grad: &Self,
+        grad_l: &Layout,
+        params: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        self.same_device(grad, "conv3d-backward-weight")?;
+        self.same_dtype(grad, "conv3d-backward-weight")?;
+        match (self, &grad) {
+            (Storage::Cpu(inp), Storage::Cpu(grad)) => {
+                let s = inp.conv3d_backward_weight(l, grad, grad_l, params)?;
+                Ok(Self::Cpu(s))
+            }
+            (Storage::Cuda(inp), Storage::Cuda(grad)) => {
+                let s = inp.conv3d_backward_weight(l, grad, grad_l, params)?;
+                Ok(Self::Cuda(s))
+            }
+            (Storage::Metal(inp), Storage::Metal(grad)) => {
+                let s = inp.conv3d_backward_weight(l, grad, grad_l, params)?;
+                Ok(Self::Metal(s))
+            }
+            (lhs, rhs) => Err(Error::DeviceMismatchBinaryOp {
+                lhs: lhs.device().location(),
+                rhs: rhs.device().location(),
+                op: "conv3d-backward-weight",
+            }
+            .bt()),
+        }
+    }
+
     pub(crate) fn conv_transpose2d(
         &self,
         l: &Layout,

--- a/candle-core/tests/conv_tests.rs
+++ b/candle-core/tests/conv_tests.rs
@@ -1,5 +1,60 @@
 use anyhow::Result;
-use candle_core::{test_device, test_utils, Device, IndexOp, Tensor};
+use candle_core::{test_device, test_utils, DType, Device, IndexOp, Tensor, Var};
+
+fn assert_close_tensors(
+    got: &Tensor,
+    expected: &Tensor,
+    tolerance: f32,
+    label: &str,
+) -> Result<()> {
+    let got = got.to_dtype(DType::F32)?.flatten_all()?.to_vec1::<f32>()?;
+    let expected = expected
+        .to_dtype(DType::F32)?
+        .flatten_all()?
+        .to_vec1::<f32>()?;
+    assert_eq!(
+        got.len(),
+        expected.len(),
+        "{label}: length mismatch, got {}, expected {}",
+        got.len(),
+        expected.len()
+    );
+    let mut max_diff = 0f32;
+    let mut max_idx = 0usize;
+    for (idx, (got, expected)) in got.iter().zip(expected.iter()).enumerate() {
+        let diff = (got - expected).abs();
+        if diff > max_diff {
+            max_diff = diff;
+            max_idx = idx;
+        }
+    }
+    assert!(
+        max_diff <= tolerance,
+        "{label}: max diff {max_diff} at {max_idx}, got {}, expected {}, tolerance {tolerance}",
+        got[max_idx],
+        expected[max_idx]
+    );
+    Ok(())
+}
+
+fn var_from_vec_dtype<S: Into<candle_core::Shape>>(
+    data: Vec<f32>,
+    shape: S,
+    dtype: DType,
+    dev: &Device,
+) -> Result<Var> {
+    let tensor = Tensor::from_vec(data, shape, dev)?.to_dtype(dtype)?;
+    Ok(Var::from_tensor(&tensor)?)
+}
+
+fn tensor_from_vec_dtype<S: Into<candle_core::Shape>>(
+    data: Vec<f32>,
+    shape: S,
+    dtype: DType,
+    dev: &Device,
+) -> Result<Tensor> {
+    Ok(Tensor::from_vec(data, shape, dev)?.to_dtype(dtype)?)
+}
 
 /* This test is based on the following script.
 import torch
@@ -929,6 +984,276 @@ fn conv2d_c_eq_h_eq_w(dev: &Device) -> Result<()> {
         "conv2d with C==H==W: top-left corner mismatch: got {actual_corner}, expected 1.4310, diff={corner_diff}"
     );
 
+    Ok(())
+}
+
+/* This test is based on the following script.
+import torch
+torch.set_printoptions(precision=6, sci_mode=False)
+
+x = torch.arange(2 * 2 * 2 * 3 * 4, dtype=torch.float32).reshape(2, 2, 2, 3, 4) / 10 - 3
+w = torch.arange(2 * 2 * 2 * 1 * 3, dtype=torch.float32).reshape(2, 2, 2, 1, 3) / 7 - 2
+y = torch.nn.functional.conv3d(
+    x,
+    w,
+    stride=(1, 2, 1),
+    padding=(1, 0, 1),
+    dilation=(1, 1, 2),
+)
+print(y.shape)
+print(y.flatten())
+*/
+#[test]
+#[allow(clippy::excessive_precision)]
+fn conv3d_forward_cpu() -> Result<()> {
+    let dev = &Device::Cpu;
+    let xs = (0..96).map(|v| v as f32 / 10. - 3.).collect::<Vec<_>>();
+    let xs = Tensor::from_vec(xs, (2, 2, 2, 3, 4), dev)?;
+    let ws = (0..24).map(|v| v as f32 / 7. - 2.).collect::<Vec<_>>();
+    let ws = Tensor::from_vec(ws, (2, 2, 2, 1, 3), dev)?;
+    let out = xs.conv3d(&ws, [1, 0, 1], [1, 2, 1], [1, 1, 2], 1)?;
+    assert_eq!(out.dims(), [2, 2, 3, 2, 2]);
+    assert_eq!(
+        test_utils::to_vec1_round(&out.flatten_all()?, 4)?,
+        [
+            8.0286, 9.3714, 5.0571, 5.9429, 14.3429, 16.5143, 7.0286, 8.2857, 4.2571, 5.0857,
+            -0.0857, 0.2857, -2.9429, -2.2857, -0.4286, -0.2286, 0.6286, 1.4286, 4.2857, 4.1714,
+            1.5143, 1.6571, 2.6571, 2.3429, -9.8, -11.2, -12.7714, -14.6286, -29.5429, -32.8571,
+            -36.8571, -41.0857, -21.8, -23.7143, -26.1429, -28.5143, 12.1429, 10.0571, 14.6571,
+            12.1143, 22.5714, 17.8857, 26.2286, 20.6286, 8.3714, 5.7714, 9.5143, 6.4571
+        ]
+    );
+    Ok(())
+}
+
+/* This test is based on the following script.
+import torch
+torch.set_printoptions(precision=6, sci_mode=False)
+
+x = torch.arange(1 * 4 * 2 * 3 * 4, dtype=torch.float32).reshape(1, 4, 2, 3, 4) / 5 - 4
+w = torch.arange(4 * 2 * 2 * 2 * 2, dtype=torch.float32).reshape(4, 2, 2, 2, 2) / 6 - 1
+y = torch.nn.functional.conv3d(
+    x,
+    w,
+    stride=(1, 1, 2),
+    padding=(0, 1, 0),
+    groups=2,
+)
+print(y.shape)
+print(y.flatten())
+*/
+#[test]
+#[allow(clippy::excessive_precision)]
+fn conv3d_grouped_cpu() -> Result<()> {
+    let dev = &Device::Cpu;
+    let xs = (0..96).map(|v| v as f32 / 5. - 4.).collect::<Vec<_>>();
+    let xs = Tensor::from_vec(xs, (1, 4, 2, 3, 4), dev)?;
+    let ws = (0..64).map(|v| v as f32 / 6. - 1.).collect::<Vec<_>>();
+    let ws = Tensor::from_vec(ws, (4, 2, 2, 2, 2), dev)?;
+    let out = xs.conv3d(&ws, [0, 1, 0], [1, 1, 2], [1, 1, 1], 2)?;
+    assert_eq!(out.dims(), [1, 4, 1, 4, 2]);
+    assert_eq!(
+        test_utils::to_vec1_round(&out.flatten_all()?, 3)?,
+        [
+            15.067, 16.4, 33.6, 35.2, 36.8, 38.4, 16.933, 17.2, 8.667, 18.533, 37.867, 56.533,
+            75.2, 93.867, 44.667, 53.467, 443.867, 462.267, 899.733, 935.467, 971.2, 1006.933,
+            488.4, 505.733, 642.267, 669.2, 1313.6, 1366.4, 1419.2, 1472., 720.933, 746.8
+        ]
+    );
+    Ok(())
+}
+
+/* This test is based on the following script.
+import torch
+torch.set_printoptions(precision=6, sci_mode=False)
+
+x = torch.arange(1 * 2 * 3 * 3 * 4, dtype=torch.float32).reshape(1, 2, 3, 3, 4) / 11 - 2
+w = torch.arange(2 * 2 * 2 * 2 * 2, dtype=torch.float32).reshape(2, 2, 2, 2, 2) / 13 - 1
+x.requires_grad_(True)
+w.requires_grad_(True)
+y = torch.nn.functional.conv3d(
+    x,
+    w,
+    stride=(1, 1, 2),
+    padding=(1, 0, 1),
+)
+loss = (y * y).sum()
+loss.backward()
+print(y.shape)
+print(y.flatten())
+print(x.grad.shape)
+print(x.grad.flatten())
+print(w.grad.shape)
+print(w.grad.flatten())
+*/
+#[test]
+#[allow(clippy::excessive_precision)]
+fn conv3d_grad_cpu() -> Result<()> {
+    let dev = &Device::Cpu;
+    let xs = (0..72).map(|v| v as f32 / 11. - 2.).collect::<Vec<_>>();
+    let xs = Var::from_vec(xs, (1, 2, 3, 3, 4), dev)?;
+    let ws = (0..32).map(|v| v as f32 / 13. - 1.).collect::<Vec<_>>();
+    let ws = Var::from_vec(ws, (2, 2, 2, 2, 2), dev)?;
+    let out = xs.conv3d(&ws, [1, 0, 1], [1, 1, 2], [1, 1, 1], 1)?;
+    assert_eq!(out.dims(), [1, 2, 4, 2, 3]);
+    assert_eq!(
+        test_utils::to_vec1_round(&out.flatten_all()?, 4)?,
+        [
+            2.2378, 4.2517, 1.958, 1.9021, 3.4685, 1.5105, 3.6923, 6.2657, 2.4615, 2.5734, 3.8042,
+            1.1189, 0.3357, -1.1189, -1.5664, -0.7832, -3.5804, -2.9091, -2.2378, -5.7063, -3.5245,
+            -3.021, -7.3846, -4.4196, 1.3427, 3.8042, 2.4056, 2.7972, 6.6014, 3.7483, 7.2727,
+            16.1119, 8.7273, 9.7343, 20.8112, 10.965, 14.6573, 30.2098, 15.4406, 17.1189, 34.9091,
+            17.6783, 7.6084, 15.3287, 7.6643, 8.6154, 17.2308, 8.5594
+        ]
+    );
+    let loss = out.sqr()?.sum_all()?;
+    let grads = loss.backward()?;
+    let grad_xs = grads.get(&xs).unwrap();
+    let grad_ws = grads.get(&ws).unwrap();
+    assert_eq!(grad_xs.dims(), [1, 2, 3, 3, 4]);
+    assert_eq!(grad_ws.dims(), [2, 2, 2, 2, 2]);
+    assert_eq!(
+        test_utils::to_vec1_round(&grad_xs.flatten_all()?, 2)?,
+        [
+            -3.44, -6.89, -2.2, -1.02, 3.37, 6.78, 16.8, 8.54, 7.57, 14.98, 20.31, 10.1, 12.81,
+            24.86, 32.77, 16.25, 41.59, 81.11, 97.64, 48.2, 29.61, 57.63, 66.24, 32.5, 26.44,
+            52.57, 58.53, 29.38, 65.62, 129.76, 142.05, 70.78, 39.66, 77.94, 84.28, 41.67, 14.46,
+            30.57, 35.25, 18.13, 42.21, 86.93, 96.95, 49.02, 28.51, 57.67, 63., 31.45, 44.76, 88.2,
+            96.12, 47.1, 108.79, 213.31, 229.84, 112.09, 64.86, 126.49, 135.09, 65.55, 51.5,
+            100.22, 106.17, 51.55, 117.67, 228.08, 240.37, 116.23, 66.65, 128.62, 134.95, 64.95
+        ]
+    );
+    assert_eq!(
+        test_utils::to_vec1_round(&grad_ws.flatten_all()?, 2)?,
+        [
+            -61.52, -71.57, -73.56, -76.78, -66.64, -68.88, -55.25, -52.12, -169.91, -118.44,
+            -181.95, -123.65, 35.89, 81.98, 47.28, 98.75, -245.1, -246.36, -97., -101.19, -11.96,
+            -13.22, 112.7, 107.05, 1087.8, 1060.17, 1235.9, 1205.34, 1110.01, 1069.2, 1234.68,
+            1189.47
+        ]
+    );
+    Ok(())
+}
+
+fn conv3d_low_precision_case(dtype: DType, tolerance: f32) -> Result<()> {
+    let dev = &Device::Cpu;
+    let input_shape = (2, 4, 4, 4, 5);
+    let weight_shape = (4, 2, 2, 2, 3);
+    let output_shape = (2, 4, 4, 2, 5);
+    let padding = [1, 0, 1];
+    let stride = [1, 2, 1];
+    let dilation = [2, 1, 1];
+    let groups = 2;
+
+    let xs = (0..(2 * 4 * 4 * 4 * 5))
+        .map(|v| (v % 17) as f32 * 0.015 - 0.12)
+        .collect::<Vec<_>>();
+    let ws = (0..(4 * 2 * 2 * 2 * 3))
+        .map(|v| (v % 13) as f32 * 0.012 - 0.072)
+        .collect::<Vec<_>>();
+    let bias = (0..4).map(|v| v as f32 * 0.01 - 0.015).collect::<Vec<_>>();
+    let grad_output = (0..(2 * 4 * 4 * 2 * 5))
+        .map(|v| (v % 11) as f32 * 0.017 - 0.085)
+        .collect::<Vec<_>>();
+
+    let xs_f32 = Var::from_vec(xs.clone(), input_shape, dev)?;
+    let ws_f32 = Var::from_vec(ws.clone(), weight_shape, dev)?;
+    let bias_f32 = Var::from_vec(bias.clone(), 4, dev)?;
+    let mut out_f32 = xs_f32.conv3d(&ws_f32, padding, stride, dilation, groups)?;
+    out_f32 = out_f32.broadcast_add(&bias_f32.reshape((1, 4, 1, 1, 1))?)?;
+    assert_eq!(out_f32.dims(), [2, 4, 4, 2, 5]);
+    let grad_output_f32 = Tensor::from_vec(grad_output.clone(), output_shape, dev)?;
+    let loss_f32 = out_f32.mul(&grad_output_f32)?.sum_all()?;
+    let grads_f32 = loss_f32.backward()?;
+
+    let xs_lp = var_from_vec_dtype(xs, input_shape, dtype, dev)?;
+    let ws_lp = var_from_vec_dtype(ws, weight_shape, dtype, dev)?;
+    let bias_lp = var_from_vec_dtype(bias, 4, dtype, dev)?;
+    let mut out_lp = xs_lp.conv3d(&ws_lp, padding, stride, dilation, groups)?;
+    out_lp = out_lp.broadcast_add(&bias_lp.reshape((1, 4, 1, 1, 1))?)?;
+    assert_eq!(out_lp.dims(), out_f32.dims());
+    assert_eq!(out_lp.dtype(), dtype);
+    assert_close_tensors(&out_lp, &out_f32, tolerance, "conv3d low precision output")?;
+
+    let grad_output_lp = tensor_from_vec_dtype(grad_output, output_shape, dtype, dev)?;
+    let loss_lp = out_lp.mul(&grad_output_lp)?.sum_all()?;
+    let grads_lp = loss_lp.backward()?;
+    let grad_xs_lp = grads_lp.get(&xs_lp).unwrap();
+    let grad_ws_lp = grads_lp.get(&ws_lp).unwrap();
+    let grad_bias_lp = grads_lp.get(&bias_lp).unwrap();
+    assert_eq!(grad_xs_lp.dtype(), dtype);
+    assert_eq!(grad_ws_lp.dtype(), dtype);
+    assert_eq!(grad_bias_lp.dtype(), dtype);
+    assert_close_tensors(
+        grad_xs_lp,
+        grads_f32.get(&xs_f32).unwrap(),
+        tolerance,
+        "conv3d low precision input grad",
+    )?;
+    assert_close_tensors(
+        grad_ws_lp,
+        grads_f32.get(&ws_f32).unwrap(),
+        tolerance,
+        "conv3d low precision weight grad",
+    )?;
+    assert_close_tensors(
+        grad_bias_lp,
+        grads_f32.get(&bias_f32).unwrap(),
+        tolerance,
+        "conv3d low precision bias grad",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn conv3d_f16_bf16_cpu() -> Result<()> {
+    conv3d_low_precision_case(DType::F16, 2e-2)?;
+    conv3d_low_precision_case(DType::BF16, 1e-1)
+}
+
+#[test]
+fn conv3d_non_contiguous_cpu() -> Result<()> {
+    let dev = &Device::Cpu;
+    let xs = (0..75).map(|v| v as f32 / 10.).collect::<Vec<_>>();
+    let xs = Tensor::from_vec(xs, (1, 1, 3, 5, 5), dev)?;
+    let xs = xs.i((.., .., .., 0..4, ..))?;
+    let ws = Tensor::ones((1, 1, 2, 2, 2), DType::F32, dev)?;
+    let out = xs.conv3d(&ws, [0, 0, 0], [1, 1, 1], [1, 1, 1], 1)?;
+    let out_contiguous = xs
+        .contiguous()?
+        .conv3d(&ws, [0, 0, 0], [1, 1, 1], [1, 1, 1], 1)?;
+    let max_diff = (out - out_contiguous)?
+        .abs()?
+        .flatten_all()?
+        .max(0)?
+        .to_scalar::<f32>()?;
+    assert!(max_diff < 1e-6, "non-contiguous conv3d diff {max_diff}");
+    Ok(())
+}
+
+#[test]
+fn conv3d_invalid_args_cpu() -> Result<()> {
+    let dev = &Device::Cpu;
+    let xs = Tensor::zeros((1, 2, 2, 2, 2), DType::F32, dev)?;
+    let ws = Tensor::zeros((1, 2, 1, 1, 1), DType::F32, dev)?;
+    assert!(xs.conv3d(&ws, [0, 0, 0], [1, 1, 1], [1, 1, 1], 0).is_err());
+    assert!(xs.conv3d(&ws, [0, 0, 0], [0, 1, 1], [1, 1, 1], 1).is_err());
+    assert!(xs.conv3d(&ws, [0, 0, 0], [1, 1, 1], [0, 1, 1], 1).is_err());
+
+    let channel_mismatch = Tensor::zeros((1, 1, 1, 1, 1), DType::F32, dev)?;
+    assert!(xs
+        .conv3d(&channel_mismatch, [0, 0, 0], [1, 1, 1], [1, 1, 1], 1)
+        .is_err());
+
+    let output_channel_mismatch = Tensor::zeros((3, 1, 1, 1, 1), DType::F32, dev)?;
+    assert!(xs
+        .conv3d(&output_channel_mismatch, [0, 0, 0], [1, 1, 1], [1, 1, 1], 2)
+        .is_err());
+
+    let too_large = Tensor::zeros((1, 2, 3, 3, 3), DType::F32, dev)?;
+    assert!(xs
+        .conv3d(&too_large, [0, 0, 0], [1, 1, 1], [1, 1, 1], 1)
+        .is_err());
     Ok(())
 }
 

--- a/candle-nn/src/conv.rs
+++ b/candle-nn/src/conv.rs
@@ -236,6 +236,74 @@ impl crate::Module for Conv2d {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Conv3dConfig {
+    pub padding: [usize; 3],
+    pub stride: [usize; 3],
+    pub dilation: [usize; 3],
+    pub groups: usize,
+}
+
+impl Default for Conv3dConfig {
+    fn default() -> Self {
+        Self {
+            padding: [0; 3],
+            stride: [1; 3],
+            dilation: [1; 3],
+            groups: 1,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Conv3d {
+    weight: Tensor,
+    bias: Option<Tensor>,
+    config: Conv3dConfig,
+}
+
+impl Conv3d {
+    pub fn new(weight: Tensor, bias: Option<Tensor>, config: Conv3dConfig) -> Self {
+        Self {
+            weight,
+            bias,
+            config,
+        }
+    }
+
+    pub fn config(&self) -> &Conv3dConfig {
+        &self.config
+    }
+
+    pub fn weight(&self) -> &Tensor {
+        &self.weight
+    }
+
+    pub fn bias(&self) -> Option<&Tensor> {
+        self.bias.as_ref()
+    }
+}
+
+impl crate::Module for Conv3d {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let x = x.conv3d(
+            &self.weight,
+            self.config.padding,
+            self.config.stride,
+            self.config.dilation,
+            self.config.groups,
+        )?;
+        match &self.bias {
+            None => Ok(x),
+            Some(bias) => {
+                let b = bias.dims1()?;
+                let bias = bias.reshape((1, b, 1, 1, 1))?;
+                Ok(x.broadcast_add(&bias)?)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ConvTranspose2dConfig {
     pub padding: usize,
     pub output_padding: usize,
@@ -429,6 +497,62 @@ pub fn conv2d_no_bias(
         init_ws,
     )?;
     Ok(Conv2d::new(ws, None, cfg))
+}
+
+pub fn conv3d(
+    in_channels: usize,
+    out_channels: usize,
+    kernel_size: [usize; 3],
+    cfg: Conv3dConfig,
+    vb: crate::VarBuilder,
+) -> Result<Conv3d> {
+    if cfg.groups == 0 {
+        candle::bail!("conv3d groups must be non-zero")
+    }
+    let init_ws = crate::init::DEFAULT_KAIMING_NORMAL;
+    let ws = vb.get_with_hints(
+        (
+            out_channels,
+            in_channels / cfg.groups,
+            kernel_size[0],
+            kernel_size[1],
+            kernel_size[2],
+        ),
+        "weight",
+        init_ws,
+    )?;
+    let bound = 1. / (in_channels as f64).sqrt();
+    let init_bs = crate::Init::Uniform {
+        lo: -bound,
+        up: bound,
+    };
+    let bs = vb.get_with_hints(out_channels, "bias", init_bs)?;
+    Ok(Conv3d::new(ws, Some(bs), cfg))
+}
+
+pub fn conv3d_no_bias(
+    in_channels: usize,
+    out_channels: usize,
+    kernel_size: [usize; 3],
+    cfg: Conv3dConfig,
+    vb: crate::VarBuilder,
+) -> Result<Conv3d> {
+    if cfg.groups == 0 {
+        candle::bail!("conv3d groups must be non-zero")
+    }
+    let init_ws = crate::init::DEFAULT_KAIMING_NORMAL;
+    let ws = vb.get_with_hints(
+        (
+            out_channels,
+            in_channels / cfg.groups,
+            kernel_size[0],
+            kernel_size[1],
+            kernel_size[2],
+        ),
+        "weight",
+        init_ws,
+    )?;
+    Ok(Conv3d::new(ws, None, cfg))
 }
 
 pub fn conv_transpose2d(

--- a/candle-nn/src/lib.rs
+++ b/candle-nn/src/lib.rs
@@ -46,9 +46,10 @@ pub mod varlen_attention {
 pub use activation::{prelu, Activation, PReLU};
 pub use batch_norm::{batch_norm, BatchNorm, BatchNormConfig};
 pub use conv::{
-    conv1d, conv1d_no_bias, conv2d, conv2d_no_bias, conv_transpose1d, conv_transpose1d_no_bias,
-    conv_transpose2d, conv_transpose2d_no_bias, Conv1d, Conv1dConfig, Conv2d, Conv2dConfig,
-    ConvTranspose1d, ConvTranspose1dConfig, ConvTranspose2d, ConvTranspose2dConfig,
+    conv1d, conv1d_no_bias, conv2d, conv2d_no_bias, conv3d, conv3d_no_bias, conv_transpose1d,
+    conv_transpose1d_no_bias, conv_transpose2d, conv_transpose2d_no_bias, Conv1d, Conv1dConfig,
+    Conv2d, Conv2dConfig, Conv3d, Conv3dConfig, ConvTranspose1d, ConvTranspose1dConfig,
+    ConvTranspose2d, ConvTranspose2dConfig,
 };
 pub use embedding::{embedding, Embedding};
 pub use func::{func, func_t, Func, FuncT};

--- a/candle-nn/tests/conv.rs
+++ b/candle-nn/tests/conv.rs
@@ -1,0 +1,198 @@
+use anyhow::Result;
+use candle::{test_utils, DType, Device, Module, Tensor, Var};
+use candle_nn::{Conv3d, Conv3dConfig};
+
+fn assert_close_tensors(
+    got: &Tensor,
+    expected: &Tensor,
+    tolerance: f32,
+    label: &str,
+) -> Result<()> {
+    let got = got.to_dtype(DType::F32)?.flatten_all()?.to_vec1::<f32>()?;
+    let expected = expected
+        .to_dtype(DType::F32)?
+        .flatten_all()?
+        .to_vec1::<f32>()?;
+    assert_eq!(
+        got.len(),
+        expected.len(),
+        "{label}: length mismatch, got {}, expected {}",
+        got.len(),
+        expected.len()
+    );
+    let mut max_diff = 0f32;
+    let mut max_idx = 0usize;
+    for (idx, (got, expected)) in got.iter().zip(expected.iter()).enumerate() {
+        let diff = (got - expected).abs();
+        if diff > max_diff {
+            max_diff = diff;
+            max_idx = idx;
+        }
+    }
+    assert!(
+        max_diff <= tolerance,
+        "{label}: max diff {max_diff} at {max_idx}, got {}, expected {}, tolerance {tolerance}",
+        got[max_idx],
+        expected[max_idx]
+    );
+    Ok(())
+}
+
+fn var_from_vec_dtype<S: Into<candle::Shape>>(
+    data: Vec<f32>,
+    shape: S,
+    dtype: DType,
+    dev: &Device,
+) -> Result<Var> {
+    let tensor = Tensor::from_vec(data, shape, dev)?.to_dtype(dtype)?;
+    Ok(Var::from_tensor(&tensor)?)
+}
+
+fn tensor_from_vec_dtype<S: Into<candle::Shape>>(
+    data: Vec<f32>,
+    shape: S,
+    dtype: DType,
+    dev: &Device,
+) -> Result<Tensor> {
+    Ok(Tensor::from_vec(data, shape, dev)?.to_dtype(dtype)?)
+}
+
+/* This test is based on the following script.
+import torch
+torch.set_printoptions(precision=6, sci_mode=False)
+
+x = torch.arange(1 * 1 * 2 * 2 * 3, dtype=torch.float32).reshape(1, 1, 2, 2, 3) / 4 - 1
+w = torch.arange(2 * 1 * 1 * 2 * 2, dtype=torch.float32).reshape(2, 1, 1, 2, 2) / 3 - 0.5
+b = torch.tensor([0.25, -0.75], dtype=torch.float32, requires_grad=True)
+y = torch.nn.functional.conv3d(x, w, b, padding=(0, 1, 0))
+print(y.shape)
+print(y.flatten())
+y.sum().backward()
+print(b.grad)
+*/
+#[test]
+#[allow(clippy::excessive_precision)]
+fn conv3d_module_bias_cpu() -> Result<()> {
+    let dev = &Device::Cpu;
+    let xs = (0..12).map(|v| v as f32 / 4. - 1.).collect::<Vec<_>>();
+    let xs = Var::from_vec(xs, (1, 1, 2, 2, 3), dev)?;
+    let ws = (0..8).map(|v| v as f32 / 3. - 0.5).collect::<Vec<_>>();
+    let ws = Var::from_vec(ws, (2, 1, 1, 2, 2), dev)?;
+    let bias = Var::from_slice(&[0.25f32, -0.75], 2, dev)?;
+    let cfg = Conv3dConfig {
+        padding: [0, 1, 0],
+        ..Default::default()
+    };
+    let conv = Conv3d::new(ws.as_tensor().clone(), Some(bias.as_tensor().clone()), cfg);
+
+    let out = conv.forward(&xs)?;
+    assert_eq!(out.dims(), [1, 2, 2, 3, 2]);
+    assert_eq!(
+        test_utils::to_vec1_round(&out.flatten_all()?, 4)?,
+        [
+            -0.2917, -0.125, 0.8333, 0.8333, 0.375, 0.2083, 0.7083, 0.875, 0.8333, 0.8333, -0.625,
+            -0.7917, -3.625, -2.7917, -2.8333, -1.5, -0.9583, -0.4583, 1.375, 2.2083, 5.1667, 6.5,
+            2.0417, 2.5417
+        ]
+    );
+
+    let grads = out.sum_all()?.backward()?;
+    let bias_grad = grads.get(&bias).unwrap();
+    assert_eq!(
+        test_utils::to_vec1_round(&bias_grad.flatten_all()?, 4)?,
+        [12., 12.]
+    );
+    assert_eq!(grads.get(&xs).unwrap().dtype(), DType::F32);
+    Ok(())
+}
+
+fn conv3d_module_low_precision_case(dtype: DType, tolerance: f32) -> Result<()> {
+    let dev = &Device::Cpu;
+    let input_shape = (1, 2, 3, 4, 4);
+    let weight_shape = (2, 1, 2, 2, 2);
+    let output_shape = (1, 2, 4, 2, 5);
+    let cfg = Conv3dConfig {
+        padding: [1, 0, 1],
+        stride: [1, 2, 1],
+        groups: 2,
+        ..Default::default()
+    };
+
+    let xs = (0..(2 * 3 * 4 * 4))
+        .map(|v| (v % 19) as f32 * 0.014 - 0.126)
+        .collect::<Vec<_>>();
+    let ws = (0..(2 * 2 * 2 * 2))
+        .map(|v| (v % 7) as f32 * 0.016 - 0.048)
+        .collect::<Vec<_>>();
+    let bias = vec![0.02f32, -0.03];
+    let grad_output = (0..(2 * 4 * 2 * 5))
+        .map(|v| (v % 9) as f32 * 0.015 - 0.06)
+        .collect::<Vec<_>>();
+
+    let xs_f32 = Var::from_vec(xs.clone(), input_shape, dev)?;
+    let ws_f32 = Var::from_vec(ws.clone(), weight_shape, dev)?;
+    let bias_f32 = Var::from_vec(bias.clone(), 2, dev)?;
+    let conv_f32 = Conv3d::new(
+        ws_f32.as_tensor().clone(),
+        Some(bias_f32.as_tensor().clone()),
+        cfg,
+    );
+    let out_f32 = conv_f32.forward(&xs_f32)?;
+    assert_eq!(out_f32.dims(), [1, 2, 4, 2, 5]);
+    let grad_output_f32 = Tensor::from_vec(grad_output.clone(), output_shape, dev)?;
+    let loss_f32 = out_f32.mul(&grad_output_f32)?.sum_all()?;
+    let grads_f32 = loss_f32.backward()?;
+
+    let xs_lp = var_from_vec_dtype(xs, input_shape, dtype, dev)?;
+    let ws_lp = var_from_vec_dtype(ws, weight_shape, dtype, dev)?;
+    let bias_lp = var_from_vec_dtype(bias, 2, dtype, dev)?;
+    let conv_lp = Conv3d::new(
+        ws_lp.as_tensor().clone(),
+        Some(bias_lp.as_tensor().clone()),
+        cfg,
+    );
+    let out_lp = conv_lp.forward(&xs_lp)?;
+    assert_eq!(out_lp.dims(), out_f32.dims());
+    assert_eq!(out_lp.dtype(), dtype);
+    assert_close_tensors(
+        &out_lp,
+        &out_f32,
+        tolerance,
+        "conv3d module low precision output",
+    )?;
+
+    let grad_output_lp = tensor_from_vec_dtype(grad_output, output_shape, dtype, dev)?;
+    let loss_lp = out_lp.mul(&grad_output_lp)?.sum_all()?;
+    let grads_lp = loss_lp.backward()?;
+    let grad_xs_lp = grads_lp.get(&xs_lp).unwrap();
+    let grad_ws_lp = grads_lp.get(&ws_lp).unwrap();
+    let grad_bias_lp = grads_lp.get(&bias_lp).unwrap();
+    assert_eq!(grad_xs_lp.dtype(), dtype);
+    assert_eq!(grad_ws_lp.dtype(), dtype);
+    assert_eq!(grad_bias_lp.dtype(), dtype);
+    assert_close_tensors(
+        grad_xs_lp,
+        grads_f32.get(&xs_f32).unwrap(),
+        tolerance,
+        "conv3d module low precision input grad",
+    )?;
+    assert_close_tensors(
+        grad_ws_lp,
+        grads_f32.get(&ws_f32).unwrap(),
+        tolerance,
+        "conv3d module low precision weight grad",
+    )?;
+    assert_close_tensors(
+        grad_bias_lp,
+        grads_f32.get(&bias_f32).unwrap(),
+        tolerance,
+        "conv3d module low precision bias grad",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn conv3d_module_f16_bf16_cpu() -> Result<()> {
+    conv3d_module_low_precision_case(DType::F16, 2e-2)?;
+    conv3d_module_low_precision_case(DType::BF16, 1e-1)
+}


### PR DESCRIPTION
Add a real 5D Conv3d path for Candle instead of relying on the model-specific split-Conv2d workaround used by Qwen3-VL. That workaround only covered the Qwen3-VL temporal-patch case by slicing a depth-2 kernel into two Conv2d calls; it did not provide general Conv3d semantics, arbitrary output depth, bias handling, or a backend Conv3d op. The tensor op uses NCDHW inputs and OI DHW weights, supports per-dimension padding, stride and dilation, and handles grouped convolution. CPU now implements forward plus autograd support for input and weight gradients. candle-nn also gets a Conv3d module; bias is applied with the usual broadcast-add path, so bias gradients come from regular autograd.

The CPU implementation follows the existing Conv2d approach where that makes sense. Forward and weight-gradient use tiled im2col buffers feeding MatMul for f16, f32 and f64, with a 1x1 fast path. bf16 and other dtypes fall back to direct kernels because the generic CPU MatMul path does not support bf16 here. Input-gradient is still direct; optimizing it would need a separate col2im/scatter-add path and is better left for another change.

CUDA and Metal are intentionally left unsupported in this patch. The backend trait has Conv3d hooks, but non-CPU backends return the normal unsupported-op error.
I have access to Nvidia and Apple hardware, so if the maintainers are happy with this MR I can implement CUDA and Metal Conv3d support in a follow-up patch.

Tests cover forward, grouped convolution, gradients, non-contiguous inputs, invalid arguments, and f16/bf16 CPU behavior. The checked-in Rust fixtures follow the existing Conv2d style: each PyTorch reference snippet lives above the Rust test, and the expected values are hard-coded with rounded test_utils assertions.

During development this was also validated with a separate PyTorch comparison harness kept outside this Candle repository, in another repo on my GitHub profile.
https://github.com/SorenDreano/test_conv3d_candle
That harness was used for thorough parity testing: it runs Candle and torch.nn.functional.conv3d on the same deterministic fixtures and compares forward output, input gradient, weight gradient, and bias gradient across a broader set of Conv3d parameter combinations.

Validation run:

- ./test_conv3d_candle/run_conv3d_validation.sh
- cargo test -p candle-core conv3d
- cargo test -p candle-nn conv3d
- cargo fmt --all -- --check
- cargo test -p candle-core
- cargo test -p candle-nn
- cargo clippy -p candle-core -p candle-nn --all-targets -- -D warnings