### PR TITLE
fix(kernels): Compilation errors on Turing Cards (Compute Cap 7.5)

### DIFF
--- a/candle-kernels/src/compatibility.cuh
+++ b/candle-kernels/src/compatibility.cuh
@@ -7,7 +7,7 @@
 
 // FIXME: the minimum compute capabilities are just guesses since the table is not specific enough
 
-#if __CUDA_ARCH__ < 800
+#if (__CUDACC_VER_MAJOR__ < 12 || __CUDACC_VER_MINOR__ < 2) && __CUDA_ARCH__ < 750
 __device__ __forceinline__ __half __hmax_nan(__half a, __half b) {
     return __hisnan(a) ? a : (__hisnan(b) ? b : __hmax(a, b));
 }


### PR DESCRIPTION
When trying to clean compile for Turing cards (GTX 16xx, RTX 20xx, ComputeCap 7.5) the exact error described in #353 returns.

Reverting the last change in `compatibility.cu` (PR #3558) to the state of #3142 the problem seems to be resolved.
Tested on CUDA Version 13.2.1 with an RTX 2080Ti.

I therefore propose to revert the PR #3558 