### PR TITLE
fix(tensor): validate shape element count in from_slice/from_vec

### DIFF
--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -522,6 +522,13 @@ impl Tensor {
         is_variable: bool,
     ) -> Result<Self> {
         let shape = shape.into_shape(data.len())?;
+        if shape.elem_count() != data.len() {
+            crate::bail!(
+                "shape {shape:?} ({} elements) does not match the {} elements in the data",
+                shape.elem_count(),
+                data.len()
+            )
+        }
         let storage = device.storage_owned(data)?;
         let none = BackpropOp::none();
         Ok(from_storage(storage, shape, none, is_variable))
@@ -567,6 +574,13 @@ impl Tensor {
         device: &Device,
     ) -> Result<Self> {
         let shape = shape.into_shape(array.len())?;
+        if shape.elem_count() != array.len() {
+            crate::bail!(
+                "shape {shape:?} ({} elements) does not match the {} elements in the data",
+                shape.elem_count(),
+                array.len()
+            )
+        }
         let storage = device.storage_from_slice(array)?;
         let none = BackpropOp::none();
         Ok(from_storage(storage, shape, none, false))

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -176,6 +176,19 @@ pub(crate) fn from_storage<S: Into<Shape>>(
     Tensor(Arc::new(tensor_))
 }
 
+// Used by the `from_vec`/`from_slice` constructors to enforce that a declared
+// shape matches the amount of data backing it, so a caller cannot build a
+// tensor that reads past its storage (see huggingface/candle#3534).
+fn check_shape_matches_len(shape: &Shape, len: usize) -> Result<()> {
+    let elem_count = shape.elem_count();
+    if elem_count != len {
+        bail!(
+            "shape {shape:?} ({elem_count} elements) does not match the {len} elements in the data"
+        )
+    }
+    Ok(())
+}
+
 impl Tensor {
     pub(crate) fn ones_impl<S: Into<Shape>>(
         shape: S,
@@ -522,13 +535,7 @@ impl Tensor {
         is_variable: bool,
     ) -> Result<Self> {
         let shape = shape.into_shape(data.len())?;
-        if shape.elem_count() != data.len() {
-            crate::bail!(
-                "shape {shape:?} ({} elements) does not match the {} elements in the data",
-                shape.elem_count(),
-                data.len()
-            )
-        }
+        check_shape_matches_len(&shape, data.len())?;
         let storage = device.storage_owned(data)?;
         let none = BackpropOp::none();
         Ok(from_storage(storage, shape, none, is_variable))
@@ -574,13 +581,7 @@ impl Tensor {
         device: &Device,
     ) -> Result<Self> {
         let shape = shape.into_shape(array.len())?;
-        if shape.elem_count() != array.len() {
-            crate::bail!(
-                "shape {shape:?} ({} elements) does not match the {} elements in the data",
-                shape.elem_count(),
-                array.len()
-            )
-        }
+        check_shape_matches_len(&shape, array.len())?;
         let storage = device.storage_from_slice(array)?;
         let none = BackpropOp::none();
         Ok(from_storage(storage, shape, none, false))

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -2094,3 +2094,30 @@ fn allocates_twice_when_transferring_to_same_device() -> Result<()> {
     assert_ne!(id1, id2);
     Ok(())
 }
+
+#[test]
+fn from_slice_validates_shape_element_count() -> Result<()> {
+    // from_slice / from_vec must reject a declared shape whose element count
+    // does not match the data length, instead of building a tensor that lies
+    // about its size and reads past its storage later (candle#3534).
+    assert!(Tensor::from_slice(&[0f32], vec![10usize], &Device::Cpu).is_err());
+    assert!(Tensor::from_slice(&[0f32], vec![1usize << 20], &Device::Cpu).is_err());
+    assert!(Tensor::from_vec(vec![0f32, 1.], vec![3usize], &Device::Cpu).is_err());
+
+    // Matching shapes and one-hole inference still succeed.
+    let t = Tensor::from_slice(&[0f32, 1., 2., 3., 4., 5.], (2, 3), &Device::Cpu)?;
+    assert_eq!(t.dims(), &[2, 3]);
+    let t = Tensor::from_slice(&[0f32, 1., 2., 3., 4., 5.], ((), 3), &Device::Cpu)?;
+    assert_eq!(t.dims(), &[2, 3]);
+    Ok(())
+}
+
+#[test]
+fn from_raw_buffer_validates_shape_element_count() -> Result<()> {
+    // from_raw_buffer routes through from_slice, so the same contract holds.
+    let raw = vec![0u8; 4]; // one f32 worth of bytes
+    assert!(Tensor::from_raw_buffer(&raw, DType::F32, &[1usize << 10], &Device::Cpu).is_err());
+    let ok = Tensor::from_raw_buffer(&raw, DType::F32, &[1], &Device::Cpu)?;
+    assert_eq!(ok.dims(), &[1]);
+    Ok(())
+}


### PR DESCRIPTION
## What

Enforce the documented contract that the data length must match the declared
shape in `Tensor::from_slice` and `Tensor::from_vec`.

Fixes #3534.

## The bug

`from_slice`/`from_vec` both document "the number of elements ... must be the
same as the number of elements defined by the shape", but never checked it.
`ShapeWithOneHole`'s blanket impl for concrete shapes ignores the `el_count`
it is handed (`shape.rs:474`), so:

```rust
let t = Tensor::from_slice(&[0.0f32], vec![10], &Device::Cpu).unwrap(); // Ok (!)
t.shape().elem_count();  // 10, but storage holds 1 element
t.to_vec1::<f32>();      // panics: range end index 10 out of range for slice of length 1
```

The tensor is constructed silently and lies about its size; any later read
against the declared shape indexes past the storage. The current safe-`Vec`
path panics, but shape-derived unsafe slicing (`get_unchecked`,
`from_raw_parts`) would be a true out-of-bounds read.

This is reachable from ordinary code and from loader frontends:
- `from_raw_buffer` → `convert_slice` → `from_slice` reaches the same state.
- `candle-onnx`'s `get_tensor` (`eval.rs:192`) builds the dim vector straight
  from `TensorProto.dims`, so a crafted `.onnx` initializer (dims `[1<<32]`,
  one element) yields a lying tensor inside the loaded model.

## The fix

Check `shape.elem_count() == data.len()` immediately after `into_shape` in
`from_vec_impl` and `from_slice`, returning an error on a mismatch.

Deliberately scoped to the two construction entry points:
- `reshape` already has its own `elem_count` check (`tensor.rs:2525`) and keeps
  its `ShapeMismatchBinaryOp` error — left untouched.
- The `ShapeWithOneHole` one-hole inference paths (`((), d)`, `(d, ())`, …)
  already produce a shape whose `elem_count` equals the data length, so they
  keep working; only the no-hole concrete-shape path is newly validated.

I avoided changing the blanket `into_shape` impl on purpose: that would also
alter `reshape`'s error type and make its existing check dead code, expanding
the blast radius beyond the reported APIs.

## Tests

Adds regression tests to `candle-core/tests/tensor_tests.rs`:
- `from_slice_validates_shape_element_count` — mismatch via `from_slice` /
  `from_vec` now errors; matching shapes and one-hole inference still succeed.
- `from_raw_buffer_validates_shape_element_count` — the `from_raw_buffer` path.

Verified RED before the fix, GREEN after. Full `candle-core` test suite passes
(tensor_tests 48 → 50); `cargo fmt --check` and `cargo clippy` clean.

## Note / out of scope

The dummy-dtype branch of `from_raw_buffer` (`F4`/`F6E2M3`/`F6E3M2`/`F8E8M0`)
builds storage directly from raw bytes and doesn't go through `from_slice`, so
it isn't covered here. Happy to follow up if you'd like that path guarded too.
