### PR TITLE
Improved neon vec dot

### DIFF
--- a/candle-core/benches/bench_main.rs
+++ b/candle-core/benches/bench_main.rs
@@ -3,6 +3,7 @@ mod benchmarks;
 use criterion::criterion_main;
 
 criterion_main!(
+    benchmarks::vec_dot::benches,
     benchmarks::affine::benches,
     benchmarks::cat::benches,
     benchmarks::contiguous::benches,

--- a/candle-core/benches/benchmarks/mod.rs
+++ b/candle-core/benches/benchmarks/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod qmatmul;
 pub(crate) mod random;
 pub(crate) mod reduce;
 pub(crate) mod unary;
+pub(crate) mod vec_dot;
 pub(crate) mod where_cond;
 
 use candle_core::{Device, Result};

--- a/candle-core/benches/benchmarks/vec_dot.rs
+++ b/candle-core/benches/benchmarks/vec_dot.rs
@@ -1,0 +1,75 @@
+use candle_core::cpu::kernels::VecOps;
+use criterion::{criterion_group, BatchSize, Criterion, Throughput};
+use half::{bf16, f16};
+
+fn bench_vec_dot_f32(c: &mut Criterion, k: usize) {
+    let a: Vec<f32> = (0..k).map(|i| i as f32).collect();
+    let b: Vec<f32> = (0..k).map(|i| i as f32 * 0.5).collect();
+    let mut out = vec![0.0; k];
+
+    let mut group = c.benchmark_group(format!("cpu_vec_dot_f32_k{k}"));
+    group.throughput(Throughput::Elements(k as u64));
+    group.bench_function("iter", |bench| {
+        bench.iter_batched(
+            || (),
+            |_| unsafe {
+                f32::vec_dot(
+                    std::hint::black_box(a.as_ptr()),
+                    std::hint::black_box(b.as_ptr()),
+                    std::hint::black_box(out.as_mut_ptr()),
+                    std::hint::black_box(k),
+                )
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.finish();
+}
+
+fn bench_vec_dot_f16(c: &mut Criterion, k: usize) {
+    let a: Vec<f16> = (0..k).map(|i| f16::from_f32(i as f32)).collect();
+    let b: Vec<f16> = (0..k).map(|i| f16::from_f32(i as f32 * 0.5)).collect();
+
+    let mut group = c.benchmark_group(format!("cpu_vec_dot_f16_k{k}"));
+    group.throughput(Throughput::Elements(k as u64));
+    group.bench_function("iter", |bench| {
+        bench.iter_batched(
+            || f16::ZERO,
+            |mut out| unsafe {
+                f16::vec_dot(a.as_ptr(), b.as_ptr(), &mut out, k);
+                out
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.finish();
+}
+
+fn bench_vec_dot_bf16(c: &mut Criterion, k: usize) {
+    let a: Vec<bf16> = (0..k).map(|i| bf16::from_f32(i as f32)).collect();
+    let b: Vec<bf16> = (0..k).map(|i| bf16::from_f32(i as f32 * 0.5)).collect();
+
+    let mut group = c.benchmark_group(format!("cpu_vec_dot_bf16_k{k}"));
+    group.throughput(Throughput::Elements(k as u64));
+    group.bench_function("iter", |bench| {
+        bench.iter_batched(
+            || bf16::ZERO,
+            |mut out| unsafe {
+                bf16::vec_dot(a.as_ptr(), b.as_ptr(), &mut out, k);
+                out
+            },
+            BatchSize::SmallInput,
+        )
+    });
+    group.finish();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    for k in [64, 128, 256, 512] {
+        bench_vec_dot_f32(c, k);
+        bench_vec_dot_f16(c, k);
+        bench_vec_dot_bf16(c, k);
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);

--- a/candle-core/src/cpu/avx.rs
+++ b/candle-core/src/cpu/avx.rs
@@ -3,8 +3,8 @@ use super::{Cpu, CpuBF16, CpuF16};
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
-use core::mem::transmute;
 use half::{bf16, f16};
+use std::{is_x86_feature_detected, mem::transmute};
 
 pub struct CurrentCpu {}
 
@@ -162,14 +162,18 @@ impl CpuBF16 for CurrentCpuBF16 {
         _mm256_set1_ps(v)
     }
 
-    #[cfg(all(target_feature = "avx512bf16", target_feature = "avx512vl"))]
     unsafe fn load(mem_addr: *const bf16) -> Self::Unit {
-        _mm256_cvtpbh_ps(transmute(_mm_loadu_si128(mem_addr as *const __m128i)))
-    }
-
-    #[cfg(not(all(target_feature = "avx512bf16", target_feature = "avx512vl")))]
-    unsafe fn load(mem_addr: *const bf16) -> Self::Unit {
-        _mm256_cvtpbh_ps(transmute(_mm_loadu_si128(mem_addr as *const __m128i)))
+        if is_x86_feature_detected!("avx512bf16") && is_x86_feature_detected!("avx512vl") {
+            _mm256_cvtpbh_ps(transmute::<__m128i, __m128bh>(_mm_loadu_si128(
+                mem_addr as *const __m128i,
+            )))
+        } else {
+            let mut tmp = [0.0f32; 8];
+            for i in 0..8 {
+                tmp[i] = (*mem_addr.add(i)).to_f32();
+            }
+            _mm256_loadu_ps(tmp.as_ptr())
+        }
     }
 
     unsafe fn vec_add(a: Self::Unit, b: Self::Unit) -> Self::Unit {
@@ -180,14 +184,19 @@ impl CpuBF16 for CurrentCpuBF16 {
         _mm256_add_ps(_mm256_mul_ps(b, c), a)
     }
 
-    #[cfg(all(target_feature = "avx512bf16", target_feature = "avx512vl"))]
     unsafe fn vec_store(mem_addr: *mut bf16, a: Self::Unit) {
-        _mm_storeu_si128(mem_addr as *mut __m128i, transmute(_mm256_cvtneps_pbh(a)))
-    }
-
-    #[cfg(not(all(target_feature = "avx512bf16", target_feature = "avx512vl")))]
-    unsafe fn vec_store(mem_addr: *mut bf16, a: Self::Unit) {
-        _mm_storeu_si128(mem_addr as *mut __m128i, transmute(_mm256_cvtneps_pbh(a)))
+        if is_x86_feature_detected!("avx512bf16") && is_x86_feature_detected!("avx512vl") {
+            _mm_storeu_si128(
+                mem_addr as *mut __m128i,
+                transmute::<__m128bh, __m128i>(_mm256_cvtneps_pbh(a)),
+            )
+        } else {
+            let mut tmp = [0.0f32; 8];
+            _mm256_storeu_ps(tmp.as_mut_ptr(), a);
+            for i in 0..8 {
+                *mem_addr.add(i) = bf16::from_f32(tmp[i]);
+            }
+        }
     }
 
     unsafe fn vec_reduce(mut x: Self::Array, y: *mut f32) {

--- a/candle-core/src/cpu/avx.rs
+++ b/candle-core/src/cpu/avx.rs
@@ -162,12 +162,12 @@ impl CpuBF16 for CurrentCpuBF16 {
         _mm256_set1_ps(v)
     }
 
-    #[cfg(target_feature = "f16c")]
+    #[cfg(all(target_feature = "avx512bf16", target_feature = "avx512vl"))]
     unsafe fn load(mem_addr: *const bf16) -> Self::Unit {
-        _mm256_cvtph_ps(_mm_loadu_si128(mem_addr as *const __m128i))
+        _mm256_cvtpbh_ps(_mm_loadu_si128(mem_addr as *const __m128i))
     }
 
-    #[cfg(not(target_feature = "f16c"))]
+    #[cfg(not(all(target_feature = "avx512bf16", target_feature = "avx512vl")))]
     unsafe fn load(mem_addr: *const bf16) -> Self::Unit {
         let mut tmp = [0.0f32; 8];
         for i in 0..8 {
@@ -184,12 +184,12 @@ impl CpuBF16 for CurrentCpuBF16 {
         _mm256_add_ps(_mm256_mul_ps(b, c), a)
     }
 
-    #[cfg(target_feature = "f16c")]
+    #[cfg(all(target_feature = "avx512bf16", target_feature = "avx512vl"))]
     unsafe fn vec_store(mem_addr: *mut bf16, a: Self::Unit) {
-        _mm_storeu_si128(mem_addr as *mut __m128i, _mm256_cvtps_ph(a, 0))
+        _mm_storeu_si128(mem_addr as *mut __m128i, _mm256_cvtneps_pbh(a))
     }
 
-    #[cfg(not(target_feature = "f16c"))]
+    #[cfg(not(all(target_feature = "avx512bf16", target_feature = "avx512vl")))]
     unsafe fn vec_store(mem_addr: *mut bf16, a: Self::Unit) {
         let mut tmp = [0.0f32; 8];
         _mm256_storeu_ps(tmp.as_mut_ptr(), a);

--- a/candle-core/src/cpu/avx.rs
+++ b/candle-core/src/cpu/avx.rs
@@ -3,7 +3,7 @@ use super::{Cpu, CpuBF16, CpuF16};
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
-
+use core::mem::transmute;
 use half::{bf16, f16};
 
 pub struct CurrentCpu {}
@@ -164,12 +164,12 @@ impl CpuBF16 for CurrentCpuBF16 {
 
     #[cfg(all(target_feature = "avx512bf16", target_feature = "avx512vl"))]
     unsafe fn load(mem_addr: *const bf16) -> Self::Unit {
-        _mm256_cvtpbh_ps(_mm_loadu_si128(mem_addr as *const __m128i))
+        _mm256_cvtpbh_ps(transmute(_mm_loadu_si128(mem_addr as *const __m128i)))
     }
 
     #[cfg(not(all(target_feature = "avx512bf16", target_feature = "avx512vl")))]
     unsafe fn load(mem_addr: *const bf16) -> Self::Unit {
-        _mm256_cvtpbh_ps(_mm_loadu_si128(mem_addr as *const __m128i))
+        _mm256_cvtpbh_ps(transmute(_mm_loadu_si128(mem_addr as *const __m128i)))
     }
 
     unsafe fn vec_add(a: Self::Unit, b: Self::Unit) -> Self::Unit {
@@ -182,12 +182,12 @@ impl CpuBF16 for CurrentCpuBF16 {
 
     #[cfg(all(target_feature = "avx512bf16", target_feature = "avx512vl"))]
     unsafe fn vec_store(mem_addr: *mut bf16, a: Self::Unit) {
-        _mm_storeu_si128(mem_addr as *mut __m128i, _mm256_cvtneps_pbh(a))
+        _mm_storeu_si128(mem_addr as *mut __m128i, transmute(_mm256_cvtneps_pbh(a)))
     }
 
     #[cfg(not(all(target_feature = "avx512bf16", target_feature = "avx512vl")))]
     unsafe fn vec_store(mem_addr: *mut bf16, a: Self::Unit) {
-        _mm_storeu_si128(mem_addr as *mut __m128i, _mm256_cvtneps_pbh(a))
+        _mm_storeu_si128(mem_addr as *mut __m128i, transmute(_mm256_cvtneps_pbh(a)))
     }
 
     unsafe fn vec_reduce(mut x: Self::Array, y: *mut f32) {

--- a/candle-core/src/cpu/avx.rs
+++ b/candle-core/src/cpu/avx.rs
@@ -169,11 +169,7 @@ impl CpuBF16 for CurrentCpuBF16 {
 
     #[cfg(not(all(target_feature = "avx512bf16", target_feature = "avx512vl")))]
     unsafe fn load(mem_addr: *const bf16) -> Self::Unit {
-        let mut tmp = [0.0f32; 8];
-        for i in 0..8 {
-            tmp[i] = (*mem_addr.add(i)).to_f32();
-        }
-        _mm256_loadu_ps(tmp.as_ptr())
+        _mm256_cvtpbh_ps(_mm_loadu_si128(mem_addr as *const __m128i))
     }
 
     unsafe fn vec_add(a: Self::Unit, b: Self::Unit) -> Self::Unit {
@@ -191,11 +187,7 @@ impl CpuBF16 for CurrentCpuBF16 {
 
     #[cfg(not(all(target_feature = "avx512bf16", target_feature = "avx512vl")))]
     unsafe fn vec_store(mem_addr: *mut bf16, a: Self::Unit) {
-        let mut tmp = [0.0f32; 8];
-        _mm256_storeu_ps(tmp.as_mut_ptr(), a);
-        for i in 0..8 {
-            *mem_addr.add(i) = bf16::from_f32(tmp[i]);
-        }
+        _mm_storeu_si128(mem_addr as *mut __m128i, _mm256_cvtneps_pbh(a))
     }
 
     unsafe fn vec_reduce(mut x: Self::Array, y: *mut f32) {

--- a/candle-core/src/cpu/avx.rs
+++ b/candle-core/src/cpu/avx.rs
@@ -12,7 +12,7 @@ const STEP: usize = 32;
 const EPR: usize = 8;
 const ARR: usize = STEP / EPR;
 
-impl Cpu<ARR> for CurrentCpu {
+impl Cpu for CurrentCpu {
     type Unit = __m256;
     type Array = [__m256; ARR];
 
@@ -66,7 +66,7 @@ impl Cpu<ARR> for CurrentCpu {
 }
 
 pub struct CurrentCpuF16 {}
-impl CpuF16<ARR> for CurrentCpuF16 {
+impl CpuF16 for CurrentCpuF16 {
     type Unit = __m256;
     type Array = [__m256; ARR];
 
@@ -142,7 +142,7 @@ impl CpuF16<ARR> for CurrentCpuF16 {
 }
 
 pub struct CurrentCpuBF16 {}
-impl CpuBF16<ARR> for CurrentCpuBF16 {
+impl CpuBF16 for CurrentCpuBF16 {
     type Unit = __m256;
     type Array = [__m256; ARR];
 

--- a/candle-core/src/cpu/avx.rs
+++ b/candle-core/src/cpu/avx.rs
@@ -18,10 +18,7 @@ impl Cpu<ARR> for CurrentCpu {
 
     const STEP: usize = STEP;
     const EPR: usize = EPR;
-
-    fn n() -> usize {
-        ARR
-    }
+    const ARR: usize = ARR;
 
     unsafe fn zero() -> Self::Unit {
         _mm256_setzero_ps()
@@ -75,10 +72,7 @@ impl CpuF16<ARR> for CurrentCpuF16 {
 
     const STEP: usize = STEP;
     const EPR: usize = EPR;
-
-    fn n() -> usize {
-        ARR
-    }
+    const ARR: usize = ARR;
 
     unsafe fn zero() -> Self::Unit {
         _mm256_setzero_ps()
@@ -154,10 +148,7 @@ impl CpuBF16<ARR> for CurrentCpuBF16 {
 
     const STEP: usize = STEP;
     const EPR: usize = EPR;
-
-    fn n() -> usize {
-        ARR
-    }
+    const ARR: usize = ARR;
 
     unsafe fn zero() -> Self::Unit {
         _mm256_setzero_ps()

--- a/candle-core/src/cpu/mod.rs
+++ b/candle-core/src/cpu/mod.rs
@@ -9,8 +9,8 @@ trait Cpu<const ARR: usize> {
     type Array;
     const STEP: usize;
     const EPR: usize;
+    const ARR: usize;
 
-    fn n() -> usize;
     unsafe fn zero() -> Self::Unit;
     unsafe fn zero_array() -> Self::Array;
     unsafe fn load(mem_addr: *const f32) -> Self::Unit;
@@ -27,8 +27,11 @@ trait CpuF16<const ARR: usize> {
     type Array;
     const STEP: usize;
     const EPR: usize;
+    const ARR: usize;
+    // How many outer loop steps to accumulate in Self::Unit before flushing to f32.
+    // Set to a finite value to bound rounding error (16 for example).
+    const FLUSH_INTERVAL: usize = usize::MAX;
 
-    fn n() -> usize;
     unsafe fn zero() -> Self::Unit;
     unsafe fn zero_array() -> Self::Array;
     unsafe fn load(mem_addr: *const f16) -> Self::Unit;
@@ -45,8 +48,8 @@ trait CpuBF16<const ARR: usize> {
     type Array;
     const STEP: usize;
     const EPR: usize;
+    const ARR: usize;
 
-    fn n() -> usize;
     unsafe fn zero() -> Self::Unit;
     unsafe fn zero_array() -> Self::Array;
     unsafe fn load(mem_addr: *const bf16) -> Self::Unit;
@@ -78,35 +81,34 @@ pub use simd128::CurrentCpu;
 pub mod neon;
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 #[cfg(target_feature = "neon")]
-pub use neon::CurrentCpu;
+pub use neon::{CurrentCpu, CurrentCpuBF16, CurrentCpuF16};
 
 #[cfg(any(
     target_feature = "neon",
     target_feature = "avx2",
     target_feature = "simd128"
 ))]
-#[inline(always)]
 pub(crate) unsafe fn vec_dot_f32(a_row: *const f32, b_row: *const f32, c: *mut f32, k: usize) {
-    let np = k & !(CurrentCpu::STEP - 1);
-
     let mut sum = CurrentCpu::zero_array();
-    let mut ax = CurrentCpu::zero_array();
-    let mut ay = CurrentCpu::zero_array();
 
-    for i in (0..np).step_by(CurrentCpu::STEP) {
-        for j in 0..CurrentCpu::n() {
-            ax[j] = CurrentCpu::load(a_row.add(i + j * CurrentCpu::EPR));
-            ay[j] = CurrentCpu::load(b_row.add(i + j * CurrentCpu::EPR));
-
-            sum[j] = CurrentCpu::vec_fma(sum[j], ax[j], ay[j]);
+    let mut i = 0;
+    while i + CurrentCpu::STEP <= k {
+        for j in 0..CurrentCpu::ARR {
+            sum[j] = CurrentCpu::vec_fma(
+                sum[j],
+                CurrentCpu::load(a_row.add(i + j * CurrentCpu::EPR)),
+                CurrentCpu::load(b_row.add(i + j * CurrentCpu::EPR)),
+            );
         }
+        i += CurrentCpu::STEP;
     }
 
     CurrentCpu::vec_reduce(sum, c);
 
     // leftovers
-    for i in np..k {
+    while i < k {
         *c += *a_row.add(i) * (*b_row.add(i));
+        i += 1;
     }
 }
 
@@ -117,7 +119,6 @@ pub(crate) unsafe fn vec_dot_f32(a_row: *const f32, b_row: *const f32, c: *mut f
 )))]
 #[inline(always)]
 pub(crate) unsafe fn vec_dot_f32(a_row: *const f32, b_row: *const f32, c: *mut f32, k: usize) {
-    // leftovers
     for i in 0..k {
         *c += *a_row.add(i) * (*b_row.add(i));
     }
@@ -136,7 +137,7 @@ pub(crate) unsafe fn vec_sum(row: *const f32, b: *mut f32, k: usize) {
     let mut x = CurrentCpu::zero_array();
 
     for i in (0..np).step_by(CurrentCpu::STEP) {
-        for j in 0..CurrentCpu::n() {
+        for j in 0..CurrentCpu::ARR {
             x[j] = CurrentCpu::load(row.add(i + j * CurrentCpu::EPR));
             sum[j] = CurrentCpu::vec_add(sum[j], x[j]);
         }
@@ -163,63 +164,70 @@ pub(crate) unsafe fn vec_sum(row: *const f32, b: *mut f32, k: usize) {
     }
 }
 
-#[cfg(target_feature = "avx2")]
-#[inline(always)]
+#[cfg(any(target_feature = "avx2", target_feature = "neon"))]
 pub(crate) unsafe fn vec_dot_f16(a_row: *const f16, b_row: *const f16, c: *mut f32, k: usize) {
     let mut sumf = 0.0f32;
-    let np = k & !(CurrentCpuF16::STEP - 1);
-
     let mut sum = CurrentCpuF16::zero_array();
-    let mut ax = CurrentCpuF16::zero_array();
-    let mut ay = CurrentCpuF16::zero_array();
-
-    for i in (0..np).step_by(CurrentCpuF16::STEP) {
-        for j in 0..CurrentCpuF16::n() {
-            ax[j] = CurrentCpuF16::load(a_row.add(i + j * CurrentCpuF16::EPR));
-            ay[j] = CurrentCpuF16::load(b_row.add(i + j * CurrentCpuF16::EPR));
-
-            sum[j] = CurrentCpuF16::vec_fma(sum[j], ax[j], ay[j]);
+    let mut steps_since_flush = 0usize;
+    let mut i = 0;
+    while i + CurrentCpu::STEP <= k {
+        for j in 0..CurrentCpuF16::ARR {
+            sum[j] = CurrentCpuF16::vec_fma(
+                sum[j],
+                CurrentCpuF16::load(a_row.add(i + j * CurrentCpuF16::EPR)),
+                CurrentCpuF16::load(b_row.add(i + j * CurrentCpuF16::EPR)),
+            );
         }
+        steps_since_flush += 1;
+        if steps_since_flush == CurrentCpuF16::FLUSH_INTERVAL {
+            let mut partial = 0.0f32;
+            CurrentCpuF16::vec_reduce(sum, &mut partial);
+            sumf += partial;
+            sum = CurrentCpuF16::zero_array();
+            steps_since_flush = 0;
+        }
+
+        i += CurrentCpuF16::STEP;
     }
 
-    CurrentCpuF16::vec_reduce(sum, &mut sumf);
+    let mut partial = 0.0f32;
+    CurrentCpuF16::vec_reduce(sum, &mut partial);
+    sumf += partial;
 
     // leftovers
-    for i in np..k {
+    while i < k {
         sumf += (*a_row.add(i)).to_f32() * (*b_row.add(i)).to_f32();
+        i += 1;
     }
     *c = sumf;
 }
 
-#[cfg(target_feature = "avx2")]
-#[inline(always)]
+#[cfg(any(target_feature = "avx2", target_feature = "neon"))]
 pub(crate) unsafe fn vec_dot_bf16(a_row: *const bf16, b_row: *const bf16, c: *mut f32, k: usize) {
-    let mut sumf = 0.0f32;
-    let np = k & !(CurrentCpuBF16::STEP - 1);
-
     let mut sum = CurrentCpuBF16::zero_array();
-    let mut ax = CurrentCpuBF16::zero_array();
-    let mut ay = CurrentCpuBF16::zero_array();
 
-    for i in (0..np).step_by(CurrentCpuBF16::STEP) {
-        for j in 0..CurrentCpuBF16::n() {
-            ax[j] = CurrentCpuBF16::load(a_row.add(i + j * CurrentCpuBF16::EPR));
-            ay[j] = CurrentCpuBF16::load(b_row.add(i + j * CurrentCpuBF16::EPR));
-
-            sum[j] = CurrentCpuBF16::vec_fma(sum[j], ax[j], ay[j]);
+    let mut i = 0;
+    while i + CurrentCpu::STEP <= k {
+        for j in 0..CurrentCpuBF16::ARR {
+            sum[j] = CurrentCpuBF16::vec_fma(
+                sum[j],
+                CurrentCpuBF16::load(a_row.add(i + j * CurrentCpuBF16::EPR)),
+                CurrentCpuBF16::load(b_row.add(i + j * CurrentCpuBF16::EPR)),
+            );
         }
+        i += CurrentCpu::STEP;
     }
 
-    CurrentCpuBF16::vec_reduce(sum, &mut sumf);
+    CurrentCpuBF16::vec_reduce(sum, c);
 
     // leftovers
-    for i in np..k {
-        sumf += (*a_row.add(i)).to_f32() * (*b_row.add(i)).to_f32();
+    while i < k {
+        *c += (*a_row.add(i)).to_f32() * (*b_row.add(i)).to_f32();
+        i += 1;
     }
-    *c = sumf;
 }
 
-#[cfg(not(target_feature = "avx2"))]
+#[cfg(not(any(target_feature = "avx2", target_feature = "neon")))]
 #[inline(always)]
 pub(crate) unsafe fn vec_dot_f16(a_row: *const f16, b_row: *const f16, c: *mut f32, k: usize) {
     // leftovers
@@ -230,7 +238,7 @@ pub(crate) unsafe fn vec_dot_f16(a_row: *const f16, b_row: *const f16, c: *mut f
     *c = sum;
 }
 
-#[cfg(not(target_feature = "avx2"))]
+#[cfg(not(any(target_feature = "avx2", target_feature = "neon")))]
 #[inline(always)]
 pub(crate) unsafe fn vec_dot_bf16(a_row: *const bf16, b_row: *const bf16, c: *mut f32, k: usize) {
     // leftovers

--- a/candle-core/src/cpu/mod.rs
+++ b/candle-core/src/cpu/mod.rs
@@ -170,7 +170,7 @@ pub(crate) unsafe fn vec_dot_f16(a_row: *const f16, b_row: *const f16, c: *mut f
     let mut sum = CurrentCpuF16::zero_array();
     let mut steps_since_flush = 0usize;
     let mut i = 0;
-    while i + CurrentCpu::STEP <= k {
+    while i + CurrentCpuF16::STEP <= k {
         for j in 0..CurrentCpuF16::ARR {
             sum[j] = CurrentCpuF16::vec_fma(
                 sum[j],
@@ -207,7 +207,7 @@ pub(crate) unsafe fn vec_dot_bf16(a_row: *const bf16, b_row: *const bf16, c: *mu
     let mut sum = CurrentCpuBF16::zero_array();
 
     let mut i = 0;
-    while i + CurrentCpu::STEP <= k {
+    while i + CurrentCpuBF16::STEP <= k {
         for j in 0..CurrentCpuBF16::ARR {
             sum[j] = CurrentCpuBF16::vec_fma(
                 sum[j],
@@ -215,7 +215,7 @@ pub(crate) unsafe fn vec_dot_bf16(a_row: *const bf16, b_row: *const bf16, c: *mu
                 CurrentCpuBF16::load(b_row.add(i + j * CurrentCpuBF16::EPR)),
             );
         }
-        i += CurrentCpu::STEP;
+        i += CurrentCpuBF16::STEP;
     }
 
     CurrentCpuBF16::vec_reduce(sum, c);

--- a/candle-core/src/cpu/mod.rs
+++ b/candle-core/src/cpu/mod.rs
@@ -1,15 +1,15 @@
 //! Traits and methods for CPU-backed Tensors
-
+#![allow(clippy::needless_range_loop)]
 pub mod erf;
 pub mod kernels;
 
 #[allow(unused)]
-trait Cpu<const ARR: usize> {
+trait Cpu {
     type Unit;
     type Array;
     const STEP: usize;
     const EPR: usize;
-    const ARR: usize;
+    const ARR: usize = Self::STEP / Self::EPR;
 
     unsafe fn zero() -> Self::Unit;
     unsafe fn zero_array() -> Self::Array;
@@ -22,12 +22,12 @@ trait Cpu<const ARR: usize> {
 }
 
 #[allow(unused)]
-trait CpuF16<const ARR: usize> {
+trait CpuF16 {
     type Unit;
     type Array;
     const STEP: usize;
     const EPR: usize;
-    const ARR: usize;
+    const ARR: usize = Self::STEP / Self::EPR;
     // How many outer loop steps to accumulate in Self::Unit before flushing to f32.
     // Set to a finite value to bound rounding error (16 for example).
     const FLUSH_INTERVAL: usize = usize::MAX;
@@ -43,12 +43,12 @@ trait CpuF16<const ARR: usize> {
 }
 
 #[allow(unused)]
-trait CpuBF16<const ARR: usize> {
+trait CpuBF16 {
     type Unit;
     type Array;
     const STEP: usize;
     const EPR: usize;
-    const ARR: usize;
+    const ARR: usize = Self::STEP / Self::EPR;
 
     unsafe fn zero() -> Self::Unit;
     unsafe fn zero_array() -> Self::Array;

--- a/candle-core/src/cpu/neon.rs
+++ b/candle-core/src/cpu/neon.rs
@@ -7,7 +7,7 @@ use core::arch::aarch64::*;
 
 pub struct CurrentCpu {}
 
-const STEP: usize = 16;
+const STEP: usize = 32;
 const EPR: usize = 4;
 const ARR: usize = STEP / EPR;
 
@@ -29,10 +29,7 @@ impl Cpu<ARR> for CurrentCpu {
 
     const STEP: usize = STEP;
     const EPR: usize = EPR;
-
-    fn n() -> usize {
-        ARR
-    }
+    const ARR: usize = ARR;
 
     unsafe fn zero() -> Self::Unit {
         vdupq_n_f32(0.0)
@@ -69,6 +66,386 @@ impl Cpu<ARR> for CurrentCpu {
         for i in 0..ARR / 4 {
             x[4 * i] = vaddq_f32(x[4 * i], x[4 * i + 2]);
         }
+        for i in 0..ARR / 8 {
+            x[8 * i] = vaddq_f32(x[8 * i], x[8 * i + 4]);
+        }
         *y = Self::reduce_one(x[0]);
     }
 }
+
+mod fp16 {
+    use super::super::CpuF16;
+    #[cfg(target_arch = "aarch64")]
+    use core::arch::aarch64::*;
+    #[cfg(target_arch = "arm")]
+    use core::arch::arm::*;
+    use half::f16;
+    use std::arch::asm;
+
+    // Fallback: widen f16 to f32 on load using FCVTL, accumulate in f32.
+    #[cfg(not(target_feature = "fp16"))]
+    mod inner {
+        use super::*;
+
+        pub struct CurrentCpuF16 {}
+
+        const STEP_F16: usize = 32;
+        const EPR_F16: usize = 4;
+        const ARR_F16: usize = STEP_F16 / EPR_F16;
+
+        impl CpuF16<ARR_F16> for CurrentCpuF16 {
+            type Unit = float32x4_t;
+            type Array = [float32x4_t; ARR_F16];
+
+            const STEP: usize = STEP_F16;
+            const EPR: usize = EPR_F16;
+            const ARR: usize = ARR_F16;
+
+            unsafe fn zero() -> Self::Unit {
+                vdupq_n_f32(0.0)
+            }
+
+            unsafe fn zero_array() -> Self::Array {
+                [Self::zero(); ARR_F16]
+            }
+
+            unsafe fn load(mem_addr: *const f16) -> Self::Unit {
+                let bits = vld1_u16(mem_addr as *const u16);
+                let result: Self::Unit;
+                asm!(
+                    "fcvtl {dst:v}.4s, {src:v}.4h",
+                    src = in(vreg) bits,
+                    dst = out(vreg) result,
+                    options(pure, nomem, nostack),
+                );
+                result
+            }
+
+            unsafe fn vec_add(a: Self::Unit, b: Self::Unit) -> Self::Unit {
+                vaddq_f32(a, b)
+            }
+
+            unsafe fn vec_fma(a: Self::Unit, b: Self::Unit, c: Self::Unit) -> Self::Unit {
+                vfmaq_f32(a, b, c)
+            }
+
+            unsafe fn vec_reduce(mut x: Self::Array, y: *mut f32) {
+                for i in 0..ARR_F16 / 2 {
+                    x[2 * i] = vaddq_f32(x[2 * i], x[2 * i + 1]);
+                }
+                for i in 0..ARR_F16 / 4 {
+                    x[4 * i] = vaddq_f32(x[4 * i], x[4 * i + 2]);
+                }
+                for i in 0..ARR_F16 / 8 {
+                    x[8 * i] = vaddq_f32(x[8 * i], x[8 * i + 4]);
+                }
+                *y = vaddvq_f32(x[0]);
+            }
+
+            unsafe fn from_f32(v: f32) -> Self::Unit {
+                vdupq_n_f32(v)
+            }
+
+            unsafe fn vec_store(mem_addr: *mut f16, a: Self::Unit) {
+                let bits: uint16x4_t;
+                asm!(
+                    "fcvtn {dst:v}.4h, {src:v}.4s",
+                    src = in(vreg) a,
+                    dst = out(vreg) bits,
+                    options(pure, nomem, nostack),
+                );
+                vst1_u16(mem_addr as *mut u16, bits);
+            }
+        }
+    }
+
+    // Optimized: accumulate in f16 using FMLA.8h, flush to f32 periodically.
+    #[cfg(target_feature = "fp16")]
+    mod inner {
+        use super::*;
+
+        pub struct CurrentCpuF16 {}
+
+        impl CurrentCpuF16 {
+            fn reduce_one(x: float16x8_t) -> f32 {
+                let result: f32;
+                unsafe {
+                    asm!(
+                        // 1. Widen bottom 4 lanes of f16x8 to a full f32x4 vector
+                        "fcvtl {bot:v}.4s, {v:v}.4h",
+                        // 2. Widen top 4 lanes of f16x8 to a second f32x4 vector
+                        "fcvtl2 {top:v}.4s, {v:v}.8h",
+                        // 3. Perform a parallel element-wise vector addition
+                        "fadd {bot:v}.4s, {bot:v}.4s, {top:v}.4s",
+                        // 4. Pairwise add 4 lanes down to 2 lanes: [A+B, C+D, ?, ?]
+                        "faddp {bot:v}.4s, {bot:v}.4s, {bot:v}.4s",
+                        // 5. Pairwise add 2 lanes down to 1 scalar: [(A+B)+(C+D), ?, ?, ?]
+                        "faddp {bot:v}.4s, {bot:v}.4s, {bot:v}.4s",
+                        // 6. Extract the scalar from the lowest lane of the vector
+                        "mov {res:s}, {bot:v}.s[0]",
+                        v = in(vreg) x,
+                        top = lateout(vreg) _,
+                        bot = out(vreg) _,
+                        res = out(vreg) result,
+                        options(nostack, preserves_flags)
+                    );
+                }
+                result
+            }
+        }
+
+        const STEP_F16: usize = 32;
+        const EPR_F16: usize = 8;
+        const ARR_F16: usize = STEP_F16 / EPR_F16;
+
+        impl CpuF16<ARR_F16> for CurrentCpuF16 {
+            type Unit = float16x8_t;
+            type Array = [float16x8_t; ARR_F16];
+
+            const STEP: usize = STEP_F16;
+            const EPR: usize = EPR_F16;
+            const ARR: usize = ARR_F16;
+            // Flush f16 accumulators to f32 every `FLUSH_INTERVAL` steps to bound rounding error.
+            const FLUSH_INTERVAL: usize = 16;
+
+            unsafe fn zero() -> Self::Unit {
+                let result: Self::Unit;
+                asm!(
+                    "movi {v:v}.8h, #0",
+                    v = out(vreg) result,
+                    options(nostack, pure, nomem)
+                );
+                result
+            }
+
+            unsafe fn zero_array() -> Self::Array {
+                [Self::zero(); ARR_F16]
+            }
+
+            unsafe fn load(mem_addr: *const f16) -> Self::Unit {
+                std::ptr::read_unaligned(mem_addr.cast())
+            }
+
+            unsafe fn vec_add(a: Self::Unit, b: Self::Unit) -> Self::Unit {
+                let result: Self::Unit;
+                asm!(
+                    "fadd {v:v}.8h, {a:v}.8h, {b:v}.8h",
+                    v = out(vreg) result,
+                    a = in(vreg) a,
+                    b = in(vreg) b,
+                    options(pure, nomem, nostack)
+                );
+                result
+            }
+
+            unsafe fn vec_fma(a: Self::Unit, b: Self::Unit, c: Self::Unit) -> Self::Unit {
+                let result: Self::Unit;
+                asm!(
+                    "fmla {a:v}.8h, {b:v}.8h, {c:v}.8h",
+                    a = inout(vreg) a => result,
+                    b = in(vreg) b,
+                    c = in(vreg) c,
+                    options(pure, nomem, nostack)
+                );
+                result
+            }
+
+            unsafe fn vec_reduce(x: Self::Array, y: *mut f32) {
+                let mut sum = 0.0f32;
+                for i in 0..ARR_F16 {
+                    sum += Self::reduce_one(x[i]);
+                }
+                *y = sum;
+            }
+
+            unsafe fn from_f32(v: f32) -> Self::Unit {
+                let result: Self::Unit;
+                asm!(
+                    "fcvt {tmp:h}, {src:s}",
+                    "fmov {w:w}, {tmp:h}",
+                    "dup {dst:v}.8h, {w:w}",
+                    src = in(vreg) v,
+                    tmp = out(vreg) _,
+                    w = out(reg) _,
+                    dst = out(vreg) result,
+                    options(nostack, pure, nomem),
+                );
+                result
+            }
+
+            unsafe fn vec_store(mem_addr: *mut f16, a: Self::Unit) {
+                asm!(
+                    "st1 {{ {vec:v}.8h }}, [{ptr}]",
+                    vec = in(vreg) a,
+                    ptr = in(reg) mem_addr,
+                    options(nostack, preserves_flags)
+                );
+            }
+        }
+    }
+
+    pub use inner::CurrentCpuF16;
+}
+
+pub use fp16::CurrentCpuF16;
+
+mod bf16 {
+    use super::super::CpuBF16;
+    use core::arch::aarch64::*;
+    use half::bf16;
+
+    // Fallback: accumulate in f32 using SHLL to widen bf16 to f32 on load.
+    #[cfg(not(target_feature = "bf16"))]
+    mod inner {
+        use super::*;
+
+        pub struct CurrentCpuBF16 {}
+
+        const STEP_BF16: usize = 32;
+        const EPR_BF16: usize = 4;
+        const ARR_BF16: usize = STEP_BF16 / EPR_BF16;
+
+        impl CpuBF16<ARR_BF16> for CurrentCpuBF16 {
+            type Unit = float32x4_t;
+            type Array = [float32x4_t; ARR_BF16];
+
+            const STEP: usize = STEP_BF16;
+            const EPR: usize = EPR_BF16;
+            const ARR: usize = ARR_BF16;
+
+            unsafe fn zero() -> Self::Unit {
+                vdupq_n_f32(0.0)
+            }
+
+            unsafe fn zero_array() -> Self::Array {
+                [Self::zero(); ARR_BF16]
+            }
+
+            unsafe fn load(mem_addr: *const bf16) -> Self::Unit {
+                // bf16 is the top 16 bits of f32; shift left by 16 to reconstruct f32 bits.
+                let i = vld1_u16(mem_addr as *const u16);
+                let s = vshll_n_u16::<16>(i);
+                vreinterpretq_f32_u32(s)
+            }
+
+            unsafe fn vec_add(a: Self::Unit, b: Self::Unit) -> Self::Unit {
+                vaddq_f32(a, b)
+            }
+
+            unsafe fn vec_fma(a: Self::Unit, b: Self::Unit, c: Self::Unit) -> Self::Unit {
+                vfmaq_f32(a, b, c)
+            }
+
+            unsafe fn vec_reduce(mut x: Self::Array, y: *mut f32) {
+                for i in 0..ARR_BF16 / 2 {
+                    x[2 * i] = vaddq_f32(x[2 * i], x[2 * i + 1]);
+                }
+                for i in 0..ARR_BF16 / 4 {
+                    x[4 * i] = vaddq_f32(x[4 * i], x[4 * i + 2]);
+                }
+                for i in 0..ARR_BF16 / 8 {
+                    x[8 * i] = vaddq_f32(x[8 * i], x[8 * i + 4]);
+                }
+                *y = vaddvq_f32(x[0]);
+            }
+
+            unsafe fn from_f32(v: f32) -> Self::Unit {
+                vdupq_n_f32(v)
+            }
+
+            unsafe fn vec_store(mem_addr: *mut bf16, a: Self::Unit) {
+                // Extract top 16 bits of each f32 lane, which is the bf16 representation.
+                let s = vreinterpretq_u32_f32(a);
+                let h = vshrn_n_u32::<16>(s);
+                vst1_u16(mem_addr as *mut u16, h);
+            }
+        }
+    }
+
+    // Optimized: BFDOT accumulates bf16 pairs directly into f32 lanes.
+    #[cfg(target_feature = "bf16")]
+    mod inner {
+        use super::*;
+        use std::arch::asm;
+
+        pub struct CurrentCpuBF16 {}
+
+        const STEP_BF16: usize = 32;
+        const EPR_BF16: usize = 8;
+        const ARR_BF16: usize = STEP_BF16 / EPR_BF16;
+
+        impl CpuBF16<ARR_BF16> for CurrentCpuBF16 {
+            type Unit = uint16x8_t;
+            type Array = [uint16x8_t; ARR_BF16];
+
+            const STEP: usize = STEP_BF16;
+            const EPR: usize = EPR_BF16;
+            const ARR: usize = ARR_BF16;
+
+            unsafe fn zero() -> Self::Unit {
+                vreinterpretq_u16_f32(vdupq_n_f32(0.0))
+            }
+
+            unsafe fn zero_array() -> Self::Array {
+                [Self::zero(); ARR_BF16]
+            }
+
+            unsafe fn load(mem_addr: *const bf16) -> Self::Unit {
+                vld1q_u16(mem_addr as *const u16)
+            }
+
+            unsafe fn vec_add(a: Self::Unit, b: Self::Unit) -> Self::Unit {
+                let result: Self::Unit;
+                asm!(
+                    "fadd {v:v}.4s, {a:v}.4s, {b:v}.4s",
+                    v = out(vreg) result,
+                    a = in(vreg) a,
+                    b = in(vreg) b,
+                    options(pure, nomem, nostack)
+                );
+                result
+            }
+
+            unsafe fn vec_fma(a: Self::Unit, b: Self::Unit, c: Self::Unit) -> Self::Unit {
+                // IMPORTANT: `a` is not bf16x8 here. It is 128 bits used as f32x4 (.4s) to accumulate
+                // results from bfdot. `b` and `c` are bf16x8 inputs (.8h).
+                // bfdot: acc[i] += (f32)b[2i]*c[2i] + (f32)b[2i+1]*c[2i+1]
+                let result: Self::Unit;
+                asm!(
+                    "bfdot {acc:v}.4s, {b:v}.8h, {c:v}.8h",
+                    acc = inout(vreg) a => result,
+                    b = in(vreg) b,
+                    c = in(vreg) c,
+                    options(pure, nomem, nostack)
+                );
+                result
+            }
+
+            unsafe fn vec_reduce(x: Self::Array, y: *mut f32) {
+                // IMPORTANT: `x` is not bf16x8 here. It is 128 bits used as f32x4.
+                // This means that if you use `vec_reduce` where `x` is actually bf16x8 you will get
+                // entirely wrong results.
+                let mut xf: [float32x4_t; ARR_BF16] = std::mem::transmute(x);
+                for i in 0..ARR_BF16 / 2 {
+                    xf[2 * i] = vaddq_f32(xf[2 * i], xf[2 * i + 1]);
+                }
+                for i in 0..ARR_BF16 / 4 {
+                    xf[4 * i] = vaddq_f32(xf[4 * i], xf[4 * i + 2]);
+                }
+                *y = vaddvq_f32(xf[0]);
+            }
+
+            unsafe fn from_f32(v: f32) -> Self::Unit {
+                vreinterpretq_u16_f32(vdupq_n_f32(v))
+            }
+
+            unsafe fn vec_store(mem_addr: *mut bf16, a: Self::Unit) {
+                vst1q_u16(mem_addr as *mut u16, a);
+            }
+        }
+    }
+
+    pub use inner::CurrentCpuBF16;
+}
+
+pub use bf16::CurrentCpuBF16;

--- a/candle-core/src/cpu/neon.rs
+++ b/candle-core/src/cpu/neon.rs
@@ -7,10 +7,6 @@ use core::arch::aarch64::*;
 
 pub struct CurrentCpu {}
 
-const STEP: usize = 32;
-const EPR: usize = 4;
-const ARR: usize = STEP / EPR;
-
 impl CurrentCpu {
     #[cfg(target_arch = "aarch64")]
     unsafe fn reduce_one(x: float32x4_t) -> f32 {
@@ -23,13 +19,12 @@ impl CurrentCpu {
     }
 }
 
-impl Cpu<ARR> for CurrentCpu {
+impl Cpu for CurrentCpu {
     type Unit = float32x4_t;
-    type Array = [float32x4_t; ARR];
+    type Array = [float32x4_t; Self::ARR];
 
-    const STEP: usize = STEP;
-    const EPR: usize = EPR;
-    const ARR: usize = ARR;
+    const STEP: usize = 32;
+    const EPR: usize = 4;
 
     unsafe fn zero() -> Self::Unit {
         vdupq_n_f32(0.0)
@@ -40,7 +35,7 @@ impl Cpu<ARR> for CurrentCpu {
     }
 
     unsafe fn zero_array() -> Self::Array {
-        [Self::zero(); ARR]
+        [Self::zero(); Self::ARR]
     }
 
     unsafe fn load(mem_addr: *const f32) -> Self::Unit {
@@ -60,13 +55,13 @@ impl Cpu<ARR> for CurrentCpu {
     }
 
     unsafe fn vec_reduce(mut x: Self::Array, y: *mut f32) {
-        for i in 0..ARR / 2 {
+        for i in 0..Self::ARR / 2 {
             x[2 * i] = vaddq_f32(x[2 * i], x[2 * i + 1]);
         }
-        for i in 0..ARR / 4 {
+        for i in 0..Self::ARR / 4 {
             x[4 * i] = vaddq_f32(x[4 * i], x[4 * i + 2]);
         }
-        for i in 0..ARR / 8 {
+        for i in 0..Self::ARR / 8 {
             x[8 * i] = vaddq_f32(x[8 * i], x[8 * i + 4]);
         }
         *y = Self::reduce_one(x[0]);
@@ -89,24 +84,19 @@ mod fp16 {
 
         pub struct CurrentCpuF16 {}
 
-        const STEP_F16: usize = 32;
-        const EPR_F16: usize = 4;
-        const ARR_F16: usize = STEP_F16 / EPR_F16;
-
-        impl CpuF16<ARR_F16> for CurrentCpuF16 {
+        impl CpuF16 for CurrentCpuF16 {
             type Unit = float32x4_t;
-            type Array = [float32x4_t; ARR_F16];
+            type Array = [float32x4_t; Self::ARR];
 
-            const STEP: usize = STEP_F16;
-            const EPR: usize = EPR_F16;
-            const ARR: usize = ARR_F16;
+            const STEP: usize = 32;
+            const EPR: usize = 4;
 
             unsafe fn zero() -> Self::Unit {
                 vdupq_n_f32(0.0)
             }
 
             unsafe fn zero_array() -> Self::Array {
-                [Self::zero(); ARR_F16]
+                [Self::zero(); Self::ARR]
             }
 
             unsafe fn load(mem_addr: *const f16) -> Self::Unit {
@@ -130,13 +120,13 @@ mod fp16 {
             }
 
             unsafe fn vec_reduce(mut x: Self::Array, y: *mut f32) {
-                for i in 0..ARR_F16 / 2 {
+                for i in 0..Self::ARR / 2 {
                     x[2 * i] = vaddq_f32(x[2 * i], x[2 * i + 1]);
                 }
-                for i in 0..ARR_F16 / 4 {
+                for i in 0..Self::ARR / 4 {
                     x[4 * i] = vaddq_f32(x[4 * i], x[4 * i + 2]);
                 }
-                for i in 0..ARR_F16 / 8 {
+                for i in 0..Self::ARR / 8 {
                     x[8 * i] = vaddq_f32(x[8 * i], x[8 * i + 4]);
                 }
                 *y = vaddvq_f32(x[0]);
@@ -194,17 +184,12 @@ mod fp16 {
             }
         }
 
-        const STEP_F16: usize = 32;
-        const EPR_F16: usize = 8;
-        const ARR_F16: usize = STEP_F16 / EPR_F16;
-
-        impl CpuF16<ARR_F16> for CurrentCpuF16 {
+        impl CpuF16 for CurrentCpuF16 {
             type Unit = float16x8_t;
-            type Array = [float16x8_t; ARR_F16];
+            type Array = [float16x8_t; Self::ARR];
 
-            const STEP: usize = STEP_F16;
-            const EPR: usize = EPR_F16;
-            const ARR: usize = ARR_F16;
+            const STEP: usize = 32;
+            const EPR: usize = 8;
             // Flush f16 accumulators to f32 every `FLUSH_INTERVAL` steps to bound rounding error.
             const FLUSH_INTERVAL: usize = 16;
 
@@ -219,7 +204,7 @@ mod fp16 {
             }
 
             unsafe fn zero_array() -> Self::Array {
-                [Self::zero(); ARR_F16]
+                [Self::zero(); Self::ARR]
             }
 
             unsafe fn load(mem_addr: *const f16) -> Self::Unit {
@@ -252,8 +237,8 @@ mod fp16 {
 
             unsafe fn vec_reduce(x: Self::Array, y: *mut f32) {
                 let mut sum = 0.0f32;
-                for i in 0..ARR_F16 {
-                    sum += Self::reduce_one(x[i]);
+                for item in x {
+                    sum += Self::reduce_one(item);
                 }
                 *y = sum;
             }
@@ -301,24 +286,19 @@ mod bf16 {
 
         pub struct CurrentCpuBF16 {}
 
-        const STEP_BF16: usize = 32;
-        const EPR_BF16: usize = 4;
-        const ARR_BF16: usize = STEP_BF16 / EPR_BF16;
-
-        impl CpuBF16<ARR_BF16> for CurrentCpuBF16 {
+        impl CpuBF16 for CurrentCpuBF16 {
             type Unit = float32x4_t;
-            type Array = [float32x4_t; ARR_BF16];
+            type Array = [float32x4_t; Self::ARR];
 
-            const STEP: usize = STEP_BF16;
-            const EPR: usize = EPR_BF16;
-            const ARR: usize = ARR_BF16;
+            const STEP: usize = 32;
+            const EPR: usize = 4;
 
             unsafe fn zero() -> Self::Unit {
                 vdupq_n_f32(0.0)
             }
 
             unsafe fn zero_array() -> Self::Array {
-                [Self::zero(); ARR_BF16]
+                [Self::zero(); Self::ARR]
             }
 
             unsafe fn load(mem_addr: *const bf16) -> Self::Unit {
@@ -337,13 +317,13 @@ mod bf16 {
             }
 
             unsafe fn vec_reduce(mut x: Self::Array, y: *mut f32) {
-                for i in 0..ARR_BF16 / 2 {
+                for i in 0..Self::ARR / 2 {
                     x[2 * i] = vaddq_f32(x[2 * i], x[2 * i + 1]);
                 }
-                for i in 0..ARR_BF16 / 4 {
+                for i in 0..Self::ARR / 4 {
                     x[4 * i] = vaddq_f32(x[4 * i], x[4 * i + 2]);
                 }
-                for i in 0..ARR_BF16 / 8 {
+                for i in 0..Self::ARR / 8 {
                     x[8 * i] = vaddq_f32(x[8 * i], x[8 * i + 4]);
                 }
                 *y = vaddvq_f32(x[0]);
@@ -370,24 +350,19 @@ mod bf16 {
 
         pub struct CurrentCpuBF16 {}
 
-        const STEP_BF16: usize = 32;
-        const EPR_BF16: usize = 8;
-        const ARR_BF16: usize = STEP_BF16 / EPR_BF16;
-
-        impl CpuBF16<ARR_BF16> for CurrentCpuBF16 {
+        impl CpuBF16 for CurrentCpuBF16 {
             type Unit = uint16x8_t;
-            type Array = [uint16x8_t; ARR_BF16];
+            type Array = [uint16x8_t; Self::ARR];
 
-            const STEP: usize = STEP_BF16;
-            const EPR: usize = EPR_BF16;
-            const ARR: usize = ARR_BF16;
+            const STEP: usize = 32;
+            const EPR: usize = 8;
 
             unsafe fn zero() -> Self::Unit {
                 vreinterpretq_u16_f32(vdupq_n_f32(0.0))
             }
 
             unsafe fn zero_array() -> Self::Array {
-                [Self::zero(); ARR_BF16]
+                [Self::zero(); Self::ARR]
             }
 
             unsafe fn load(mem_addr: *const bf16) -> Self::Unit {
@@ -425,11 +400,11 @@ mod bf16 {
                 // IMPORTANT: `x` is not bf16x8 here. It is 128 bits used as f32x4.
                 // This means that if you use `vec_reduce` where `x` is actually bf16x8 you will get
                 // entirely wrong results.
-                let mut xf: [float32x4_t; ARR_BF16] = std::mem::transmute(x);
-                for i in 0..ARR_BF16 / 2 {
+                let mut xf: [float32x4_t; Self::ARR] = std::mem::transmute(x);
+                for i in 0..Self::ARR / 2 {
                     xf[2 * i] = vaddq_f32(xf[2 * i], xf[2 * i + 1]);
                 }
-                for i in 0..ARR_BF16 / 4 {
+                for i in 0..Self::ARR / 4 {
                     xf[4 * i] = vaddq_f32(xf[4 * i], xf[4 * i + 2]);
                 }
                 *y = vaddvq_f32(xf[0]);

--- a/candle-core/src/cpu/simd128.rs
+++ b/candle-core/src/cpu/simd128.rs
@@ -7,7 +7,7 @@ const STEP: usize = 16;
 const EPR: usize = 4;
 const ARR: usize = STEP / EPR;
 
-impl Cpu<ARR> for CurrentCpu {
+impl Cpu for CurrentCpu {
     type Unit = v128;
     type Array = [v128; ARR];
 

--- a/candle-core/src/cpu/simd128.rs
+++ b/candle-core/src/cpu/simd128.rs
@@ -13,10 +13,7 @@ impl Cpu<ARR> for CurrentCpu {
 
     const STEP: usize = STEP;
     const EPR: usize = EPR;
-
-    fn n() -> usize {
-        ARR
-    }
+    const ARR: usize = ARR;
 
     unsafe fn zero() -> Self::Unit {
         f32x4_splat(0.0)

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -1113,7 +1113,7 @@ fn ggml_matmul_error_test_<T: GgmlType>(a: &[f32], b: &[f32], err_m: f32) -> Res
 fn quantized_mm() -> Result<()> {
     ggml_matmul_error_test::<f32>()?;
     ggml_matmul_error_test::<half::f16>()?;
-    //ggml_matmul_error_test::<half::bf16>()?; TODO: Fails on ubuntu and windows. Check CpuBF16 impl
+    ggml_matmul_error_test::<half::bf16>()?;
     ggml_matmul_error_test::<k_quants::BlockQ4_0>()?;
     ggml_matmul_error_test::<k_quants::BlockQ4_1>()?;
     ggml_matmul_error_test::<k_quants::BlockQ5_0>()?;

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -1111,6 +1111,13 @@ fn ggml_matmul_error_test_<T: GgmlType>(a: &[f32], b: &[f32], err_m: f32) -> Res
 
 #[test]
 fn quantized_mm() -> Result<()> {
+    println!(
+        "avx: {}, neon: {}, simd128: {}, f16c: {}",
+        candle_core::utils::with_avx(),
+        candle_core::utils::with_neon(),
+        candle_core::utils::with_simd128(),
+        candle_core::utils::with_f16c()
+    );
     ggml_matmul_error_test::<f32>()?;
     ggml_matmul_error_test::<half::f16>()?;
     ggml_matmul_error_test::<half::bf16>()?;

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -1111,13 +1111,6 @@ fn ggml_matmul_error_test_<T: GgmlType>(a: &[f32], b: &[f32], err_m: f32) -> Res
 
 #[test]
 fn quantized_mm() -> Result<()> {
-    println!(
-        "avx: {}, neon: {}, simd128: {}, f16c: {}",
-        candle_core::utils::with_avx(),
-        candle_core::utils::with_neon(),
-        candle_core::utils::with_simd128(),
-        candle_core::utils::with_f16c()
-    );
     ggml_matmul_error_test::<f32>()?;
     ggml_matmul_error_test::<half::f16>()?;
     ggml_matmul_error_test::<half::bf16>()?;


### PR DESCRIPTION
Between 600-1800% increase in throughput. Also fixes a bug in the AVX `CpuBF16` impl.

<details>
<summary>Benchmark results:</summary>

```
cpu_vec_dot_f32_k64/iter
                        time:   [3.6506 ns 3.8527 ns 4.2179 ns]
                        thrpt:  [15.173 Gelem/s 16.612 Gelem/s 17.531 Gelem/s]
                 change:
                        time:   [−91.557% −91.270% −90.749%] (p = 0.00 < 0.05)
                        thrpt:  [+981.01% +1045.5% +1084.4%]
                        Performance has improved.

cpu_vec_dot_f16_k64/iter
                        time:   [2.7149 ns 2.7359 ns 2.7619 ns]
                        thrpt:  [23.172 Gelem/s 23.393 Gelem/s 23.573 Gelem/s]
                 change:
                        time:   [−85.635% −85.534% −85.420%] (p = 0.00 < 0.05)
                        thrpt:  [+585.86% +591.27% +596.16%]
                        Performance has improved.

cpu_vec_dot_bf16_k64/iter
                        time:   [3.1274 ns 3.1532 ns 3.1773 ns]
                        thrpt:  [20.143 Gelem/s 20.297 Gelem/s 20.464 Gelem/s]
                 change:
                        time:   [−80.043% −79.959% −79.876%] (p = 0.00 < 0.05)
                        thrpt:  [+396.91% +398.97% +401.09%]
                        Performance has improved.

cpu_vec_dot_f32_k128/iter
                        time:   [6.3057 ns 6.3534 ns 6.4041 ns]
                        thrpt:  [19.987 Gelem/s 20.147 Gelem/s 20.299 Gelem/s]
                 change:
                        time:   [−92.193% −92.160% −92.124%] (p = 0.00 < 0.05)
                        thrpt:  [+1169.6% +1175.5% +1181.0%]
                        Performance has improved.

cpu_vec_dot_f16_k128/iter
                        time:   [3.8105 ns 3.8168 ns 3.8231 ns]
                        thrpt:  [33.480 Gelem/s 33.536 Gelem/s 33.591 Gelem/s]
                 change:
                        time:   [−93.010% −92.491% −92.130%] (p = 0.00 < 0.05)
                        thrpt:  [+1170.7% +1231.7% +1330.5%]
                        Performance has improved.

cpu_vec_dot_bf16_k128/iter
                        time:   [5.1521 ns 5.2101 ns 5.2703 ns]
                        thrpt:  [24.287 Gelem/s 24.568 Gelem/s 24.844 Gelem/s]
                 change:
                        time:   [−87.273% −87.210% −87.139%] (p = 0.00 < 0.05)
                        thrpt:  [+677.52% +681.87% +685.76%]
                        Performance has improved.

cpu_vec_dot_f32_k256/iter
                        time:   [11.856 ns 11.928 ns 12.018 ns]
                        thrpt:  [21.302 Gelem/s 21.462 Gelem/s 21.592 Gelem/s]
                 change:
                        time:   [−92.124% −92.056% −91.988%] (p = 0.00 < 0.05)
                        thrpt:  [+1148.1% +1158.8% +1169.7%]
                        Performance has improved.

cpu_vec_dot_f16_k256/iter
                        time:   [6.3393 ns 6.3600 ns 6.3808 ns]
                        thrpt:  [40.120 Gelem/s 40.251 Gelem/s 40.383 Gelem/s]
                 change:
                        time:   [−94.576% −94.255% −94.019%] (p = 0.00 < 0.05)
                        thrpt:  [+1572.1% +1640.6% +1743.7%]
                        Performance has improved.

cpu_vec_dot_bf16_k256/iter
                        time:   [9.0996 ns 9.1382 ns 9.1757 ns]
                        thrpt:  [27.900 Gelem/s 28.014 Gelem/s 28.133 Gelem/s]
                 change:
                        time:   [−89.446% −89.403% −89.359%] (p = 0.00 < 0.05)
                        thrpt:  [+839.76% +843.66% +847.50%]
                        Performance has improved.

cpu_vec_dot_f32_k512/iter
                        time:   [22.168 ns 22.208 ns 22.250 ns]
                        thrpt:  [23.011 Gelem/s 23.055 Gelem/s 23.096 Gelem/s]
                 change:
                        time:   [−92.776% −92.736% −92.699%] (p = 0.00 < 0.05)
                        thrpt:  [+1269.6% +1276.6% +1284.3%]
                        Performance has improved.

cpu_vec_dot_f16_k512/iter
                        time:   [12.848 ns 12.881 ns 12.915 ns]
                        thrpt:  [39.644 Gelem/s 39.748 Gelem/s 39.852 Gelem/s]
                 change:
                        time:   [−94.957% −94.935% −94.915%] (p = 0.00 < 0.05)
                        thrpt:  [+1866.4% +1874.4% +1882.8%]
                        Performance has improved.

cpu_vec_dot_bf16_k512/iter
                        time:   [16.952 ns 17.004 ns 17.056 ns]
                        thrpt:  [30.019 Gelem/s 30.111 Gelem/s 30.203 Gelem/s]
                 change:
                        time:   [−92.220% −92.173% −92.120%] (p = 0.00 < 0.05)
                        thrpt:  [+1169.0% +1177.7% +1185.3%]
                        Performance has improved.
```
</details>

Turns out the simd optimized `vec_dot_f32` path was _slower_ than a simple scalar version because of `#[inline(always)]`.
Simply removing the inline macro made most of the difference. The rest of the optimizations account for ~2% improvement.

I also added neon optimized f16/bf16 impls. The f16 neon intrinsics and all of bf16 are unstable, so we use direct inline asm instead.
When the fp16/bf16 target features are missing we fall back to loading into f32x4 and get the same performance characteristics as neon `CurrentCpu` from then on.

Accumulating in f16 meant losing some precision (ggml test fails), but accumulating in f32 meant losing ~50% of the performance. To get the best of both worlds I added `FLUSH_INTERVAL` to the `CpuF16` trait, which indicates at what interval we should flush the inner f16 accumulation to the outer f32 result. Currently only used on neon + fp16 with `FLUSH_INTERVAL = 16`, which resulted in ~90-95% of the imprecise all f16 performance.

Supersedes #3516 