### PR TITLE
Fix Qwen3-VL multimodal RoPE and prefill attention mask

### DIFF
--- a/candle-transformers/src/models/qwen3_vl/config.rs
+++ b/candle-transformers/src/models/qwen3_vl/config.rs
@@ -43,6 +43,14 @@ pub struct VisionConfig {
     pub deepstack_visual_indexes: Vec<usize>,
 }
 
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct RopeScaling {
+    #[serde(default)]
+    pub mrope_section: Vec<usize>,
+    #[serde(default)]
+    pub rope_type: Option<String>,
+}
+
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct TextConfig {
     pub head_dim: usize,
@@ -58,6 +66,8 @@ pub struct TextConfig {
     pub tie_word_embeddings: bool,
     pub rope_theta: f64,
     pub sliding_window: Option<usize>,
+    #[serde(default)]
+    pub rope_scaling: Option<RopeScaling>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]

--- a/candle-transformers/src/models/qwen3_vl/mod.rs
+++ b/candle-transformers/src/models/qwen3_vl/mod.rs
@@ -11,6 +11,7 @@ mod text;
 mod vision;
 
 pub use config::Config;
+pub use text::{compute_mrope_position_ids, single_token_position_ids, ImageGrid};
 
 use crate::models::deepseek2::NonZeroOp;
 
@@ -53,25 +54,28 @@ impl Qwen3VLModel {
         .to_dtype(dtype)
     }
 
+    /// `position_ids` has shape `(3, batch, seq_len)` and carries the
+    /// temporal/height/width M-RoPE ids. `cache_position` is the number
+    /// of tokens already present in the KV cache.
     #[allow(clippy::too_many_arguments)]
     pub fn forward(
-        &self,
+        &mut self,
         input_ids: &Tensor,
         pixel_values: Option<Tensor>,
         pixel_values_videos: Option<Tensor>,
         image_grid_thw: Option<Tensor>,
         video_grid_thw: Option<Tensor>,
-        seqlens: Vec<usize>,
         continuous_img_pad: Vec<Vec<(usize, usize)>>,
         continuous_vid_pad: Vec<Vec<(usize, usize)>>,
-        seqlen_offsets: &[usize],
+        position_ids: &Tensor,
+        cache_position: usize,
     ) -> Result<Tensor> {
         let (bs, seqlen) = input_ids.dims2()?;
-        let attention_mask = if seqlen <= 1 {
+        let attention_mask = if seqlen > 1 {
             Some(self.prepare_decoder_attention_mask(
                 bs,
                 seqlen,
-                seqlen_offsets[0],
+                cache_position,
                 self.text.dtype,
                 input_ids.device(),
             )?)
@@ -249,22 +253,17 @@ impl Qwen3VLModel {
             _ => (None, None),
         };
 
-        let mut ropeidx_attn_mask_bs = Vec::new();
-        let max_seqlens = *seqlens.iter().max().unwrap();
-        for len in &seqlens {
-            ropeidx_attn_mask_bs.push(Tensor::new(
-                [vec![1f32; *len], vec![0f32; max_seqlens - len]].concat(),
-                input_ids.device(),
-            )?);
-        }
-
         let out = self.text.forward_embeds(
             input_embeds,
             attention_mask.as_ref(),
-            seqlen_offsets,
+            position_ids,
             visual_pos_masks.as_ref(),
             deepstack_visual_embeds.as_deref(),
         )?;
         Ok(out)
+    }
+
+    pub fn clear_kv_cache(&mut self) {
+        self.text.clear_kv_cache();
     }
 }

--- a/candle-transformers/src/models/qwen3_vl/text.rs
+++ b/candle-transformers/src/models/qwen3_vl/text.rs
@@ -1,8 +1,8 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use candle::{DType, Device, IndexOp, Result, Tensor};
+use candle::{DType, Device, IndexOp, Result, Tensor, D};
 use candle_nn::{
-    embedding, kv_cache::KvCache, linear, linear_b, rms_norm, Activation, Embedding, Linear,
+    embedding, kv_cache::ConcatKvCache, linear, linear_b, rms_norm, Activation, Embedding, Linear,
     Module, RmsNorm, VarBuilder,
 };
 
@@ -12,6 +12,8 @@ use super::config::TextConfig;
 pub struct RotaryEmbedding {
     cos: Tensor,
     sin: Tensor,
+    mrope_section: Option<[usize; 3]>,
+    head_dim: usize,
 }
 
 impl RotaryEmbedding {
@@ -19,9 +21,34 @@ impl RotaryEmbedding {
         base: f32,
         head_dim: usize,
         max_position_embeddings: usize,
+        mrope_section: Vec<usize>,
         device: &Device,
         dtype: DType,
     ) -> Result<Self> {
+        let mrope_section = match mrope_section.as_slice() {
+            [] => None,
+            [t, h, w] => {
+                let expected = head_dim / 2;
+                let Some(sum) = t.checked_add(*h).and_then(|sum| sum.checked_add(*w)) else {
+                    candle::bail!("mrope_section {:?} overflows usize", mrope_section);
+                };
+                if sum != expected {
+                    candle::bail!(
+                        "mrope_section {:?} sums to {} but head_dim / 2 = {}",
+                        mrope_section,
+                        sum,
+                        expected
+                    );
+                }
+                Some([*t, *h, *w])
+            }
+            _ => {
+                candle::bail!(
+                    "mrope_section must be empty or have 3 entries, got {}",
+                    mrope_section.len()
+                )
+            }
+        };
         let inv_freq: Vec<_> = (0..head_dim)
             .step_by(2)
             .map(|i| 1f32 / base.powf(i as f32 / head_dim as f32))
@@ -35,31 +62,111 @@ impl RotaryEmbedding {
         let sin = freqs.sin()?.to_dtype(dtype)?;
         let cos = freqs.cos()?.to_dtype(dtype)?;
 
-        Ok(Self { cos, sin })
+        Ok(Self {
+            cos,
+            sin,
+            mrope_section,
+            head_dim,
+        })
     }
 
     pub fn forward(
         &self,
         q: &Tensor,
         k: &Tensor,
-        seqlen_offsets: &[usize],
+        position_ids: &Tensor,
     ) -> Result<(Tensor, Tensor)> {
-        let (_b_sz, _qh, seq_len, _n_embd) = q.dims4()?;
-
-        let rope = candle_nn::rotary_emb::rope;
-
-        let mut q_embeds = Vec::new();
-        let mut k_embeds = Vec::new();
-        for (i, offset) in seqlen_offsets.iter().enumerate() {
-            let cos = self.cos.narrow(0, *offset, seq_len)?;
-            let sin = self.sin.narrow(0, *offset, seq_len)?;
-            let q_embed = rope(&q.i(i)?.unsqueeze(0)?.contiguous()?, &cos, &sin)?;
-            let k_embed = rope(&k.i(i)?.unsqueeze(0)?.contiguous()?, &cos, &sin)?;
-            q_embeds.push(q_embed);
-            k_embeds.push(k_embed);
-        }
-        Ok((Tensor::cat(&q_embeds, 0)?, Tensor::cat(&k_embeds, 0)?))
+        let (cos, sin) = self.build_cos_sin(position_ids)?;
+        let cos = cos.unsqueeze(1)?;
+        let sin = sin.unsqueeze(1)?;
+        let q_embed = apply_rotation(q, &cos, &sin)?;
+        let k_embed = apply_rotation(k, &cos, &sin)?;
+        Ok((q_embed, k_embed))
     }
+
+    fn build_cos_sin(&self, position_ids: &Tensor) -> Result<(Tensor, Tensor)> {
+        let (three, batch, seq_len) = position_ids.dims3()?;
+        if three != 3 {
+            candle::bail!("position_ids axis 0 must be 3, got {three}");
+        }
+        let half_dim = self.head_dim / 2;
+        let Some(mrope_section) = self.mrope_section else {
+            let pos = position_ids.i(0)?.flatten_all()?;
+            let cos = self
+                .cos
+                .index_select(&pos, 0)?
+                .reshape((batch, seq_len, half_dim))?;
+            let sin = self
+                .sin
+                .index_select(&pos, 0)?
+                .reshape((batch, seq_len, half_dim))?;
+            let cos = Tensor::cat(&[&cos, &cos], D::Minus1)?;
+            let sin = Tensor::cat(&[&sin, &sin], D::Minus1)?;
+            return Ok((cos, sin));
+        };
+        let cos_per_axis = self.gather_axis(position_ids, batch, seq_len, &self.cos)?;
+        let sin_per_axis = self.gather_axis(position_ids, batch, seq_len, &self.sin)?;
+        let cos = apply_interleaved_mrope(&cos_per_axis, mrope_section, half_dim)?;
+        let sin = apply_interleaved_mrope(&sin_per_axis, mrope_section, half_dim)?;
+        let cos = Tensor::cat(&[&cos, &cos], D::Minus1)?;
+        let sin = Tensor::cat(&[&sin, &sin], D::Minus1)?;
+        Ok((cos, sin))
+    }
+
+    fn gather_axis(
+        &self,
+        position_ids: &Tensor,
+        batch: usize,
+        seq_len: usize,
+        table: &Tensor,
+    ) -> Result<[Tensor; 3]> {
+        let half_dim = self.head_dim / 2;
+        let gather = |axis: usize| -> Result<Tensor> {
+            let pos = position_ids.i(axis)?.flatten_all()?;
+            table
+                .index_select(&pos, 0)?
+                .reshape((batch, seq_len, half_dim))
+        };
+        Ok([gather(0)?, gather(1)?, gather(2)?])
+    }
+}
+
+fn apply_interleaved_mrope(
+    per_axis: &[Tensor; 3],
+    mrope_section: [usize; 3],
+    half_dim: usize,
+) -> Result<Tensor> {
+    let mut axis_for: Vec<usize> = vec![0usize; half_dim];
+    for (dim, offset) in [(1usize, 1usize), (2usize, 2usize)] {
+        let length = mrope_section[dim].saturating_mul(3);
+        let mut idx = offset;
+        while idx < length && idx < half_dim {
+            axis_for[idx] = dim;
+            idx += 3;
+        }
+    }
+    let mut bands: Vec<Tensor> = Vec::new();
+    let mut run_start = 0usize;
+    while run_start < half_dim {
+        let current_axis = axis_for[run_start];
+        let mut run_end = run_start + 1;
+        while run_end < half_dim && axis_for[run_end] == current_axis {
+            run_end += 1;
+        }
+        bands.push(per_axis[current_axis].narrow(D::Minus1, run_start, run_end - run_start)?);
+        run_start = run_end;
+    }
+    Tensor::cat(&bands, D::Minus1)
+}
+
+fn apply_rotation(x: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
+    let x = x.contiguous()?;
+    let head_dim = x.dim(D::Minus1)?;
+    let half = head_dim / 2;
+    let x1 = x.narrow(D::Minus1, 0, half)?;
+    let x2 = x.narrow(D::Minus1, half, half)?;
+    let rotated = Tensor::cat(&[&x2.neg()?, &x1], D::Minus1)?;
+    x.broadcast_mul(cos)? + rotated.broadcast_mul(sin)?
 }
 
 struct Mlp {
@@ -100,11 +207,11 @@ struct Attention {
     k_norm: RmsNorm,
     num_heads: usize,
     num_kv_heads: usize,
+    num_kv_groups: usize,
     head_dim: usize,
     rotary_emb: Arc<RotaryEmbedding>,
-    n_kv_groups: usize,
     softmax_scale: f64,
-    kv_cache: Arc<Mutex<KvCache>>,
+    kv_cache: ConcatKvCache,
 }
 
 impl Attention {
@@ -137,68 +244,63 @@ impl Attention {
             k_norm,
             num_heads,
             num_kv_heads,
+            num_kv_groups: num_heads / num_kv_heads,
             head_dim: cfg.head_dim,
             rotary_emb,
-            n_kv_groups: cfg.num_attention_heads / cfg.num_key_value_heads,
             softmax_scale: 1.0 / (cfg.head_dim as f64).sqrt(),
-            kv_cache: Arc::new(Mutex::new(KvCache::new(2, cfg.max_position_embeddings))),
+            kv_cache: ConcatKvCache::new(2),
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn forward(
-        &self,
+        &mut self,
         xs: &Tensor,
         attention_mask: Option<&Tensor>,
-        seqlen_offsets: &[usize],
+        position_ids: &Tensor,
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
-        let mut q = self.q_proj.forward(xs)?;
-        let mut k = self.k_proj.forward(xs)?;
-        let mut v = self.v_proj.forward(xs)?;
+        let q = self.q_proj.forward(xs)?;
+        let k = self.k_proj.forward(xs)?;
+        let v = self.v_proj.forward(xs)?;
 
-        q = q
+        let q = q
             .reshape((b_sz, q_len, self.num_heads, self.head_dim))?
             .transpose(1, 2)?;
-        k = k
+        let k = k
             .reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?
             .transpose(1, 2)?;
-        v = v
+        let v = v
             .reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?
             .transpose(1, 2)?;
 
-        q = q.apply(&self.q_norm)?;
-        k = k.apply(&self.k_norm)?;
+        let q = q.apply(&self.q_norm)?;
+        let k = k.apply(&self.k_norm)?;
 
-        (q, k) = self.rotary_emb.forward(&q, &k, seqlen_offsets)?;
-
+        let (q, k) = self.rotary_emb.forward(&q, &k, position_ids)?;
         let q = q.contiguous()?;
         let k = k.contiguous()?;
         let v = v.contiguous()?;
 
-        let (k, v) = self
-            .kv_cache
-            .lock()
-            .expect("Need a lock because of the deepstack injection")
-            .append(&k, &v)?;
+        let (k, v) = self.kv_cache.append(&k, &v)?;
+        let k = crate::utils::repeat_kv(k, self.num_kv_groups)?.contiguous()?;
+        let v = crate::utils::repeat_kv(v, self.num_kv_groups)?.contiguous()?;
 
-        let k = crate::utils::repeat_kv(k, self.n_kv_groups)?.contiguous()?;
-        let v = crate::utils::repeat_kv(v, self.n_kv_groups)?.contiguous()?;
-
-        let mut attn_output = {
-            let attn_weights = (q.matmul(&k.transpose(2, 3)?)? * self.softmax_scale)?;
-
-            let attn_weights = match attention_mask {
-                None => attn_weights,
-                Some(mask) => attn_weights.broadcast_add(mask)?,
-            };
-            let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
-            attn_weights.matmul(&v)?
+        let attn_weights = (q.matmul(&k.transpose(2, 3)?)? * self.softmax_scale)?;
+        let attn_weights = match attention_mask {
+            None => attn_weights,
+            Some(mask) => attn_weights.broadcast_add(mask)?,
         };
-
-        attn_output = attn_output.transpose(1, 2)?.reshape((b_sz, q_len, ()))?;
+        let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
+        let attn_output = attn_weights
+            .matmul(&v)?
+            .transpose(1, 2)?
+            .reshape((b_sz, q_len, ()))?;
 
         self.o_proj.forward(&attn_output)
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.kv_cache.reset();
     }
 }
 
@@ -228,24 +330,25 @@ impl DecoderLayer {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn forward(
-        &self,
+        &mut self,
         xs: &Tensor,
         attention_mask: Option<&Tensor>,
-        seqlen_offsets: &[usize],
+        position_ids: &Tensor,
     ) -> Result<Tensor> {
         let residual = xs;
         let xs = self.input_layernorm.forward(xs)?;
-        let xs = self
-            .self_attn
-            .forward(&xs, attention_mask, seqlen_offsets)?;
+        let xs = self.self_attn.forward(&xs, attention_mask, position_ids)?;
         let xs = (xs + residual)?;
         let residual = &xs;
         let xs = self
             .mlp
             .forward(&xs.apply(&self.post_attention_layernorm)?)?;
         residual + xs
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.self_attn.clear_kv_cache();
     }
 }
 
@@ -264,10 +367,16 @@ impl Qwen3VLTextModel {
 
         let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, vb_m.pp("embed_tokens"))?;
 
+        let mrope_section = cfg
+            .rope_scaling
+            .as_ref()
+            .map(|rs| rs.mrope_section.clone())
+            .unwrap_or_default();
         let rotary_emb = Arc::new(RotaryEmbedding::new(
             cfg.rope_theta as f32,
             cfg.head_dim,
             cfg.max_position_embeddings,
+            mrope_section,
             vb.device(),
             vb_m.dtype(),
         )?);
@@ -301,31 +410,30 @@ impl Qwen3VLTextModel {
     }
 
     pub fn forward_embeds(
-        &self,
+        &mut self,
         mut xs: Tensor,
         attention_mask: Option<&Tensor>,
-        seqlen_offsets: &[usize],
+        position_ids: &Tensor,
         visual_pos_masks: Option<&Tensor>,
         deepstack_visual_embeds: Option<&[Tensor]>,
     ) -> Result<Tensor> {
         let (_, seq_len, _) = xs.dims3()?;
 
-        for (i, layer) in self.layers.iter().enumerate() {
+        for (i, layer) in self.layers.iter_mut().enumerate() {
             xs = layer.forward(
                 &xs,
                 attention_mask
                     .as_ref()
                     .map(|m| m.to_device(xs.device()).unwrap())
                     .as_ref(),
-                seqlen_offsets,
+                position_ids,
             )?;
 
-            // Integrate DeepStack visual features when provided.
             if let (Some(visual_pos_masks), Some(deepstack)) =
                 (visual_pos_masks, deepstack_visual_embeds)
             {
                 if i < deepstack.len() {
-                    xs = self.deepstack_process(xs, visual_pos_masks, &deepstack[i])?;
+                    xs = Self::deepstack_process(xs, visual_pos_masks, &deepstack[i])?;
                 }
             }
         }
@@ -339,7 +447,6 @@ impl Qwen3VLTextModel {
     }
 
     fn deepstack_process(
-        &self,
         hidden_states: Tensor,
         visual_pos_masks: &Tensor,
         visual_embeds: &Tensor,
@@ -391,5 +498,362 @@ impl Qwen3VLTextModel {
 
         hidden_flat = hidden_flat.scatter_add(&linear_index, &visual_embeds, 0)?;
         hidden_flat.reshape((batch, seq, hidden))
+    }
+
+    pub fn clear_kv_cache(&mut self) {
+        for layer in self.layers.iter_mut() {
+            layer.clear_kv_cache();
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ImageGrid {
+    pub grid_h: usize,
+    pub grid_w: usize,
+}
+
+fn position_id(pos: usize) -> Result<u32> {
+    if pos > u32::MAX as usize {
+        candle::bail!("position id {pos} exceeds u32::MAX");
+    }
+    Ok(pos as u32)
+}
+
+fn offset_position_id(base: usize, offset: usize) -> Result<u32> {
+    let Some(pos) = base.checked_add(offset) else {
+        candle::bail!("position id overflow");
+    };
+    position_id(pos)
+}
+
+/// Build 3D M-RoPE position IDs for a prefill that may contain text
+/// and image tokens. Returns a `(3, batch, seq_len)` U32 tensor and
+/// the highest position used in each batch row (decode for row `b`
+/// should resume at `max_positions[b] + 1`).
+///
+/// `image_pad_spans[b]` lists `(start, end_exclusive)` ranges holding
+/// image-pad placeholders in batch `b`, in order. `image_grids[b][k]`
+/// is the grid for the k-th image in batch `b`; `grid_h * grid_w`
+/// must equal the matching span length.
+pub fn compute_mrope_position_ids(
+    batch: usize,
+    seq_len: usize,
+    image_pad_spans: &[Vec<(usize, usize)>],
+    image_grids: &[Vec<ImageGrid>],
+    device: &Device,
+) -> Result<(Tensor, Vec<usize>)> {
+    if image_pad_spans.len() != batch {
+        candle::bail!(
+            "image_pad_spans has {} entries but batch is {batch}",
+            image_pad_spans.len()
+        );
+    }
+    if image_grids.len() != batch {
+        candle::bail!(
+            "image_grids has {} entries but batch is {batch}",
+            image_grids.len()
+        );
+    }
+    let mut pos_t = vec![0u32; batch * seq_len];
+    let mut pos_h = vec![0u32; batch * seq_len];
+    let mut pos_w = vec![0u32; batch * seq_len];
+    let mut max_per_batch: Vec<usize> = vec![0; batch];
+    for (b, spans) in image_pad_spans.iter().enumerate() {
+        let grids = &image_grids[b];
+        if spans.len() != grids.len() {
+            candle::bail!(
+                "batch {b} has {} image spans but {} grids",
+                spans.len(),
+                grids.len()
+            );
+        }
+        let mut prev_end = 0usize;
+        for (span_idx, (&(span_start, span_end), &grid)) in
+            spans.iter().zip(grids.iter()).enumerate()
+        {
+            if span_start >= span_end {
+                candle::bail!(
+                    "batch {b} span {span_idx} has invalid range {:?}",
+                    (span_start, span_end)
+                );
+            }
+            if span_end > seq_len {
+                candle::bail!(
+                    "batch {b} span {span_idx} ends at {span_end} but seq_len is {seq_len}"
+                );
+            }
+            if span_start < prev_end {
+                candle::bail!(
+                    "batch {b} spans must be sorted and non-overlapping; \
+                     span {} ends at {prev_end} but span {span_idx} starts at {span_start}",
+                    span_idx - 1,
+                );
+            }
+            if grid.grid_h == 0 || grid.grid_w == 0 {
+                candle::bail!(
+                    "batch {b} grid {span_idx} has invalid shape {}x{}",
+                    grid.grid_h,
+                    grid.grid_w
+                );
+            }
+            let Some(expected_len) = grid.grid_h.checked_mul(grid.grid_w) else {
+                candle::bail!(
+                    "batch {b} grid {span_idx} shape {}x{} overflows",
+                    grid.grid_h,
+                    grid.grid_w
+                );
+            };
+            let span_len = span_end - span_start;
+            if span_len != expected_len {
+                candle::bail!(
+                    "batch {b} span {:?} length {span_len} does not match grid {}x{} = {expected_len}",
+                    (span_start, span_end),
+                    grid.grid_h,
+                    grid.grid_w,
+                );
+            }
+            prev_end = span_end;
+        }
+        let row_start = b * seq_len;
+        let mut counter: usize = 0;
+        let mut span_iter = spans.iter().enumerate().peekable();
+        let mut s = 0usize;
+        while s < seq_len {
+            if let Some(&(grid_idx, &(span_start, span_end))) = span_iter.peek() {
+                if s == span_start {
+                    let grid = grids[grid_idx];
+                    let span_len = span_end - span_start;
+                    let offset = position_id(counter)?;
+                    for vision_idx in 0..span_len {
+                        let token_idx = row_start + span_start + vision_idx;
+                        let h_pos = offset_position_id(counter, vision_idx / grid.grid_w)?;
+                        let w_pos = offset_position_id(counter, vision_idx % grid.grid_w)?;
+                        pos_t[token_idx] = offset;
+                        pos_h[token_idx] = h_pos;
+                        pos_w[token_idx] = w_pos;
+                    }
+                    let span_max = grid.grid_h.max(grid.grid_w);
+                    let Some(next_counter) = counter.checked_add(span_max) else {
+                        candle::bail!("batch {b} position counter overflow");
+                    };
+                    counter = next_counter;
+                    max_per_batch[b] = max_per_batch[b].max(counter.saturating_sub(1));
+                    s = span_end;
+                    span_iter.next();
+                    continue;
+                }
+            }
+            let token_idx = row_start + s;
+            let c = position_id(counter)?;
+            pos_t[token_idx] = c;
+            pos_h[token_idx] = c;
+            pos_w[token_idx] = c;
+            max_per_batch[b] = max_per_batch[b].max(counter);
+            let Some(next_counter) = counter.checked_add(1) else {
+                candle::bail!("batch {b} position counter overflow");
+            };
+            counter = next_counter;
+            s += 1;
+        }
+    }
+    let to_tensor =
+        |v: Vec<u32>| -> Result<Tensor> { Tensor::from_vec(v, (batch, seq_len), device) };
+    let pos = Tensor::stack(
+        &[to_tensor(pos_t)?, to_tensor(pos_h)?, to_tensor(pos_w)?],
+        0,
+    )?;
+    Ok((pos, max_per_batch))
+}
+
+/// Build a `(3, batch, 1)` U32 position-id tensor where each batch
+/// row carries `t = h = w = positions[b]`. For incremental decode,
+/// pass `positions[b] = previous_max + 1`.
+pub fn single_token_position_ids(positions: &[usize], device: &Device) -> Result<Tensor> {
+    if positions.is_empty() {
+        candle::bail!("single_token_position_ids needs at least one batch row");
+    }
+    let batch = positions.len();
+    let values: Vec<u32> = positions
+        .iter()
+        .map(|&p| position_id(p))
+        .collect::<Result<_>>()?;
+    let t = Tensor::from_vec(values.clone(), (batch, 1), device)?;
+    let h = Tensor::from_vec(values.clone(), (batch, 1), device)?;
+    let w = Tensor::from_vec(values, (batch, 1), device)?;
+    Tensor::stack(&[t, h, w], 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mrope_position_ids_pure_text() -> Result<()> {
+        let device = Device::Cpu;
+        let (ids, max_per_batch) =
+            compute_mrope_position_ids(1, 5, &[Vec::new()], &[Vec::new()], &device)?;
+        assert_eq!(ids.dims(), &[3, 1, 5]);
+        assert_eq!(max_per_batch, vec![4]);
+        for axis in 0..3 {
+            let row: Vec<u32> = ids.i(axis)?.i(0)?.to_vec1()?;
+            assert_eq!(row, vec![0, 1, 2, 3, 4], "axis {axis}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn mrope_position_ids_image_in_middle() -> Result<()> {
+        let device = Device::Cpu;
+        let grid = ImageGrid {
+            grid_h: 2,
+            grid_w: 3,
+        };
+        let (ids, max_per_batch) =
+            compute_mrope_position_ids(1, 9, &[vec![(2, 8)]], &[vec![grid]], &device)?;
+        assert_eq!(ids.dims(), &[3, 1, 9]);
+        let t: Vec<u32> = ids.i(0)?.i(0)?.to_vec1()?;
+        let h: Vec<u32> = ids.i(1)?.i(0)?.to_vec1()?;
+        let w: Vec<u32> = ids.i(2)?.i(0)?.to_vec1()?;
+        assert_eq!(&t[..2], &[0, 1]);
+        assert_eq!(&h[..2], &[0, 1]);
+        assert_eq!(&w[..2], &[0, 1]);
+        assert_eq!(&t[2..8], &[2, 2, 2, 2, 2, 2]);
+        assert_eq!(&h[2..8], &[2, 2, 2, 3, 3, 3]);
+        assert_eq!(&w[2..8], &[2, 3, 4, 2, 3, 4]);
+        assert_eq!(t[8], 5);
+        assert_eq!(h[8], 5);
+        assert_eq!(w[8], 5);
+        assert_eq!(max_per_batch, vec![5]);
+        Ok(())
+    }
+
+    #[test]
+    fn mrope_position_ids_per_batch_layouts_independent() -> Result<()> {
+        let device = Device::Cpu;
+        let grid_a = ImageGrid {
+            grid_h: 1,
+            grid_w: 2,
+        };
+        let grid_b = ImageGrid {
+            grid_h: 2,
+            grid_w: 2,
+        };
+        let (ids, max_per_batch) = compute_mrope_position_ids(
+            2,
+            5,
+            &[vec![(1, 3)], vec![(0, 4)]],
+            &[vec![grid_a], vec![grid_b]],
+            &device,
+        )?;
+        assert_eq!(ids.dims(), &[3, 2, 5]);
+        assert_eq!(max_per_batch, vec![4, 2]);
+        Ok(())
+    }
+
+    #[test]
+    fn mrope_position_ids_span_length_mismatch_errs() {
+        let device = Device::Cpu;
+        let grid = ImageGrid {
+            grid_h: 2,
+            grid_w: 3,
+        };
+        let result = compute_mrope_position_ids(1, 4, &[vec![(0, 4)]], &[vec![grid]], &device);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn mrope_position_ids_rejects_malformed_spans() {
+        let device = Device::Cpu;
+        let grid = ImageGrid {
+            grid_h: 1,
+            grid_w: 2,
+        };
+
+        let reversed = compute_mrope_position_ids(1, 5, &[vec![(3, 2)]], &[vec![grid]], &device);
+        assert!(reversed.is_err());
+
+        let out_of_bounds =
+            compute_mrope_position_ids(1, 5, &[vec![(3, 6)]], &[vec![grid]], &device);
+        assert!(out_of_bounds.is_err());
+
+        let overlapping =
+            compute_mrope_position_ids(1, 5, &[vec![(1, 3), (2, 4)]], &[vec![grid, grid]], &device);
+        assert!(overlapping.is_err());
+    }
+
+    #[test]
+    fn mrope_position_ids_rejects_empty_grid() {
+        let device = Device::Cpu;
+        let grid = ImageGrid {
+            grid_h: 0,
+            grid_w: 2,
+        };
+        let result = compute_mrope_position_ids(1, 2, &[vec![(0, 2)]], &[vec![grid]], &device);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn single_token_position_ids_per_batch() -> Result<()> {
+        let device = Device::Cpu;
+        let ids = single_token_position_ids(&[7, 11], &device)?;
+        assert_eq!(ids.dims(), &[3, 2, 1]);
+        for axis in 0..3 {
+            assert_eq!(ids.i(axis)?.i(0)?.i(0)?.to_scalar::<u32>()?, 7);
+            assert_eq!(ids.i(axis)?.i(1)?.i(0)?.to_scalar::<u32>()?, 11);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn rope_table_construction_matches_legacy_for_1d_mode() -> Result<()> {
+        let device = Device::Cpu;
+        let rope = RotaryEmbedding::new(10_000f32, 64, 32, Vec::new(), &device, DType::F32)?;
+        let legacy_cos = rope.cos.narrow(0, 7, 1)?;
+        let pos = Tensor::from_vec(vec![7u32; 3], (3, 1, 1), &device)?;
+        let (cos, _sin) = rope.build_cos_sin(&pos)?;
+        let cos_half = cos.narrow(D::Minus1, 0, 32)?.squeeze(0)?.squeeze(0)?;
+        let cos_half_vec: Vec<f32> = cos_half.to_vec1()?;
+        let legacy_vec: Vec<f32> = legacy_cos.squeeze(0)?.to_vec1()?;
+        assert_eq!(cos_half_vec, legacy_vec);
+        Ok(())
+    }
+
+    #[test]
+    fn interleaved_mrope_axis_pattern_matches_reference() -> Result<()> {
+        let device = Device::Cpu;
+        let head_dim_half = 16usize;
+        let make = |base: f32| -> Result<Tensor> {
+            let v: Vec<f32> = (0..head_dim_half).map(|i| base + i as f32).collect();
+            Tensor::from_vec(v, (1usize, 1, head_dim_half), &device)
+        };
+        let per_axis = [make(100.0)?, make(200.0)?, make(300.0)?];
+        let section = [8usize, 4, 4];
+        let out = apply_interleaved_mrope(&per_axis, section, head_dim_half)?;
+        let row: Vec<f32> = out.i(0)?.i(0)?.to_vec1()?;
+        let expected: Vec<f32> = vec![
+            100.0, 201.0, 302.0, 103.0, 204.0, 305.0, 106.0, 207.0, 308.0, 109.0, 210.0, 311.0,
+            112.0, 113.0, 114.0, 115.0,
+        ];
+        assert_eq!(row, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn interleaved_mrope_equals_1d_when_all_axes_equal() -> Result<()> {
+        let device = Device::Cpu;
+        let mrope_section = vec![24usize, 20, 20];
+        let head_dim = 128usize;
+        let rope =
+            RotaryEmbedding::new(10_000f32, head_dim, 64, mrope_section, &device, DType::F32)?;
+        let rope_1d =
+            RotaryEmbedding::new(10_000f32, head_dim, 64, Vec::new(), &device, DType::F32)?;
+        let pos = Tensor::from_vec(vec![5u32, 5u32, 5u32], (3, 1, 1), &device)?;
+        let (cos_mrope, _) = rope.build_cos_sin(&pos)?;
+        let (cos_1d, _) = rope_1d.build_cos_sin(&pos)?;
+        let mrope_vec: Vec<f32> = cos_mrope.squeeze(0)?.squeeze(0)?.to_vec1()?;
+        let one_d_vec: Vec<f32> = cos_1d.squeeze(0)?.squeeze(0)?.to_vec1()?;
+        assert_eq!(mrope_vec, one_d_vec);
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

This is an AI-assisted PR. It was created to resolve a candle issue in a personal project which does its inferencing with a 100% pure Rust stack. Errors were encountered when trying to get results with a Qwen3-VL, which generated looping gibberish. This PR creates production quality output with Qwen3-VL models.

Two bugs in the `qwen3_vl` model (#3145) that together broke image-conditioned generation:

1. **M-RoPE was a no-op.** The published Qwen3-VL configs set `rope_scaling.mrope_interleaved=true` with a `[T, H, W]` section summing to `head_dim / 2`. The previous `RotaryEmbedding` ignored that block and ran a single 1D counter over the whole sequence, so vision tokens carried no row/column/temporal distinction. The model generated fluent text uncorrelated with the image. `RotaryEmbedding` now matches HF `Qwen3VLTextRotaryEmbedding.apply_interleaved_mrope`; an empty section preserves the 1D path byte-for-byte.

2. **Prefill mask was inverted.** `Qwen3VLModel::forward` built the causal mask when `seq_len == 1` and skipped it otherwise, mirror of what's needed. Sibling `qwen2.rs` has the correct condition. With M-RoPE wired up but the mask still inverted the model emitted `<|im_end|>` as its first token after prefill.

- [HF `Qwen3VLTextRotaryEmbedding` M-RoPE implementation](https://github.com/huggingface/transformers/blob/a0fb01c6cda2301cb54de0efde5fac405836c4fe/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py#L303-L392)
- [HF `get_vision_position_ids` / `get_rope_index` position layout](https://github.com/huggingface/transformers/blob/a0fb01c6cda2301cb54de0efde5fac405836c4fe/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py#L892-L1041)
- [`qwen2.rs` causal mask condition](candle-transformers/src/models/qwen2.rs#L347-L354)


## API change

`Qwen3VLModel::forward`'s `seqlen_offsets: &[usize]` is replaced with `position_ids: &Tensor` (shape `(3, batch, seq_len)`, U32) and `cache_position: usize`. The two can't be collapsed: M-RoPE advances positions by `max(grid_h, grid_w)` across an image span while the KV cache grows by the placeholder count. Helpers `compute_mrope_position_ids` and `single_token_position_ids` plus an `ImageGrid` type are exported so callers don't have to reconstruct the layout.

Also switches the per-layer KV cache to `ConcatKvCache` to match `qwen3.rs`, and adds `clear_kv_cache` in the spirit of #3536.

## Tests ran

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --tests --examples --benches -- -D warnings`
- [x] `cargo test -p candle-transformers qwen3_vl` — 10 cases covering 1D parity, the `[THWTHW...T]` index pattern, all-axes-equal invariance, per-batch position layouts, and span/grid error surfacing
- [x] Manual: loaded `Qwen/Qwen3-VL-4B-Instruct` and confirmed image-conditioned output now tracks the image content