### PR TITLE
fix(kernels): provide __hmax_nan/__hmin_nan fallback for sm_75 (Turing)

### DIFF
--- a/candle-kernels/src/compatibility.cuh
+++ b/candle-kernels/src/compatibility.cuh
@@ -7,7 +7,7 @@
 
 // FIXME: the minimum compute capabilities are just guesses since the table is not specific enough
 
-#if (__CUDACC_VER_MAJOR__ < 12 || __CUDACC_VER_MINOR__ < 2) && __CUDA_ARCH__ < 750
+#if __CUDA_ARCH__ < 800
 __device__ __forceinline__ __half __hmax_nan(__half a, __half b) {
     return __hisnan(a) ? a : (__hisnan(b) ? b : __hmax(a, b));
 }


### PR DESCRIPTION
  CUDA 12.x removed the software fallback for __hmax_nan/__hmin_nan on
  architectures below sm_80. The previous guard __CUDA_ARCH__ < 750 excluded
  exactly sm_75 (GTX 1650/1660/T4). Changed boundary to < 800 since these
  become native hardware instructions on sm_80 (Ampere) and above.

  - GPU affected: sm_75 (GTX 1650, 1660, T4) with CUDA 12.x
  - Root cause: __CUDA_ARCH__ < 750 boundary is off-by-one — sm_75 = 750 so the condition is false, skipping the software fallback. __hmax_nan/__hmin_nan are hardware-only on sm_80+.
  - Fix: Change guard to __CUDA_ARCH__ < 800, which correctly covers all pre-Ampere architectures.
  - Tested with: CUDA 12.0, GTX 1650 (sm_75), candle-kernels 0.10.2