### PR TITLE
[Metal] Expose kernel_mul_mm_id wrapper and parallelize rowids fan-out

### DIFF
--- a/candle-core/benches/bench_main.rs
+++ b/candle-core/benches/bench_main.rs
@@ -12,6 +12,7 @@ criterion_main!(
     benchmarks::conv_transpose2d::benches,
     benchmarks::matmul::benches,
     benchmarks::qmatmul::benches,
+    benchmarks::qmatmul_id::benches,
     benchmarks::random::benches,
     benchmarks::reduce::benches,
     benchmarks::unary::benches,

--- a/candle-core/benches/benchmarks/mod.rs
+++ b/candle-core/benches/benchmarks/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod conv_transpose2d;
 pub(crate) mod copy;
 pub(crate) mod matmul;
 pub(crate) mod qmatmul;
+pub(crate) mod qmatmul_id;
 pub(crate) mod random;
 pub(crate) mod reduce;
 pub(crate) mod unary;

--- a/candle-core/benches/benchmarks/qmatmul_id.rs
+++ b/candle-core/benches/benchmarks/qmatmul_id.rs
@@ -1,0 +1,160 @@
+//! Microbench for the per-expert quantized matmul kernel
+//! (`kernel_mul_mm_id`, exposed in candle-metal-kernels as
+//! `call_quantized_matmul_mm_id`).
+//!
+//! This bench drives the kernel directly: there is no `QMatMul` integration
+//! yet (the wrapper is meant to be invoked from a `CustomOp` by callers that
+//! own their own MoE routing logic). The benchmark stages a quantized
+//! per-expert weight stack `[E, N, K]`, an `f32` input `[M, K]`, an `i32`
+//! routing table `[M, T]`, and dispatches the kernel in a tight loop.
+//!
+//! Shapes are picked to match Qwen3-MoE's FFN dims (N=2048, K=4096), with
+//! M sweeping the decode (M=1) / small prefill (M=32) / chunked-prefill
+//! (M=256) regimes. Dtype is fixed to Q4_K (the common MoE quantization).
+
+use crate::benchmarks::BenchDeviceHandler;
+use candle_core::Device;
+use criterion::{criterion_group, Criterion};
+
+#[cfg(feature = "metal")]
+use crate::benchmarks::BenchDevice;
+#[cfg(feature = "metal")]
+use candle_core::{quantized, Tensor};
+#[cfg(feature = "metal")]
+use criterion::Throughput;
+#[cfg(feature = "metal")]
+use std::hint::black_box;
+#[cfg(feature = "metal")]
+use std::time::Instant;
+
+#[cfg(feature = "metal")]
+fn run_bench_metal(c: &mut Criterion, device: &Device, m: usize) {
+    use candle_core::quantized::GgmlDType;
+
+    let dtype = GgmlDType::Q4K;
+    let num_experts = 128usize;
+    let experts_per_tok = 8usize;
+    let n = 2048usize;
+    let k = 4096usize;
+
+    // 1. Build quantized expert weights `[E, N, K]` on the CPU, then
+    //    upload the raw quantized bytes to a Metal buffer.
+    let weights_f32: Vec<f32> = (0..(num_experts * n * k))
+        .map(|v| (v as f32) / ((num_experts * n * k) as f32))
+        .collect();
+    let weights_tensor =
+        Tensor::from_slice(&weights_f32, (num_experts, n, k), &Device::Cpu).unwrap();
+    let qtensor = quantized::QTensor::quantize(&weights_tensor, dtype).unwrap();
+    let qbytes = qtensor.data().unwrap();
+
+    let metal_device = match device {
+        Device::Metal(d) => d.clone(),
+        _ => return,
+    };
+
+    let weight_buf = metal_device.new_buffer_with_data(qbytes.as_ref()).unwrap();
+
+    // Quantized strides (bytes). Layout is row-major over `[E, N, K]`.
+    let type_size = dtype.type_size();
+    let block_size = dtype.block_size();
+    let row_bytes = (k / block_size) * type_size;
+    let expert_bytes = n * row_bytes;
+    let src0_shape = [num_experts, n, k];
+    let src0_stride_bytes = [
+        expert_bytes * num_experts,
+        expert_bytes,
+        row_bytes,
+        type_size,
+    ];
+    // call_quantized_matmul_mm_id reads only nb01 (row stride) and nb02
+    // (per-expert stride); the deeper strides are unused but we plumb a
+    // 4-element stride array for symmetry with `mm_t`.
+    let src0_stride = [
+        src0_stride_bytes[0],
+        src0_stride_bytes[1],
+        src0_stride_bytes[2],
+        src0_stride_bytes[3],
+    ];
+
+    // 2. Build an `f32` input `[M, K]` and upload.
+    let input_f32: Vec<f32> = (0..(m * k))
+        .map(|v| (v as f32) / ((m * k) as f32))
+        .collect();
+    let input_buf = metal_device.new_buffer_with_data(&input_f32).unwrap();
+    let f32_size = core::mem::size_of::<f32>();
+    let src1_shape = [m, k];
+    let src1_stride = [k * f32_size, f32_size];
+
+    // 3. Build a routing table `[M, T]` of `i32` expert ids in
+    //    [0, num_experts).
+    let ids_i32: Vec<i32> = (0..(m * experts_per_tok))
+        .map(|v| ((v * 17) % num_experts) as i32)
+        .collect();
+    let ids_buf = metal_device.new_buffer_with_data(&ids_i32).unwrap();
+    let i32_size = core::mem::size_of::<i32>();
+    let ids_shape = [m, experts_per_tok];
+    let ids_stride = [experts_per_tok * i32_size, i32_size];
+
+    // 4. Allocate an output buffer `[M, T, N]` of `f32`.
+    let out_elems = m * experts_per_tok * n;
+    let out_buf = metal_device
+        .new_buffer(out_elems, candle_core::DType::F32, "qmatmul_id_out")
+        .unwrap();
+
+    // FLOPs per dispatch: M tokens * T slots * 2 * N * K.
+    let flops = (m as u64) * (experts_per_tok as u64) * 2 * (n as u64) * (k as u64);
+
+    let bench_name = format!("qmatmul_id_q4k_n{}_k{}_m{}", n, k, m);
+    let mut group = c.benchmark_group(device.bench_name(bench_name));
+    group.sample_size(50);
+    group.throughput(Throughput::Bytes(flops));
+    group.bench_function("iter", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            for _ in 0..iters {
+                let encoder = metal_device.command_encoder().unwrap();
+                candle_metal_kernels::call_quantized_matmul_mm_id(
+                    metal_device.device(),
+                    &encoder,
+                    metal_device.kernels(),
+                    dtype.into(),
+                    black_box(&src0_shape),
+                    black_box(&src0_stride),
+                    black_box(&weight_buf),
+                    black_box(&src1_shape),
+                    black_box(&src1_stride),
+                    black_box(&input_buf),
+                    0,
+                    black_box(&ids_shape),
+                    black_box(&ids_stride),
+                    black_box(&ids_buf),
+                    0,
+                    black_box(&[m, experts_per_tok, n]),
+                    0,
+                    black_box(&out_buf),
+                )
+                .unwrap();
+                drop(encoder);
+            }
+            metal_device.wait_until_completed().unwrap();
+            start.elapsed()
+        })
+    });
+    group.finish();
+}
+
+#[cfg(not(feature = "metal"))]
+fn run_bench_metal(_c: &mut Criterion, _device: &Device, _m: usize) {}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let handler = BenchDeviceHandler::new().unwrap();
+    for device in handler.devices {
+        if matches!(device, Device::Metal(_)) {
+            for m in [1usize, 32, 256] {
+                run_bench_metal(c, &device, m);
+            }
+        }
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);

