### PR TITLE
Add htod cache for cuda graphs

### DIFF
--- a/candle-core/src/cuda_backend/device.rs
+++ b/candle-core/src/cuda_backend/device.rs
@@ -5,8 +5,8 @@ pub use cudarc;
 use cudarc::driver::CudaFunction;
 use float8::F8E4M3;
 use half::{bf16, f16};
-use std::any::TypeId;
-use std::cell::RefCell;
+use std::any::{Any, TypeId};
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -31,8 +31,21 @@ unsafe impl Send for CudaRng {}
 const CUDA_GRAPH_HTOD_CACHE_MAX_BYTES: usize = 4096;
 
 thread_local! {
-    static CUDA_GRAPH_HTOD_CACHE: RefCell<HashMap<(DeviceId, TypeId, Vec<u8>), Box<dyn std::any::Any>>> =
+    static CUDA_GRAPH_HTOD_CACHE: RefCell<HashMap<(DeviceId, TypeId, Vec<u8>), Box<dyn Any>>> =
         RefCell::new(HashMap::new());
+    static CUDA_GRAPH_HTOD_CACHE_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+#[must_use]
+pub struct CudaGraphHtodCacheGuard;
+
+impl Drop for CudaGraphHtodCacheGuard {
+    fn drop(&mut self) {
+        CUDA_GRAPH_HTOD_CACHE_DEPTH.with(|depth| {
+            debug_assert!(depth.get() > 0);
+            depth.set(depth.get().saturating_sub(1));
+        });
+    }
 }
 
 pub struct ModuleStore {
@@ -73,6 +86,11 @@ impl CudaDevice {
         self.stream.alloc_zeros::<T>(len).w()
     }
 
+    pub fn enable_cuda_graph_htod_cache(&self) -> CudaGraphHtodCacheGuard {
+        CUDA_GRAPH_HTOD_CACHE_DEPTH.with(|depth| depth.set(depth.get() + 1));
+        CudaGraphHtodCacheGuard
+    }
+
     pub fn memcpy_htod<
         T: cudarc::driver::DeviceRepr + 'static,
         Src: cudarc::driver::HostSlice<T> + ?Sized,
@@ -82,7 +100,7 @@ impl CudaDevice {
         src: &Src,
         dst: &mut Dst,
     ) -> Result<()> {
-        if cuda_graph_pinned_htod_enabled() && !src.is_empty() {
+        if cuda_graph_htod_cache_enabled() && !src.is_empty() {
             return self.memcpy_htod_capture_cached(src, dst);
         }
         self.stream.memcpy_htod(src, dst).w()
@@ -126,7 +144,7 @@ impl CudaDevice {
         &self,
         src: &Src,
     ) -> Result<cudarc::driver::CudaSlice<T>> {
-        if cuda_graph_pinned_htod_enabled() && !src.is_empty() {
+        if cuda_graph_htod_cache_enabled() && !src.is_empty() {
             return self.clone_htod_capture_cached(src);
         }
         self.stream.clone_htod(src).w()
@@ -209,10 +227,8 @@ impl CudaDevice {
     }
 }
 
-fn cuda_graph_pinned_htod_enabled() -> bool {
-    std::env::var("CANDLE_CUDA_GRAPH_PINNED_HTOD")
-        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
-        .unwrap_or(false)
+fn cuda_graph_htod_cache_enabled() -> bool {
+    CUDA_GRAPH_HTOD_CACHE_DEPTH.with(|depth| depth.get() > 0)
 }
 
 pub struct CudaFunc {

--- a/candle-core/src/cuda_backend/device.rs
+++ b/candle-core/src/cuda_backend/device.rs
@@ -5,6 +5,8 @@ pub use cudarc;
 use cudarc::driver::CudaFunction;
 use float8::F8E4M3;
 use half::{bf16, f16};
+use std::any::TypeId;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -25,6 +27,13 @@ impl DeviceId {
 
 struct CudaRng(cudarc::curand::CudaRng);
 unsafe impl Send for CudaRng {}
+
+const CUDA_GRAPH_HTOD_CACHE_MAX_BYTES: usize = 4096;
+
+thread_local! {
+    static CUDA_GRAPH_HTOD_CACHE: RefCell<HashMap<(DeviceId, TypeId, Vec<u8>), Box<dyn std::any::Any>>> =
+        RefCell::new(HashMap::new());
+}
 
 pub struct ModuleStore {
     mdls: [Option<Arc<cudarc::driver::CudaModule>>; kernels::ALL_IDS.len()],
@@ -65,7 +74,7 @@ impl CudaDevice {
     }
 
     pub fn memcpy_htod<
-        T: cudarc::driver::DeviceRepr,
+        T: cudarc::driver::DeviceRepr + 'static,
         Src: cudarc::driver::HostSlice<T> + ?Sized,
         Dst: cudarc::driver::DevicePtrMut<T>,
     >(
@@ -73,6 +82,9 @@ impl CudaDevice {
         src: &Src,
         dst: &mut Dst,
     ) -> Result<()> {
+        if cuda_graph_pinned_htod_enabled() && !src.is_empty() {
+            return self.memcpy_htod_capture_cached(src, dst);
+        }
         self.stream.memcpy_htod(src, dst).w()
     }
 
@@ -107,12 +119,100 @@ impl CudaDevice {
         self.stream.memcpy_dtoh(src, dst).w()
     }
 
-    pub fn clone_htod<T: cudarc::driver::DeviceRepr, Src: cudarc::driver::HostSlice<T> + ?Sized>(
+    pub fn clone_htod<
+        T: cudarc::driver::DeviceRepr + 'static,
+        Src: cudarc::driver::HostSlice<T> + ?Sized,
+    >(
         &self,
         src: &Src,
     ) -> Result<cudarc::driver::CudaSlice<T>> {
+        if cuda_graph_pinned_htod_enabled() && !src.is_empty() {
+            return self.clone_htod_capture_cached(src);
+        }
         self.stream.clone_htod(src).w()
     }
+
+    fn memcpy_htod_capture_cached<
+        T: cudarc::driver::DeviceRepr + 'static,
+        Src: cudarc::driver::HostSlice<T> + ?Sized,
+        Dst: cudarc::driver::DevicePtrMut<T>,
+    >(
+        &self,
+        src: &Src,
+        dst: &mut Dst,
+    ) -> Result<()> {
+        assert!(dst.len() >= src.len());
+        if let Some(cached) = self.cached_htod_slice(src)? {
+            return self.stream.memcpy_dtod(&cached, dst).w();
+        }
+        self.stream.memcpy_htod(src, dst).w()
+    }
+
+    fn clone_htod_capture_cached<
+        T: cudarc::driver::DeviceRepr + 'static,
+        Src: cudarc::driver::HostSlice<T> + ?Sized,
+    >(
+        &self,
+        src: &Src,
+    ) -> Result<cudarc::driver::CudaSlice<T>> {
+        if let Some(cached) = self.cached_htod_slice(src)? {
+            return Ok(cached);
+        }
+        self.stream.clone_htod(src).w()
+    }
+
+    fn cached_htod_slice<
+        T: cudarc::driver::DeviceRepr + 'static,
+        Src: cudarc::driver::HostSlice<T> + ?Sized,
+    >(
+        &self,
+        src: &Src,
+    ) -> Result<Option<cudarc::driver::CudaSlice<T>>> {
+        let (src_slice, _sync) = unsafe { src.stream_synced_slice(&self.stream) };
+        let byte_len = std::mem::size_of_val(src_slice);
+        if byte_len > CUDA_GRAPH_HTOD_CACHE_MAX_BYTES {
+            if self.cuda_graph_capture_active() {
+                crate::bail!("CUDA graph capture cannot upload uncached host data");
+            }
+            return Ok(None);
+        }
+
+        let bytes =
+            unsafe { std::slice::from_raw_parts(src_slice.as_ptr().cast::<u8>(), byte_len) }
+                .to_vec();
+        let key = (self.id, TypeId::of::<T>(), bytes);
+        if let Some(cached) = CUDA_GRAPH_HTOD_CACHE.with(|cache| {
+            cache.borrow().get(&key).and_then(|cached| {
+                cached
+                    .downcast_ref::<cudarc::driver::CudaSlice<T>>()
+                    .cloned()
+            })
+        }) {
+            return Ok(Some(cached));
+        }
+        if self.cuda_graph_capture_active() {
+            crate::bail!("CUDA graph capture missing cached host data");
+        }
+
+        let cached = self.stream.clone_htod(src).w()?;
+        CUDA_GRAPH_HTOD_CACHE.with(|cache| {
+            cache.borrow_mut().insert(key, Box::new(cached.clone()));
+        });
+        Ok(Some(cached))
+    }
+
+    fn cuda_graph_capture_active(&self) -> bool {
+        matches!(
+            self.stream.capture_status(),
+            Ok(status) if status != cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_NONE
+        )
+    }
+}
+
+fn cuda_graph_pinned_htod_enabled() -> bool {
+    std::env::var("CANDLE_CUDA_GRAPH_PINNED_HTOD")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
+        .unwrap_or(false)
 }
 
 pub struct CudaFunc {

--- a/candle-flash-attn-v3/hkernel/flash_api.cu
+++ b/candle-flash-attn-v3/hkernel/flash_api.cu
@@ -172,7 +172,7 @@ void print_params(const Flash_fwd_params &p) {
 }
 
 
-void run_mha_fwd(Flash_fwd_params &params, cudaStream_t stream) {
+void run_mha_fwd_v3(Flash_fwd_params &params, cudaStream_t stream) {
     // Select a numeric code for precision:
     //   3 = cutlass::float_e4m3_t  (fp8)
     //   2 = cutlass::bfloat16_t    (bf16)
@@ -199,7 +199,7 @@ void run_mha_fwd(Flash_fwd_params &params, cudaStream_t stream) {
     });
 }
 
-extern "C" void run_mha(
+extern "C" void run_mha_v3(
     void *q_ptr,
     void *k_ptr,
     void *v_ptr,
@@ -325,5 +325,5 @@ extern "C" void run_mha(
     // print_params(params);
     
     cudaStream_t stream = 0; // Use the default stream.
-    run_mha_fwd(params, stream);
+    run_mha_fwd_v3(params, stream);
 }

--- a/candle-flash-attn-v3/src/ffi.rs
+++ b/candle-flash-attn-v3/src/ffi.rs
@@ -10,7 +10,7 @@
 use core::ffi::{c_int, c_void};
 
 extern "C" {
-    pub(crate) fn run_mha(
+    pub(crate) fn run_mha_v3(
         q_ptr: *const c_void,
         k_ptr: *const c_void,
         v_ptr: *const c_void,

--- a/candle-flash-attn-v3/src/lib.rs
+++ b/candle-flash-attn-v3/src/lib.rs
@@ -102,7 +102,7 @@ impl FlashAttn {
         if num_heads % num_heads_k != 0 {
             candle::bail!("number of k/v heads {num_heads_k} must divide number of heads in query {num_heads}")
         }
-        let use_gqa_packing = match num_heads_k / num_heads {
+        let use_gqa_packing = match num_heads / num_heads_k {
             2 | 4 | 8 | 16 | 32 => self.use_gqa_packing as i32,
             _ => 0,
         };
@@ -186,7 +186,7 @@ impl FlashAttn {
             let (v_ptr, _guard) = v.device_ptr(&stream);
             let (dst_ptr, _guard) = dst.device_ptr(&stream);
             let (softmax_lse_ptr, _guard) = softmax_lse.device_ptr(&stream);
-            ffi::run_mha(
+            ffi::run_mha_v3(
                 q_ptr as *const core::ffi::c_void,
                 k_ptr as *const core::ffi::c_void,
                 v_ptr as *const core::ffi::c_void,
@@ -530,7 +530,7 @@ impl FlashAttnVarLen {
         if num_heads % num_heads_k != 0 {
             candle::bail!("number of k/v heads {num_heads_k} must divide number of heads in query {num_heads}")
         }
-        let use_gqa_packing = match num_heads_k / num_heads {
+        let use_gqa_packing = match num_heads / num_heads_k {
             2 | 4 | 8 | 16 | 32 => self.use_gqa_packing as i32,
             _ => 0,
         };
@@ -632,7 +632,7 @@ impl FlashAttnVarLen {
             let (softmax_lse_ptr, _guard) = softmax_lse.device_ptr(&stream);
             let (seqlens_q_ptr, _guard) = seqlens_q.device_ptr(&stream);
             let (seqlens_k_ptr, _guard) = seqlens_k.device_ptr(&stream);
-            ffi::run_mha(
+            ffi::run_mha_v3(
                 q_ptr as *const core::ffi::c_void,
                 k_ptr as *const core::ffi::c_void,
                 v_ptr as *const core::ffi::c_void,


### PR DESCRIPTION
Cache small host-to-device uploads behind `CANDLE_CUDA_GRAPH_PINNED_HTOD` so CUDA graph capture can reuse device-resident copies instead of uploading host data during capture.

Needed because CUDA graph capture cannot safely include normal host-to-device uploads from pageable host memory. For example, `[dims, stride]` metadata that we upload for tensor layouts.