### PR TITLE
fix(qwen3): build causal mask batch-independently (#3582)

### DIFF
--- a/candle-transformers/src/models/qwen3.rs
+++ b/candle-transformers/src/models/qwen3.rs
@@ -403,6 +403,41 @@ impl DecoderLayer {
     }
 }
 
+/// Builds the additive causal attention mask of shape `(1, 1, tgt, tgt + offset)`.
+///
+/// The mask values depend only on the query/key positions, never on the batch,
+/// so it is built with a leading batch dim of `1` and broadcast across the batch
+/// by `broadcast_add` in attention. Shaping this `b`-independent buffer as
+/// `(b, 1, tgt, tgt + offset)` claims `b×` the elements actually present, so every
+/// batch row but the first reads past the buffer and is masked incorrectly
+/// (see https://github.com/huggingface/candle/issues/3582).
+fn build_causal_mask(
+    tgt: usize,
+    offset: usize,
+    sw: Option<usize>,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    let minf = f32::NEG_INFINITY;
+    let mask: Vec<_> = (0..tgt)
+        .flat_map(|i| {
+            (0..(tgt + offset)).map(move |j| {
+                let past_ok = j <= i + offset;
+                let sw_ok = match sw {
+                    Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
+                    None => true,
+                };
+                if past_ok && sw_ok {
+                    0.
+                } else {
+                    minf
+                }
+            })
+        })
+        .collect();
+    Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), device)?.to_dtype(dtype)
+}
+
 #[derive(Debug, Clone)]
 pub struct Model {
     embed_tokens: candle_nn::Embedding,
@@ -437,35 +472,8 @@ impl Model {
         }
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| {
-                    let past_ok = j <= i + offset;
-                    let sw_ok = match sw {
-                        Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
-                        None => true,
-                    };
-                    if past_ok && sw_ok {
-                        0.
-                    } else {
-                        minf
-                    }
-                })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
-        let (b, l) = input.dims2()?;
+        let (_b, l) = input.dims2()?;
         let mut h = self.embed_tokens.forward(input)?;
 
         // Build causal mask only for the standard attention fallback path.