--- a/candle-core/benches/benchmarks/qmatmul_id.rs
+++ b/candle-core/benches/benchmarks/qmatmul_id.rs
@@ -45,10 +45,7 @@ use std::hint::black_box;
 use std::time::Instant;
 
 #[cfg(feature = "metal")]
-fn run_bench_metal(c: &mut Criterion, device: &Device, m: usize) {
-    use candle_core::quantized::GgmlDType;
-
-    let dtype = GgmlDType::Q4K;
+fn run_bench_metal(c: &mut Criterion, device: &Device, dtype: candle_core::quantized::GgmlDType, m: usize) {
     let num_experts = 128usize;
     let experts_per_tok = 8usize;
     let n = 2048usize;
@@ -121,7 +118,14 @@ fn run_bench_metal(c: &mut Criterion, device: &Device, m: usize) {
     // FLOPs per dispatch: M tokens * T slots * 2 * N * K.
     let flops = (m as u64) * (experts_per_tok as u64) * 2 * (n as u64) * (k as u64);
 
-    let bench_name = format!("qmatmul_id_q4k_n{}_k{}_m{}", n, k, m);
+    let dtype_label = match dtype {
+        candle_core::quantized::GgmlDType::Q4K => "q4k",
+        candle_core::quantized::GgmlDType::F16 => "f16",
+        candle_core::quantized::GgmlDType::F32 => "f32",
+        candle_core::quantized::GgmlDType::Q8_0 => "q8_0",
+        _ => "other",
+    };
+    let bench_name = format!("qmatmul_id_{}_n{}_k{}_m{}", dtype_label, n, k, m);
     let mut group = c.benchmark_group(device.bench_name(bench_name));
     group.sample_size(50);
     // Pass FLOPs as `Elements`; Criterion will print "Gelem/s" but the value
@@ -163,7 +167,7 @@ fn run_bench_metal(c: &mut Criterion, device: &Device, m: usize) {
 }
 
 #[cfg(not(feature = "metal"))]
-fn run_bench_metal(_c: &mut Criterion, _device: &Device, _m: usize) {}
+fn run_bench_metal(_c: &mut Criterion, _device: &Device, _dtype: candle_core::quantized::GgmlDType, _m: usize) {}
 
 #[cfg(feature = "metal")]
 fn run_bench_mm_t_baseline(c: &mut Criterion, device: &Device, m_per_expert: usize) {
@@ -211,8 +215,18 @@ fn criterion_benchmark(c: &mut Criterion) {
     let handler = BenchDeviceHandler::new().unwrap();
     for device in handler.devices {
         if matches!(device, Device::Metal(_)) {
+            #[cfg(feature = "metal")]
+            use candle_core::quantized::GgmlDType;
+            #[cfg(feature = "metal")]
             for m in [1usize, 32, 256] {
-                run_bench_metal(c, &device, m);
+                run_bench_metal(c, &device, GgmlDType::Q4K, m);
+            }
+            // F16 weight tensor is `num_experts * N * K * 2` bytes (~2.1 GB
+            // for the Qwen3-MoE shapes here); skip the M=256 case to keep
+            // memory comfortable on a 16 GB Mac.
+            #[cfg(feature = "metal")]
+            for m in [1usize, 32] {
+                run_bench_metal(c, &device, GgmlDType::F16, m);
             }
             // Baseline through the existing `QMatMul::forward` path, one
             // dispatch per expert. The pairings are: M=1 / decode -> only

--- a/candle-core/benches/benchmarks/qmatmul_id.rs
+++ b/candle-core/benches/benchmarks/qmatmul_id.rs
@@ -1,16 +1,30 @@
 //! Microbench for the per-expert quantized matmul kernel
 //! (`kernel_mul_mm_id`, exposed in candle-metal-kernels as
-//! `call_quantized_matmul_mm_id`).
+//! `call_quantized_matmul_mm_id`), plus a baseline that drives the existing
+//! `QMatMul::forward` path at the equivalent per-expert work shape.
 //!
-//! This bench drives the kernel directly: there is no `QMatMul` integration
-//! yet (the wrapper is meant to be invoked from a `CustomOp` by callers that
-//! own their own MoE routing logic). The benchmark stages a quantized
-//! per-expert weight stack `[E, N, K]`, an `f32` input `[M, K]`, an `i32`
-//! routing table `[M, T]`, and dispatches the kernel in a tight loop.
+//! The fused bench (`qmatmul_id_q4k_*`) stages a quantized per-expert weight
+//! stack `[E, N, K]`, an `f32` input `[M, K]`, an `i32` routing table
+//! `[M, T]`, and dispatches `kernel_mul_mm_id` in a tight loop. Shapes match
+//! Qwen3-MoE's FFN dims (N=2048, K=4096); M sweeps decode (1), small
+//! prefill (32), and chunked prefill (256). Dtype is Q4_K (the common MoE
+//! quantization).
 //!
-//! Shapes are picked to match Qwen3-MoE's FFN dims (N=2048, K=4096), with
-//! M sweeping the decode (M=1) / small prefill (M=32) / chunked-prefill
-//! (M=256) regimes. Dtype is fixed to Q4_K (the common MoE quantization).
+//! The baseline bench (`qmatmul_mm_t_baseline_q4k_*`) measures a single
+//! expert's worth of work through `QMatMul::forward` at M equal to the
+//! average tokens-per-expert in the fused case (T=8, E=128 -> 0, 2, 16 for
+//! the three M values). The naive 128-dispatch alternative would pay this
+//! cost once per expert; comparing `fused_time` to `baseline_time * E`
+//! shows when the fused kernel actually wins.
+//!
+//! The vendored `kernel_mul_mm_id` at `quantized.metal:7301` has an
+//! unparallelized rowids fan-out (TODO in the upstream source): every
+//! thread of every threadgroup independently scans the full `M*T` ids
+//! buffer. This is visible as the M=256 regression in the fused bench.
+//!
+//! Units: the throughput field carries FLOPs (`2*M*N*K` per matmul, times
+//! T for the fused case). Criterion prints it as "Gelem/s" but the value
+//! is GFLOPs/s.
 
 use crate::benchmarks::BenchDeviceHandler;
 use candle_core::Device;
@@ -19,7 +33,10 @@ use criterion::{criterion_group, Criterion};
 #[cfg(feature = "metal")]
 use crate::benchmarks::BenchDevice;
 #[cfg(feature = "metal")]
-use candle_core::{quantized, Tensor};
+use candle_core::{
+    quantized::{self, QMatMul},
+    Module, Tensor,
+};
 #[cfg(feature = "metal")]
 use criterion::Throughput;
 #[cfg(feature = "metal")]
@@ -107,7 +124,9 @@ fn run_bench_metal(c: &mut Criterion, device: &Device, m: usize) {
     let bench_name = format!("qmatmul_id_q4k_n{}_k{}_m{}", n, k, m);
     let mut group = c.benchmark_group(device.bench_name(bench_name));
     group.sample_size(50);
-    group.throughput(Throughput::Bytes(flops));
+    // Pass FLOPs as `Elements`; Criterion will print "Gelem/s" but the value
+    // is GFLOPs/s.
+    group.throughput(Throughput::Elements(flops));
     group.bench_function("iter", move |b| {
         b.iter_custom(|iters| {
             let start = Instant::now();
@@ -146,12 +165,62 @@ fn run_bench_metal(c: &mut Criterion, device: &Device, m: usize) {
 #[cfg(not(feature = "metal"))]
 fn run_bench_metal(_c: &mut Criterion, _device: &Device, _m: usize) {}
 
+#[cfg(feature = "metal")]
+fn run_bench_mm_t_baseline(c: &mut Criterion, device: &Device, m_per_expert: usize) {
+    use candle_core::quantized::GgmlDType;
+
+    let dtype = GgmlDType::Q4K;
+    let n = 2048usize;
+    let k = 4096usize;
+
+    let lhs_data: Vec<f32> = (0..(m_per_expert * k))
+        .map(|v| (v as f32) / ((m_per_expert * k) as f32))
+        .collect();
+    let rhs_data: Vec<f32> = (0..(n * k)).map(|v| (v as f32) / ((n * k) as f32)).collect();
+
+    let lhs = Tensor::from_slice(&lhs_data, (m_per_expert, k), device).unwrap();
+    let rhs = Tensor::from_slice(&rhs_data, (k, n), device).unwrap();
+    let qtensor = quantized::QTensor::quantize(&rhs.t().unwrap(), dtype).unwrap();
+    let matmul = QMatMul::from_qtensor(qtensor).unwrap();
+
+    let flops = (m_per_expert as u64) * 2 * (n as u64) * (k as u64);
+
+    let bench_name = format!("qmatmul_mm_t_baseline_q4k_n{}_k{}_m{}", n, k, m_per_expert);
+    let mut group = c.benchmark_group(device.bench_name(bench_name));
+    group.sample_size(50);
+    group.throughput(Throughput::Elements(flops));
+    let lhs = black_box(lhs);
+    let matmul = black_box(matmul);
+    group.bench_function("iter", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            for _ in 0..iters {
+                matmul.forward(&lhs).unwrap();
+            }
+            device.sync().unwrap();
+            start.elapsed()
+        })
+    });
+    group.finish();
+}
+
+#[cfg(not(feature = "metal"))]
+fn run_bench_mm_t_baseline(_c: &mut Criterion, _device: &Device, _m_per_expert: usize) {}
+
 fn criterion_benchmark(c: &mut Criterion) {
     let handler = BenchDeviceHandler::new().unwrap();
     for device in handler.devices {
         if matches!(device, Device::Metal(_)) {
             for m in [1usize, 32, 256] {
                 run_bench_metal(c, &device, m);
+            }
+            // Baseline through the existing `QMatMul::forward` path, one
+            // dispatch per expert. The pairings are: M=1 / decode -> only
+            // T=8 experts hit (M_per_expert=1); M=32 -> 256/128 = 2 average;
+            // M=256 -> 2048/128 = 16 average. The naive 128-dispatch cost
+            // is roughly `baseline_time(m_per_expert) * num_experts_hit`.
+            for m_per_expert in [1usize, 2, 16] {
+                run_bench_mm_t_baseline(c, &device, m_per_expert);
             }
         }
     }

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -279,6 +279,203 @@ pub fn call_quantized_matmul_mm_t(
     Ok(())
 }
 
+/// Indirect / per-expert quantized matmul, as used by MoE FFNs.
+///
+/// Mirrors `kernel_mul_mm_id` in `metal_src/quantized.metal` (a single-pass
+/// adaptation of the llama.cpp MoE kernel). The weight tensor `src0s` is a
+/// stack of `num_experts` quantized matrices of shape `[n, k]`. The input
+/// `src1` is a dense `[num_tokens, k]` matrix in `f32`. `ids` selects which
+/// experts each token routes to, shape `[num_tokens, experts_per_token]` in
+/// `i32`. The output `dst` is `f32` of shape
+/// `[num_tokens, experts_per_token, n]` laid out as
+/// `dst[t, e, j] = dst[t * experts_per_token * n + e * n + j]`, i.e. each
+/// `(token, slot)` pair writes one row of size `n`.
+///
+/// This is the single-pass variant; llama.cpp's `_id_map0` pre-pass is not
+/// vendored here. Callers that need to integrate with `QMatmul` should drive
+/// this from a `CustomOp`; auto-dispatch through `forward_via_f16` is
+/// intentionally out of scope (see ivarflakstad's review of candle #3444).
+#[allow(clippy::too_many_arguments)]
+pub fn call_quantized_matmul_mm_id(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    dtype: GgmlDType,
+    // src0s: [num_experts, n, k] quantized
+    src0_shape: &[usize],
+    src0_stride: &[usize],
+    src0s: &Buffer,
+    // src1: [num_tokens, k] f32
+    src1_shape: &[usize],
+    src1_stride: &[usize],
+    src1: &Buffer,
+    src1_offset: usize,
+    // ids: [num_tokens, experts_per_token] i32
+    ids_shape: &[usize],
+    ids_stride: &[usize],
+    ids: &Buffer,
+    ids_offset: usize,
+    // dst: [num_tokens, experts_per_token, n] f32
+    dst_shape: &[usize],
+    dst_offset: usize,
+    dst: &Buffer,
+) -> Result<(), MetalKernelError> {
+    if src0_shape.len() < 3 {
+        return Err(MetalKernelError::InvalidInput(format!(
+            "qmatmul_id: src0 must have rank >= 3 (got {:?})",
+            src0_shape
+        )));
+    }
+    if src1_shape.len() < 2 {
+        return Err(MetalKernelError::InvalidInput(format!(
+            "qmatmul_id: src1 must have rank >= 2 (got {:?})",
+            src1_shape
+        )));
+    }
+    if ids_shape.len() != 2 {
+        return Err(MetalKernelError::InvalidInput(format!(
+            "qmatmul_id: ids must have rank == 2 (got {:?})",
+            ids_shape
+        )));
+    }
+
+    // src0s shape: [..., ne02, ne01, ne00] = [..., num_experts, n, k]
+    let r = src0_shape.len();
+    let ne00 = src0_shape[r - 1] as i64;
+    let ne01 = src0_shape[r - 2] as i64;
+    let ne02 = src0_shape[r - 3] as i64;
+
+    let sr = src0_stride.len();
+    let nb01 = src0_stride[sr - 2] as i64;
+    let nb02 = src0_stride[sr - 3] as i64;
+
+    // src1 shape: [..., num_tokens, k]. The kernel reads it as 4D
+    // [ne13, ne12, ne11, ne10] with byte strides nb1x. For the common
+    // single-batch case ne13 = ne12 = 1, ne11 = num_tokens, ne10 = k.
+    let r1 = src1_shape.len();
+    let ne11 = if r1 >= 2 {
+        src1_shape[r1 - 2] as i64
+    } else {
+        1
+    };
+    let ne12 = if r1 >= 3 {
+        src1_shape[r1 - 3] as i64
+    } else {
+        1
+    };
+    let ne13 = if r1 >= 4 {
+        src1_shape[r1 - 4] as i64
+    } else {
+        1
+    };
+
+    let s1 = src1_stride.len();
+    let nb10 = src1_stride[s1 - 1] as i64;
+    let nb11 = if s1 >= 2 {
+        src1_stride[s1 - 2] as i64
+    } else {
+        0
+    };
+    let nb12 = if s1 >= 3 {
+        src1_stride[s1 - 3] as i64
+    } else {
+        0
+    };
+
+    // ids shape: [nei1, nei0] = [num_tokens, experts_per_token].
+    let nei0 = ids_shape[1] as i64;
+    let nei1 = ids_shape[0] as i64;
+    let nbi1 = ids_stride[0] as i64;
+
+    // dst shape: trailing dims are [..., ne1, ne0]. ne0 is n (cols per
+    // expert output); ne1 is the total slot count (num_tokens *
+    // experts_per_token) when laid out flat. The MSL only reads ne0, ne1,
+    // and nb1; the kernel itself addresses rows through `rowids` and
+    // strides through `ne0` / `ne0*ne1`.
+    let dr = dst_shape.len();
+    let ne0 = dst_shape[dr - 1] as i64;
+    let ne1 = (nei0 * nei1) as i64;
+    let nb1 = (ne0 as usize * core::mem::size_of::<f32>()) as i64;
+
+    let thread_groups_count = MTLSize {
+        width: divide(ne1 as usize, 32),
+        height: divide(ne0 as usize, 64),
+        depth: ne02 as usize,
+    };
+    let threads_per_threadgroup = MTLSize {
+        width: 128,
+        height: 1,
+        depth: 1,
+    };
+
+    let name = match dtype {
+        GgmlDType::Q4_0 => "kernel_mul_mm_id_q4_0_f32",
+        GgmlDType::Q4_1 => "kernel_mul_mm_id_q4_1_f32",
+        GgmlDType::Q5_0 => "kernel_mul_mm_id_q5_0_f32",
+        GgmlDType::Q5_1 => "kernel_mul_mm_id_q5_1_f32",
+        GgmlDType::Q8_0 => "kernel_mul_mm_id_q8_0_f32",
+        GgmlDType::Q2K => "kernel_mul_mm_id_q2_K_f32",
+        GgmlDType::Q3K => "kernel_mul_mm_id_q3_K_f32",
+        GgmlDType::Q4K => "kernel_mul_mm_id_q4_K_f32",
+        GgmlDType::Q5K => "kernel_mul_mm_id_q5_K_f32",
+        GgmlDType::Q6K => "kernel_mul_mm_id_q6_K_f32",
+        GgmlDType::F16 => "kernel_mul_mm_id_f16_f32",
+        GgmlDType::F32 => "kernel_mul_mm_id_f32_f32",
+        GgmlDType::BF16 => Err(MetalKernelError::UnsupportedDTypeForOp(
+            "BF16",
+            "qmatmul_id",
+        ))?,
+        GgmlDType::Q8_1 => Err(MetalKernelError::UnsupportedDTypeForOp(
+            "Q8_1",
+            "qmatmul_id",
+        ))?,
+        GgmlDType::Q8K => Err(MetalKernelError::UnsupportedDTypeForOp("Q8K", "qmatmul_id"))?,
+    };
+
+    // Silence unused-warnings for shape fields the kernel does not read.
+    let _ = ne01;
+
+    let pipeline = kernels.load_pipeline(device, Source::Quantized, name)?;
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    set_params!(
+        encoder,
+        (
+            src0s,
+            (src1, src1_offset),
+            Output::with_offset(dst, dst_offset),
+            (ids, ids_offset),
+            nei0,
+            nei1,
+            nbi1,
+            ne00,
+            ne02,
+            nb01,
+            nb02,
+            ne11,
+            ne12,
+            ne13,
+            nb10,
+            nb11,
+            nb12,
+            ne0,
+            ne1,
+            nb1
+        )
+    );
+
+    // 8192 bytes for the simdgroup tile buffer (matches kernel_mul_mm), plus
+    // a ushort2 per (token, slot) pair used by the rowids fan-out at the top
+    // of kernel_mul_mm_id.
+    let shared_bytes = 8192 + (nei0 as usize) * (nei1 as usize) * core::mem::size_of::<u32>();
+    encoder.set_threadgroup_memory_length(0, shared_bytes);
+
+    encoder.dispatch_thread_groups(thread_groups_count, threads_per_threadgroup);
+    Ok(())
+}
+
 fn divide(m: usize, b: usize) -> usize {
     m.div_ceil(b)
 }

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -349,56 +349,52 @@ pub fn call_quantized_matmul_mm_id(
     let nb01 = src0_stride[sr - 2] as i64;
     let nb02 = src0_stride[sr - 3] as i64;
 
-    // src1 shape: [..., num_tokens, k]. The kernel reads it as 4D
-    // [ne13, ne12, ne11, ne10] with byte strides nb1x. For the common
-    // single-batch case ne13 = ne12 = 1, ne11 = num_tokens, ne10 = k.
+    // src1 is `[num_tokens, k]`. The kernel addresses it as 3D
+    // `[ne12, ne11, ne10]` and reads
+    //   src1 + nb12 * id[1] + nb11 * (id[0] % ne11) + nb10 * k_chunk
+    // where id = (slot, token). We want the same per-token input row read
+    // for every slot, so the slot dim must be singleton: set ne11 = 1,
+    // nb11 = 0, and route num_tokens into ne12 (with nb12 as the
+    // token-to-token byte stride).
     let r1 = src1_shape.len();
-    let ne11 = if r1 >= 2 {
-        src1_shape[r1 - 2] as i64
-    } else {
-        1
-    };
-    let ne12 = if r1 >= 3 {
-        src1_shape[r1 - 3] as i64
-    } else {
-        1
-    };
-    let ne13 = if r1 >= 4 {
-        src1_shape[r1 - 4] as i64
-    } else {
-        1
-    };
+    if r1 != 2 {
+        return Err(MetalKernelError::InvalidInput(format!(
+            "qmatmul_id: src1 must be 2D [num_tokens, k] (got rank {})",
+            r1
+        )));
+    }
+    let ne11 = 1i64;
+    let ne12 = src1_shape[r1 - 2] as i64;
+    let ne13 = 1i64;
 
     let s1 = src1_stride.len();
     let nb10 = src1_stride[s1 - 1] as i64;
-    let nb11 = if s1 >= 2 {
-        src1_stride[s1 - 2] as i64
-    } else {
-        0
-    };
-    let nb12 = if s1 >= 3 {
-        src1_stride[s1 - 3] as i64
-    } else {
-        0
-    };
+    let nb11 = 0i64;
+    let nb12 = src1_stride[s1 - 2] as i64;
 
     // ids shape: [nei1, nei0] = [num_tokens, experts_per_token].
     let nei0 = ids_shape[1] as i64;
     let nei1 = ids_shape[0] as i64;
     let nbi1 = ids_stride[0] as i64;
 
-    // dst shape: trailing dims are [..., ne1, ne0]. ne0 is n (cols per
-    // expert output); ne1 is the total slot count (num_tokens *
-    // experts_per_token) when laid out flat. The MSL only reads ne0, ne1,
-    // and nb1; the kernel itself addresses rows through `rowids` and
-    // strides through `ne0` / `ne0*ne1`.
+    // dst layout: [num_tokens, experts_per_token, ne0] contiguous, i.e.
+    // dst[token, slot, j] = dst[token * (T * ne0) + slot * ne0 + j].
+    // The kernel writes at `jid[0] * ne0 + jid[1] * (ne0 * ne1)` where
+    // jid[0] = slot and jid[1] = token, so the per-token byte multiplier
+    // must equal T * ne0; that means the host `ne1` parameter must equal
+    // T (= nei0), not nei0 * nei1.
     let dr = dst_shape.len();
     let ne0 = dst_shape[dr - 1] as i64;
-    let ne1 = (nei0 * nei1) as i64;
+    let ne1 = nei0;
     let nb1 = (ne0 as usize * core::mem::size_of::<f32>()) as i64;
 
+    // The grid X dim must be wide enough for the worst-case per-expert
+    // routing count (= nei0 * nei1 if all routings concentrate on a
+    // single expert). The kernel's per-expert early-exit
+    // `if (r1 * BLOCK_SIZE_N >= _ne1) return;` clamps unused tiles.
+    let max_routings_per_expert = (nei0 * nei1) as usize;
     let thread_groups_count = MTLSize {
-        width: divide(ne1 as usize, 32),
+        width: divide(max_routings_per_expert, 32),
         height: divide(ne0 as usize, 64),
         depth: ne02 as usize,
     };

--- a/candle-metal-kernels/src/metal_src/quantized.metal
+++ b/candle-metal-kernels/src/metal_src/quantized.metal
@@ -7295,24 +7295,38 @@ kernel void kernel_mul_mm_id(
 
     device const uchar * src0 = src0s + i02*nb02;
 
-    // row indices
+    // row indices, stored in threadgroup memory just past the 8192-byte
+    // simdgroup tile region.
     threadgroup ushort2 * rowids = (threadgroup ushort2 *)(shared_memory + 8192);
 
-    // TODO: parallelize this loop
-    int64_t _ne1 = 0;
-    for (ushort ii1 = 0; ii1 < nei1; ii1++) {
-        for (ushort ii0 = 0; ii0 < nei0; ii0++) {
-            int32_t id = ((device int32_t *) (ids + ii1*nbi1))[ii0];
-            if (id == i02) {
-                //if (tiitg == 0) {
-                    rowids[_ne1] = ushort2(ii0, ii1);
-                //}
-                _ne1++;
-            }
+    // Parallelized rowids fan-out. Upstream ggml-metal-quantized.metal
+    // carries a "TODO: parallelize this loop" here and runs the scan
+    // serially in every thread of the threadgroup; for the typical MoE
+    // shape (num_experts=128, T=8) at large M this dominates the kernel
+    // runtime. Each thread now scans a stride-128 slice of the ids buffer,
+    // claims an output slot via an atomic counter, and writes its rowid in
+    // place. The downstream matmul reads rowids by index and writes into
+    // dst[jid[0], jid[1], :], so rowid order may be non-deterministic
+    // without affecting the output.
+    threadgroup atomic_uint rowids_count;
+    if (tiitg == 0) {
+        atomic_store_explicit(&rowids_count, 0u, memory_order_relaxed);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    const uint scan_total = (uint)(nei0 * nei1);
+    for (uint idx = tiitg; idx < scan_total; idx += 128u) {
+        const ushort ii1 = (ushort)(idx / (uint)nei0);
+        const ushort ii0 = (ushort)(idx % (uint)nei0);
+        const int32_t id = ((device int32_t *) (ids + ii1*nbi1))[ii0];
+        if (id == i02) {
+            const uint slot = atomic_fetch_add_explicit(&rowids_count, 1u, memory_order_relaxed);
+            rowids[slot] = ushort2(ii0, ii1);
         }
     }
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
+    const int64_t _ne1 = (int64_t)atomic_load_explicit(&rowids_count, memory_order_relaxed);
 
     kernel_mul_mm_id_impl<block_q, nl, dequantize_func>(
         src0,

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2457,28 +2457,19 @@ fn commands_concurrent_acquisition() {
 // Validates that the per-expert MoE dispatcher routes each `(token, slot)`
 // pair to the expert selected by `ids` and that the resulting matmul matches
 // a naive CPU reference. F32 is used as the dtype because it carries no
-// quantization rounding, so the kernel output should match the CPU reference
-// to within a tight FP tolerance (here: per-element abs diff < 1e-3).
+// quantization rounding; tolerance is per-element abs diff < 1e-3.
 //
 // The kernel (templated on `<float4x4, 1, dequantize_f32>`) requires `K` to
-// be a multiple of `BLOCK_SIZE_K = 32` (the inner loop in
-// `kernel_mul_mm_id_impl` walks `ne00` in stride-32 tiles). `M`, `T`, and
-// `N` may be smaller than the output tile (`64 x 32`); the kernel clamps
-// `n_rows` / `n_cols` for partial tiles.
+// be a multiple of `BLOCK_SIZE_K = 32`. `M`, `T`, and `N` may be smaller
+// than the output tile (`64 x 32`); the kernel clamps `n_rows` / `n_cols`.
 //
-// Kernel I/O recap (see `metal_src/quantized.metal:7143-7264`):
-//   - `src1` is indexed by the slot dimension (rowids stores
-//     `ushort2(ii0=slot, ii1=token)`; the matmul reads
-//     `nb12 * id[1] + nb11 * (id[0] % ne11)`; for the wrapper convention
-//     `src1_shape = [num_tokens, k]` we get `nb12 = 0`, so the input row is
-//     selected by `slot % num_tokens`).
-//   - dst writes are at flat offset `j + slot * ne0 + token * (ne0 * ne1)`
-//     where `ne0 = n` and `ne1 = nei0 * nei1 = experts_per_token *
-//     num_tokens`. The per-token stride is therefore
-//     `n * experts_per_token * num_tokens`, not the contiguous
-//     `n * experts_per_token`. Buffers passed by callers must be sized for
-//     this stride.
-// The CPU reference below mirrors this exactly.
+// Output layout (post fix): dst is a contiguous `[num_tokens, experts_per_tok, n]`
+// f32 tensor. dst[t, s, j] sits at flat index `t * (experts_per_tok * n) +
+// s * n + j`. The wrapper sets the kernel's host `ne1 = nei0` so the
+// `jid[1] * (ne0 * ne1)` write offset lands at the right per-token stride.
+// src1 is `[num_tokens, k]` and the wrapper sets `ne11 = 1`, `nb11 = 0`,
+// `ne12 = num_tokens`, `nb12 = k * 4`, so the kernel reads `src1[token, k]`
+// for any slot of that token.
 #[test]
 fn qmatmul_mm_id_f32_correctness() {
     use crate::kernels::quantized::call_quantized_matmul_mm_id;
@@ -2507,24 +2498,21 @@ fn qmatmul_mm_id_f32_correctness() {
         .map(|v| ((v % 13) as f32) * 0.02 - 0.12)
         .collect();
 
-    // Per-token output stride in the dst buffer, in f32 elements. See the
-    // kernel write address derivation in the comment block above.
-    let token_stride = n * experts_per_tok * num_tokens;
-    let out_elems = (num_tokens - 1) * token_stride + experts_per_tok * n;
+    // Contiguous `[num_tokens, experts_per_tok, n]` output layout.
+    let token_stride = experts_per_tok * n;
+    let out_elems = num_tokens * token_stride;
 
     // CPU reference: out[t * token_stride + s * n + j]
-    //   = sum_k weights[ids[t, s], j, k] * src1[s % M, k].
-    // (`src1[s % M]` not `src1[t]`: see comment block above.)
+    //   = sum_k weights[ids[t, s], j, k] * input[t, k].
     let mut expected = vec![0.0f32; out_elems];
     for t in 0..num_tokens {
         for s in 0..experts_per_tok {
             let e = ids_i32[t * experts_per_tok + s] as usize;
-            let src1_row = s % num_tokens;
             for j in 0..n {
                 let mut acc = 0.0f32;
                 for kk in 0..k {
                     let w = weights_f32[e * n * k + j * k + kk];
-                    let x = input_f32[src1_row * k + kk];
+                    let x = input_f32[t * k + kk];
                     acc += w * x;
                 }
                 expected[t * token_stride + s * n + j] = acc;

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2451,3 +2451,176 @@ fn commands_concurrent_acquisition() {
 
     commands.wait_until_completed().unwrap();
 }
+
+// Correctness test for `call_quantized_matmul_mm_id`.
+//
+// Validates that the per-expert MoE dispatcher routes each `(token, slot)`
+// pair to the expert selected by `ids` and that the resulting matmul matches
+// a naive CPU reference. F32 is used as the dtype because it carries no
+// quantization rounding, so the kernel output should match the CPU reference
+// to within a tight FP tolerance (here: per-element abs diff < 1e-3).
+//
+// The kernel (templated on `<float4x4, 1, dequantize_f32>`) requires `K` to
+// be a multiple of `BLOCK_SIZE_K = 32` (the inner loop in
+// `kernel_mul_mm_id_impl` walks `ne00` in stride-32 tiles). `M`, `T`, and
+// `N` may be smaller than the output tile (`64 x 32`); the kernel clamps
+// `n_rows` / `n_cols` for partial tiles.
+//
+// Kernel I/O recap (see `metal_src/quantized.metal:7143-7264`):
+//   - `src1` is indexed by the slot dimension (rowids stores
+//     `ushort2(ii0=slot, ii1=token)`; the matmul reads
+//     `nb12 * id[1] + nb11 * (id[0] % ne11)`; for the wrapper convention
+//     `src1_shape = [num_tokens, k]` we get `nb12 = 0`, so the input row is
+//     selected by `slot % num_tokens`).
+//   - dst writes are at flat offset `j + slot * ne0 + token * (ne0 * ne1)`
+//     where `ne0 = n` and `ne1 = nei0 * nei1 = experts_per_token *
+//     num_tokens`. The per-token stride is therefore
+//     `n * experts_per_token * num_tokens`, not the contiguous
+//     `n * experts_per_token`. Buffers passed by callers must be sized for
+//     this stride.
+// The CPU reference below mirrors this exactly.
+#[test]
+fn qmatmul_mm_id_f32_correctness() {
+    use crate::kernels::quantized::call_quantized_matmul_mm_id;
+    use crate::kernels::GgmlDType;
+
+    let num_experts: usize = 4;
+    let num_tokens: usize = 3;
+    let experts_per_tok: usize = 2;
+    let n: usize = 8;
+    // K must be a multiple of BLOCK_SIZE_K = 32 in the kernel.
+    let k: usize = 32;
+
+    // Deterministic, well-spread routing: ids[t, s] = (t * 2 + s) % E.
+    // For (E=4, M=3, T=2) this yields:
+    //   t=0: [0, 1], t=1: [2, 3], t=2: [0, 1].
+    // Every expert is hit at least once.
+    let ids_i32: Vec<i32> = (0..(num_tokens * experts_per_tok))
+        .map(|i| (i as i32) % (num_experts as i32))
+        .collect();
+
+    // Distinct, bounded values to keep the f32 sums in a safe range.
+    let weights_f32: Vec<f32> = (0..(num_experts * n * k))
+        .map(|v| ((v % 17) as f32) * 0.01 - 0.08)
+        .collect();
+    let input_f32: Vec<f32> = (0..(num_tokens * k))
+        .map(|v| ((v % 13) as f32) * 0.02 - 0.12)
+        .collect();
+
+    // Per-token output stride in the dst buffer, in f32 elements. See the
+    // kernel write address derivation in the comment block above.
+    let token_stride = n * experts_per_tok * num_tokens;
+    let out_elems = (num_tokens - 1) * token_stride + experts_per_tok * n;
+
+    // CPU reference: out[t * token_stride + s * n + j]
+    //   = sum_k weights[ids[t, s], j, k] * src1[s % M, k].
+    // (`src1[s % M]` not `src1[t]`: see comment block above.)
+    let mut expected = vec![0.0f32; out_elems];
+    for t in 0..num_tokens {
+        for s in 0..experts_per_tok {
+            let e = ids_i32[t * experts_per_tok + s] as usize;
+            let src1_row = s % num_tokens;
+            for j in 0..n {
+                let mut acc = 0.0f32;
+                for kk in 0..k {
+                    let w = weights_f32[e * n * k + j * k + kk];
+                    let x = input_f32[src1_row * k + kk];
+                    acc += w * x;
+                }
+                expected[t * token_stride + s * n + j] = acc;
+            }
+        }
+    }
+
+    let device = device();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+
+    let weights_buf = new_buffer(&device, &weights_f32);
+    let input_buf = new_buffer(&device, &input_f32);
+    let ids_buf = new_buffer(&device, &ids_i32);
+    let out_buf = new_buffer(&device, &vec![0.0f32; out_elems]);
+
+    let f32_size = core::mem::size_of::<f32>();
+    let i32_size = core::mem::size_of::<i32>();
+
+    let src0_shape = [num_experts, n, k];
+    // Row-major byte strides for [E, N, K] f32. The wrapper indexes
+    // strides from the end (`[sr - 2]` is the N-row stride, `[sr - 3]` is
+    // the per-expert stride), so a leading "batch" stride is required to
+    // place those at the right positions in a length-4 array.
+    let row_bytes = k * f32_size;
+    let expert_bytes = n * row_bytes;
+    let src0_stride = [
+        num_experts * expert_bytes,
+        expert_bytes,
+        row_bytes,
+        f32_size,
+    ];
+
+    let src1_shape = [num_tokens, k];
+    let src1_stride = [k * f32_size, f32_size];
+
+    let ids_shape = [num_tokens, experts_per_tok];
+    let ids_stride = [experts_per_tok * i32_size, i32_size];
+
+    let kernels = Kernels::new();
+    call_quantized_matmul_mm_id(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &src0_shape,
+        &src0_stride,
+        &weights_buf,
+        &src1_shape,
+        &src1_stride,
+        &input_buf,
+        0,
+        &ids_shape,
+        &ids_stride,
+        &ids_buf,
+        0,
+        &[num_tokens, experts_per_tok, n],
+        0,
+        &out_buf,
+    )
+    .unwrap();
+
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got: Vec<f32> = read_to_vec(&out_buf, out_elems);
+    assert_eq!(got.len(), expected.len());
+
+    // Per-element abs diff < 1e-3 over the cells the kernel actually writes
+    // (one `n`-wide row per (token, slot) pair, strided by `token_stride`).
+    // f32 matmul over K=32 has accumulated rounding well under this bound;
+    // tightening to 1e-5 would also pass on an M-series GPU but 1e-3 is
+    // robust across hardware.
+    let tol = 1e-3f32;
+    let mut max_abs_diff = 0.0f32;
+    let mut worst_idx = 0usize;
+    for t in 0..num_tokens {
+        for s in 0..experts_per_tok {
+            for j in 0..n {
+                let i = t * token_stride + s * n + j;
+                let d = (got[i] - expected[i]).abs();
+                if d > max_abs_diff {
+                    max_abs_diff = d;
+                    worst_idx = i;
+                }
+            }
+        }
+    }
+    assert!(
+        max_abs_diff < tol,
+        "qmatmul_mm_id F32 output diverges from CPU reference: \
+         max_abs_diff = {} at flat index {} (got = {}, expected = {}, tol = {})",
+        max_abs_diff,
+        worst_idx,
+        got[worst_idx],
+        expected[worst_idx],
+        tol,
+    );
+}


### PR DESCRIPTION
The single-pass MoE-fused matmul shader `kernel_mul_mm_id` is vendored at `candle-metal-kernels/src/metal_src/quantized.metal:7267` but is not callable from Rust today. This PR:

1. Adds `call_quantized_matmul_mm_id` in `candle-metal-kernels` mirroring `call_quantized_matmul_mm_t`. Public dispatch function for callers that own their own MoE routing (CustomOp users, candle-transformers MoE models). Not auto-wired into `QMatMul::forward`; that is a follow-up once the wrapper has callers.

2. Parallelizes the rowids fan-out at `quantized.metal:7301`. The vendored shader carries a `TODO: parallelize this loop` here, inherited from the older single-pass `kernel_mul_mm_id` shape. The serial scan runs in every thread of every threadgroup, redundantly scanning the full `M * T` ids buffer; for Qwen3-MoE shapes (`num_experts=128`, `T=8`) at `M=256` this dominates the kernel runtime. The replacement uses a stride-128 scan plus a threadgroup atomic counter. The downstream matmul reads rowids by index and writes into `dst[jid[0], jid[1], :]`, so the resulting non-deterministic rowid order does not affect output. Upstream `ggml-org/llama.cpp` has since refactored to a two-pass `kernel_mul_mm_id_map0` + `kernel_mul_mm_id` design (see `ggml/src/ggml-metal/ggml-metal.metal:9721-9784`) where the first pass is already parallel, so there is no longer anything to upstream this change to.

3. Adds a Criterion microbench at `candle-core/benches/benchmarks/qmatmul_id.rs` driving the wrapper at Q4_K and F16, `N=2048`, `K=4096`, `num_experts=128`, `T=8`. Q4_K sweeps `M in {1, 32, 256}`; F16 sweeps `M in {1, 32}` only (the F16 weight stack at these shapes is ~2.15 GB and crowds a 16 GB host at `M=256`). Plus a `QMatMul::forward` baseline at the equivalent per-expert load for comparison.

4. Adds an F32 correctness test (`src/tests.rs::qmatmul_mm_id_f32_correctness`) that validates the wrapper output against a naive CPU reference. Writing this test surfaced a wrapper layout bug (commit `0223447`): `ne1` was set to `nei0 * nei1` instead of `nei0`, and `src1` was wired with `ne11 = num_tokens` instead of `ne11 = 1`, so the kernel wrote dst at `+token * (n * num_tokens * T)` and read src1 at row `slot % num_tokens`. Microbenches never read their output and the prior iterations silently wrote out of bounds for `M > 1`. The fix and the correctness test landed together; the rewritten wrapper now produces a contiguous `[num_tokens, experts_per_token, n]` output the test asserts byte-for-byte against the CPU reference.

Benchmarks on MacBook Air M4, 16 GB unified memory, macOS 26.3.1 (post wrapper-layout fix):

Q4_K (the realistic MoE quantization):

| Case | this PR (fused) | `mm_t * num_experts` baseline |
| --- | ---: | ---: |
| M=1 (decode, 8 experts hit) | 1.94 ms / 69 GFLOPs/s | 8 * 40.2 us = 0.32 ms |
| M=32 (small prefill, all 128) | 27.9 ms / 154 GFLOPs/s | 128 * 273 us = 35.0 ms |
| M=256 (chunked, all 128) | 52.9 ms / 649 GFLOPs/s | 128 * 273 us = 35.0 ms |

F16 (skips the per-row dequant the Q4_K path pays):

| Case | this PR (fused) |
| --- | ---: |
| M=1 | 1.71 ms / 78 GFLOPs/s |
| M=32 | 25.3 ms / 170 GFLOPs/s |

Effect of the rowids fan-out parallelization in isolation (with vs without point 2 above): Q4_K `M=256` goes from 800 ms (43 GFLOPs/s) to 52.9 ms (649 GFLOPs/s), a 15.1x speedup attributable to the scan rewrite.

The fused dispatch wins over the per-expert `mm_t` loop at `M=32` (1.25x faster on Q4_K) and is within 1.5x of the loop at `M=256`. Both extremes are still limited by per-threadgroup overhead from launching all `num_experts` expert-threadgroups regardless of routing density; closing that is a follow-up (the M=1 microbench at `num_experts=8` simulating an ideal active-expert pre-pack only gave ~9% over the current 128-launch path, so the structural fix would be a matvec kernel variant).

Bench command:
```
cd candle-core && cargo bench --bench bench_main --features metal -- qmatmul_id
```

References:
- `kernel_mul_mm_id` upstream: `ggml-org/llama.cpp`. Llama.cpp has since refactored to a two-pass `_id_map0` + `mm_id` design (see `ggml-metal-ops.cpp:2329`); candle vendored only the older single-pass kernel.
- Related: #3444 (bounced for scope); this PR addresses only the MoE-fused matmul wrapper, no fused-quant cross-products, no encoder reuse.
