### PR TITLE
[CPU] Shared threadpool + less contention

### DIFF
--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -21,7 +21,7 @@ gemm = { workspace = true }
 half = { workspace = true }
 float8 = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
-libc = { workspace = true, optional = true }
+libc = { workspace = true }
 libm = { workspace = true }
 memmap2 = { workspace = true }
 num-traits = { workspace = true }
@@ -49,8 +49,8 @@ default = []
 cuda = ["cudarc", "dep:candle-kernels", "candle-ug?/cuda"]
 cudnn = ["cuda", "cudarc/cudnn"]
 nccl = ["cuda", "cudarc/nccl"]
-mkl = ["dep:libc", "dep:intel-mkl-src"]
-accelerate = ["dep:libc", "dep:accelerate-src"]
+mkl = ["dep:intel-mkl-src"]
+accelerate = ["dep:accelerate-src"]
 metal = [
     "dep:objc2-metal",
     "dep:objc2-foundation",

--- a/candle-core/src/device.rs
+++ b/candle-core/src/device.rs
@@ -259,6 +259,22 @@ impl Device {
         Ok(Self::Metal(crate::MetalDevice::new(ordinal)?))
     }
 
+    /// Run `f` with device specific context.
+    ///
+    /// On CPU this installs candle's private rayon thread pool for the
+    /// duration of `f`, keeping worker threads warm across the many short
+    /// parallel sections in a model forward pass. Currently noop for other backends.
+    pub fn with_context<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R + Send,
+        R: Send,
+    {
+        match self {
+            Self::Cpu => crate::utils::with_threadpool(f),
+            _ => f(),
+        }
+    }
+
     pub fn set_seed(&self, seed: u64) -> Result<()> {
         match self {
             Self::Cpu => CpuDevice.set_seed(seed),

--- a/candle-core/src/utils.rs
+++ b/candle-core/src/utils.rs
@@ -1,5 +1,6 @@
 //! Useful functions for checking features.
 use std::str::FromStr;
+use std::sync::OnceLock;
 
 pub fn get_num_threads() -> usize {
     // Respond to the same environment variable as rayon.
@@ -8,8 +9,79 @@ pub fn get_num_threads() -> usize {
         .and_then(|s| usize::from_str(&s).ok())
     {
         Some(x) if x > 0 => x,
-        Some(_) | None => num_cpus::get(),
+        _ => default_num_threads(),
     }
+}
+
+fn default_num_threads() -> usize {
+    let physical = {
+        #[cfg(target_os = "macos")]
+        {
+            perf_core_count().unwrap_or_else(num_cpus::get_physical)
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            num_cpus::get_physical()
+        }
+    };
+    let physical = physical.max(1); // safeguard against bad number
+    if physical <= 4 {
+        physical
+    } else {
+        // NOTE: When the CPU backend is optimized further so as not to trash shared
+        // caches etc the amount of threads can be increased.
+        physical.min(physical / 2)
+    }
+}
+
+/// On Apple Silicon: P-core count via `hw.perflevel0.logicalcpu`.
+/// Returns None on Intel Macs (key absent) or on error.
+#[cfg(target_os = "macos")]
+fn perf_core_count() -> Option<usize> {
+    use std::os::raw::c_void;
+    let mut count: u32 = 0;
+    let mut size = std::mem::size_of::<u32>();
+    let ret = unsafe {
+        libc::sysctlbyname(
+            c"hw.perflevel0.logicalcpu".as_ptr().cast(),
+            &mut count as *mut u32 as *mut c_void,
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    (ret == 0 && count > 0).then_some(count as usize)
+}
+
+static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+
+pub(crate) fn candle_pool() -> &'static rayon::ThreadPool {
+    POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(get_num_threads())
+            .start_handler(|_| set_thread_affinity())
+            .build()
+            .expect("failed to build candle rayon threadpool")
+    })
+}
+
+#[cfg(target_os = "macos")]
+/// Elevate the thread QoS so macOS prefers running on Performance (P) cores.
+fn set_thread_affinity() {
+    use libc::{pthread_set_qos_class_self_np, qos_class_t::QOS_CLASS_USER_INTERACTIVE};
+    unsafe {
+        pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+#[inline(always)]
+fn set_thread_affinity() {
+    // On non‑macOS platforms we currently leave thread affinity untouched.
+}
+
+pub(crate) fn with_threadpool<F: FnOnce() -> R + Send, R: Send>(f: F) -> R {
+    candle_pool().install(f)
 }
 
 pub fn has_accelerate() -> bool {

--- a/candle-examples/examples/quantized-qwen3/main.rs
+++ b/candle-examples/examples/quantized-qwen3/main.rs
@@ -245,68 +245,71 @@ fn main() -> anyhow::Result<()> {
 
     let start_prompt_processing = std::time::Instant::now();
 
-    let mut next_token = if !args.split_prompt {
-        let input = Tensor::new(tokens, &device)?.unsqueeze(0)?;
-        let logits = model.forward(&input, 0)?;
-        let logits = logits.squeeze(0)?;
-        logits_processor.sample(&logits)?
-    } else {
-        let mut next_token = 0;
-        for (pos, token) in tokens.iter().enumerate() {
-            let input = Tensor::new(&[*token], &device)?.unsqueeze(0)?;
-            let logits = model.forward(&input, pos)?;
+    let (prompt_dt, sampled, dt) = device.with_context(|| -> anyhow::Result<_> {
+        let mut next_token = if !args.split_prompt {
+            let input = Tensor::new(tokens, &device)?.unsqueeze(0)?;
+            let logits = model.forward(&input, 0)?;
             let logits = logits.squeeze(0)?;
-            next_token = logits_processor.sample(&logits)?
-        }
-        next_token
-    };
-
-    let prompt_dt = start_prompt_processing.elapsed();
-
-    all_tokens.push(next_token);
-
-    if let Some(t) = tos.next_token(next_token)? {
-        print!("{t}");
-        std::io::stdout().flush()?;
-    }
-
-    let eos_token = *tos.tokenizer().get_vocab(true).get("<|im_end|>").unwrap();
-
-    let start_post_prompt = std::time::Instant::now();
-
-    let mut sampled = 0;
-    for index in 0..to_sample {
-        let input = Tensor::new(&[next_token], &device)?.unsqueeze(0)?;
-        let logits = model.forward(&input, tokens.len() + index)?;
-        let logits = logits.squeeze(0)?;
-        let logits = if args.repeat_penalty == 1. {
-            logits
+            logits_processor.sample(&logits)?
         } else {
-            let start_at = all_tokens.len().saturating_sub(args.repeat_last_n);
-            candle_transformers::utils::apply_repeat_penalty(
-                &logits,
-                args.repeat_penalty,
-                &all_tokens[start_at..],
-            )?
+            let mut next_token = 0;
+            for (pos, token) in tokens.iter().enumerate() {
+                let input = Tensor::new(&[*token], &device)?.unsqueeze(0)?;
+                let logits = model.forward(&input, pos)?;
+                let logits = logits.squeeze(0)?;
+                next_token = logits_processor.sample(&logits)?
+            }
+            next_token
         };
-        next_token = logits_processor.sample(&logits)?;
+
+        let prompt_dt = start_prompt_processing.elapsed();
+
         all_tokens.push(next_token);
+
         if let Some(t) = tos.next_token(next_token)? {
             print!("{t}");
             std::io::stdout().flush()?;
         }
-        sampled += 1;
-        if next_token == eos_token {
-            break;
-        };
-    }
+
+        let eos_token = *tos.tokenizer().get_vocab(true).get("<|im_end|>").unwrap();
+
+        let start_post_prompt = std::time::Instant::now();
+
+        let mut sampled = 0;
+        for index in 0..to_sample {
+            let input = Tensor::new(&[next_token], &device)?.unsqueeze(0)?;
+            let logits = model.forward(&input, tokens.len() + index)?;
+            let logits = logits.squeeze(0)?;
+            let logits = if args.repeat_penalty == 1. {
+                logits
+            } else {
+                let start_at = all_tokens.len().saturating_sub(args.repeat_last_n);
+                candle_transformers::utils::apply_repeat_penalty(
+                    &logits,
+                    args.repeat_penalty,
+                    &all_tokens[start_at..],
+                )?
+            };
+            next_token = logits_processor.sample(&logits)?;
+            all_tokens.push(next_token);
+            if let Some(t) = tos.next_token(next_token)? {
+                print!("{t}");
+                std::io::stdout().flush()?;
+            }
+            sampled += 1;
+            if next_token == eos_token {
+                break;
+            };
+        }
+
+        Ok((prompt_dt, sampled, start_post_prompt.elapsed()))
+    })?;
 
     if let Some(rest) = tos.decode_rest().map_err(candle::Error::msg)? {
         print!("{rest}");
     }
 
     std::io::stdout().flush()?;
-    let dt = start_post_prompt.elapsed();
     println!(
         "\n\n{:4} prompt tokens processed: {:.2} token/s",
         tokens.len(),

--- a/candle-nn/src/attention/cpu_flash/causal.rs
+++ b/candle-nn/src/attention/cpu_flash/causal.rs
@@ -7,7 +7,7 @@ use candle::{DType, Device, Result, Storage, Tensor, WithDType};
 use rayon::prelude::*;
 use std::iter::Sum;
 
-use super::standard::{vec_dot, FLASH_ATTN_POOL};
+use super::standard::vec_dot;
 
 /// Prefetch a cache line for read.
 #[inline(always)]
@@ -221,68 +221,66 @@ fn causal_decode_f32(
 
     let mut out = vec![0f32; h_q * d];
 
-    FLASH_ATTN_POOL.install(|| {
-        out.par_chunks_mut(d).enumerate().for_each_init(
-            || vec![0f32; d],
-            |acc, (h_i, out_chunk)| {
-                let slope = 2.0f32.powf(-max_bias * ((h_i + 1) as f32) / n2 as f32);
-                let k_head_off = (h_i / rk) * d;
-                let v_head_off = (h_i / rv) * d;
-                let q_row = &q_data[h_i * d..(h_i + 1) * d];
+    out.par_chunks_mut(d).enumerate().for_each_init(
+        || vec![0f32; d],
+        |acc, (h_i, out_chunk)| {
+            let slope = 2.0f32.powf(-max_bias * ((h_i + 1) as f32) / n2 as f32);
+            let k_head_off = (h_i / rk) * d;
+            let v_head_off = (h_i / rv) * d;
+            let q_row = &q_data[h_i * d..(h_i + 1) * d];
 
-                acc.fill(0.0);
-                let mut m = f32::NEG_INFINITY;
-                let mut ssum = 0.0f32;
+            acc.fill(0.0);
+            let mut m = f32::NEG_INFINITY;
+            let mut ssum = 0.0f32;
 
-                for kv_pos in 0..kv_len {
-                    let alibi_bias = slope * (kv_pos as f32 - (kv_len - 1) as f32);
-                    let k_base = kv_pos * k_seq_stride + k_head_off;
-                    let k_row = &k_data[k_base..k_base + d];
+            for kv_pos in 0..kv_len {
+                let alibi_bias = slope * (kv_pos as f32 - (kv_len - 1) as f32);
+                let k_base = kv_pos * k_seq_stride + k_head_off;
+                let k_row = &k_data[k_base..k_base + d];
 
-                    if kv_pos + 1 < kv_len {
-                        prefetch_read(k_data[k_base + k_seq_stride..].as_ptr());
-                    }
-
-                    let mut score = dot_f32(q_row, k_row) * scale_pre;
-                    if do_softcap {
-                        score = logit_softcap * score.tanh();
-                    }
-                    score += alibi_bias;
-
-                    let v_base = kv_pos * v_seq_stride + v_head_off;
-                    let v_row = &v_data[v_base..v_base + d];
-
-                    if kv_pos + 1 < kv_len {
-                        prefetch_read(v_data[v_base + v_seq_stride..].as_ptr());
-                    }
-
-                    if score > m {
-                        let scale_old = f32::exp(m - score);
-                        for t in 0..d {
-                            acc[t] *= scale_old;
-                        }
-                        ssum *= scale_old;
-                        m = score;
-                        for t in 0..d {
-                            acc[t] += v_row[t];
-                        }
-                        ssum += 1.0;
-                    } else {
-                        let w = f32::exp(score - m);
-                        for t in 0..d {
-                            acc[t] += v_row[t] * w;
-                        }
-                        ssum += w;
-                    }
+                if kv_pos + 1 < kv_len {
+                    prefetch_read(k_data[k_base + k_seq_stride..].as_ptr());
                 }
 
-                let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
-                for t in 0..d {
-                    out_chunk[t] = acc[t] * inv;
+                let mut score = dot_f32(q_row, k_row) * scale_pre;
+                if do_softcap {
+                    score = logit_softcap * score.tanh();
                 }
-            },
-        );
-    });
+                score += alibi_bias;
+
+                let v_base = kv_pos * v_seq_stride + v_head_off;
+                let v_row = &v_data[v_base..v_base + d];
+
+                if kv_pos + 1 < kv_len {
+                    prefetch_read(v_data[v_base + v_seq_stride..].as_ptr());
+                }
+
+                if score > m {
+                    let scale_old = f32::exp(m - score);
+                    for t in 0..d {
+                        acc[t] *= scale_old;
+                    }
+                    ssum *= scale_old;
+                    m = score;
+                    for t in 0..d {
+                        acc[t] += v_row[t];
+                    }
+                    ssum += 1.0;
+                } else {
+                    let w = f32::exp(score - m);
+                    for t in 0..d {
+                        acc[t] += v_row[t] * w;
+                    }
+                    ssum += w;
+                }
+            }
+
+            let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
+            for t in 0..d {
+                out_chunk[t] = acc[t] * inv;
+            }
+        },
+    );
 
     Tensor::from_vec(out, (h_q, 1usize, d), &Device::Cpu)
 }
@@ -308,62 +306,60 @@ fn causal_decode_f32_lean(
 
     let mut out = vec![0f32; h_q * d];
 
-    FLASH_ATTN_POOL.install(|| {
-        out.par_chunks_mut(d).enumerate().for_each_init(
-            || vec![0f32; d],
-            |acc, (h_i, out_chunk)| {
-                let k_head_off = (h_i / rk) * d;
-                let v_head_off = (h_i / rv) * d;
-                let q_row = &q_data[h_i * d..(h_i + 1) * d];
+    out.par_chunks_mut(d).enumerate().for_each_init(
+        || vec![0f32; d],
+        |acc, (h_i, out_chunk)| {
+            let k_head_off = (h_i / rk) * d;
+            let v_head_off = (h_i / rv) * d;
+            let q_row = &q_data[h_i * d..(h_i + 1) * d];
 
-                acc.fill(0.0);
-                let mut m = f32::NEG_INFINITY;
-                let mut ssum = 0.0f32;
+            acc.fill(0.0);
+            let mut m = f32::NEG_INFINITY;
+            let mut ssum = 0.0f32;
 
-                for kv_pos in 0..kv_len {
-                    let k_base = kv_pos * k_seq_stride + k_head_off;
-                    let k_row = &k_data[k_base..k_base + d];
+            for kv_pos in 0..kv_len {
+                let k_base = kv_pos * k_seq_stride + k_head_off;
+                let k_row = &k_data[k_base..k_base + d];
 
-                    if kv_pos + 1 < kv_len {
-                        prefetch_read(k_data[k_base + k_seq_stride..].as_ptr());
-                    }
-
-                    let score = dot_f32(q_row, k_row) * scale;
-
-                    let v_base = kv_pos * v_seq_stride + v_head_off;
-                    let v_row = &v_data[v_base..v_base + d];
-
-                    if kv_pos + 1 < kv_len {
-                        prefetch_read(v_data[v_base + v_seq_stride..].as_ptr());
-                    }
-
-                    if score > m {
-                        let scale_old = f32::exp(m - score);
-                        for t in 0..d {
-                            acc[t] *= scale_old;
-                        }
-                        ssum *= scale_old;
-                        m = score;
-                        for t in 0..d {
-                            acc[t] += v_row[t];
-                        }
-                        ssum += 1.0;
-                    } else {
-                        let w = f32::exp(score - m);
-                        for t in 0..d {
-                            acc[t] += v_row[t] * w;
-                        }
-                        ssum += w;
-                    }
+                if kv_pos + 1 < kv_len {
+                    prefetch_read(k_data[k_base + k_seq_stride..].as_ptr());
                 }
 
-                let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
-                for t in 0..d {
-                    out_chunk[t] = acc[t] * inv;
+                let score = dot_f32(q_row, k_row) * scale;
+
+                let v_base = kv_pos * v_seq_stride + v_head_off;
+                let v_row = &v_data[v_base..v_base + d];
+
+                if kv_pos + 1 < kv_len {
+                    prefetch_read(v_data[v_base + v_seq_stride..].as_ptr());
                 }
-            },
-        );
-    });
+
+                if score > m {
+                    let scale_old = f32::exp(m - score);
+                    for t in 0..d {
+                        acc[t] *= scale_old;
+                    }
+                    ssum *= scale_old;
+                    m = score;
+                    for t in 0..d {
+                        acc[t] += v_row[t];
+                    }
+                    ssum += 1.0;
+                } else {
+                    let w = f32::exp(score - m);
+                    for t in 0..d {
+                        acc[t] += v_row[t] * w;
+                    }
+                    ssum += w;
+                }
+            }
+
+            let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
+            for t in 0..d {
+                out_chunk[t] = acc[t] * inv;
+            }
+        },
+    );
 
     Tensor::from_vec(out, (h_q, 1usize, d), &Device::Cpu)
 }
@@ -389,58 +385,56 @@ pub fn causal_decode_f32_interleaved(
 
     let mut out = vec![0f32; h_q * d];
 
-    FLASH_ATTN_POOL.install(|| {
-        out.par_chunks_mut(d).enumerate().for_each_init(
-            || vec![0f32; d],
-            |acc, (h_i, out_chunk)| {
-                let kv_head = h_i / rk;
-                let kv_head_off = kv_head * kv_head_stride;
-                let q_row = &q_data[h_i * d..(h_i + 1) * d];
+    out.par_chunks_mut(d).enumerate().for_each_init(
+        || vec![0f32; d],
+        |acc, (h_i, out_chunk)| {
+            let kv_head = h_i / rk;
+            let kv_head_off = kv_head * kv_head_stride;
+            let q_row = &q_data[h_i * d..(h_i + 1) * d];
 
-                acc.fill(0.0);
-                let mut m = f32::NEG_INFINITY;
-                let mut ssum = 0.0f32;
+            acc.fill(0.0);
+            let mut m = f32::NEG_INFINITY;
+            let mut ssum = 0.0f32;
 
-                for kv_pos in 0..kv_len {
-                    // K and V share a base pointer (adjacent in memory)
-                    let kv_base = kv_pos * kv_seq_stride + kv_head_off;
-                    let k_row = &kv_data[kv_base..kv_base + d];
-                    let v_row = &kv_data[kv_base + d..kv_base + 2 * d];
+            for kv_pos in 0..kv_len {
+                // K and V share a base pointer (adjacent in memory)
+                let kv_base = kv_pos * kv_seq_stride + kv_head_off;
+                let k_row = &kv_data[kv_base..kv_base + d];
+                let v_row = &kv_data[kv_base + d..kv_base + 2 * d];
 
-                    // One prefetch loads both next K and V
-                    if kv_pos + 1 < kv_len {
-                        prefetch_read(kv_data[kv_base + kv_seq_stride..].as_ptr());
-                    }
-
-                    let score = dot_f32(q_row, k_row) * scale;
-
-                    if score > m {
-                        let scale_old = f32::exp(m - score);
-                        for t in 0..d {
-                            acc[t] *= scale_old;
-                        }
-                        ssum *= scale_old;
-                        m = score;
-                        for t in 0..d {
-                            acc[t] += v_row[t];
-                        }
-                        ssum += 1.0;
-                    } else {
-                        let w = f32::exp(score - m);
-                        for t in 0..d {
-                            acc[t] += v_row[t] * w;
-                        }
-                        ssum += w;
-                    }
+                // One prefetch loads both next K and V
+                if kv_pos + 1 < kv_len {
+                    prefetch_read(kv_data[kv_base + kv_seq_stride..].as_ptr());
                 }
 
-                let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
-                for t in 0..d {
-                    out_chunk[t] = acc[t] * inv;
+                let score = dot_f32(q_row, k_row) * scale;
+
+                if score > m {
+                    let scale_old = f32::exp(m - score);
+                    for t in 0..d {
+                        acc[t] *= scale_old;
+                    }
+                    ssum *= scale_old;
+                    m = score;
+                    for t in 0..d {
+                        acc[t] += v_row[t];
+                    }
+                    ssum += 1.0;
+                } else {
+                    let w = f32::exp(score - m);
+                    for t in 0..d {
+                        acc[t] += v_row[t] * w;
+                    }
+                    ssum += w;
                 }
-            },
-        );
-    });
+            }
+
+            let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
+            for t in 0..d {
+                out_chunk[t] = acc[t] * inv;
+            }
+        },
+    );
 
     Tensor::from_vec(out, (h_q, 1usize, d), &Device::Cpu)
 }
@@ -486,89 +480,87 @@ fn causal_prefill_f32(
 
     let mut out = vec![0f32; h_q * s_q * d];
 
-    FLASH_ATTN_POOL.install(|| {
-        out.par_chunks_mut(d)
-            .with_min_len(64)
-            .enumerate()
-            .for_each_init(
-                || vec![0f32; d],
-                |acc, (row_idx, out_chunk)| {
-                    let h_i = row_idx / s_q;
-                    let q_pos = row_idx % s_q;
+    out.par_chunks_mut(d)
+        .with_min_len(64)
+        .enumerate()
+        .for_each_init(
+            || vec![0f32; d],
+            |acc, (row_idx, out_chunk)| {
+                let h_i = row_idx / s_q;
+                let q_pos = row_idx % s_q;
 
-                    let slope = if max_bias > 0.0 {
-                        2.0f32.powf(-max_bias * ((h_i + 1) as f32) / n2 as f32)
+                let slope = if max_bias > 0.0 {
+                    2.0f32.powf(-max_bias * ((h_i + 1) as f32) / n2 as f32)
+                } else {
+                    0.0
+                };
+
+                let k_head_off = (h_i / rk) * d;
+                let v_head_off = (h_i / rv) * d;
+
+                let q_base = q_pos * q_seq_stride + h_i * d;
+                let q_row = &q_data[q_base..q_base + d];
+
+                acc.fill(0.0);
+                let mut m = f32::NEG_INFINITY;
+                let mut ssum = 0.0f32;
+
+                let kv_end = (q_pos + kv_offset + 1).min(kv_len);
+
+                for kv_pos in 0..kv_end {
+                    let alibi_bias = if max_bias > 0.0 {
+                        slope * (kv_pos as i64 - (q_pos + kv_offset) as i64) as f32
                     } else {
                         0.0
                     };
 
-                    let k_head_off = (h_i / rk) * d;
-                    let v_head_off = (h_i / rv) * d;
+                    let k_base = kv_pos * k_seq_stride + k_head_off;
+                    let k_row = &k_data[k_base..k_base + d];
 
-                    let q_base = q_pos * q_seq_stride + h_i * d;
-                    let q_row = &q_data[q_base..q_base + d];
-
-                    acc.fill(0.0);
-                    let mut m = f32::NEG_INFINITY;
-                    let mut ssum = 0.0f32;
-
-                    let kv_end = (q_pos + kv_offset + 1).min(kv_len);
-
-                    for kv_pos in 0..kv_end {
-                        let alibi_bias = if max_bias > 0.0 {
-                            slope * (kv_pos as i64 - (q_pos + kv_offset) as i64) as f32
-                        } else {
-                            0.0
-                        };
-
-                        let k_base = kv_pos * k_seq_stride + k_head_off;
-                        let k_row = &k_data[k_base..k_base + d];
-
-                        if kv_pos + 1 < kv_end {
-                            prefetch_read(k_data[k_base + k_seq_stride..].as_ptr());
-                        }
-
-                        let mut score = dot_f32(q_row, k_row) * scale_pre;
-                        if do_softcap {
-                            score = logit_softcap * score.tanh();
-                        }
-                        score += alibi_bias;
-
-                        let v_base = kv_pos * v_seq_stride + v_head_off;
-                        let v_row = &v_data[v_base..v_base + d];
-
-                        if kv_pos + 1 < kv_end {
-                            prefetch_read(v_data[v_base + v_seq_stride..].as_ptr());
-                        }
-
-                        if score > m {
-                            let scale_old = f32::exp(m - score);
-                            for t in 0..d {
-                                acc[t] *= scale_old;
-                            }
-                            ssum *= scale_old;
-                            m = score;
-
-                            for t in 0..d {
-                                acc[t] += v_row[t];
-                            }
-                            ssum += 1.0;
-                        } else {
-                            let w = f32::exp(score - m);
-                            for t in 0..d {
-                                acc[t] += v_row[t] * w;
-                            }
-                            ssum += w;
-                        }
+                    if kv_pos + 1 < kv_end {
+                        prefetch_read(k_data[k_base + k_seq_stride..].as_ptr());
                     }
 
-                    let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
-                    for t in 0..d {
-                        out_chunk[t] = acc[t] * inv;
+                    let mut score = dot_f32(q_row, k_row) * scale_pre;
+                    if do_softcap {
+                        score = logit_softcap * score.tanh();
                     }
-                },
-            );
-    });
+                    score += alibi_bias;
+
+                    let v_base = kv_pos * v_seq_stride + v_head_off;
+                    let v_row = &v_data[v_base..v_base + d];
+
+                    if kv_pos + 1 < kv_end {
+                        prefetch_read(v_data[v_base + v_seq_stride..].as_ptr());
+                    }
+
+                    if score > m {
+                        let scale_old = f32::exp(m - score);
+                        for t in 0..d {
+                            acc[t] *= scale_old;
+                        }
+                        ssum *= scale_old;
+                        m = score;
+
+                        for t in 0..d {
+                            acc[t] += v_row[t];
+                        }
+                        ssum += 1.0;
+                    } else {
+                        let w = f32::exp(score - m);
+                        for t in 0..d {
+                            acc[t] += v_row[t] * w;
+                        }
+                        ssum += w;
+                    }
+                }
+
+                let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
+                for t in 0..d {
+                    out_chunk[t] = acc[t] * inv;
+                }
+            },
+        );
 
     Tensor::from_vec(out, (h_q, s_q, d), &Device::Cpu)
 }
@@ -596,72 +588,70 @@ fn causal_prefill_f32_lean(
 
     let mut out = vec![0f32; h_q * s_q * d];
 
-    FLASH_ATTN_POOL.install(|| {
-        out.par_chunks_mut(d)
-            .with_min_len(64)
-            .enumerate()
-            .for_each_init(
-                || vec![0f32; d],
-                |acc, (row_idx, out_chunk)| {
-                    let h_i = row_idx / s_q;
-                    let q_pos = row_idx % s_q;
+    out.par_chunks_mut(d)
+        .with_min_len(64)
+        .enumerate()
+        .for_each_init(
+            || vec![0f32; d],
+            |acc, (row_idx, out_chunk)| {
+                let h_i = row_idx / s_q;
+                let q_pos = row_idx % s_q;
 
-                    let k_head_off = (h_i / rk) * d;
-                    let v_head_off = (h_i / rv) * d;
+                let k_head_off = (h_i / rk) * d;
+                let v_head_off = (h_i / rv) * d;
 
-                    let q_base = q_pos * q_seq_stride + h_i * d;
-                    let q_row = &q_data[q_base..q_base + d];
+                let q_base = q_pos * q_seq_stride + h_i * d;
+                let q_row = &q_data[q_base..q_base + d];
 
-                    acc.fill(0.0);
-                    let mut m = f32::NEG_INFINITY;
-                    let mut ssum = 0.0f32;
+                acc.fill(0.0);
+                let mut m = f32::NEG_INFINITY;
+                let mut ssum = 0.0f32;
 
-                    let kv_end = (q_pos + kv_offset + 1).min(kv_len);
+                let kv_end = (q_pos + kv_offset + 1).min(kv_len);
 
-                    for kv_pos in 0..kv_end {
-                        let k_base = kv_pos * k_seq_stride + k_head_off;
-                        let k_row = &k_data[k_base..k_base + d];
+                for kv_pos in 0..kv_end {
+                    let k_base = kv_pos * k_seq_stride + k_head_off;
+                    let k_row = &k_data[k_base..k_base + d];
 
-                        if kv_pos + 1 < kv_end {
-                            prefetch_read(k_data[k_base + k_seq_stride..].as_ptr());
-                        }
-
-                        let score = dot_f32(q_row, k_row) * scale;
-
-                        let v_base = kv_pos * v_seq_stride + v_head_off;
-                        let v_row = &v_data[v_base..v_base + d];
-
-                        if kv_pos + 1 < kv_end {
-                            prefetch_read(v_data[v_base + v_seq_stride..].as_ptr());
-                        }
-
-                        if score > m {
-                            let scale_old = f32::exp(m - score);
-                            for t in 0..d {
-                                acc[t] *= scale_old;
-                            }
-                            ssum *= scale_old;
-                            m = score;
-                            for t in 0..d {
-                                acc[t] += v_row[t];
-                            }
-                            ssum += 1.0;
-                        } else {
-                            let w = f32::exp(score - m);
-                            for t in 0..d {
-                                acc[t] += v_row[t] * w;
-                            }
-                            ssum += w;
-                        }
+                    if kv_pos + 1 < kv_end {
+                        prefetch_read(k_data[k_base + k_seq_stride..].as_ptr());
                     }
 
-                    let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
-                    for t in 0..d {
-                        out_chunk[t] = acc[t] * inv;
+                    let score = dot_f32(q_row, k_row) * scale;
+
+                    let v_base = kv_pos * v_seq_stride + v_head_off;
+                    let v_row = &v_data[v_base..v_base + d];
+
+                    if kv_pos + 1 < kv_end {
+                        prefetch_read(v_data[v_base + v_seq_stride..].as_ptr());
                     }
-                },
-            );
-    });
+
+                    if score > m {
+                        let scale_old = f32::exp(m - score);
+                        for t in 0..d {
+                            acc[t] *= scale_old;
+                        }
+                        ssum *= scale_old;
+                        m = score;
+                        for t in 0..d {
+                            acc[t] += v_row[t];
+                        }
+                        ssum += 1.0;
+                    } else {
+                        let w = f32::exp(score - m);
+                        for t in 0..d {
+                            acc[t] += v_row[t] * w;
+                        }
+                        ssum += w;
+                    }
+                }
+
+                let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
+                for t in 0..d {
+                    out_chunk[t] = acc[t] * inv;
+                }
+            },
+        );
 
     Tensor::from_vec(out, (h_q, s_q, d), &Device::Cpu)
 }
@@ -696,10 +686,109 @@ fn causal_decode_generic<T: WithDType + Sum + num_traits::real::Real>(
 
     let mut out = vec![0f32; h_q * d];
 
-    FLASH_ATTN_POOL.install(|| {
-        out.par_chunks_mut(d).enumerate().for_each_init(
+    out.par_chunks_mut(d).enumerate().for_each_init(
+        || vec![0f32; d],
+        |acc, (h_i, out_chunk)| {
+            let slope = if max_bias > 0.0 {
+                2.0f32.powf(-max_bias * ((h_i + 1) as f32) / n2 as f32)
+            } else {
+                0.0
+            };
+            let k_head_off = (h_i / rk) * d;
+            let v_head_off = (h_i / rv) * d;
+            let q_row = &q_data[h_i * d..(h_i + 1) * d];
+
+            acc.fill(0.0);
+            let mut m = f32::NEG_INFINITY;
+            let mut ssum = 0.0f32;
+
+            for kv_pos in 0..kv_len {
+                let alibi_bias = if max_bias > 0.0 {
+                    slope * (kv_pos as f32 - (kv_len - 1) as f32)
+                } else {
+                    0.0
+                };
+                let k_base = kv_pos * k_seq_stride + k_head_off;
+                let k_row = &k_data[k_base..k_base + d];
+                let mut s_val = vec_dot::<T>(q_row, k_row).to_f32().unwrap_or(0.0);
+                s_val *= scale_pre;
+                if do_softcap {
+                    s_val = logit_softcap * s_val.tanh();
+                }
+                s_val += alibi_bias;
+
+                if s_val > m {
+                    let ms = (m - s_val).exp();
+                    for t in 0..d {
+                        acc[t] *= ms;
+                    }
+                    ssum *= ms;
+                    m = s_val;
+                    let v_base = kv_pos * v_seq_stride + v_head_off;
+                    let v_row = &v_data[v_base..v_base + d];
+                    for t in 0..d {
+                        acc[t] += v_row[t].to_f32().unwrap_or(0.0);
+                    }
+                    ssum += 1.0;
+                } else {
+                    let w = (s_val - m).exp();
+                    let v_base = kv_pos * v_seq_stride + v_head_off;
+                    let v_row = &v_data[v_base..v_base + d];
+                    for t in 0..d {
+                        acc[t] += v_row[t].to_f32().unwrap_or(0.0) * w;
+                    }
+                    ssum += w;
+                }
+            }
+            let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
+            for t in 0..d {
+                out_chunk[t] = acc[t] * inv;
+            }
+        },
+    );
+
+    Tensor::from_vec(out, (h_q, 1usize, d), &Device::Cpu)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn causal_prefill_generic<T: WithDType + Sum + num_traits::real::Real>(
+    q_data: &[T],
+    k_data: &[T],
+    v_data: &[T],
+    s_q: usize,
+    h_q: usize,
+    h_kv: usize,
+    h_v: usize,
+    d: usize,
+    kv_len: usize,
+    scale: f32,
+    kv_offset: usize,
+    max_bias: f32,
+    logit_softcap: f32,
+) -> Result<Tensor> {
+    let rk = h_q / h_kv;
+    let rv = h_q / h_v;
+    let n2 = 2_usize.pow((h_q as f32).log2().ceil() as u32);
+    let (scale_pre, do_softcap) = if logit_softcap != 0.0 {
+        (scale / logit_softcap, true)
+    } else {
+        (scale, false)
+    };
+
+    let q_seq_stride = h_q * d;
+    let k_seq_stride = h_kv * d;
+    let v_seq_stride = h_v * d;
+
+    let mut out = vec![0f32; h_q * s_q * d];
+
+    out.par_chunks_mut(d)
+        .with_min_len(64)
+        .enumerate()
+        .for_each_init(
             || vec![0f32; d],
-            |acc, (h_i, out_chunk)| {
+            |acc, (row_idx, out_chunk)| {
+                let h_i = row_idx / s_q;
+                let q_pos = row_idx % s_q;
                 let slope = if max_bias > 0.0 {
                     2.0f32.powf(-max_bias * ((h_i + 1) as f32) / n2 as f32)
                 } else {
@@ -707,15 +796,17 @@ fn causal_decode_generic<T: WithDType + Sum + num_traits::real::Real>(
                 };
                 let k_head_off = (h_i / rk) * d;
                 let v_head_off = (h_i / rv) * d;
-                let q_row = &q_data[h_i * d..(h_i + 1) * d];
+                let q_base = q_pos * q_seq_stride + h_i * d;
+                let q_row = &q_data[q_base..q_base + d];
 
                 acc.fill(0.0);
                 let mut m = f32::NEG_INFINITY;
                 let mut ssum = 0.0f32;
+                let kv_end = (q_pos + kv_offset + 1).min(kv_len);
 
-                for kv_pos in 0..kv_len {
+                for kv_pos in 0..kv_end {
                     let alibi_bias = if max_bias > 0.0 {
-                        slope * (kv_pos as f32 - (kv_len - 1) as f32)
+                        slope * (kv_pos as i64 - (q_pos + kv_offset) as i64) as f32
                     } else {
                         0.0
                     };
@@ -757,111 +848,6 @@ fn causal_decode_generic<T: WithDType + Sum + num_traits::real::Real>(
                 }
             },
         );
-    });
-
-    Tensor::from_vec(out, (h_q, 1usize, d), &Device::Cpu)
-}
-
-#[allow(clippy::too_many_arguments)]
-fn causal_prefill_generic<T: WithDType + Sum + num_traits::real::Real>(
-    q_data: &[T],
-    k_data: &[T],
-    v_data: &[T],
-    s_q: usize,
-    h_q: usize,
-    h_kv: usize,
-    h_v: usize,
-    d: usize,
-    kv_len: usize,
-    scale: f32,
-    kv_offset: usize,
-    max_bias: f32,
-    logit_softcap: f32,
-) -> Result<Tensor> {
-    let rk = h_q / h_kv;
-    let rv = h_q / h_v;
-    let n2 = 2_usize.pow((h_q as f32).log2().ceil() as u32);
-    let (scale_pre, do_softcap) = if logit_softcap != 0.0 {
-        (scale / logit_softcap, true)
-    } else {
-        (scale, false)
-    };
-
-    let q_seq_stride = h_q * d;
-    let k_seq_stride = h_kv * d;
-    let v_seq_stride = h_v * d;
-
-    let mut out = vec![0f32; h_q * s_q * d];
-
-    FLASH_ATTN_POOL.install(|| {
-        out.par_chunks_mut(d)
-            .with_min_len(64)
-            .enumerate()
-            .for_each_init(
-                || vec![0f32; d],
-                |acc, (row_idx, out_chunk)| {
-                    let h_i = row_idx / s_q;
-                    let q_pos = row_idx % s_q;
-                    let slope = if max_bias > 0.0 {
-                        2.0f32.powf(-max_bias * ((h_i + 1) as f32) / n2 as f32)
-                    } else {
-                        0.0
-                    };
-                    let k_head_off = (h_i / rk) * d;
-                    let v_head_off = (h_i / rv) * d;
-                    let q_base = q_pos * q_seq_stride + h_i * d;
-                    let q_row = &q_data[q_base..q_base + d];
-
-                    acc.fill(0.0);
-                    let mut m = f32::NEG_INFINITY;
-                    let mut ssum = 0.0f32;
-                    let kv_end = (q_pos + kv_offset + 1).min(kv_len);
-
-                    for kv_pos in 0..kv_end {
-                        let alibi_bias = if max_bias > 0.0 {
-                            slope * (kv_pos as i64 - (q_pos + kv_offset) as i64) as f32
-                        } else {
-                            0.0
-                        };
-                        let k_base = kv_pos * k_seq_stride + k_head_off;
-                        let k_row = &k_data[k_base..k_base + d];
-                        let mut s_val = vec_dot::<T>(q_row, k_row).to_f32().unwrap_or(0.0);
-                        s_val *= scale_pre;
-                        if do_softcap {
-                            s_val = logit_softcap * s_val.tanh();
-                        }
-                        s_val += alibi_bias;
-
-                        if s_val > m {
-                            let ms = (m - s_val).exp();
-                            for t in 0..d {
-                                acc[t] *= ms;
-                            }
-                            ssum *= ms;
-                            m = s_val;
-                            let v_base = kv_pos * v_seq_stride + v_head_off;
-                            let v_row = &v_data[v_base..v_base + d];
-                            for t in 0..d {
-                                acc[t] += v_row[t].to_f32().unwrap_or(0.0);
-                            }
-                            ssum += 1.0;
-                        } else {
-                            let w = (s_val - m).exp();
-                            let v_base = kv_pos * v_seq_stride + v_head_off;
-                            let v_row = &v_data[v_base..v_base + d];
-                            for t in 0..d {
-                                acc[t] += v_row[t].to_f32().unwrap_or(0.0) * w;
-                            }
-                            ssum += w;
-                        }
-                    }
-                    let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
-                    for t in 0..d {
-                        out_chunk[t] = acc[t] * inv;
-                    }
-                },
-            );
-    });
 
     Tensor::from_vec(out, (h_q, s_q, d), &Device::Cpu)
 }

--- a/candle-nn/src/attention/cpu_flash/standard.rs
+++ b/candle-nn/src/attention/cpu_flash/standard.rs
@@ -16,35 +16,9 @@
 //! is shared across all flash attention calls.
 
 use candle::{Device, Result, Storage, Tensor, WithDType};
-use std::sync::LazyLock;
 use std::{f32, iter::Sum};
 
 use rayon::prelude::*;
-use rayon::ThreadPool;
-
-#[cfg(target_os = "macos")]
-/// Elevate the thread QoS so macOS prefers running it on Performance (P) cores.
-unsafe fn set_thread_affinity() {
-    use libc::{pthread_set_qos_class_self_np, qos_class_t::QOS_CLASS_USER_INTERACTIVE};
-    pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
-}
-
-#[cfg(not(target_os = "macos"))]
-#[inline(always)]
-unsafe fn set_thread_affinity() {
-    // On non‑macOS platforms we currently leave affinity untouched.
-}
-
-/// Rayon pool used by the flash‑attention CPU kernels, with a per‑thread
-/// start handler that applies our affinity hint exactly once.
-pub(crate) static FLASH_ATTN_POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
-    rayon::ThreadPoolBuilder::new()
-        .start_handler(|_| unsafe {
-            set_thread_affinity();
-        })
-        .build()
-        .expect("Failed to build custom Rayon thread‑pool for flash‑attention")
-});
 
 const DOT_CHUNK: usize = 4;
 
@@ -216,87 +190,84 @@ fn flash_attn_decode<T: WithDType + Sum + num_traits::real::Real>(
 
     let mut out = vec![0f32; h * dv];
 
-    FLASH_ATTN_POOL.install(|| {
-        out.par_chunks_mut(dv).enumerate().for_each_init(
-            || vec![0f32; dv],
-            |vkq, (h_i, out_chunk)| {
-                let slope = if max_bias > 0.0 {
-                    2.0f32.powf(-max_bias * ((h_i + 1) as f32) / n2 as f32)
+    out.par_chunks_mut(dv).enumerate().for_each_init(
+        || vec![0f32; dv],
+        |vkq, (h_i, out_chunk)| {
+            let slope = if max_bias > 0.0 {
+                2.0f32.powf(-max_bias * ((h_i + 1) as f32) / n2 as f32)
+            } else {
+                1.0
+            };
+
+            let k_head = h_i / rk2;
+            let v_head = h_i / rv2;
+
+            let q_base = h_i * qstride[2];
+            let q_row = &q_data[q_base..q_base + d];
+
+            // Reset accumulator
+            vkq.fill(0.0);
+            let mut s = 0.0f32;
+            let mut m = f32::NEG_INFINITY;
+
+            for kv_pos in 0..kv_len {
+                // Mask
+                let mv = if let Some(mv_vec) = mask_vec {
+                    let mval = mv_vec[kv_pos];
+                    slope * mval.to_f32().unwrap_or(0.0)
                 } else {
-                    1.0
+                    0.0
                 };
-
-                let k_head = h_i / rk2;
-                let v_head = h_i / rv2;
-
-                let q_base = h_i * qstride[2];
-                let q_row = &q_data[q_base..q_base + d];
-
-                // Reset accumulator
-                vkq.fill(0.0);
-                let mut s = 0.0f32;
-                let mut m = f32::NEG_INFINITY;
-
-                for kv_pos in 0..kv_len {
-                    // Mask
-                    let mv = if let Some(mv_vec) = mask_vec {
-                        let mval = mv_vec[kv_pos];
-                        slope * mval.to_f32().unwrap_or(0.0)
-                    } else {
-                        0.0
-                    };
-                    if mv == f32::NEG_INFINITY {
-                        continue;
-                    }
-
-                    let k_base = kv_pos * kstride[1] + k_head * kstride[2];
-                    let k_row = &k_data[k_base..k_base + d];
-
-                    let mut s_val = vec_dot::<T>(q_row, k_row).to_f32().unwrap_or(0.0);
-
-                    s_val *= scale_pre;
-                    if do_softcap {
-                        s_val = logit_softcap * s_val.tanh();
-                    }
-                    s_val += mv;
-
-                    // Online softmax
-                    let m_old = m;
-                    let mut ms = 1.0f32;
-                    let mut vs = 1.0f32;
-                    if s_val > m {
-                        m = s_val;
-                        ms = (m_old - m).exp();
-                        for v in vkq.iter_mut() {
-                            *v *= ms;
-                        }
-                    } else {
-                        vs = (s_val - m).exp();
-                    }
-
-                    let v_base = kv_pos * vstride[1] + v_head * vstride[2];
-                    if v_contiguous {
-                        let v_row = &v_data[v_base..v_base + dv];
-                        for d_i in 0..dv {
-                            vkq[d_i] += v_row[d_i].to_f32().unwrap_or(0.0) * vs;
-                        }
-                    } else {
-                        for d_i in 0..dv {
-                            vkq[d_i] +=
-                                v_data[v_base + d_i * vstride[3]].to_f32().unwrap_or(0.0) * vs;
-                        }
-                    }
-
-                    s = s * ms + vs;
+                if mv == f32::NEG_INFINITY {
+                    continue;
                 }
 
-                let inv_s = if s > 0.0 { 1.0 / s } else { 0.0 };
-                for (out_v, acc_v) in out_chunk.iter_mut().zip(vkq.iter()) {
-                    *out_v = *acc_v * inv_s;
+                let k_base = kv_pos * kstride[1] + k_head * kstride[2];
+                let k_row = &k_data[k_base..k_base + d];
+
+                let mut s_val = vec_dot::<T>(q_row, k_row).to_f32().unwrap_or(0.0);
+
+                s_val *= scale_pre;
+                if do_softcap {
+                    s_val = logit_softcap * s_val.tanh();
                 }
-            },
-        );
-    });
+                s_val += mv;
+
+                // Online softmax
+                let m_old = m;
+                let mut ms = 1.0f32;
+                let mut vs = 1.0f32;
+                if s_val > m {
+                    m = s_val;
+                    ms = (m_old - m).exp();
+                    for v in vkq.iter_mut() {
+                        *v *= ms;
+                    }
+                } else {
+                    vs = (s_val - m).exp();
+                }
+
+                let v_base = kv_pos * vstride[1] + v_head * vstride[2];
+                if v_contiguous {
+                    let v_row = &v_data[v_base..v_base + dv];
+                    for d_i in 0..dv {
+                        vkq[d_i] += v_row[d_i].to_f32().unwrap_or(0.0) * vs;
+                    }
+                } else {
+                    for d_i in 0..dv {
+                        vkq[d_i] += v_data[v_base + d_i * vstride[3]].to_f32().unwrap_or(0.0) * vs;
+                    }
+                }
+
+                s = s * ms + vs;
+            }
+
+            let inv_s = if s > 0.0 { 1.0 / s } else { 0.0 };
+            for (out_v, acc_v) in out_chunk.iter_mut().zip(vkq.iter()) {
+                *out_v = *acc_v * inv_s;
+            }
+        },
+    );
 
     Tensor::from_vec(out, (1usize, h, 1usize, dv), &Device::Cpu)
 }
@@ -339,92 +310,90 @@ fn flash_attn_prefill<T: WithDType + Sum + num_traits::real::Real>(
 
     let mut out = vec![0f32; h * q_len * dv];
 
-    FLASH_ATTN_POOL.install(|| {
-        out.par_chunks_mut(dv)
-            .with_min_len(64)
-            .enumerate()
-            .for_each_init(
-                || vec![0f32; dv],
-                |vkq, (row_idx, out_chunk)| {
-                    let h_i = row_idx / q_len;
-                    let q_pos = row_idx % q_len;
+    out.par_chunks_mut(dv)
+        .with_min_len(64)
+        .enumerate()
+        .for_each_init(
+            || vec![0f32; dv],
+            |vkq, (row_idx, out_chunk)| {
+                let h_i = row_idx / q_len;
+                let q_pos = row_idx % q_len;
 
-                    let slope = if max_bias > 0.0 {
-                        2.0f32.powf(-max_bias * ((h_i + 1) as f32) / n2 as f32)
+                let slope = if max_bias > 0.0 {
+                    2.0f32.powf(-max_bias * ((h_i + 1) as f32) / n2 as f32)
+                } else {
+                    1.0
+                };
+
+                let k_head = h_i / rk2;
+                let v_head = h_i / rv2;
+
+                // Reset accumulator
+                vkq.fill(0.0);
+                let mut s = 0.0f32;
+                let mut m = f32::NEG_INFINITY;
+
+                let q_base = q_pos * qstride[1] + h_i * qstride[2];
+                let q_row = &q_data[q_base..q_base + d];
+
+                for kv_pos in 0..kv_len {
+                    let mv = if let Some(mv_vec) = mask_vec {
+                        let mval = mv_vec[q_pos * kv_len + kv_pos];
+                        slope * mval.to_f32().unwrap_or(0.0)
                     } else {
-                        1.0
+                        0.0
                     };
-
-                    let k_head = h_i / rk2;
-                    let v_head = h_i / rv2;
-
-                    // Reset accumulator
-                    vkq.fill(0.0);
-                    let mut s = 0.0f32;
-                    let mut m = f32::NEG_INFINITY;
-
-                    let q_base = q_pos * qstride[1] + h_i * qstride[2];
-                    let q_row = &q_data[q_base..q_base + d];
-
-                    for kv_pos in 0..kv_len {
-                        let mv = if let Some(mv_vec) = mask_vec {
-                            let mval = mv_vec[q_pos * kv_len + kv_pos];
-                            slope * mval.to_f32().unwrap_or(0.0)
-                        } else {
-                            0.0
-                        };
-                        if mv == f32::NEG_INFINITY {
-                            continue;
-                        }
-
-                        let k_base = kv_pos * kstride[1] + k_head * kstride[2];
-                        let k_row = &k_data[k_base..k_base + d];
-
-                        let mut s_val = vec_dot::<T>(q_row, k_row).to_f32().unwrap_or(0.0);
-                        s_val *= scale_pre;
-                        if do_softcap {
-                            s_val = logit_softcap * s_val.tanh();
-                        }
-                        s_val += mv;
-
-                        // Online softmax
-                        let m_old = m;
-                        let mut ms = 1.0f32;
-                        let mut vs = 1.0f32;
-                        if s_val > m {
-                            m = s_val;
-                            ms = (m_old - m).exp();
-                            for v in vkq.iter_mut() {
-                                *v *= ms;
-                            }
-                        } else {
-                            vs = (s_val - m).exp();
-                        }
-
-                        let v_base = kv_pos * vstride[1] + v_head * vstride[2];
-                        if v_contiguous {
-                            let v_row = &v_data[v_base..v_base + dv];
-                            for d_i in 0..dv {
-                                vkq[d_i] += v_row[d_i].to_f32().unwrap_or(0.0) * vs;
-                            }
-                        } else {
-                            for d_i in 0..dv {
-                                vkq[d_i] +=
-                                    v_data[v_base + d_i * vstride[3]].to_f32().unwrap_or(0.0) * vs;
-                            }
-                        }
-
-                        s = s * ms + vs;
+                    if mv == f32::NEG_INFINITY {
+                        continue;
                     }
 
-                    let inv_s = if s > 0.0 { 1.0 / s } else { 0.0 };
-                    for v in vkq.iter_mut() {
-                        *v *= inv_s;
+                    let k_base = kv_pos * kstride[1] + k_head * kstride[2];
+                    let k_row = &k_data[k_base..k_base + d];
+
+                    let mut s_val = vec_dot::<T>(q_row, k_row).to_f32().unwrap_or(0.0);
+                    s_val *= scale_pre;
+                    if do_softcap {
+                        s_val = logit_softcap * s_val.tanh();
                     }
-                    out_chunk.copy_from_slice(vkq);
-                },
-            );
-    });
+                    s_val += mv;
+
+                    // Online softmax
+                    let m_old = m;
+                    let mut ms = 1.0f32;
+                    let mut vs = 1.0f32;
+                    if s_val > m {
+                        m = s_val;
+                        ms = (m_old - m).exp();
+                        for v in vkq.iter_mut() {
+                            *v *= ms;
+                        }
+                    } else {
+                        vs = (s_val - m).exp();
+                    }
+
+                    let v_base = kv_pos * vstride[1] + v_head * vstride[2];
+                    if v_contiguous {
+                        let v_row = &v_data[v_base..v_base + dv];
+                        for d_i in 0..dv {
+                            vkq[d_i] += v_row[d_i].to_f32().unwrap_or(0.0) * vs;
+                        }
+                    } else {
+                        for d_i in 0..dv {
+                            vkq[d_i] +=
+                                v_data[v_base + d_i * vstride[3]].to_f32().unwrap_or(0.0) * vs;
+                        }
+                    }
+
+                    s = s * ms + vs;
+                }
+
+                let inv_s = if s > 0.0 { 1.0 / s } else { 0.0 };
+                for v in vkq.iter_mut() {
+                    *v *= inv_s;
+                }
+                out_chunk.copy_from_slice(vkq);
+            },
+        );
 
     Tensor::from_vec(out, (1usize, h, q_len, dv), &Device::Cpu)
 }

--- a/candle-nn/src/attention/cpu_flash/varlen.rs
+++ b/candle-nn/src/attention/cpu_flash/varlen.rs
@@ -11,8 +11,6 @@ use candle::{DType, Device, Result, Storage, Tensor};
 use half::f16;
 use rayon::prelude::*;
 
-use super::standard::FLASH_ATTN_POOL;
-
 /// Fused variable-length flash attention on CPU.
 ///
 /// **Input shapes** (packed, no batch dim):
@@ -219,92 +217,90 @@ pub fn flash_attn_varlen_cpu(
                 s
             }
 
-            FLASH_ATTN_POOL.install(|| {
-                out.par_chunks_mut(d).enumerate().for_each_init(
-                    || vec![0f32; d],
-                    |acc, (row, out_row)| {
-                        let q_idx = row / hq;
-                        let h = row % hq;
+            out.par_chunks_mut(d).enumerate().for_each_init(
+                || vec![0f32; d],
+                |acc, (row, out_row)| {
+                    let q_idx = row / hq;
+                    let h = row % hq;
 
-                        let b = batch_of_q[q_idx];
-                        let q_pos = pos_in_b[q_idx];
+                    let b = batch_of_q[q_idx];
+                    let q_pos = pos_in_b[q_idx];
 
-                        let lq = seqlens_q_vec[b] as usize;
-                        let lk = seqlens_k_vec[b] as usize;
-                        if lq == 0 || lk == 0 {
-                            out_row.fill(0.0);
-                            return;
+                    let lq = seqlens_q_vec[b] as usize;
+                    let lk = seqlens_k_vec[b] as usize;
+                    if lq == 0 || lk == 0 {
+                        out_row.fill(0.0);
+                        return;
+                    }
+
+                    let start_k = cumsum_k[b];
+                    let offset = lk as isize - lq as isize;
+
+                    let Some((j0, j1)) =
+                        key_range(q_pos, lk, offset, causal, window_left, window_right)
+                    else {
+                        out_row.fill(0.0);
+                        return;
+                    };
+                    if j0 > j1 {
+                        out_row.fill(0.0);
+                        return;
+                    }
+
+                    let k_head = h / rk;
+                    let v_head = h / rv;
+
+                    let slope = slopes.as_ref().map(|s| s[h]).unwrap_or(0.0);
+                    let i_k = q_pos as isize + offset;
+
+                    let q_base = (q_idx * hq + h) * d;
+                    let q_row = &q_data[q_base..q_base + d];
+
+                    acc.fill(0.0);
+                    let mut m = f32::NEG_INFINITY;
+                    let mut ssum = 0.0f32;
+
+                    for j in j0..=j1 {
+                        let k_base = ((start_k + j) * hk + k_head) * d;
+                        let k_row = &k_data[k_base..k_base + d];
+
+                        let mut score = dot_f32(q_row, k_row) * softmax_scale;
+                        if slopes.is_some() {
+                            score += alibi_bias(slope, i_k, j as isize, causal);
                         }
 
-                        let start_k = cumsum_k[b];
-                        let offset = lk as isize - lq as isize;
-
-                        let Some((j0, j1)) =
-                            key_range(q_pos, lk, offset, causal, window_left, window_right)
-                        else {
-                            out_row.fill(0.0);
-                            return;
-                        };
-                        if j0 > j1 {
-                            out_row.fill(0.0);
-                            return;
-                        }
-
-                        let k_head = h / rk;
-                        let v_head = h / rv;
-
-                        let slope = slopes.as_ref().map(|s| s[h]).unwrap_or(0.0);
-                        let i_k = q_pos as isize + offset;
-
-                        let q_base = (q_idx * hq + h) * d;
-                        let q_row = &q_data[q_base..q_base + d];
-
-                        acc.fill(0.0);
-                        let mut m = f32::NEG_INFINITY;
-                        let mut ssum = 0.0f32;
-
-                        for j in j0..=j1 {
-                            let k_base = ((start_k + j) * hk + k_head) * d;
-                            let k_row = &k_data[k_base..k_base + d];
-
-                            let mut score = dot_f32(q_row, k_row) * softmax_scale;
-                            if slopes.is_some() {
-                                score += alibi_bias(slope, i_k, j as isize, causal);
+                        if score > m {
+                            let scale_old = (m - score).exp();
+                            #[allow(clippy::needless_range_loop)]
+                            for t in 0..d {
+                                acc[t] *= scale_old;
                             }
+                            ssum *= scale_old;
+                            m = score;
 
-                            if score > m {
-                                let scale_old = (m - score).exp();
-                                #[allow(clippy::needless_range_loop)]
-                                for t in 0..d {
-                                    acc[t] *= scale_old;
-                                }
-                                ssum *= scale_old;
-                                m = score;
-
-                                let v_base = ((start_k + j) * hv + v_head) * d;
-                                let v_row = &v_data[v_base..v_base + d];
-                                for t in 0..d {
-                                    acc[t] += v_row[t];
-                                }
-                                ssum += 1.0;
-                            } else {
-                                let w = (score - m).exp();
-                                let v_base = ((start_k + j) * hv + v_head) * d;
-                                let v_row = &v_data[v_base..v_base + d];
-                                for t in 0..d {
-                                    acc[t] += v_row[t] * w;
-                                }
-                                ssum += w;
+                            let v_base = ((start_k + j) * hv + v_head) * d;
+                            let v_row = &v_data[v_base..v_base + d];
+                            for t in 0..d {
+                                acc[t] += v_row[t];
                             }
+                            ssum += 1.0;
+                        } else {
+                            let w = (score - m).exp();
+                            let v_base = ((start_k + j) * hv + v_head) * d;
+                            let v_row = &v_data[v_base..v_base + d];
+                            for t in 0..d {
+                                acc[t] += v_row[t] * w;
+                            }
+                            ssum += w;
                         }
+                    }
 
-                        let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
-                        for t in 0..d {
-                            out_row[t] = acc[t] * inv;
-                        }
-                    },
-                );
-            });
+                    let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
+                    for t in 0..d {
+                        out_row[t] = acc[t] * inv;
+                    }
+                },
+            );
 
             Tensor::from_vec(out, (total_q, hq, d), &Device::Cpu)
         }
@@ -352,92 +348,90 @@ pub fn flash_attn_varlen_cpu(
 
             let mut out = vec![f16::from_f32(0.0); total_q * hq * d];
 
-            FLASH_ATTN_POOL.install(|| {
-                out.par_chunks_mut(d).enumerate().for_each_init(
-                    || (vec![0f32; d], vec![0f32; d]),
-                    |(q_row_f32, acc), (row, out_row)| {
-                        let q_idx = row / hq;
-                        let h = row % hq;
+            out.par_chunks_mut(d).enumerate().for_each_init(
+                || (vec![0f32; d], vec![0f32; d]),
+                |(q_row_f32, acc), (row, out_row)| {
+                    let q_idx = row / hq;
+                    let h = row % hq;
 
-                        let b = batch_of_q[q_idx];
-                        let q_pos = pos_in_b[q_idx];
+                    let b = batch_of_q[q_idx];
+                    let q_pos = pos_in_b[q_idx];
 
-                        let lq = seqlens_q_vec[b] as usize;
-                        let lk = seqlens_k_vec[b] as usize;
-                        if lq == 0 || lk == 0 {
-                            out_row.fill(f16::from_f32(0.0));
-                            return;
+                    let lq = seqlens_q_vec[b] as usize;
+                    let lk = seqlens_k_vec[b] as usize;
+                    if lq == 0 || lk == 0 {
+                        out_row.fill(f16::from_f32(0.0));
+                        return;
+                    }
+
+                    let start_k = cumsum_k[b];
+                    let offset = lk as isize - lq as isize;
+
+                    let Some((j0, j1)) =
+                        key_range(q_pos, lk, offset, causal, window_left, window_right)
+                    else {
+                        out_row.fill(f16::from_f32(0.0));
+                        return;
+                    };
+                    if j0 > j1 {
+                        out_row.fill(f16::from_f32(0.0));
+                        return;
+                    }
+
+                    let k_head = h / rk;
+                    let v_head = h / rv;
+
+                    let slope = slopes.as_ref().map(|s| s[h]).unwrap_or(0.0);
+                    let i_k = q_pos as isize + offset;
+
+                    let q_base = (q_idx * hq + h) * d;
+                    for t in 0..d {
+                        q_row_f32[t] = q_data[q_base + t].to_f32();
+                    }
+
+                    acc.fill(0.0);
+                    let mut m = f32::NEG_INFINITY;
+                    let mut ssum = 0.0f32;
+
+                    for j in j0..=j1 {
+                        let k_base = ((start_k + j) * hk + k_head) * d;
+                        let k_row = &k_data[k_base..k_base + d];
+
+                        let mut score = dot_qf32_kf16(q_row_f32, k_row) * softmax_scale;
+                        if slopes.is_some() {
+                            score += alibi_bias(slope, i_k, j as isize, causal);
                         }
 
-                        let start_k = cumsum_k[b];
-                        let offset = lk as isize - lq as isize;
-
-                        let Some((j0, j1)) =
-                            key_range(q_pos, lk, offset, causal, window_left, window_right)
-                        else {
-                            out_row.fill(f16::from_f32(0.0));
-                            return;
-                        };
-                        if j0 > j1 {
-                            out_row.fill(f16::from_f32(0.0));
-                            return;
-                        }
-
-                        let k_head = h / rk;
-                        let v_head = h / rv;
-
-                        let slope = slopes.as_ref().map(|s| s[h]).unwrap_or(0.0);
-                        let i_k = q_pos as isize + offset;
-
-                        let q_base = (q_idx * hq + h) * d;
-                        for t in 0..d {
-                            q_row_f32[t] = q_data[q_base + t].to_f32();
-                        }
-
-                        acc.fill(0.0);
-                        let mut m = f32::NEG_INFINITY;
-                        let mut ssum = 0.0f32;
-
-                        for j in j0..=j1 {
-                            let k_base = ((start_k + j) * hk + k_head) * d;
-                            let k_row = &k_data[k_base..k_base + d];
-
-                            let mut score = dot_qf32_kf16(q_row_f32, k_row) * softmax_scale;
-                            if slopes.is_some() {
-                                score += alibi_bias(slope, i_k, j as isize, causal);
+                        if score > m {
+                            let scale_old = (m - score).exp();
+                            #[allow(clippy::needless_range_loop)]
+                            for t in 0..d {
+                                acc[t] *= scale_old;
                             }
+                            ssum *= scale_old;
+                            m = score;
 
-                            if score > m {
-                                let scale_old = (m - score).exp();
-                                #[allow(clippy::needless_range_loop)]
-                                for t in 0..d {
-                                    acc[t] *= scale_old;
-                                }
-                                ssum *= scale_old;
-                                m = score;
-
-                                let v_base = ((start_k + j) * hv + v_head) * d;
-                                for t in 0..d {
-                                    acc[t] += v_data[v_base + t].to_f32();
-                                }
-                                ssum += 1.0;
-                            } else {
-                                let w = (score - m).exp();
-                                let v_base = ((start_k + j) * hv + v_head) * d;
-                                for t in 0..d {
-                                    acc[t] += v_data[v_base + t].to_f32() * w;
-                                }
-                                ssum += w;
+                            let v_base = ((start_k + j) * hv + v_head) * d;
+                            for t in 0..d {
+                                acc[t] += v_data[v_base + t].to_f32();
                             }
+                            ssum += 1.0;
+                        } else {
+                            let w = (score - m).exp();
+                            let v_base = ((start_k + j) * hv + v_head) * d;
+                            for t in 0..d {
+                                acc[t] += v_data[v_base + t].to_f32() * w;
+                            }
+                            ssum += w;
                         }
+                    }
 
-                        let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
-                        for t in 0..d {
-                            out_row[t] = f16::from_f32(acc[t] * inv);
-                        }
-                    },
-                );
-            });
+                    let inv = if ssum > 0.0 { 1.0 / ssum } else { 0.0 };
+                    for t in 0..d {
+                        out_row[t] = f16::from_f32(acc[t] * inv);
+                    }
+                },
+            );
 
             Tensor::from_vec(out, (total_q, hq, d), &Device::Cpu)
         }


### PR DESCRIPTION
This PR adds a candle specific shared threadpool and reduces the default amount of threads used when running a model on CPU.

To use the shared threadpool you'll want to run the model within `device.with_context(|| { ... })` as that installs the threadpool _once_. See quantized-qwen3 example for reference.

old
```
So let the world feel their song—  
For butterflies are true light.

  14 prompt tokens processed: 68.56 token/s
 384 tokens generated: 33.03 token/s
```
new
```
So let the world feel their song—  
For butterflies are true light.

  14 prompt tokens processed: 164.66 token/s
 384 tokens generated: 103.41 token/s
```