### PR TITLE
Fix FAv3 packing and symbol overlap

### DIFF
--- a/candle-flash-attn-v3/hkernel/flash_api.cu
+++ b/candle-flash-attn-v3/hkernel/flash_api.cu
@@ -172,7 +172,7 @@ void print_params(const Flash_fwd_params &p) {
 }
 
 
-void run_mha_fwd(Flash_fwd_params &params, cudaStream_t stream) {
+void run_mha_fwd_v3(Flash_fwd_params &params, cudaStream_t stream) {
     // Select a numeric code for precision:
     //   3 = cutlass::float_e4m3_t  (fp8)
     //   2 = cutlass::bfloat16_t    (bf16)
@@ -199,7 +199,7 @@ void run_mha_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     });
 }
 
-extern "C" void run_mha(
+extern "C" void run_mha_v3(
     void *q_ptr,
     void *k_ptr,
     void *v_ptr,
@@ -325,5 +325,5 @@ extern "C" void run_mha(
     // print_params(params);
     
     cudaStream_t stream = 0; // Use the default stream.
-    run_mha_fwd(params, stream);
+    run_mha_fwd_v3(params, stream);
 }

--- a/candle-flash-attn-v3/src/ffi.rs
+++ b/candle-flash-attn-v3/src/ffi.rs
@@ -10,7 +10,7 @@
 use core::ffi::{c_int, c_void};
 
 extern "C" {
-    pub(crate) fn run_mha(
+    pub(crate) fn run_mha_v3(
         q_ptr: *const c_void,
         k_ptr: *const c_void,
         v_ptr: *const c_void,

--- a/candle-flash-attn-v3/src/lib.rs
+++ b/candle-flash-attn-v3/src/lib.rs
@@ -102,7 +102,7 @@ impl FlashAttn {
         if num_heads % num_heads_k != 0 {
             candle::bail!("number of k/v heads {num_heads_k} must divide number of heads in query {num_heads}")
         }
-        let use_gqa_packing = match num_heads_k / num_heads {
+        let use_gqa_packing = match num_heads / num_heads_k {
             2 | 4 | 8 | 16 | 32 => self.use_gqa_packing as i32,
             _ => 0,
         };
@@ -186,7 +186,7 @@ impl FlashAttn {
             let (v_ptr, _guard) = v.device_ptr(&stream);
             let (dst_ptr, _guard) = dst.device_ptr(&stream);
             let (softmax_lse_ptr, _guard) = softmax_lse.device_ptr(&stream);
-            ffi::run_mha(
+            ffi::run_mha_v3(
                 q_ptr as *const core::ffi::c_void,
                 k_ptr as *const core::ffi::c_void,
                 v_ptr as *const core::ffi::c_void,
@@ -530,7 +530,7 @@ impl FlashAttnVarLen {
         if num_heads % num_heads_k != 0 {
             candle::bail!("number of k/v heads {num_heads_k} must divide number of heads in query {num_heads}")
         }
-        let use_gqa_packing = match num_heads_k / num_heads {
+        let use_gqa_packing = match num_heads / num_heads_k {
             2 | 4 | 8 | 16 | 32 => self.use_gqa_packing as i32,
             _ => 0,
         };
@@ -632,7 +632,7 @@ impl FlashAttnVarLen {
             let (softmax_lse_ptr, _guard) = softmax_lse.device_ptr(&stream);
             let (seqlens_q_ptr, _guard) = seqlens_q.device_ptr(&stream);
             let (seqlens_k_ptr, _guard) = seqlens_k.device_ptr(&stream);
-            ffi::run_mha(
+            ffi::run_mha_v3(
                 q_ptr as *const core::ffi::c_void,
                 k_ptr as *const core::ffi::c_void,
                 v_ptr as *const core::ffi::c_void,


### PR DESCRIPTION
1. GQA packing ratio bug
`num_heads_k / num_heads` -> `num_heads / num_heads_k`
For normal GQA, num_heads > num_kv_heads, so the old expression integer-divides to 0 and silently disables GQA packing.

2. FA2/FA3 exported symbol collision
`run_mha` -> `run_mha_v3`, which helps fix a linking error when candle-flash-attn and candle-flash-attn-v3 are linked into the same binary.