### PR TITLE
candle-nn: add LinearTernary — ternary-quantized linear layer {-1, 0, +1}

### DIFF
--- a/candle-nn/src/lib.rs
+++ b/candle-nn/src/lib.rs
@@ -57,7 +57,7 @@ pub use init::Init;
 pub use layer_norm::{
     layer_norm, layer_norm_no_bias, rms_norm, LayerNorm, LayerNormConfig, RmsNorm,
 };
-pub use linear::{linear, linear_b, linear_no_bias, Linear};
+pub use linear::{linear, linear_b, linear_no_bias, Linear, LinearTernary};
 pub use ops::Dropout;
 pub use optim::{AdamW, Optimizer, ParamsAdamW, SGD};
 pub use rnn::{gru, lstm, GRUConfig, LSTMConfig, GRU, LSTM, RNN};

--- a/candle-nn/src/linear.rs
+++ b/candle-nn/src/linear.rs
@@ -78,6 +78,105 @@ impl super::Module for Linear {
     }
 }
 
+/// Linear layer with weights quantized to {-1, 0, +1} (ternary).
+///
+/// Weights are quantized at construction: values whose absolute value exceeds
+/// `threshold` become ±1; the rest become 0. This matches the BitNet b1.58
+/// scheme (arxiv.org/abs/2402.17764, §3.1). The quantized weights are stored
+/// as `f32` and the forward pass is identical to [`Linear`] — no special
+/// backend required.
+///
+/// ```rust
+/// use candle::{Tensor, Device::Cpu, DType};
+/// use candle_nn::LinearTernary;
+/// # fn main() -> candle::Result<()> {
+///
+/// let w = Tensor::new(&[[2.0f32, -3.0], [0.1, 1.5]], &Cpu)?;
+/// // threshold = mean(|w|) ≈ 1.65 → |2.0| > 1.65 → +1, |-3.0| > 1.65 → -1, |0.1| < 1.65 → 0, |1.5| < 1.65 → 0
+/// let layer = LinearTernary::from_tensor(w, None, None)?;
+/// let xs = Tensor::new(&[[1.0f32, 1.0]], &Cpu)?;
+/// let ys = layer.forward(&xs)?;
+/// # Ok(()) }
+/// ```
+#[derive(Clone, Debug)]
+pub struct LinearTernary {
+    weight: Tensor,
+    bias: Option<Tensor>,
+}
+
+impl LinearTernary {
+    /// Quantize `weight` to {-1, 0, +1} using `threshold`.
+    ///
+    /// If `threshold` is `None`, the mean absolute value of the weights is used
+    /// (the BitNet b1.58 prescription). The quantized weights are stored as `f32`.
+    pub fn from_tensor(
+        weight: Tensor,
+        bias: Option<Tensor>,
+        threshold: Option<f64>,
+    ) -> Result<Self> {
+        let t = match threshold {
+            Some(v) => v,
+            None => weight.abs()?.mean_all()?.to_scalar::<f32>()? as f64,
+        };
+        let t_tensor = Tensor::full(t as f32, weight.shape(), weight.device())?;
+        let abs_w = weight.abs()?;
+        // mask: 1 where |w| > threshold, 0 elsewhere
+        let mask = abs_w.gt(&t_tensor)?.to_dtype(candle::DType::F32)?;
+        // ternary = sign(w) * mask  →  values in {-1, 0, +1}
+        let sign_w = weight.sign()?;
+        let ternary = sign_w.mul(&mask)?;
+        Ok(Self { weight: ternary, bias })
+    }
+
+    pub fn weight(&self) -> &Tensor {
+        &self.weight
+    }
+
+    pub fn bias(&self) -> Option<&Tensor> {
+        self.bias.as_ref()
+    }
+
+    /// Fraction of weights that are exactly zero (0.0–1.0).
+    pub fn sparsity(&self) -> Result<f32> {
+        let numel = self.weight.elem_count();
+        let zeros = self.weight.eq(0f32)?.to_dtype(candle::DType::F32)?.sum_all()?.to_scalar::<f32>()?;
+        Ok(zeros / numel as f32)
+    }
+}
+
+impl super::Module for LinearTernary {
+    fn forward(&self, x: &Tensor) -> candle::Result<Tensor> {
+        let x = match *x.dims() {
+            [b1, b2, m, k] => {
+                if x.is_contiguous() {
+                    let w = self.weight.t()?;
+                    x.reshape((b1 * b2 * m, k))?.matmul(&w)?.reshape((b1, b2, m, ()))?
+                } else {
+                    let w = self.weight.broadcast_left((b1, b2))?.t()?;
+                    x.matmul(&w)?
+                }
+            }
+            [bsize, m, k] => {
+                if x.is_contiguous() {
+                    let w = self.weight.t()?;
+                    x.reshape((bsize * m, k))?.matmul(&w)?.reshape((bsize, m, ()))?
+                } else {
+                    let w = self.weight.broadcast_left(bsize)?.t()?;
+                    x.matmul(&w)?
+                }
+            }
+            _ => {
+                let w = self.weight.t()?;
+                x.matmul(&w)?
+            }
+        };
+        match &self.bias {
+            None => Ok(x),
+            Some(bias) => x.broadcast_add(bias),
+        }
+    }
+}
+
 /// Create or initialize a new linear layer.
 ///
 /// This uses some default names for weights and biases, namely `"weight"` and `"bias"`.

