### PR TITLE
Add QTensor row dequantization helper

### DIFF
--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -117,6 +117,60 @@ impl QMetalStorage {
         ))
     }
 
+    pub fn dequantize_rows(
+        &self,
+        indices: &[u32],
+        row_dim: usize,
+        num_rows: usize,
+    ) -> Result<MetalStorage> {
+        for &idx in indices {
+            if idx as usize >= num_rows {
+                crate::bail!("row index {idx} out of bounds (num_rows={num_rows})");
+            }
+        }
+
+        let output_elem_count = indices.len() * row_dim;
+        let indices_buffer = self.device.new_buffer_with_data(indices)?;
+        let output_buffer =
+            self.device
+                .new_buffer(output_elem_count, DType::F32, "dequantize_rows")?;
+
+        let kernel_dtype = match self.dtype {
+            GgmlDType::Q4_0 => candle_metal_kernels::GgmlDType::Q4_0,
+            GgmlDType::Q4_1 => candle_metal_kernels::GgmlDType::Q4_1,
+            GgmlDType::Q5_0 => candle_metal_kernels::GgmlDType::Q5_0,
+            GgmlDType::Q5_1 => candle_metal_kernels::GgmlDType::Q5_1,
+            GgmlDType::Q8_0 => candle_metal_kernels::GgmlDType::Q8_0,
+            GgmlDType::Q2K => candle_metal_kernels::GgmlDType::Q2K,
+            GgmlDType::Q3K => candle_metal_kernels::GgmlDType::Q3K,
+            GgmlDType::Q4K => candle_metal_kernels::GgmlDType::Q4K,
+            GgmlDType::Q5K => candle_metal_kernels::GgmlDType::Q5K,
+            GgmlDType::Q6K => candle_metal_kernels::GgmlDType::Q6K,
+            dtype => crate::bail!("dequantize_rows not supported for {dtype:?}"),
+        };
+
+        let encoder = self.device.command_encoder()?;
+        candle_metal_kernels::call_quantized_get_rows(
+            self.device.device(),
+            &encoder,
+            self.device.kernels(),
+            kernel_dtype,
+            row_dim,
+            indices.len(),
+            &self.buffer,
+            &indices_buffer,
+            &output_buffer,
+        )
+        .map_err(crate::Error::wrap)?;
+
+        Ok(MetalStorage::new(
+            output_buffer,
+            self.device.clone(),
+            output_elem_count,
+            DType::F32,
+        ))
+    }
+
     pub fn quantize(&mut self, src: &MetalStorage) -> Result<()> {
         // Quantization only happens on CPU for now.
         let src = src.to_cpu::<f32>()?;

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -633,6 +633,84 @@ impl QTensor {
         crate::tensor::from_storage(storage, self.shape.clone(), none, false).to_device(device)
     }
 
+    pub fn dequantize_rows(&self, indices: &[u32], device: &Device) -> Result<Tensor> {
+        let dims = self.shape.dims();
+        if dims.len() != 2 {
+            crate::bail!("dequantize_rows requires a 2D tensor, got {:?}", self.shape);
+        }
+
+        let n_rows = dims[0];
+        let row_dim = dims[1];
+        let dtype = self.dtype();
+        let block_size = dtype.block_size();
+        if !row_dim.is_multiple_of(block_size) {
+            crate::bail!(
+                "row_dim {row_dim} is not a multiple of block_size {block_size} for {dtype:?}"
+            );
+        }
+
+        #[cfg(feature = "metal")]
+        if let QStorage::Metal(metal_storage) = &self.storage {
+            let metal_out = metal_storage.dequantize_rows(indices, row_dim, n_rows)?;
+            let none = crate::op::BackpropOp::none();
+            return crate::tensor::from_storage(
+                Storage::Metal(metal_out),
+                (indices.len(), row_dim),
+                none,
+                false,
+            )
+            .to_device(device);
+        }
+
+        let blocks_per_row = row_dim / block_size;
+        let type_size = dtype.type_size();
+        let bytes_per_row = blocks_per_row * type_size;
+        let data = self.data()?;
+        let mut output = vec![0f32; indices.len() * row_dim];
+
+        macro_rules! dequant_rows {
+            ($block_ty:ty) => {{
+                for (out_row, &idx) in indices.iter().enumerate() {
+                    let idx = idx as usize;
+                    if idx >= n_rows {
+                        crate::bail!("row index {idx} out of bounds (n_rows={n_rows})");
+                    }
+
+                    let byte_offset = idx * bytes_per_row;
+                    let row_bytes = &data[byte_offset..byte_offset + bytes_per_row];
+                    let blocks = unsafe {
+                        std::slice::from_raw_parts(
+                            row_bytes.as_ptr().cast::<$block_ty>(),
+                            blocks_per_row,
+                        )
+                    };
+                    let out_slice = &mut output[out_row * row_dim..(out_row + 1) * row_dim];
+                    <$block_ty as k_quants::GgmlType>::to_float(blocks, out_slice);
+                }
+            }};
+        }
+
+        match dtype {
+            GgmlDType::Q4_0 => dequant_rows!(BlockQ4_0),
+            GgmlDType::Q4_1 => dequant_rows!(BlockQ4_1),
+            GgmlDType::Q5_0 => dequant_rows!(BlockQ5_0),
+            GgmlDType::Q5_1 => dequant_rows!(BlockQ5_1),
+            GgmlDType::Q8_0 => dequant_rows!(BlockQ8_0),
+            GgmlDType::Q8_1 => dequant_rows!(BlockQ8_1),
+            GgmlDType::Q2K => dequant_rows!(BlockQ2K),
+            GgmlDType::Q3K => dequant_rows!(BlockQ3K),
+            GgmlDType::Q4K => dequant_rows!(BlockQ4K),
+            GgmlDType::Q5K => dequant_rows!(BlockQ5K),
+            GgmlDType::Q6K => dequant_rows!(BlockQ6K),
+            GgmlDType::Q8K => dequant_rows!(BlockQ8K),
+            GgmlDType::F32 | GgmlDType::F16 | GgmlDType::BF16 => {
+                crate::bail!("dequantize_rows not needed for {dtype:?}, use index_select");
+            }
+        }
+
+        Tensor::from_vec(output, (indices.len(), row_dim), &Device::Cpu)?.to_device(device)
+    }
+
     pub fn dequantize_f16(&self, device: &Device) -> Result<Tensor> {
         // In the CUDA case, we have a specialized kernel as this can be useful for volta
         // architectures. https://github.com/huggingface/candle/issues/2136

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -261,6 +261,49 @@ test_device!(quantized_matmul, qmm_cpu, qmm_cuda, qmm_metal);
 test_device!(quantized_matmul_neg, qmm_n_cpu, qmm_n_cuda, qmm_n_metal);
 test_device!(qmm_batch, qmm_b_cpu, qmm_b_cuda, qmm_b_metal);
 
+fn qtensor_dequantize_rows(device: &Device) -> Result<()> {
+    let src = Tensor::from_vec(
+        (0..6 * 256)
+            .map(|i| ((i % 173) as f32 - 86.) / 19.)
+            .collect(),
+        (6, 256),
+        device,
+    )?;
+    let qtensor = quantized::QTensor::quantize(&src, GgmlDType::Q4K)?;
+    let indices = [4u32, 1, 4, 0];
+    let index_tensor = Tensor::new(indices.to_vec(), device)?;
+
+    let got = qtensor.dequantize_rows(&indices, device)?;
+    let expected = qtensor.dequantize(device)?.index_select(&index_tensor, 0)?;
+    let diff = (&got - &expected)?.abs()?.sum_all()?.to_scalar::<f32>()?;
+    assert_eq!(got.shape().dims(), [indices.len(), 256]);
+    assert_eq!(diff, 0.0);
+    Ok(())
+}
+
+#[test]
+fn qtensor_dequantize_rows_out_of_bounds() -> Result<()> {
+    let device = Device::Cpu;
+    let src = Tensor::from_vec(
+        (0..3 * 256).map(|i| i as f32 / 17.).collect(),
+        (3, 256),
+        &device,
+    )?;
+    let qtensor = quantized::QTensor::quantize(&src, GgmlDType::Q4K)?;
+    let err = qtensor
+        .dequantize_rows(&[3], &device)
+        .expect_err("out-of-bounds row access should fail");
+    assert!(err.to_string().contains("out of bounds"));
+    Ok(())
+}
+
+test_device!(
+    qtensor_dequantize_rows,
+    qtensor_dequantize_rows_cpu,
+    qtensor_dequantize_rows_cuda,
+    qtensor_dequantize_rows_metal
+);
+
 fn quantize_q4_0(device: &Device) -> Result<()> {
     let src = (0..32 * 4).map(|v| v as f32).collect::<Vec<_>>();
 

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -174,6 +174,88 @@ pub fn call_quantized_matmul_mv_t(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn call_quantized_get_rows(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    dtype: GgmlDType,
+    row_dim: usize,
+    num_indices: usize,
+    src0: &Buffer,
+    indices: &Buffer,
+    dst: &Buffer,
+) -> Result<(), MetalKernelError> {
+    let name = match dtype {
+        GgmlDType::Q4_0 => "kernel_get_rows_q4_0",
+        GgmlDType::Q4_1 => "kernel_get_rows_q4_1",
+        GgmlDType::Q5_0 => "kernel_get_rows_q5_0",
+        GgmlDType::Q5_1 => "kernel_get_rows_q5_1",
+        GgmlDType::Q8_0 => "kernel_get_rows_q8_0",
+        GgmlDType::Q2K => "kernel_get_rows_q2_K",
+        GgmlDType::Q3K => "kernel_get_rows_q3_K",
+        GgmlDType::Q4K => "kernel_get_rows_q4_K",
+        GgmlDType::Q5K => "kernel_get_rows_q5_K",
+        GgmlDType::Q6K => "kernel_get_rows_q6_K",
+        dtype => {
+            return Err(MetalKernelError::LoadLibraryError(format!(
+                "get_rows not supported for {dtype:?}"
+            )));
+        }
+    };
+
+    let (type_size, block_size) = match dtype {
+        GgmlDType::Q4_0 => (18, 32),
+        GgmlDType::Q4_1 => (20, 32),
+        GgmlDType::Q5_0 => (22, 32),
+        GgmlDType::Q5_1 => (24, 32),
+        GgmlDType::Q8_0 => (34, 32),
+        GgmlDType::Q2K => (84, 256),
+        GgmlDType::Q3K => (110, 256),
+        GgmlDType::Q4K => (144, 256),
+        GgmlDType::Q5K => (176, 256),
+        GgmlDType::Q6K => (210, 256),
+        _ => unreachable!(),
+    };
+    let blocks_per_row = row_dim / block_size;
+    let nb01 = (blocks_per_row * type_size) as u64;
+
+    let ne00 = row_dim as i64;
+    let nb02 = 0u64;
+    let ne10 = num_indices as i64;
+    let nb10 = 4u64;
+    let nb11 = 0u64;
+    let nb1 = (row_dim * std::mem::size_of::<f32>()) as u64;
+    let nb2 = 0u64;
+
+    let pipeline = kernels.load_pipeline(device, Source::Quantized, name)?;
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    set_params!(
+        encoder,
+        (
+            src0, indices, dst, ne00, nb01, nb02, ne10, nb10, nb11, nb1, nb2
+        )
+    );
+
+    let threads_per_row = (row_dim / 16).min(1024);
+    let thread_groups_count = MTLSize {
+        width: num_indices,
+        height: 1,
+        depth: 1,
+    };
+    let threads_per_threadgroup = MTLSize {
+        width: threads_per_row,
+        height: 1,
+        depth: 1,
+    };
+
+    encoder.dispatch_thread_groups(thread_groups_count, threads_per_threadgroup);
+    Ok(())
+}
+
 /// - src0 is usually weight
 /// - src1 is usually xs
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Summary
- add QTensor::dequantize_rows for selecting rows from 2D quantized tensors without dequantizing the full tensor
- add a Metal get_rows launcher using the existing quantized Metal kernels
- cover CPU row selection and out-of-bounds behavior in quantized tests

## Tests
- cargo test -p candle-core qtensor_dequantize_rows