### PR TITLE
flash-attn: launch kernels on the caller's CUDA stream

### DIFF
--- a/candle-flash-attn-v3/hkernel/flash_api.cu
+++ b/candle-flash-attn-v3/hkernel/flash_api.cu
@@ -247,7 +247,12 @@ extern "C" void run_mha_v3(
     int window_size_right,
 
     uint32_t total_q,
-    uint32_t total_k
+    uint32_t total_k,
+
+    // Stream to launch the kernels on (e.g. the caller's current CUDA
+    // stream). Passing NULL launches on the legacy default stream,
+    // matching the previous behaviour.
+    void *cuda_stream
 ) {
     Flash_fwd_params params;
     // Reset the parameters
@@ -324,6 +329,6 @@ extern "C" void run_mha_v3(
 
     // print_params(params);
     
-    cudaStream_t stream = 0; // Use the default stream.
+    cudaStream_t stream = static_cast<cudaStream_t>(cuda_stream);
     run_mha_fwd_v3(params, stream);
 }

--- a/candle-flash-attn-v3/src/ffi.rs
+++ b/candle-flash-attn-v3/src/ffi.rs
@@ -59,6 +59,8 @@ extern "C" {
 
         total_q: u32,
         total_k: u32,
+
+        cuda_stream: *mut c_void,
     );
 
 }

--- a/candle-flash-attn-v3/src/lib.rs
+++ b/candle-flash-attn-v3/src/lib.rs
@@ -228,6 +228,7 @@ impl FlashAttn {
                 /* window_size_right */ window_size_right,
                 /* total_q, dummy */ 0u32,
                 /* total_k, dummy */ 0u32,
+                /* cuda_stream */ stream.cu_stream() as *mut core::ffi::c_void,
             )
         }
 
@@ -674,6 +675,7 @@ impl FlashAttnVarLen {
                 /* window_size_right */ window_size_right,
                 /* total_q */ total_q as u32,
                 /* total_k */ total_k as u32,
+                /* cuda_stream */ stream.cu_stream() as *mut core::ffi::c_void,
             )
         }
 

--- a/candle-flash-attn/kernels/flash_api.cu
+++ b/candle-flash-attn/kernels/flash_api.cu
@@ -58,7 +58,12 @@ extern "C" void run_mha(
     int window_size_left,
     int window_size_right,
 
-    float softcap
+    float softcap,
+
+    // Stream to launch the kernels on (e.g. the caller's current CUDA
+    // stream). Passing NULL launches on the legacy default stream,
+    // matching the previous behaviour.
+    void *cuda_stream
 ) {
     Flash_fwd_params params;
     // Reset the parameters
@@ -131,6 +136,6 @@ extern "C" void run_mha(
     params.num_splits = 1;
     params.unpadded_lse = unpadded_lse;
 
-    cudaStream_t stream = 0; // Use the default stream.
+    cudaStream_t stream = static_cast<cudaStream_t>(cuda_stream);
     run_mha_fwd(params, stream);
 }

--- a/candle-flash-attn/src/ffi.rs
+++ b/candle-flash-attn/src/ffi.rs
@@ -48,6 +48,8 @@ extern "C" {
         window_size_right: c_int,
 
         softcap: f32,
+
+        cuda_stream: *mut c_void,
     );
 
 }

--- a/candle-flash-attn/src/lib.rs
+++ b/candle-flash-attn/src/lib.rs
@@ -204,6 +204,7 @@ impl FlashAttn {
                 /* window_size_left */ window_size_left,
                 /* window_size_right */ window_size_right,
                 /* softcap */ self.softcap.unwrap_or(0f32),
+                /* cuda_stream */ stream.cu_stream() as *mut core::ffi::c_void,
             )
         }
 
@@ -669,6 +670,7 @@ impl FlashAttnVarLen {
                 /* window_size_left */ window_size_left,
                 /* window_size_right */ window_size_right,
                 /* softcap */ self.softcap.unwrap_or(0.0),
+                /* cuda_stream */ stream.cu_stream() as *mut core::ffi::c_void,
             )
         }
 


### PR DESCRIPTION
While attempting to capturing a CUDA graph for a model I was working on I ran into this stream issue.

candle-flash-attn's run_mha and candle-flash-attn-v3's run_mha_v3 hard-code `cudaStream_t stream = 0`.
When the candle device runs on the context's legacy default stream this happens to be the same stream and everything is ordered.
But when candle runs on a created stream (Device::new_cuda_with_stream, or any multi-stream setup), the attention kernels launch on a different stream than the one that produced Q/K/V and the one that consumes the output, with no ordering between them, a data race.
It also makes these ops impossible to record with CUDA graph stream capture: the legacy default stream cannot be captured, and kernels launched outside the captured stream do not become part of the graph.

#3565 already routes the buffer device_ptr guards through the device's stream; this PR completes it by launching the kernels on that stream too.