@@ -475,7 +483,13 @@ impl Model {
         #[cfg(feature = "flash-attn")]
         let needs_mask = self.device.is_cpu() && l > 1;
         let causal = if needs_mask {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(build_causal_mask(
+                l,
+                offset,
+                None,
+                &self.device,
+                self.dtype,
+            )?)
         } else {
             None
         };
@@ -514,5 +528,46 @@ impl ModelForCausalLM {
 
     pub fn clear_kv_cache(&mut self) {
         self.base.clear_kv_cache();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression test for https://github.com/huggingface/candle/issues/3582:
+    // the additive causal mask is independent of the batch dimension, so it must
+    // be built with a leading batch dim of 1 and broadcast across the batch.
+    // Shaping it `(b, 1, tgt, tgt + offset)` from a `b`-independent buffer claims
+    // `b×` the elements actually present, corrupting every batch row but the first.
+    #[test]
+    fn causal_mask_is_batch_independent_and_broadcasts() {
+        let device = Device::Cpu;
+        let neg = f32::NEG_INFINITY;
+
+        let mask = build_causal_mask(3, 0, None, &device, DType::F32).unwrap();
+        assert_eq!(
+            mask.dims(),
+            &[1, 1, 3, 3],
+            "mask must carry a leading batch dim of 1 so broadcast_add applies it to every row",
+        );
+
+        // Broadcasting onto a 2-sequence batch must mask both rows identically and causally.
+        let scores = Tensor::zeros((2, 1, 3, 3), DType::F32, &device).unwrap();
+        let masked = scores
+            .broadcast_add(&mask)
+            .unwrap()
+            .squeeze(1)
+            .unwrap()
+            .to_vec3::<f32>()
+            .unwrap();
+
+        assert_eq!(
+            masked[0], masked[1],
+            "both batch rows must receive the same causal mask",
+        );
+        assert_eq!(masked[0][0], vec![0.0, neg, neg]);
+        assert_eq!(masked[0][1], vec![0.0, 0.0, neg]);
+        assert_eq!(masked[0][2], vec![0.0, 0.0, 0.0]);
     }
 }

--- a/candle-transformers/src/models/qwen3.rs
+++ b/candle-transformers/src/models/qwen3.rs
@@ -423,8 +423,11 @@ fn build_causal_mask(
         .flat_map(|i| {
             (0..(tgt + offset)).map(move |j| {
                 let past_ok = j <= i + offset;
+                // Within the window iff `(i + offset) - j <= w`, rearranged to
+                // `j + w >= i + offset` to stay in `usize` (no signed casts, no
+                // subtraction underflow when `j > i + offset`).
                 let sw_ok = match sw {
-                    Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
+                    Some(w) => j + w >= i + offset,
                     None => true,
                 };
                 if past_ok && sw_ok {
@@ -569,5 +572,28 @@ mod tests {
         assert_eq!(masked[0][0], vec![0.0, neg, neg]);
         assert_eq!(masked[0][1], vec![0.0, 0.0, neg]);
         assert_eq!(masked[0][2], vec![0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn causal_mask_respects_sliding_window() {
+        // With a sliding window of `w`, query i may attend to key j only when it is
+        // both causal (j <= i + offset) and within the window (i + offset - j <= w).
+        let device = Device::Cpu;
+        let neg = f32::NEG_INFINITY;
+
+        let mask = build_causal_mask(4, 0, Some(1), &device, DType::F32)
+            .unwrap()
+            .squeeze(0)
+            .unwrap()
+            .squeeze(0)
+            .unwrap()
+            .to_vec2::<f32>()
+            .unwrap();
+
+        // window = 1: each query sees itself and the single preceding position.
+        assert_eq!(mask[0], vec![0.0, neg, neg, neg]);
+        assert_eq!(mask[1], vec![0.0, 0.0, neg, neg]);
+        assert_eq!(mask[2], vec![neg, 0.0, 0.0, neg]);
+        assert_eq!(mask[3], vec![neg, neg, 0.0, 0.0]);
     }
 }

--- a/candle-transformers/src/models/qwen3.rs
+++ b/candle-transformers/src/models/qwen3.rs
@@ -404,13 +404,6 @@ impl DecoderLayer {
 }
 
 /// Builds the additive causal attention mask of shape `(1, 1, tgt, tgt + offset)`.
-///
-/// The mask values depend only on the query/key positions, never on the batch,
-/// so it is built with a leading batch dim of `1` and broadcast across the batch
-/// by `broadcast_add` in attention. Shaping this `b`-independent buffer as
-/// `(b, 1, tgt, tgt + offset)` claims `b×` the elements actually present, so every
-/// batch row but the first reads past the buffer and is masked incorrectly
-/// (see https://github.com/huggingface/candle/issues/3582).
 fn build_causal_mask(
     tgt: usize,
     offset: usize,
@@ -538,11 +531,7 @@ impl ModelForCausalLM {
 mod tests {
     use super::*;
 
-    // Regression test for https://github.com/huggingface/candle/issues/3582:
-    // the additive causal mask is independent of the batch dimension, so it must
-    // be built with a leading batch dim of 1 and broadcast across the batch.
-    // Shaping it `(b, 1, tgt, tgt + offset)` from a `b`-independent buffer claims
-    // `b×` the elements actually present, corrupting every batch row but the first.
+    // Regression test for https://github.com/huggingface/candle/issues/3582
     #[test]
     fn causal_mask_is_batch_independent_and_broadcasts() {
         let device = Device::Cpu;


### PR DESCRIPTION
## Motivation

Closes #3582.

`Qwen3` produces incorrect output for batch size > 1. `Model::causal_mask` builds
the additive mask buffer with `tgt * (tgt + offset)` elements — independent of the
batch — but then shapes it `(b, 1, tgt, tgt + offset)`. `Tensor::from_slice` with a
fully-specified shape doesn't validate the element count (the blanket
`ShapeWithOneHole` impl ignores it), so for `b > 1` the tensor claims `b×` the
elements that actually exist in storage. Batch row 0 reads the correct mask; every
row after it reads past the buffer and is masked incorrectly. The mask only feeds
the standard matmul attention path via `scores.broadcast_add(m)`, so this surfaces
there (e.g. Metal) and disappears at `b = 1` — matching the report.

## Modifications

- Extracted the mask construction into a `build_causal_mask` free function that
  shapes the mask `(1, 1, tgt, tgt + offset)` and lets the existing
  `broadcast_add` apply it across the batch. This is correct for any `b` and also
  drops the redundant per-batch allocation.
- `Model::forward` now calls `build_causal_mask` directly; the `b` it used to pass
  into the mask is no longer needed.

## Tests

- Added regression test `causal_mask_is_batch_independent_and_broadcasts`,
  asserting the mask carries a leading batch dim of 1 and, broadcast onto a
  2-sequence batch, produces an identical causal mask for both rows. It fails on
  the old `(b, 1, …)` shape and passes after the fix.
- `cargo test -p candle-transformers --lib` passes (14 tests).
- `cargo fmt --check` and `cargo clippy` are clean.
