### PR TITLE
Metal: fix CPU readback race under concurrent command submission

### DIFF
--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -176,6 +176,16 @@ impl MetalDevice {
         Ok(())
     }
 
+    /// Commit and wait on the buffer holding the caller's work; safe for concurrent CPU readbacks.
+    pub fn flush_and_wait_current(&self) -> Result<()> {
+        self.commands
+            .flush_and_wait_current()
+            .map_err(MetalError::from)?;
+
+        self.drop_unused_buffers()?;
+        Ok(())
+    }
+
     pub fn kernels(&self) -> &Kernels {
         &self.kernels
     }

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -1946,7 +1946,7 @@ impl MetalStorage {
             blit.set_label("blit_to_cpu");
             blit.copy_from_buffer(&self.buffer, 0, &buffer, 0, size);
         }
-        self.device.wait_until_completed()?;
+        self.device.flush_and_wait_current()?;
         Ok(read_to_vec(&buffer, self.count))
     }
 }

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -42,7 +42,7 @@ impl QMetalStorage {
             blit.set_label("blit_to_cpu");
             blit.copy_from_buffer(&self.buffer, 0, &buffer, 0, self.buffer.length());
         }
-        self.device.wait_until_completed()?;
+        self.device.flush_and_wait_current()?;
         let mut out = vec![0.0; elem_count];
         let block_len = elem_count / self.dtype.block_size();
         match self.dtype {
@@ -345,7 +345,7 @@ impl QMetalStorage {
             blit.set_label("blit_to_cpu");
             blit.copy_from_buffer(&self.buffer, 0, &buffer, 0, self.buffer.length());
         }
-        self.device.wait_until_completed()?;
+        self.device.flush_and_wait_current()?;
         Ok(read_to_vec::<u8>(&buffer, self.storage_size_in_bytes()))
     }
 }

--- a/candle-core/tests/metal_concurrent_tests.rs
+++ b/candle-core/tests/metal_concurrent_tests.rs
@@ -1,0 +1,54 @@
+#![cfg(feature = "metal")]
+
+use candle_core::{Device, Result, Tensor};
+
+// readbacks must wait on the command buffer holding their own blit, not shared device state
+#[test]
+fn concurrent_readback() -> Result<()> {
+    let device = Device::new_metal(0)?;
+    std::thread::scope(|scope| {
+        for thread in 0..8usize {
+            let device = device.clone();
+            scope.spawn(move || {
+                for iter in 0..100usize {
+                    let value = (thread * 1000 + iter) as f64;
+                    let a = Tensor::full(value as f32, (64, 64), &device).unwrap();
+                    let b = a.affine(2.0, 1.0).unwrap();
+                    let values = b.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+                    let expected = (2.0 * value + 1.0) as f32;
+                    assert!(
+                        values.iter().all(|&x| x == expected),
+                        "thread {thread} iter {iter}: expected {expected}, got {:?}",
+                        &values[..4]
+                    );
+                }
+            });
+        }
+    });
+    Ok(())
+}
+
+#[test]
+fn concurrent_quantized_data_roundtrip() -> Result<()> {
+    use candle_core::quantized::{GgmlDType, QTensor};
+    let device = Device::new_metal(0)?;
+    std::thread::scope(|scope| {
+        for thread in 0..8usize {
+            let device = device.clone();
+            scope.spawn(move || {
+                for iter in 0..25usize {
+                    let src = Tensor::rand(-1f32, 1f32, (256, 256), &device).unwrap();
+                    let q = QTensor::quantize(&src, GgmlDType::Q8_0).unwrap();
+                    let bytes = q.data().unwrap();
+                    let q2 = QTensor::quantize(&src, GgmlDType::Q8_0).unwrap();
+                    let bytes2 = q2.data().unwrap();
+                    assert_eq!(
+                        bytes, bytes2,
+                        "thread {thread} iter {iter}: data() readback mismatch"
+                    );
+                }
+            });
+        }
+    });
+    Ok(())
+}

--- a/candle-metal-kernels/src/metal/commands.rs
+++ b/candle-metal-kernels/src/metal/commands.rs
@@ -257,6 +257,26 @@ impl Commands {
         Ok(())
     }
 
+    /// Commit the current command buffer and wait on that specific buffer, for CPU readbacks.
+    /// [`Self::wait_until_completed`] waits on the last in-flight buffer, which a concurrent
+    /// `flush_and_wait` on another thread may already have taken, returning before our work ran.
+    pub fn flush_and_wait_current(&self) -> Result<(), MetalKernelError> {
+        let cb = {
+            let mut state = self.state.lock()?;
+            self.commit_swap_locked(&mut state, 0)?;
+            state.in_flight.last().cloned()
+        };
+        if let Some(cb) = cb {
+            Self::ensure_completed(&cb)?;
+            // queue is FIFO: everything committed before cb is done too; keep errored for reporting
+            let mut state = self.state.lock()?;
+            state
+                .in_flight
+                .retain(|c| c.status() != MTLCommandBufferStatus::Completed);
+        }
+        Ok(())
+    }
+
     pub fn flush(&self) -> Result<(), MetalKernelError> {
         let mut state = self.state.lock()?;
         if self.compute_count.load(Ordering::Acquire) > 0 {

--- a/candle-metal-kernels/src/metal/commands.rs
+++ b/candle-metal-kernels/src/metal/commands.rs
@@ -268,7 +268,7 @@ impl Commands {
         };
         if let Some(cb) = cb {
             Self::ensure_completed(&cb)?;
-            // queue is FIFO: everything committed before cb is done too; keep errored for reporting
+            // queue is FIFO: everything committed before cb is done too
             let mut state = self.state.lock()?;
             state
                 .in_flight


### PR DESCRIPTION
CPU readbacks (`MetalStorage::to_cpu`, `QMetalStorage::{data, dequantize}`) encoded a blit into the shared rotating command buffer and then called `wait_until_completed`, which commits the current buffer and waits on the last in-flight one. With concurrent submissions from other threads, the in-flight list can be taken by another thread's `flush_and_wait` between the blit encode and the wait, causing the reader to return before its blit has executed and to read stale or unwritten destination memory.

This PR adds `Commands::flush_and_wait_current`, which commits the current command buffer while holding the state lock and waits on that specific buffer. Command queues execute buffers in commit order, so completion of this buffer also covers anything committed before it by other threads. Completed buffers are drained from the in-flight list to keep it bounded under readback-heavy workloads.