### PR TITLE
Parameter cache for CUDA kernel launch

### DIFF
--- a/candle-core/src/cuda_backend/device.rs
+++ b/candle-core/src/cuda_backend/device.rs
@@ -156,7 +156,7 @@ impl CudaDevice {
     }
 
     fn check_capture_copy(&self, op: &str) -> Result<()> {
-        if super::CUDA_PARAM_CACHE_ENABLED.with(|e| e.get()) {
+        if cuda_graph_htod_cache_enabled() {
             let is_capturing = self.cuda_graph_capture_active();
             if is_capturing {
                 crate::bail!(
@@ -245,7 +245,7 @@ impl CudaDevice {
     }
 }
 
-fn cuda_graph_htod_cache_enabled() -> bool {
+pub(crate) fn cuda_graph_htod_cache_enabled() -> bool {
     CUDA_GRAPH_HTOD_CACHE_DEPTH.with(|depth| depth.get() > 0)
 }
 

--- a/candle-core/src/cuda_backend/device.rs
+++ b/candle-core/src/cuda_backend/device.rs
@@ -113,6 +113,7 @@ impl CudaDevice {
         &self,
         src: &Src,
     ) -> Result<Vec<T>> {
+        self.check_capture_copy("clone_dtoh")?;
         self.stream.clone_dtoh(src).w()
     }
 
@@ -137,6 +138,7 @@ impl CudaDevice {
         src: &Src,
         dst: &mut Dst,
     ) -> Result<()> {
+        self.check_capture_copy("memcpy_dtoh")?;
         self.stream.memcpy_dtoh(src, dst).w()
     }
 
@@ -151,6 +153,19 @@ impl CudaDevice {
             return self.clone_htod_capture_cached(src);
         }
         self.stream.clone_htod(src).w()
+    }
+
+    fn check_capture_copy(&self, op: &str) -> Result<()> {
+        if super::CUDA_PARAM_CACHE_ENABLED.with(|e| e.get()) {
+            let is_capturing = self.cuda_graph_capture_active();
+            if is_capturing {
+                crate::bail!(
+                    "{op} during CUDA graph capture: host/device copies are not \
+                     permitted while capturing (use param cache for kernel parameters)"
+                );
+            }
+        }
+        Ok(())
     }
 
     fn memcpy_htod_capture_cached<

--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -10,6 +10,9 @@ use cudarc::driver::{
     CudaSlice, DevicePtr, DeviceRepr, LaunchConfig, PushKernelArg, ValidAsZeroBits,
 };
 use half::{bf16, f16};
+use std::cell::Cell;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
 
 #[cfg(feature = "cudnn")]
 pub mod cudnn;
@@ -20,8 +23,35 @@ pub use device::{CudaDevice, DeviceId};
 pub use error::{CudaError, WrapErr};
 pub use utils::{Map1, Map1Any, Map2, Map2Any, Map2InPlace, Map3, S};
 
+static CUDA_PARAM_CACHE: OnceLock<Mutex<HashMap<(DeviceId, Vec<usize>), Arc<CudaSlice<usize>>>>> =
+    OnceLock::new();
+
+thread_local! {
+    static CUDA_PARAM_CACHE_ENABLED: Cell<bool> = const { Cell::new(false) };
+}
+
+pub struct CudaParamCacheGuard {
+    previous: bool,
+}
+
+impl Drop for CudaParamCacheGuard {
+    fn drop(&mut self) {
+        CUDA_PARAM_CACHE_ENABLED.with(|enabled| enabled.set(self.previous));
+    }
+}
+
+pub fn cuda_param_cache_scope(enabled: bool) -> CudaParamCacheGuard {
+    let previous = CUDA_PARAM_CACHE_ENABLED.with(|cache_enabled| {
+        let previous = cache_enabled.get();
+        cache_enabled.set(enabled);
+        previous
+    });
+    CudaParamCacheGuard { previous }
+}
+
 pub enum SlicePtrOrNull<T> {
     Ptr(CudaSlice<T>),
+    Cached(Arc<CudaSlice<T>>),
     Null,
 }
 
@@ -29,6 +59,7 @@ impl<T: DeviceRepr> SlicePtrOrNull<T> {
     pub fn builder_arg<'a, 'b: 'a>(&'b self, builder: &mut cudarc::driver::LaunchArgs<'a>) {
         match self {
             SlicePtrOrNull::Ptr(slice) => builder.arg(slice),
+            SlicePtrOrNull::Cached(slice) => builder.arg(slice.as_ref()),
             SlicePtrOrNull::Null => builder.arg(&0usize),
         };
     }
@@ -53,13 +84,33 @@ impl crate::scalar::Scalar {
 }
 
 impl SlicePtrOrNull<usize> {
+    pub fn params_from_vec(dev: &CudaDevice, params: Vec<usize>) -> Result<Self> {
+        if CUDA_PARAM_CACHE_ENABLED.with(|enabled| enabled.get()) {
+            let key = (dev.id(), params.clone());
+            let cache = CUDA_PARAM_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+            if let Some(slice) = cache.lock().unwrap().get(&key).cloned() {
+                return Ok(SlicePtrOrNull::Cached(slice));
+            }
+
+            let is_capturing = dev.cuda_stream().capture_status()
+                == Ok(cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_ACTIVE);
+            if !is_capturing {
+                let slice = Arc::new(dev.clone_htod(&params)?);
+                let mut cache = cache.lock().unwrap();
+                let slice = cache.entry(key).or_insert_with(|| slice).clone();
+                return Ok(SlicePtrOrNull::Cached(slice));
+            }
+        }
+
+        Ok(SlicePtrOrNull::Ptr(dev.clone_htod(&params)?))
+    }
+
     pub fn params_from_layout(dev: &CudaDevice, l: &Layout) -> Result<Self> {
-        let ds = if l.is_contiguous() {
-            SlicePtrOrNull::Null
+        if l.is_contiguous() {
+            Ok(SlicePtrOrNull::Null)
         } else {
-            SlicePtrOrNull::Ptr(dev.clone_htod(&[l.dims(), l.stride()].concat())?)
-        };
-        Ok(ds)
+            Self::params_from_vec(dev, [l.dims(), l.stride()].concat())
+        }
     }
 }
 
@@ -187,7 +238,7 @@ impl Map1 for Im2Col1D {
         let l_out = self.l_out(dims[2]);
         let threads = dims[0] * l_out * dims[1];
         let cfg = LaunchConfig::for_num_elems(threads as u32);
-        let ds = dev.clone_htod(&[dims, layout.stride()].concat())?;
+        let ds = SlicePtrOrNull::params_from_vec(dev, [dims, layout.stride()].concat())?;
         let src = &src.slice(layout.start_offset()..);
         let func = dev.get_or_load_func(&kernel_name::<T>("im2col1d"), &kernels::CONV)?;
         // SAFETY: Set later by running the kernel.
@@ -199,7 +250,7 @@ impl Map1 for Im2Col1D {
         barg!(builder, self.stride);
         barg!(builder, self.padding);
         barg!(builder, self.dilation);
-        builder.arg(&ds);
+        ds.builder_arg(&mut builder);
         builder.arg(src);
         builder.arg(&dst);
         // SAFETY: ffi.
@@ -238,7 +289,7 @@ impl Map1 for Im2Col {
         let (h_out, w_out) = self.hw_out(dims[2], dims[3]);
         let dst_el = dims[0] * h_out * w_out * dims[1] * self.h_k * self.w_k;
         let cfg = LaunchConfig::for_num_elems(dst_el as u32);
-        let ds = dev.clone_htod(&[dims, layout.stride()].concat())?;
+        let ds = SlicePtrOrNull::params_from_vec(dev, [dims, layout.stride()].concat())?;
         let src = &src.slice(layout.start_offset()..);
         let func = dev.get_or_load_func(&kernel_name::<T>("im2col"), &kernels::CONV)?;
         // SAFETY: Set later by running the kernel.
@@ -252,7 +303,7 @@ impl Map1 for Im2Col {
         barg!(builder, self.stride);
         barg!(builder, self.padding);
         barg!(builder, self.dilation);
-        builder.arg(&ds);
+        ds.builder_arg(&mut builder);
         builder.arg(src);
         builder.arg(&dst);
         // SAFETY: ffi.
@@ -330,7 +381,8 @@ impl Map1Any for FastReduce<'_> {
             block_dim: (block_dim as u32, 1, 1),
             shared_mem_bytes: 0,
         };
-        let ds = dev.clone_htod(&[dims.as_slice(), stride.as_slice()].concat())?;
+        let ds =
+            SlicePtrOrNull::params_from_vec(dev, [dims.as_slice(), stride.as_slice()].concat())?;
         let src = &src.slice(layout.start_offset()..);
         let (name, check_empty, return_index) = match self.1 {
             ReduceOp::Sum => ("fast_sum", false, false),
@@ -350,7 +402,7 @@ impl Map1Any for FastReduce<'_> {
             barg!(builder, src_el);
             barg!(builder, el_to_sum_per_block);
             barg!(builder, src_dims.len());
-            builder.arg(&ds);
+            ds.builder_arg(&mut builder);
             builder.arg(src);
             builder.arg(&out);
             // SAFETY: ffi.
@@ -363,7 +415,7 @@ impl Map1Any for FastReduce<'_> {
             barg!(builder, src_el);
             barg!(builder, el_to_sum_per_block);
             barg!(builder, src_dims.len());
-            builder.arg(&ds);
+            ds.builder_arg(&mut builder);
             builder.arg(src);
             builder.arg(&out);
             // SAFETY: ffi.
@@ -429,7 +481,7 @@ impl Map1 for IndexSelect<'_> {
         };
         let ids_shape = ids_l.shape();
         let ids_dims = ids_shape.dims();
-        let ds = dev.clone_htod(&[ids_dims, ids_l.stride()].concat())?;
+        let ds = SlicePtrOrNull::params_from_vec(dev, [ids_dims, ids_l.stride()].concat())?;
         let src = match src_l.contiguous_offsets() {
             Some((o1, o2)) => src.slice(o1..o2),
             None => Err(crate::Error::RequiresContiguous { op: "index-select" }.bt())?,
@@ -446,7 +498,7 @@ impl Map1 for IndexSelect<'_> {
         let mut builder = func.builder();
         barg!(builder, dst_el);
         barg!(builder, ids_dims.len());
-        builder.arg(&ds);
+        ds.builder_arg(&mut builder);
         barg!(builder, ids);
         builder.arg(&src);
         builder.arg(&out);
@@ -702,10 +754,10 @@ impl Map2 for Conv1D<'_> {
         } else {
             crate::bail!("unexpected input shape for conv1d {dims:?}")
         };
-        let ds = dev.clone_htod(&ds)?;
+        let ds = SlicePtrOrNull::params_from_vec(dev, ds)?;
         let mut builder = func.builder();
         barg!(builder, el, l_out, p.stride, p.padding, p.dilation);
-        builder.arg(&ds);
+        ds.builder_arg(&mut builder);
         builder.arg(inp);
         builder.arg(k);
         builder.arg(&out);
@@ -745,10 +797,10 @@ impl Map2 for Conv2D<'_> {
         } else {
             crate::bail!("unexpected input shape for conv2d {dims:?}")
         };
-        let ds = dev.clone_htod(&ds)?;
+        let ds = SlicePtrOrNull::params_from_vec(dev, ds)?;
         let mut builder = func.builder();
         barg!(builder, el, out_w, out_h, p.stride, p.padding, p.dilation);
-        builder.arg(&ds);
+        ds.builder_arg(&mut builder);
         builder.arg(inp);
         builder.arg(k);
         builder.arg(&out);
@@ -816,7 +868,7 @@ impl Map2 for ConvTranspose1D<'_> {
         } else {
             crate::bail!("unexpected input shape for conv_transpose1d {dims:?}")
         };
-        let ds = dev.clone_htod(&ds)?;
+        let ds = SlicePtrOrNull::params_from_vec(dev, ds)?;
         let mut builder = func.builder();
         barg!(builder, el);
         barg!(builder, l_out);
@@ -824,7 +876,7 @@ impl Map2 for ConvTranspose1D<'_> {
         barg!(builder, p.padding);
         barg!(builder, p.output_padding);
         barg!(builder, p.dilation);
-        builder.arg(&ds);
+        ds.builder_arg(&mut builder);
         builder.arg(inp);
         builder.arg(k);
         builder.arg(&out);
@@ -864,7 +916,7 @@ impl Map2 for ConvTranspose2D<'_> {
         } else {
             crate::bail!("unexpected input shape for conv_transpose2d {dims:?}")
         };
-        let ds = dev.clone_htod(&ds)?;
+        let ds = SlicePtrOrNull::params_from_vec(dev, ds)?;
         let mut builder = func.builder();
         barg!(builder, el);
         barg!(builder, out_w);
@@ -873,7 +925,7 @@ impl Map2 for ConvTranspose2D<'_> {
         barg!(builder, p.padding);
         barg!(builder, p.output_padding);
         barg!(builder, p.dilation);
-        builder.arg(&ds);
+        ds.builder_arg(&mut builder);
         builder.arg(inp);
         builder.arg(k);
         builder.arg(&out);
@@ -924,14 +976,14 @@ impl Map1 for Pool2D {
         let func = dev.get_or_load_func(&kernel_name::<T>(kname), &kernels::CONV)?;
         // SAFETY: Set later by running the kernel.
         let out = unsafe { dev.alloc::<T>(dst_el)? };
-        let ds = dev.clone_htod(&ds)?;
+        let ds = SlicePtrOrNull::params_from_vec(dev, ds)?;
         let mut builder = func.builder();
         barg!(builder, el);
         barg!(builder, self.w_k);
         barg!(builder, self.h_k);
         barg!(builder, self.w_stride);
         barg!(builder, self.h_stride);
-        builder.arg(&ds);
+        ds.builder_arg(&mut builder);
         builder.arg(inp);
         builder.arg(&out);
         // SAFETY: ffi.
@@ -963,7 +1015,7 @@ impl Map1 for UpsampleNearest2D {
         let func = dev.get_or_load_func(&kernel_name::<T>("upsample_nearest2d"), &kernels::CONV)?;
         // SAFETY: Set later by running the kernel.
         let out = unsafe { dev.alloc::<T>(dst_el)? };
-        let ds = dev.clone_htod(&ds)?;
+        let ds = SlicePtrOrNull::params_from_vec(dev, ds)?;
         let scale_w = dims[2] as f64 / out_w as f64;
         let scale_h = dims[3] as f64 / out_h as f64;
         let mut builder = func.builder();
@@ -971,7 +1023,7 @@ impl Map1 for UpsampleNearest2D {
         barg!(builder, out_h);
         barg!(builder, scale_w);
         barg!(builder, scale_h);
-        builder.arg(&ds);
+        ds.builder_arg(&mut builder);
         builder.arg(inp);
         builder.arg(&out);
         // SAFETY: ffi.
@@ -1012,7 +1064,7 @@ impl Map1 for UpsampleBilinear2D {
 
         // SAFETY: Set later by running the kernel.
         let out = unsafe { dev.alloc::<T>(dst_el)? };
-        let ds = dev.clone_htod(&ds)?;
+        let ds = SlicePtrOrNull::params_from_vec(dev, ds)?;
 
         let mut builder = func.builder();
         barg!(builder, out_w);
@@ -1022,7 +1074,7 @@ impl Map1 for UpsampleBilinear2D {
         barg!(builder, self.scale_h_factor.unwrap_or(0.0));
         barg!(builder, self.scale_w_factor.is_some());
         barg!(builder, self.scale_w_factor.unwrap_or(0.0));
-        builder.arg(&ds);
+        ds.builder_arg(&mut builder);
         builder.arg(inp);
         builder.arg(&out);
 
@@ -1067,8 +1119,10 @@ impl Map2 for WhereCond<'_> {
         let dims = shape.dims();
         let el = shape.elem_count();
         let cfg = LaunchConfig::for_num_elems(el as u32);
-        let ds =
-            dev.clone_htod(&[dims, ids_l.stride(), layout_t.stride(), layout_f.stride()].concat())?;
+        let ds = SlicePtrOrNull::params_from_vec(
+            dev,
+            [dims, ids_l.stride(), layout_t.stride(), layout_f.stride()].concat(),
+        )?;
         let t = &t.slice(layout_t.start_offset()..);
         let f = &f.slice(layout_f.start_offset()..);
         let func = dev.get_or_load_func(&kernel_name::<T>(name), &kernels::TERNARY)?;
@@ -1077,7 +1131,7 @@ impl Map2 for WhereCond<'_> {
         let mut builder = func.builder();
         barg!(builder, el);
         barg!(builder, dims.len());
-        builder.arg(&ds);
+        ds.builder_arg(&mut builder);
         barg!(builder, ids);
         builder.arg(t);
         builder.arg(f);
@@ -1104,7 +1158,7 @@ impl<U: crate::op::BinaryOpT> Map2 for U {
         let dims_and_strides = if lhs_l.is_contiguous() && rhs_l.is_contiguous() {
             SlicePtrOrNull::Null
         } else {
-            SlicePtrOrNull::Ptr(dev.clone_htod(&[dims, lhs_l.stride(), rhs_l.stride()].concat())?)
+            SlicePtrOrNull::params_from_vec(dev, [dims, lhs_l.stride(), rhs_l.stride()].concat())?
         };
         let lhs = &lhs.slice(lhs_l.start_offset()..);
         let rhs = &rhs.slice(rhs_l.start_offset()..);
@@ -1141,7 +1195,7 @@ impl Map2Any for Cmp {
         let dims_and_strides = if lhs_l.is_contiguous() && rhs_l.is_contiguous() {
             SlicePtrOrNull::Null
         } else {
-            SlicePtrOrNull::Ptr(dev.clone_htod(&[dims, lhs_l.stride(), rhs_l.stride()].concat())?)
+            SlicePtrOrNull::params_from_vec(dev, [dims, lhs_l.stride(), rhs_l.stride()].concat())?
         };
         let lhs = &lhs.slice(lhs_l.start_offset()..);
         let rhs = &rhs.slice(rhs_l.start_offset()..);

--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -10,7 +10,6 @@ use cudarc::driver::{
     CudaSlice, DevicePtr, DeviceRepr, LaunchConfig, PushKernelArg, ValidAsZeroBits,
 };
 use half::{bf16, f16};
-use std::cell::Cell;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -26,29 +25,6 @@ pub use utils::{Map1, Map1Any, Map2, Map2Any, Map2InPlace, Map3, S};
 type ParamCache = HashMap<(DeviceId, Vec<usize>), Arc<CudaSlice<usize>>>;
 
 static CUDA_PARAM_CACHE: OnceLock<Mutex<ParamCache>> = OnceLock::new();
-
-thread_local! {
-    pub(crate) static CUDA_PARAM_CACHE_ENABLED: Cell<bool> = const { Cell::new(false) };
-}
-
-pub struct CudaParamCacheGuard {
-    previous: bool,
-}
-
-impl Drop for CudaParamCacheGuard {
-    fn drop(&mut self) {
-        CUDA_PARAM_CACHE_ENABLED.with(|enabled| enabled.set(self.previous));
-    }
-}
-
-pub fn cuda_param_cache_scope(enabled: bool) -> CudaParamCacheGuard {
-    let previous = CUDA_PARAM_CACHE_ENABLED.with(|cache_enabled| {
-        let previous = cache_enabled.get();
-        cache_enabled.set(enabled);
-        previous
-    });
-    CudaParamCacheGuard { previous }
-}
 
 pub enum SlicePtrOrNull<T> {
     Ptr(CudaSlice<T>),
@@ -86,7 +62,7 @@ impl crate::scalar::Scalar {
 
 impl SlicePtrOrNull<usize> {
     pub fn params_from_vec(dev: &CudaDevice, params: Vec<usize>) -> Result<Self> {
-        if CUDA_PARAM_CACHE_ENABLED.with(|enabled| enabled.get()) {
+        if device::cuda_graph_htod_cache_enabled() {
             let key = (dev.id(), params.clone());
             let cache = CUDA_PARAM_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
             if let Some(slice) = cache.lock().unwrap().get(&key).cloned() {
@@ -102,7 +78,7 @@ impl SlicePtrOrNull<usize> {
                 );
             }
 
-            let slice = Arc::new(dev.clone_htod(&params)?);
+            let slice = Arc::new(dev.cuda_stream().clone_htod(&params).w()?);
             let mut cache = cache.lock().unwrap();
             let slice = cache.entry(key).or_insert_with(|| slice).clone();
             return Ok(SlicePtrOrNull::Cached(slice));
@@ -1753,7 +1729,7 @@ impl BackendStorage for CudaStorage {
     }
 
     fn to_cpu_storage(&self) -> Result<CpuStorage> {
-        if CUDA_PARAM_CACHE_ENABLED.with(|e| e.get()) {
+        if device::cuda_graph_htod_cache_enabled() {
             let is_capturing = self.device.cuda_stream().capture_status()
                 == Ok(cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_ACTIVE);
             if is_capturing {

--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -35,22 +35,15 @@ pub struct CudaParamCacheGuard {
     previous: bool,
 }
 
-impl CudaParamCacheGuard {
-    pub fn clear_cache(&self) {
-        if let Some(cache) = CUDA_PARAM_CACHE.get() {
-            cache.lock().unwrap().clear();
-        }
-    }
-}
-
 impl Drop for CudaParamCacheGuard {
     fn drop(&mut self) {
         CUDA_PARAM_CACHE_ENABLED.with(|enabled| enabled.set(self.previous));
-        if !self.previous {
-            if let Some(cache) = CUDA_PARAM_CACHE.get() {
-                cache.lock().unwrap().clear();
-            }
-        }
+    }
+}
+
+pub fn clear_cuda_param_cache() {
+    if let Some(cache) = CUDA_PARAM_CACHE.get() {
+        cache.lock().unwrap().clear();
     }
 }
 

--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -28,7 +28,7 @@ type ParamCache = HashMap<(DeviceId, Vec<usize>), Arc<CudaSlice<usize>>>;
 static CUDA_PARAM_CACHE: OnceLock<Mutex<ParamCache>> = OnceLock::new();
 
 thread_local! {
-    static CUDA_PARAM_CACHE_ENABLED: Cell<bool> = const { Cell::new(false) };
+    pub(crate) static CUDA_PARAM_CACHE_ENABLED: Cell<bool> = const { Cell::new(false) };
 }
 
 pub struct CudaParamCacheGuard {
@@ -1753,6 +1753,16 @@ impl BackendStorage for CudaStorage {
     }
 
     fn to_cpu_storage(&self) -> Result<CpuStorage> {
+        if CUDA_PARAM_CACHE_ENABLED.with(|e| e.get()) {
+            let is_capturing = self.device.cuda_stream().capture_status()
+                == Ok(cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_ACTIVE);
+            if is_capturing {
+                crate::bail!(
+                    "to_cpu_storage during CUDA graph capture: host/device copies are not \
+                     permitted while capturing"
+                );
+            }
+        }
         match &self.slice {
             CudaStorageSlice::U8(slice) => {
                 let cpu_storage = slice.stream().clone_dtoh(slice).w()?;

--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -23,8 +23,9 @@ pub use device::{CudaDevice, DeviceId};
 pub use error::{CudaError, WrapErr};
 pub use utils::{Map1, Map1Any, Map2, Map2Any, Map2InPlace, Map3, S};
 
-static CUDA_PARAM_CACHE: OnceLock<Mutex<HashMap<(DeviceId, Vec<usize>), Arc<CudaSlice<usize>>>>> =
-    OnceLock::new();
+type ParamCache = HashMap<(DeviceId, Vec<usize>), Arc<CudaSlice<usize>>>;
+
+static CUDA_PARAM_CACHE: OnceLock<Mutex<ParamCache>> = OnceLock::new();
 
 thread_local! {
     static CUDA_PARAM_CACHE_ENABLED: Cell<bool> = const { Cell::new(false) };
@@ -34,9 +35,22 @@ pub struct CudaParamCacheGuard {
     previous: bool,
 }
 
+impl CudaParamCacheGuard {
+    pub fn clear_cache(&self) {
+        if let Some(cache) = CUDA_PARAM_CACHE.get() {
+            cache.lock().unwrap().clear();
+        }
+    }
+}
+
 impl Drop for CudaParamCacheGuard {
     fn drop(&mut self) {
         CUDA_PARAM_CACHE_ENABLED.with(|enabled| enabled.set(self.previous));
+        if !self.previous {
+            if let Some(cache) = CUDA_PARAM_CACHE.get() {
+                cache.lock().unwrap().clear();
+            }
+        }
     }
 }
 
@@ -94,12 +108,17 @@ impl SlicePtrOrNull<usize> {
 
             let is_capturing = dev.cuda_stream().capture_status()
                 == Ok(cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_ACTIVE);
-            if !is_capturing {
-                let slice = Arc::new(dev.clone_htod(&params)?);
-                let mut cache = cache.lock().unwrap();
-                let slice = cache.entry(key).or_insert_with(|| slice).clone();
-                return Ok(SlicePtrOrNull::Cached(slice));
+            if is_capturing {
+                crate::bail!(
+                    "h2d param cache miss during CUDA graph capture: \
+                     warmup did not populate all required parameter vectors"
+                );
             }
+
+            let slice = Arc::new(dev.clone_htod(&params)?);
+            let mut cache = cache.lock().unwrap();
+            let slice = cache.entry(key).or_insert_with(|| slice).clone();
+            return Ok(SlicePtrOrNull::Cached(slice));
         }
 
         Ok(SlicePtrOrNull::Ptr(dev.clone_htod(&params)?))
@@ -1747,6 +1766,16 @@ impl BackendStorage for CudaStorage {
     }
 
     fn to_cpu_storage(&self) -> Result<CpuStorage> {
+        if CUDA_PARAM_CACHE_ENABLED.with(|enabled| enabled.get()) {
+            let is_capturing = self.device.cuda_stream().capture_status()
+                == Ok(cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_ACTIVE);
+            if is_capturing {
+                crate::bail!(
+                    "d2h copy attempted during CUDA graph capture: \
+                     device-to-host transfers are not permitted while capturing"
+                );
+            }
+        }
         match &self.slice {
             CudaStorageSlice::U8(slice) => {
                 let cpu_storage = slice.stream().clone_dtoh(slice).w()?;

--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -41,12 +41,6 @@ impl Drop for CudaParamCacheGuard {
     }
 }
 
-pub fn clear_cuda_param_cache() {
-    if let Some(cache) = CUDA_PARAM_CACHE.get() {
-        cache.lock().unwrap().clear();
-    }
-}
-
 pub fn cuda_param_cache_scope(enabled: bool) -> CudaParamCacheGuard {
     let previous = CUDA_PARAM_CACHE_ENABLED.with(|cache_enabled| {
         let previous = cache_enabled.get();
@@ -1759,16 +1753,6 @@ impl BackendStorage for CudaStorage {
     }
 
     fn to_cpu_storage(&self) -> Result<CpuStorage> {
-        if CUDA_PARAM_CACHE_ENABLED.with(|enabled| enabled.get()) {
-            let is_capturing = self.device.cuda_stream().capture_status()
-                == Ok(cudarc::driver::sys::CUstreamCaptureStatus::CU_STREAM_CAPTURE_STATUS_ACTIVE);
-            if is_capturing {
-                crate::bail!(
-                    "d2h copy attempted during CUDA graph capture: \
-                     device-to-host transfers are not permitted while capturing"
-                );
-            }
-        }
         match &self.slice {
             CudaStorageSlice::U8(slice) => {
                 let cpu_storage = slice.stream().clone_dtoh(slice).w()?;


### PR DESCRIPTION
**Summary**

Candle uses `htod` to copy kernel launch parameters to the device, which makes CUDA graph capture inefficient because it captures tens of host-to-device operations in each forward pass. This PR addresses the kernel launch bottleneck by caching kernel parameters, delivering ~10% performance speedup across **ALL** models, as validated in vLLM.rs (xinfer): https://github.com/guoqingbao/xinfer/pull/371.

**Usage:**

Before CUDA graph capture, enable the parameter cache and run a warmup step. This caches the kernel launch parameters:

```rust
let _guard = CudaDevice::enable_cuda_graph_htod_cache();
for b in 0..bs {
    let _ = self.model.forward(&input_ids_bs, ...)?;
}
```

Then perform the actual CUDA graph capture:

```rust

for b in 0..bs {
   self.model.start_capture(b)?;
    let out = self.model.forward(&input_ids_bs, ...)?;
    // Save out.
    self.model.end_capture()?;
}

```

**Results** from xinfer:

| Model | Quantization | Size | GPU | Conventional CUDA graph | CUDA graph + parameter cache | Speedup |
|---|---|---:|---|---:|---:|---:|
| Qwen3-30B-A3B | NVFP4 | 30B MoE | RTX 5090 | 175.30 tokens/s | 181.59 tokens/s | 3.59% |
| Gemma4-26B-A4B | NVFP4 | 26B MoE | RTX 5090 | 131.00 tokens/s | 137.23 tokens/s | 4.76% |
| Ministral-3-3B (Multimodal) | ISQ (BF16→Q4K) | 3B | A100 | 171.92 tokens/s | 193.67 tokens/s | 12.65% |
| DeepSeek-R1-0528-Qwen3-8B | Q4_K_M | 8B | A100 | 124.87 tokens/s | 139.25 tokens/s | 11.52% |
| Llama-3.1-8B | ISQ (BF16→Q4K) | 8B | A100 | 120.74 tokens/s | 133.10 tokens/s | 10.24% |
| Qwen3-VL-8B-Instruct (Multimodal) | Q8_0 | 8B | A100 | 105.31 tokens/s | 112.51 tokens/s | 6.84% |
| Qwen3.6-35B-A3B (Multimodal) | FP8 | 35B MoE | Hopper | 102.00 tokens/s | 110.00 tokens/s | 7.84% |
| Qwen3-30B-A3B | NVFP4 | 30B MoE | V100 | 67.10 tokens/s | 72.86 tokens/s | 8.58% |
| GLM-4-9B-0414 | Q4_K_M | 9B | A100 | 70.38 tokens/s | 77.48 tokens/s | 10.09% |
| MiniMax-M2.5 | NVFP4 | 229B MoE | Hopper ×2 | 62.00 tokens/s | 64.50 tokens/s | 4.03% |
| Qwen3.5-27B (Multimodal) | Q4_K_M | 27B Dense | Hopper | 45.20 tokens/s | 49.33 tokens/s | 9.14% |
| Qwen3.5-27B/Qwen3.6-27B | FP8 | 27B Dense | Hopper | 42.00 tokens/s | 45.00 tokens/s | 7.14% |
| QwQ-32B | Q4_K_M | 32B | A100 | 41.36 tokens/s | 46.02 tokens/s | 11.27% |
| Gemma4-31B | ISQ (BF16→Q4K) | 31B Dense | Hopper | 41.00 tokens/s | 47.00 tokens/s | 14.63% |

Note: This PR does not benefit `candle-examples` by default. It is intended for downstream projects that rely on Candle and support CUDA graphs.