### PR TITLE
⁠fix(core): validate shape element count in ShapeWithOneHole blanket impl (#3534)⁠

### DIFF
--- a/candle-core/src/shape.rs
+++ b/candle-core/src/shape.rs
@@ -472,8 +472,15 @@ pub trait ShapeWithOneHole {
 }
 
 impl<S: Into<Shape>> ShapeWithOneHole for S {
-    fn into_shape(self, _el_count: usize) -> Result<Shape> {
-        Ok(self.into())
+    fn into_shape(self, el_count: usize) -> Result<Shape> {
+        let shape: Shape = self.into();
+        if shape.elem_count() != el_count {
+            crate::bail!(
+                "shape {shape:?} declares {} elements but storage has {el_count}",
+                shape.elem_count()
+            );
+        }
+        Ok(shape)
     }
 }
 

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -2094,3 +2094,30 @@ fn allocates_twice_when_transferring_to_same_device() -> Result<()> {
     assert_ne!(id1, id2);
     Ok(())
 }
+
+#[test]
+fn from_slice_validates_shape_element_count() -> Result<()> {
+    // from_slice / from_vec must reject a declared shape whose element count
+    // does not match the data length, instead of building a tensor that lies
+    // about its size and reads past its storage later (candle#3534).
+    assert!(Tensor::from_slice(&[0f32], vec![10usize], &Device::Cpu).is_err());
+    assert!(Tensor::from_slice(&[0f32], vec![1usize << 20], &Device::Cpu).is_err());
+    assert!(Tensor::from_vec(vec![0f32, 1.], vec![3usize], &Device::Cpu).is_err());
+
+    // Matching shapes and one-hole inference still succeed.
+    let t = Tensor::from_slice(&[0f32, 1., 2., 3., 4., 5.], (2, 3), &Device::Cpu)?;
+    assert_eq!(t.dims(), &[2, 3]);
+    let t = Tensor::from_slice(&[0f32, 1., 2., 3., 4., 5.], ((), 3), &Device::Cpu)?;
+    assert_eq!(t.dims(), &[2, 3]);
+    Ok(())
+}
+
+#[test]
+fn from_raw_buffer_validates_shape_element_count() -> Result<()> {
+    // from_raw_buffer routes through from_slice, so the same contract holds.
+    let raw = vec![0u8; 4]; // one f32 worth of bytes
+    assert!(Tensor::from_raw_buffer(&raw, DType::F32, &[1usize << 10], &Device::Cpu).is_err());
+    let ok = Tensor::from_raw_buffer(&raw, DType::F32, &[1], &Device::Cpu)?;
+    assert_eq!(ok.dims(), &[1]);
+    Ok(())
+}


### PR DESCRIPTION
Closes #3534

This PR adds the missing shape element count validation in the `ShapeWithOneHole` blanket implementation for `S: Into<Shape>`. 

Previously, the `_el_count` parameter was ignored, allowing the creation of tensors with invalid shapes, which led to out-of-bounds reads and panics (especially via the ONNX loader as reported in #3534).

Please feel free to modify or add regression tests if needed!