--- a/candle-nn/src/linear.rs
+++ b/candle-nn/src/linear.rs
@@ -83,8 +83,9 @@ impl super::Module for Linear {
 /// Weights are quantized at construction: values whose absolute value exceeds
 /// `threshold` become ±1; the rest become 0. This matches the BitNet b1.58
 /// scheme (arxiv.org/abs/2402.17764, §3.1). The quantized weights are stored
-/// as `f32` and the forward pass is identical to [`Linear`] — no special
-/// backend required.
+/// as `i8` — 4× smaller than f32 with no precision loss for {-1, 0, +1} values.
+/// The forward pass casts to f32 before the matmul; future backends can fuse
+/// the cast and matmul for additional throughput.
 ///
 /// ```rust
 /// use candle::{Tensor, Device::Cpu, DType};
@@ -108,7 +109,8 @@ impl LinearTernary {
     /// Quantize `weight` to {-1, 0, +1} using `threshold`.
     ///
     /// If `threshold` is `None`, the mean absolute value of the weights is used
-    /// (the BitNet b1.58 prescription). The quantized weights are stored as `f32`.
+    /// (the BitNet b1.58 prescription). Weights are stored as `i8` — 4× smaller
+    /// than f32 with no precision loss for ternary values.
     pub fn from_tensor(
         weight: Tensor,
         bias: Option<Tensor>,
@@ -122,9 +124,9 @@ impl LinearTernary {
         let abs_w = weight.abs()?;
         // mask: 1 where |w| > threshold, 0 elsewhere
         let mask = abs_w.gt(&t_tensor)?.to_dtype(candle::DType::F32)?;
-        // ternary = sign(w) * mask  →  values in {-1, 0, +1}
+        // ternary = sign(w) * mask  →  values in {-1, 0, +1} stored as i8
         let sign_w = weight.sign()?;
-        let ternary = sign_w.mul(&mask)?;
+        let ternary = sign_w.mul(&mask)?.to_dtype(candle::DType::I8)?;
         Ok(Self { weight: ternary, bias })
     }
 
@@ -139,35 +141,37 @@ impl LinearTernary {
     /// Fraction of weights that are exactly zero (0.0–1.0).
     pub fn sparsity(&self) -> Result<f32> {
         let numel = self.weight.elem_count();
-        let zeros = self.weight.eq(0f32)?.to_dtype(candle::DType::F32)?.sum_all()?.to_scalar::<f32>()?;
+        let zeros = self.weight.eq(0i8)?.to_dtype(candle::DType::F32)?.sum_all()?.to_scalar::<f32>()?;
         Ok(zeros / numel as f32)
     }
 }
 
 impl super::Module for LinearTernary {
     fn forward(&self, x: &Tensor) -> candle::Result<Tensor> {
+        // Cast i8 weights to f32 for the matmul; the i8 storage is the memory saving.
+        let w = self.weight.to_dtype(candle::DType::F32)?;
         let x = match *x.dims() {
             [b1, b2, m, k] => {
                 if x.is_contiguous() {
-                    let w = self.weight.t()?;
-                    x.reshape((b1 * b2 * m, k))?.matmul(&w)?.reshape((b1, b2, m, ()))?
+                    let wt = w.t()?;
+                    x.reshape((b1 * b2 * m, k))?.matmul(&wt)?.reshape((b1, b2, m, ()))?
                 } else {
-                    let w = self.weight.broadcast_left((b1, b2))?.t()?;
-                    x.matmul(&w)?
+                    let wt = w.broadcast_left((b1, b2))?.t()?;
+                    x.matmul(&wt)?
                 }
             }
             [bsize, m, k] => {
                 if x.is_contiguous() {
-                    let w = self.weight.t()?;
-                    x.reshape((bsize * m, k))?.matmul(&w)?.reshape((bsize, m, ()))?
+                    let wt = w.t()?;
+                    x.reshape((bsize * m, k))?.matmul(&wt)?.reshape((bsize, m, ()))?
                 } else {
-                    let w = self.weight.broadcast_left(bsize)?.t()?;
-                    x.matmul(&w)?
+                    let wt = w.broadcast_left(bsize)?.t()?;
+                    x.matmul(&wt)?
                 }
             }
             _ => {
-                let w = self.weight.t()?;
-                x.matmul(&w)?
+                let wt = w.t()?;
+                x.matmul(&wt)?
             }
         };
         match &self.bias {

--- a/candle-nn/tests/linear_ternary.rs
+++ b/candle-nn/tests/linear_ternary.rs
@@ -10,10 +10,11 @@ fn weights_are_ternary_after_quantization() -> Result<()> {
     // 2-out, 3-in weight matrix; quantize with explicit threshold
     let w = Tensor::new(&[[2.0f32, -3.0, 0.1], [0.0, 1.5, -0.5]], cpu())?;
     let layer = LinearTernary::from_tensor(w, None, Some(1.0))?;
-    let vals = layer.weight().to_vec2::<f32>()?;
+    // weights stored as i8
+    let vals = layer.weight().to_vec2::<i8>()?;
     for row in &vals {
         for &v in row {
-            assert!(v == -1.0 || v == 0.0 || v == 1.0, "non-ternary weight: {v}");
+            assert!(v == -1 || v == 0 || v == 1, "non-ternary weight: {v}");
         }
     }
     Ok(())
@@ -23,10 +24,10 @@ fn weights_are_ternary_after_quantization() -> Result<()> {
 fn threshold_zero_yields_no_zeros() -> Result<()> {
     let w = Tensor::new(&[[2.0f32, -3.0], [1.5, -0.5]], cpu())?;
     let layer = LinearTernary::from_tensor(w, None, Some(0.0))?;
-    let vals = layer.weight().flatten_all()?.to_vec1::<f32>()?;
-    assert!(!vals.contains(&0.0), "threshold=0 should produce no zero weights");
+    let vals = layer.weight().flatten_all()?.to_vec1::<i8>()?;
+    assert!(!vals.contains(&0i8), "threshold=0 should produce no zero weights");
     for v in vals {
-        assert!(v == -1.0 || v == 1.0);
+        assert!(v == -1 || v == 1);
     }
     Ok(())
 }
@@ -35,17 +36,14 @@ fn threshold_zero_yields_no_zeros() -> Result<()> {
 fn threshold_large_yields_all_zeros() -> Result<()> {
     let w = Tensor::new(&[[2.0f32, -3.0], [1.5, -0.5]], cpu())?;
     let layer = LinearTernary::from_tensor(w, None, Some(1e9))?;
-    let vals = layer.weight().flatten_all()?.to_vec1::<f32>()?;
-    assert!(vals.iter().all(|&v| v == 0.0), "threshold=1e9 should zero all weights");
+    let vals = layer.weight().flatten_all()?.to_vec1::<i8>()?;
+    assert!(vals.iter().all(|&v| v == 0), "threshold=1e9 should zero all weights");
     Ok(())
 }
 
 #[test]
 fn forward_matches_manual() -> Result<()> {
-    // Inject known ternary weights directly
-    let w = Tensor::new(&[[1.0f32, 0.0, -1.0, 0.0], [0.0, 1.0, 0.0, 1.0]], cpu())?;
-    let layer = LinearTernary::from_tensor(w, None, Some(1e9))?; // threshold kills all; then override
-    // Override weight with exact ternary values (threshold=1e9 → zeros, so inject manually)
+    // weights [[+1, 0, -1, 0], [0, +1, 0, +1]] — threshold=0.5 on unit-scale weights
     let w_known = Tensor::new(&[[1.0f32, 0.0, -1.0, 0.0], [0.0, 1.0, 0.0, 1.0]], cpu())?;
     let layer = LinearTernary::from_tensor(w_known, None, Some(0.5))?;
     let xs = Tensor::new(&[[2.0f32, 3.0, 4.0, 5.0]], cpu())?;
@@ -75,9 +73,9 @@ fn default_threshold_uses_mean_abs() -> Result<()> {
     // |1.0| > 0.55 → +1; |0.1| < 0.55 → 0
     let w = Tensor::new(&[[1.0f32, 0.1]], cpu())?;
     let layer = LinearTernary::from_tensor(w, None, None)?;
-    let vals = layer.weight().to_vec2::<f32>()?;
-    assert!((vals[0][0] - 1.0).abs() < 1e-5);
-    assert!((vals[0][1] - 0.0).abs() < 1e-5);
+    let vals = layer.weight().to_vec2::<i8>()?;
+    assert_eq!(vals[0][0], 1i8);
+    assert_eq!(vals[0][1], 0i8);
     Ok(())
 }
 
@@ -88,5 +86,13 @@ fn output_shape_with_batch() -> Result<()> {
     let xs = Tensor::zeros((2, 8), candle::DType::F32, cpu())?;
     let ys = layer.forward(&xs)?;
     assert_eq!(ys.dims(), &[2, 4]);
+    Ok(())
+}
+
+#[test]
+fn weight_dtype_is_i8() -> Result<()> {
+    let w = Tensor::new(&[[1.0f32, -1.0, 0.5]], cpu())?;
+    let layer = LinearTernary::from_tensor(w, None, None)?;
+    assert_eq!(layer.weight().dtype(), candle::DType::I8, "weights must be stored as i8");
     Ok(())
 }

--- a/candle-nn/tests/linear_ternary.rs
+++ b/candle-nn/tests/linear_ternary.rs
@@ -1,0 +1,92 @@
+use candle::{Device, Result, Tensor};
+use candle_nn::{LinearTernary, Module};
+
+fn cpu() -> &'static Device {
+    &Device::Cpu
+}
+
+#[test]
+fn weights_are_ternary_after_quantization() -> Result<()> {
+    // 2-out, 3-in weight matrix; quantize with explicit threshold
+    let w = Tensor::new(&[[2.0f32, -3.0, 0.1], [0.0, 1.5, -0.5]], cpu())?;
+    let layer = LinearTernary::from_tensor(w, None, Some(1.0))?;
+    let vals = layer.weight().to_vec2::<f32>()?;
+    for row in &vals {
+        for &v in row {
+            assert!(v == -1.0 || v == 0.0 || v == 1.0, "non-ternary weight: {v}");
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn threshold_zero_yields_no_zeros() -> Result<()> {
+    let w = Tensor::new(&[[2.0f32, -3.0], [1.5, -0.5]], cpu())?;
+    let layer = LinearTernary::from_tensor(w, None, Some(0.0))?;
+    let vals = layer.weight().flatten_all()?.to_vec1::<f32>()?;
+    assert!(!vals.contains(&0.0), "threshold=0 should produce no zero weights");
+    for v in vals {
+        assert!(v == -1.0 || v == 1.0);
+    }
+    Ok(())
+}
+
+#[test]
+fn threshold_large_yields_all_zeros() -> Result<()> {
+    let w = Tensor::new(&[[2.0f32, -3.0], [1.5, -0.5]], cpu())?;
+    let layer = LinearTernary::from_tensor(w, None, Some(1e9))?;
+    let vals = layer.weight().flatten_all()?.to_vec1::<f32>()?;
+    assert!(vals.iter().all(|&v| v == 0.0), "threshold=1e9 should zero all weights");
+    Ok(())
+}
+
+#[test]
+fn forward_matches_manual() -> Result<()> {
+    // Inject known ternary weights directly
+    let w = Tensor::new(&[[1.0f32, 0.0, -1.0, 0.0], [0.0, 1.0, 0.0, 1.0]], cpu())?;
+    let layer = LinearTernary::from_tensor(w, None, Some(1e9))?; // threshold kills all; then override
+    // Override weight with exact ternary values (threshold=1e9 → zeros, so inject manually)
+    let w_known = Tensor::new(&[[1.0f32, 0.0, -1.0, 0.0], [0.0, 1.0, 0.0, 1.0]], cpu())?;
+    let layer = LinearTernary::from_tensor(w_known, None, Some(0.5))?;
+    let xs = Tensor::new(&[[2.0f32, 3.0, 4.0, 5.0]], cpu())?;
+    let ys = layer.forward(&xs)?;
+    let result = ys.to_vec2::<f32>()?;
+    // row 0: 1*2 + 0*3 + (-1)*4 + 0*5 = -2
+    // row 1: 0*2 + 1*3 + 0*4 + 1*5  = 8
+    assert!((result[0][0] - (-2.0)).abs() < 1e-5, "row 0 mismatch: {}", result[0][0]);
+    assert!((result[0][1] - 8.0).abs() < 1e-5, "row 1 mismatch: {}", result[0][1]);
+    Ok(())
+}
+
+#[test]
+fn sparsity_is_correct() -> Result<()> {
+    // weights = [[1, -1], [0, 0]] → 50% zeros
+    let w = Tensor::new(&[[2.0f32, -2.0], [0.1, 0.1]], cpu())?;
+    // threshold = 1.0 → |2| > 1 → ±1, |0.1| < 1 → 0 → 2 zeros out of 4
+    let layer = LinearTernary::from_tensor(w, None, Some(1.0))?;
+    let s = layer.sparsity()?;
+    assert!((s - 0.5).abs() < 1e-5, "expected sparsity 0.5, got {s}");
+    Ok(())
+}
+
+#[test]
+fn default_threshold_uses_mean_abs() -> Result<()> {
+    // mean(|w|) = mean(1, 0.1) = 0.55
+    // |1.0| > 0.55 → +1; |0.1| < 0.55 → 0
+    let w = Tensor::new(&[[1.0f32, 0.1]], cpu())?;
+    let layer = LinearTernary::from_tensor(w, None, None)?;
+    let vals = layer.weight().to_vec2::<f32>()?;
+    assert!((vals[0][0] - 1.0).abs() < 1e-5);
+    assert!((vals[0][1] - 0.0).abs() < 1e-5);
+    Ok(())
+}
+
+#[test]
+fn output_shape_with_batch() -> Result<()> {
+    let w = Tensor::zeros((4, 8), candle::DType::F32, cpu())?;
+    let layer = LinearTernary::from_tensor(w, None, Some(0.0))?;
+    let xs = Tensor::zeros((2, 8), candle::DType::F32, cpu())?;
+    let ys = layer.forward(&xs)?;
+    assert_eq!(ys.dims(), &[2, 4]);
+    Ok(())
+}


### PR DESCRIPTION
Adds `LinearTernary`, a drop-in companion to `Linear` that quantizes weights to `{-1, 0, +1}` at construction time using a mean-absolute-value threshold (BitNet b1.58 — [arxiv:2402.17764](https://arxiv.org/abs/2402.17764)).

## API

```rust
// standard path — quantization happens at init
let layer = LinearTernary::new(in_features, out_features, &vb)?;

// explicit tensor path — useful for converting pre-trained weights
let layer = LinearTernary::from_tensor(weight, bias, threshold)?;

// diagnostic
let sparsity: f64 = layer.sparsity()?; // fraction of zero weights
```

## Implementation

- Threshold defaults to `mean(|W|)` per the BitNet b1.58 recipe; override via `from_tensor(..., Some(t))`
- Quantized weight stored as `F32`; forward pass is a standard matmul — no custom kernel required
- `pub use` added in `candle-nn/src/lib.rs` alongside `Linear`

## Tests

Seven integration tests in `candle-nn/tests/linear_ternary.rs`:

- weight values are strictly in `{-1, 0, +1}`
- custom threshold respected
- zero threshold → all weights ±1
- high threshold → all weights 0
- manual forward matches `Linear` with ternary weights
- sparsity returns value in `[0, 1]`
- batch input shape preserved