### PR TITLE
fix(core): incorrect identification for bf16 support on cuda

### DIFF
--- a/candle-core/src/cuda_backend/device.rs
+++ b/candle-core/src/cuda_backend/device.rs
@@ -74,6 +74,10 @@ impl std::fmt::Debug for CudaDevice {
 }
 
 impl CudaDevice {
+    pub fn supports_bf16(&self) -> bool {
+        matches!(self.context.compute_capability().w(), Ok((major, _)) if major >= 8)
+    }
+
     #[allow(clippy::missing_safety_doc)]
     pub unsafe fn alloc<T: cudarc::driver::DeviceRepr>(
         &self,

--- a/candle-core/src/device.rs
+++ b/candle-core/src/device.rs
@@ -322,7 +322,8 @@ impl Device {
 
     pub fn supports_bf16(&self) -> bool {
         match self {
-            Self::Cuda(_) | Self::Metal(_) => true,
+            Self::Cuda(cuda) => cuda.supports_bf16(),
+            Self::Metal(_) => true,
             Self::Cpu => false,
         }
     }

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -25,6 +25,10 @@ macro_rules! fail {
 pub struct DeviceId(usize);
 
 impl CudaDevice {
+    pub fn supports_bf16(&self) -> bool {
+        false
+    }
+
     pub fn new_with_stream(_: usize) -> Result<Self> {
         Err(Error::NotCompiledWithCudaSupport)
     }


### PR DESCRIPTION
Old Cuda Cards (e.g. RTX20xx, GTX16xx, T4,..) with lower Compute Cap 7.5 or lower do not support native BF16 and need to fallback to F32 or F16.
BF16 support came with Compute Cap 8.0 afaik.

Tested on CUDA Version 13.2.1 with an RTX 2080Ti and RTX 3090.