### PR TITLE
gemma4/text: get E2B, E4B, 12B and 31B to load (and seemingly work).

### DIFF
--- a/candle-examples/examples/gemma4/main.rs
+++ b/candle-examples/examples/gemma4/main.rs
@@ -303,7 +303,7 @@ fn main() -> Result<()> {
             }
         };
         config.use_flash_attn = args.use_flash_attn;
-        let model = TextModel::new(&config, vb)?;
+        let model = TextModel::new(&config, vb.pp("model").pp("language_model"))?;
         ModelKind::TextOnly(model)
     };
 

--- a/candle-examples/examples/gemma4/main.rs
+++ b/candle-examples/examples/gemma4/main.rs
@@ -91,9 +91,13 @@ impl TextGeneration {
         std::io::stdout().flush()?;
 
         let mut generated_tokens = 0usize;
-        let eos_token = match self.tokenizer.get_token("</s>") {
+        let eos_token = match self.tokenizer.get_token("<eos>") {
             Some(token) => token,
-            None => anyhow::bail!("cannot find the </s> token"),
+            None => anyhow::bail!("cannot find the <eos> token"),
+        };
+        let end_of_turn_token = match self.tokenizer.get_token("<turn|>") {
+            Some(token) => token,
+            None => anyhow::bail!("cannot find the <turn|> token"),
         };
         let start_gen = std::time::Instant::now();
         for index in 0..sample_len {
@@ -120,7 +124,7 @@ impl TextGeneration {
             let next_token = self.logits_processor.sample(&logits)?;
             tokens.push(next_token);
             generated_tokens += 1;
-            if next_token == eos_token {
+            if [eos_token, end_of_turn_token].contains(&next_token) {
                 break;
             }
             if let Some(t) = self.tokenizer.next_token(next_token)? {

--- a/candle-transformers/src/models/gemma4/audio.rs
+++ b/candle-transformers/src/models/gemma4/audio.rs
@@ -404,13 +404,23 @@ impl ConformerAttention {
         let attn_vb = vb.pp("self_attn");
         let relative_position_embedding = RelativePositionEmbedding::new(cfg, attn_vb.clone())?;
         let per_dim_scale = attn_vb.get(head_dim, "per_dim_scale")?;
-        let q_proj =
-            candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("q_proj"))?;
-        let k_proj =
-            candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("k_proj"))?;
-        let v_proj =
-            candle_nn::linear_no_bias(hidden_size, num_heads * head_dim, attn_vb.pp("v_proj"))?;
-        let post = candle_nn::linear_no_bias(hidden_size, hidden_size, attn_vb.pp("post"))?;
+        let q_proj = candle_nn::linear_no_bias(
+            hidden_size,
+            num_heads * head_dim,
+            attn_vb.pp("q_proj").pp("linear"),
+        )?;
+        let k_proj = candle_nn::linear_no_bias(
+            hidden_size,
+            num_heads * head_dim,
+            attn_vb.pp("k_proj").pp("linear"),
+        )?;
+        let v_proj = candle_nn::linear_no_bias(
+            hidden_size,
+            num_heads * head_dim,
+            attn_vb.pp("v_proj").pp("linear"),
+        )?;
+        let post =
+            candle_nn::linear_no_bias(hidden_size, hidden_size, attn_vb.pp("post").pp("linear"))?;
 
         let pre_attn_norm = RmsNorm::new(hidden_size, cfg.rms_norm_eps, vb.pp("norm_pre_attn"))?;
         let post_norm = RmsNorm::new(hidden_size, cfg.rms_norm_eps, vb.pp("norm_post_attn"))?;
@@ -666,12 +676,12 @@ impl ConformerFeedForward {
             ffw_layer_1: candle_nn::linear_no_bias(
                 cfg.hidden_size,
                 cfg.hidden_size * 4,
-                vb.pp("ffw_layer_1"),
+                vb.pp("ffw_layer_1").pp("linear"),
             )?,
             ffw_layer_2: candle_nn::linear_no_bias(
                 cfg.hidden_size * 4,
                 cfg.hidden_size,
-                vb.pp("ffw_layer_2"),
+                vb.pp("ffw_layer_2").pp("linear"),
             )?,
             post_layer_norm: RmsNorm::new(
                 cfg.hidden_size,
@@ -720,7 +730,7 @@ impl ConformerLightConv1d {
             linear_start: candle_nn::linear_no_bias(
                 cfg.hidden_size,
                 cfg.hidden_size * 2,
-                vb.pp("linear_start"),
+                vb.pp("linear_start").pp("linear"),
             )?,
             depthwise_conv1d: candle_nn::conv1d_no_bias(
                 cfg.hidden_size,
@@ -739,7 +749,7 @@ impl ConformerLightConv1d {
             linear_end: candle_nn::linear_no_bias(
                 cfg.hidden_size,
                 cfg.hidden_size,
-                vb.pp("linear_end"),
+                vb.pp("linear_end").pp("linear"),
             )?,
             causal_padding: cfg.conf_conv_kernel_size - 1,
             gradient_clipping: cfg.gradient_clipping,

--- a/candle-transformers/src/models/gemma4/config.rs
+++ b/candle-transformers/src/models/gemma4/config.rs
@@ -43,6 +43,9 @@ fn default_sliding_window_pattern() -> usize {
 fn default_global_head_dim() -> usize {
     512
 }
+fn default_attention_k_eq_v() -> bool {
+    false
+}
 fn default_use_flash_attn() -> bool {
     false
 }
@@ -104,6 +107,8 @@ pub struct Gemma4TextConfig {
     pub layer_types: Vec<String>,
     #[serde(default = "default_global_head_dim")]
     pub global_head_dim: usize,
+    #[serde(default = "default_attention_k_eq_v")]
+    pub attention_k_eq_v: bool,
     pub num_global_key_value_heads: Option<usize>,
     pub rope_parameters: Option<Gemma4RopeParameters>,
     pub use_bidirectional_attention: Option<String>,

--- a/candle-transformers/src/models/gemma4/config.rs
+++ b/candle-transformers/src/models/gemma4/config.rs
@@ -114,6 +114,9 @@ pub struct Gemma4TextConfig {
     pub use_bidirectional_attention: Option<String>,
     #[serde(default = "default_use_flash_attn")]
     pub use_flash_attn: bool,
+
+    pub vocab_size_per_layer_input: usize,
+    pub hidden_size_per_layer_input: usize,
 }
 
 impl Gemma4TextConfig {

--- a/candle-transformers/src/models/gemma4/config.rs
+++ b/candle-transformers/src/models/gemma4/config.rs
@@ -117,6 +117,11 @@ pub struct Gemma4TextConfig {
 
     pub vocab_size_per_layer_input: usize,
     pub hidden_size_per_layer_input: usize,
+
+    #[serde(default)]
+    pub num_kv_shared_layers: usize,
+    #[serde(default)]
+    pub use_double_wide_mlp: bool,
 }
 
 impl Gemma4TextConfig {

--- a/candle-transformers/src/models/gemma4/mod.rs
+++ b/candle-transformers/src/models/gemma4/mod.rs
@@ -167,7 +167,7 @@ impl Model {
         }
 
         self.language_model
-            .forward_embeds(&input_embeds, seqlen_offset, b_size, seq_len)
+            .forward_embeds(input_ids, &input_embeds, seqlen_offset, b_size, seq_len)
     }
 
     pub fn clear_kv_cache(&mut self) {

--- a/candle-transformers/src/models/gemma4/text.rs
+++ b/candle-transformers/src/models/gemma4/text.rs
@@ -9,7 +9,7 @@ use candle_nn::{linear_b as linear_bias, Activation, Linear, VarBuilder};
 
 use super::config::Gemma4TextConfig;
 
-// ── RmsNorm (Gemma-style with +1 offset) ────────────────────────────────────
+// ── RmsNorm (Gemma-style, but without any offset) ───────────────────────────
 
 #[derive(Debug, Clone)]
 struct RmsNorm {
@@ -35,9 +35,7 @@ impl Module for RmsNorm {
         let x = x.to_dtype(internal_dtype)?;
         let norm_x = (x.sqr()?.sum_keepdim(D::Minus1)? / hidden_size as f64)?;
         let x_normed = x.broadcast_div(&(norm_x + self.eps)?.sqrt()?)?;
-        x_normed
-            .to_dtype(x_dtype)?
-            .broadcast_mul(&(&self.weight + 1.0)?)
+        x_normed.to_dtype(x_dtype)?.broadcast_mul(&self.weight)
     }
 }
 

--- a/candle-transformers/src/models/gemma4/text.rs
+++ b/candle-transformers/src/models/gemma4/text.rs
@@ -221,7 +221,7 @@ enum KvCache {
 struct Attention {
     q_proj: Linear,
     k_proj: Linear,
-    v_proj: Linear,
+    v_proj: Option<Linear>,
     o_proj: Linear,
     q_norm: RmsNorm,
     k_norm: RmsNorm,
@@ -251,19 +251,31 @@ impl Attention {
         let bias = cfg.attention_bias;
         let is_sliding = cfg.is_sliding(layer_idx);
 
-        let (head_dim, num_kv_heads) = if is_sliding {
-            (cfg.head_dim, cfg.num_key_value_heads)
+        let head_dim = if is_sliding {
+            cfg.head_dim
         } else {
-            let global_kv = cfg
-                .num_global_key_value_heads
-                .unwrap_or(cfg.num_key_value_heads);
-            (cfg.global_head_dim, global_kv)
+            cfg.global_head_dim
+        };
+
+        let use_alternative_attention = cfg.attention_k_eq_v && !is_sliding;
+        let num_kv_heads = if use_alternative_attention {
+            cfg.num_global_key_value_heads.ok_or_else(|| {
+                candle::Error::Msg(
+                    "missing `num_global_key_value_heads` \
+                     (required by `attention_k_eq_v` for full layers)"
+                        .to_string(),
+                )
+            })?
+        } else {
+            cfg.num_key_value_heads
         };
 
         let num_kv_groups = num_heads / num_kv_heads;
         let q_proj = linear_bias(hidden_sz, num_heads * head_dim, bias, vb.pp("q_proj"))?;
         let k_proj = linear_bias(hidden_sz, num_kv_heads * head_dim, bias, vb.pp("k_proj"))?;
-        let v_proj = linear_bias(hidden_sz, num_kv_heads * head_dim, bias, vb.pp("v_proj"))?;
+        let v_proj = (!use_alternative_attention)
+            .then(|| linear_bias(hidden_sz, num_kv_heads * head_dim, bias, vb.pp("v_proj")))
+            .transpose()?;
         let o_proj = linear_bias(num_heads * head_dim, hidden_sz, bias, vb.pp("o_proj"))?;
         let q_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
         let k_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
@@ -311,7 +323,10 @@ impl Attention {
 
         let mut q = self.q_proj.forward(xs)?;
         let mut k = self.k_proj.forward(xs)?;
-        let v = self.v_proj.forward(xs)?;
+        let v = match &self.v_proj {
+            Some(v_proj) => v_proj.forward(xs)?,
+            _ => k.clone(),
+        };
 
         q = q
             .reshape((b_sz, q_len, self.num_heads, self.head_dim))?

--- a/candle-transformers/src/models/gemma4/text.rs
+++ b/candle-transformers/src/models/gemma4/text.rs
@@ -80,18 +80,15 @@ impl RotaryEmbedding {
         })
     }
 
-    fn apply_rotary_emb_qkv(
+    fn rotary_emb_cos_sin_for_query(
         &self,
         q: &Tensor,
-        k: &Tensor,
         seqlen_offset: usize,
     ) -> Result<(Tensor, Tensor)> {
         let (_b_sz, _h, seq_len, _n_embd) = q.dims4()?;
         let cos = self.cos.narrow(0, seqlen_offset, seq_len)?;
         let sin = self.sin.narrow(0, seqlen_offset, seq_len)?;
-        let q_embed = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
-        let k_embed = candle_nn::rotary_emb::rope(&k.contiguous()?, &cos, &sin)?;
-        Ok((q_embed, k_embed))
+        Ok((cos, sin))
     }
 }
 
@@ -133,18 +130,15 @@ impl ProportionalRotaryEmbedding {
         Ok(Self { cos, sin })
     }
 
-    fn apply_rotary_emb_qkv(
+    fn rotary_emb_cos_sin_for_query(
         &self,
         q: &Tensor,
-        k: &Tensor,
         seqlen_offset: usize,
     ) -> Result<(Tensor, Tensor)> {
         let (_b_sz, _h, seq_len, _n_embd) = q.dims4()?;
         let cos = self.cos.narrow(0, seqlen_offset, seq_len)?;
         let sin = self.sin.narrow(0, seqlen_offset, seq_len)?;
-        let q_embed = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
-        let k_embed = candle_nn::rotary_emb::rope(&k.contiguous()?, &cos, &sin)?;
-        Ok((q_embed, k_embed))
+        Ok((cos, sin))
     }
 }
 
@@ -213,26 +207,45 @@ enum KvCache {
     Rotating(candle_nn::kv_cache::RotatingKvCache),
 }
 
+// FIXME(eddyb) where should this be placed?
+#[derive(Default)]
+struct SharedKvStates {
+    for_full: Option<(Tensor, Tensor)>,
+    for_sliding: Option<(Tensor, Tensor)>,
+}
+
 // ── Attention ───────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone)]
 struct Attention {
+    kv: KvSource,
     q_proj: Linear,
-    k_proj: Linear,
-    v_proj: Option<Linear>,
     o_proj: Linear,
     q_norm: RmsNorm,
-    k_norm: RmsNorm,
     num_heads: usize,
-    num_kv_heads: usize,
     num_kv_groups: usize,
     head_dim: usize,
-    rms_norm_eps: f64,
     is_sliding: bool,
     rotary_emb_global: Arc<ProportionalRotaryEmbedding>,
     rotary_emb_local: Arc<RotaryEmbedding>,
-    kv_cache: KvCache,
     use_flash_attn: bool,
+}
+
+// FIXME(eddyb) where should this be placed?
+#[derive(Debug, Clone)]
+enum KvSource {
+    Computed {
+        k_proj: Linear,
+        v_proj: Option<Linear>,
+        k_norm: RmsNorm,
+        num_kv_heads: usize,
+        rms_norm_eps: f64,
+        kv_cache: KvCache,
+
+        // FIXME(eddyb) suboptimal name? should maybe mention "store to shared".
+        store_full_length_kv: bool,
+    },
+    Shared,
 }
 
 impl Attention {
@@ -270,42 +283,63 @@ impl Attention {
 
         let num_kv_groups = num_heads / num_kv_heads;
         let q_proj = linear_bias(hidden_sz, num_heads * head_dim, bias, vb.pp("q_proj"))?;
-        let k_proj = linear_bias(hidden_sz, num_kv_heads * head_dim, bias, vb.pp("k_proj"))?;
-        let v_proj = (!use_alternative_attention)
-            .then(|| linear_bias(hidden_sz, num_kv_heads * head_dim, bias, vb.pp("v_proj")))
-            .transpose()?;
         let o_proj = linear_bias(num_heads * head_dim, hidden_sz, bias, vb.pp("o_proj"))?;
         let q_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
-        let k_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
 
-        let kv_cache = if is_sliding {
-            KvCache::Rotating(candle_nn::kv_cache::RotatingKvCache::new(
-                2,
-                cfg.effective_sliding_window(),
-            ))
+        let first_kv_shared_layer_idx = cfg
+            .num_hidden_layers
+            .saturating_sub(cfg.num_kv_shared_layers);
+        let is_kv_shared_layer = layer_idx >= first_kv_shared_layer_idx;
+
+        let kv = if is_kv_shared_layer {
+            KvSource::Shared
         } else {
-            KvCache::Normal(candle_nn::kv_cache::KvCache::new(
-                2,
-                cfg.max_position_embeddings,
-            ))
+            let k_proj = linear_bias(hidden_sz, num_kv_heads * head_dim, bias, vb.pp("k_proj"))?;
+            let v_proj = (!use_alternative_attention)
+                .then(|| linear_bias(hidden_sz, num_kv_heads * head_dim, bias, vb.pp("v_proj")))
+                .transpose()?;
+            let k_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
+
+            let store_full_length_kv = !is_kv_shared_layer
+                && Some(layer_idx)
+                    == cfg.layer_types[..first_kv_shared_layer_idx]
+                        .iter()
+                        .rposition(|t| *t == cfg.layer_types[layer_idx]);
+
+            let kv_cache = if is_sliding {
+                KvCache::Rotating(candle_nn::kv_cache::RotatingKvCache::new(
+                    2,
+                    cfg.effective_sliding_window(),
+                ))
+            } else {
+                KvCache::Normal(candle_nn::kv_cache::KvCache::new(
+                    2,
+                    cfg.max_position_embeddings,
+                ))
+            };
+
+            KvSource::Computed {
+                k_proj,
+                v_proj,
+                k_norm,
+                num_kv_heads,
+                rms_norm_eps: cfg.rms_norm_eps,
+                kv_cache,
+                store_full_length_kv,
+            }
         };
 
         Ok(Self {
+            kv,
             q_proj,
-            k_proj,
-            v_proj,
             o_proj,
             q_norm,
-            k_norm,
             num_heads,
-            num_kv_heads,
             num_kv_groups,
             head_dim,
-            rms_norm_eps: cfg.rms_norm_eps,
             is_sliding,
             rotary_emb_global,
             rotary_emb_local,
-            kv_cache,
             use_flash_attn: cfg.use_flash_attn,
         })
     }
@@ -316,44 +350,80 @@ impl Attention {
         attention_mask: Option<&Tensor>,
         sliding_attention_mask: Option<&Tensor>,
         seqlen_offset: usize,
+
+        shared_kv_states: &mut SharedKvStates,
     ) -> Result<Tensor> {
         let (b_sz, q_len, _) = xs.dims3()?;
 
         let mut q = self.q_proj.forward(xs)?;
-        let mut k = self.k_proj.forward(xs)?;
-        let v = match &self.v_proj {
-            Some(v_proj) => v_proj.forward(xs)?,
-            _ => k.clone(),
-        };
 
         q = q
             .reshape((b_sz, q_len, self.num_heads, self.head_dim))?
             .transpose(1, 2)?;
-        k = k
-            .reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?
-            .transpose(1, 2)?;
-        let v = v
-            .reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?
-            .transpose(1, 2)?;
 
-        // Q/K norms
         q = self.q_norm.forward(&q)?;
-        k = self.k_norm.forward(&k)?;
-        // V norm (RMS without learned weight)
-        let v = v_norm(&v, self.rms_norm_eps)?;
 
-        // Apply RoPE
-        let (q, k) = if self.is_sliding {
+        let (cos, sin) = if self.is_sliding {
             self.rotary_emb_local
-                .apply_rotary_emb_qkv(&q, &k, seqlen_offset)?
+                .rotary_emb_cos_sin_for_query(&q, seqlen_offset)?
         } else {
             self.rotary_emb_global
-                .apply_rotary_emb_qkv(&q, &k, seqlen_offset)?
+                .rotary_emb_cos_sin_for_query(&q, seqlen_offset)?
         };
+        let q = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
 
-        let (k, v) = match &mut self.kv_cache {
-            KvCache::Normal(cache) => cache.append(&k, &v)?,
-            KvCache::Rotating(cache) => cache.append(&k, &v)?,
+        let (k, v) = match self.kv {
+            KvSource::Computed {
+                ref k_proj,
+                ref v_proj,
+                ref k_norm,
+                num_kv_heads,
+                rms_norm_eps,
+                ref mut kv_cache,
+                store_full_length_kv,
+            } => {
+                let mut k = k_proj.forward(xs)?;
+                let mut v = match v_proj {
+                    Some(v_proj) => v_proj.forward(xs)?,
+                    _ => k.clone(),
+                };
+                k = k
+                    .reshape((b_sz, q_len, num_kv_heads, self.head_dim))?
+                    .transpose(1, 2)?;
+                v = v
+                    .reshape((b_sz, q_len, num_kv_heads, self.head_dim))?
+                    .transpose(1, 2)?;
+
+                k = k_norm.forward(&k)?;
+
+                k = candle_nn::rotary_emb::rope(&k.contiguous()?, &cos, &sin)?;
+
+                // V norm (RMS without learned weight)
+                v = v_norm(&v, rms_norm_eps)?;
+
+                let (k, v) = match kv_cache {
+                    KvCache::Normal(cache) => cache.append(&k, &v)?,
+                    KvCache::Rotating(cache) => cache.append(&k, &v)?,
+                };
+
+                if store_full_length_kv {
+                    let kv = (k.clone(), v.clone());
+                    if self.is_sliding {
+                        shared_kv_states.for_sliding = Some(kv);
+                    } else {
+                        shared_kv_states.for_full = Some(kv);
+                    }
+                }
+
+                (k, v)
+            }
+            KvSource::Shared => {
+                if self.is_sliding {
+                    shared_kv_states.for_sliding.clone().unwrap()
+                } else {
+                    shared_kv_states.for_full.clone().unwrap()
+                }
+            }
         };
 
         let k = crate::utils::repeat_kv(k, self.num_kv_groups)?.contiguous()?;
@@ -387,9 +457,12 @@ impl Attention {
     }
 
     fn clear_kv_cache(&mut self) {
-        match &mut self.kv_cache {
-            KvCache::Normal(c) => c.reset(),
-            KvCache::Rotating(c) => c.reset(),
+        match &mut self.kv {
+            KvSource::Computed { kv_cache, .. } => match kv_cache {
+                KvCache::Normal(c) => c.reset(),
+                KvCache::Rotating(c) => c.reset(),
+            },
+            KvSource::Shared => {}
         }
     }
 }
@@ -437,9 +510,18 @@ impl DecoderLayer {
             layer_idx,
             vb.pp("self_attn"),
         )?;
+        let first_kv_shared_layer_idx = cfg
+            .num_hidden_layers
+            .saturating_sub(cfg.num_kv_shared_layers);
+        let is_kv_shared = first_kv_shared_layer_idx > 0 && layer_idx >= first_kv_shared_layer_idx;
+        let effective_intermediate = if cfg.use_double_wide_mlp && is_kv_shared {
+            cfg.intermediate_size * 2
+        } else {
+            cfg.intermediate_size
+        };
         let mlp = MLP::new(
             cfg.hidden_size,
-            cfg.intermediate_size,
+            effective_intermediate,
             cfg.hidden_activation,
             false,
             vb.pp("mlp"),
@@ -508,12 +590,17 @@ impl DecoderLayer {
         seqlen_offset: usize,
 
         per_layer_input: Option<&Tensor>,
+        shared_kv_states: &mut SharedKvStates,
     ) -> Result<Tensor> {
         let residual = xs;
         let xs = self.input_layernorm.forward(xs)?;
-        let xs =
-            self.self_attn
-                .forward(&xs, attention_mask, sliding_attention_mask, seqlen_offset)?;
+        let xs = self.self_attn.forward(
+            &xs,
+            attention_mask,
+            sliding_attention_mask,
+            seqlen_offset,
+            shared_kv_states,
+        )?;
         let xs = xs.apply(&self.post_attention_layernorm)?;
         let xs = (xs + residual)?;
         let residual = &xs;
@@ -766,6 +853,8 @@ impl TextModel {
             })
             .transpose()?;
 
+        let mut shared_kv_states = SharedKvStates::default();
+
         let mut xs = xs.clone();
         for (i, layer) in self.layers.iter_mut().enumerate() {
             xs = layer.forward(
@@ -778,6 +867,7 @@ impl TextModel {
                     .map(|per_layer_inputs| per_layer_inputs.get_on_dim(2, i))
                     .transpose()?
                     .as_ref(),
+                &mut shared_kv_states,
             )?
         }
         let logits = xs

--- a/candle-transformers/src/models/gemma4/text.rs
+++ b/candle-transformers/src/models/gemma4/text.rs
@@ -408,6 +408,17 @@ struct DecoderLayer {
     is_sliding: bool,
 
     layer_scalar: Tensor,
+
+    pli_mixer: Option<PerLayerInputMixer>,
+}
+
+// FIXME(eddyb) where should this be placed? should fields have `per_layer`?
+#[derive(Debug, Clone)]
+struct PerLayerInputMixer {
+    per_layer_input_gate: Linear,
+    act_fn: Activation,
+    per_layer_projection: Linear,
+    post_per_layer_input_norm: RmsNorm,
 }
 
 impl DecoderLayer {
@@ -450,6 +461,30 @@ impl DecoderLayer {
             cfg.rms_norm_eps,
             vb.pp("post_feedforward_layernorm"),
         )?;
+
+        let pli_mixer = if cfg.hidden_size_per_layer_input > 0 {
+            Some(PerLayerInputMixer {
+                per_layer_input_gate: candle_nn::linear_no_bias(
+                    cfg.hidden_size,
+                    cfg.hidden_size_per_layer_input,
+                    vb.pp("per_layer_input_gate"),
+                )?,
+                act_fn: cfg.hidden_activation,
+                per_layer_projection: candle_nn::linear_no_bias(
+                    cfg.hidden_size_per_layer_input,
+                    cfg.hidden_size,
+                    vb.pp("per_layer_projection"),
+                )?,
+                post_per_layer_input_norm: RmsNorm::new(
+                    cfg.hidden_size,
+                    cfg.rms_norm_eps,
+                    vb.pp("post_per_layer_input_norm"),
+                )?,
+            })
+        } else {
+            None
+        };
+
         Ok(Self {
             self_attn,
             mlp,
@@ -460,6 +495,8 @@ impl DecoderLayer {
             is_sliding,
 
             layer_scalar: vb.get(1, "layer_scalar")?,
+
+            pli_mixer,
         })
     }
 
@@ -469,6 +506,8 @@ impl DecoderLayer {
         attention_mask: Option<&Tensor>,
         sliding_attention_mask: Option<&Tensor>,
         seqlen_offset: usize,
+
+        per_layer_input: Option<&Tensor>,
     ) -> Result<Tensor> {
         let residual = xs;
         let xs = self.input_layernorm.forward(xs)?;
@@ -482,6 +521,20 @@ impl DecoderLayer {
         let xs = xs.apply(&self.mlp)?;
         let xs = xs.apply(&self.post_feedforward_layernorm)?;
         let xs = (residual + xs)?;
+
+        let xs = match (&self.pli_mixer, per_layer_input) {
+            (Some(pli_mixer), Some(per_layer_input)) => {
+                let residual = &xs;
+                let xs = xs.apply(&pli_mixer.per_layer_input_gate)?;
+                let xs = xs.apply(&pli_mixer.act_fn)?;
+                let xs = (xs * per_layer_input)?;
+                let xs = xs.apply(&pli_mixer.per_layer_projection)?;
+                let xs = xs.apply(&pli_mixer.post_per_layer_input_norm)?;
+                (residual + xs)?
+            }
+            (None, None) => xs,
+            _ => unreachable!(),
+        };
 
         xs.broadcast_mul(&self.layer_scalar)
     }
@@ -542,6 +595,17 @@ pub struct TextModel {
     dtype: DType,
     hidden_size: usize,
     sliding_window: usize,
+
+    ple: Option<PerLayerEmbeddings>,
+}
+
+// FIXME(eddyb) where should this be placed? should fields have `per_layer`?
+#[derive(Debug, Clone)]
+struct PerLayerEmbeddings {
+    hidden_size_per_layer_input: usize,
+    embed_tokens_per_layer: candle_nn::Embedding,
+    per_layer_model_projection: Linear,
+    per_layer_projection_norm: RmsNorm,
 }
 
 impl TextModel {
@@ -584,6 +648,30 @@ impl TextModel {
         } else {
             candle_nn::linear_no_bias(cfg.hidden_size, cfg.vocab_size, vb.pp("lm_head"))?
         };
+
+        let ple = if cfg.hidden_size_per_layer_input > 0 {
+            Some(PerLayerEmbeddings {
+                hidden_size_per_layer_input: cfg.hidden_size_per_layer_input,
+                embed_tokens_per_layer: candle_nn::embedding(
+                    cfg.vocab_size_per_layer_input,
+                    cfg.num_hidden_layers * cfg.hidden_size_per_layer_input,
+                    vb.pp("embed_tokens_per_layer"),
+                )?,
+                per_layer_model_projection: candle_nn::linear_no_bias(
+                    cfg.hidden_size,
+                    cfg.num_hidden_layers * cfg.hidden_size_per_layer_input,
+                    vb_m.pp("per_layer_model_projection"),
+                )?,
+                per_layer_projection_norm: RmsNorm::new(
+                    cfg.hidden_size_per_layer_input,
+                    cfg.rms_norm_eps,
+                    vb_m.pp("per_layer_projection_norm"),
+                )?,
+            })
+        } else {
+            None
+        };
+
         Ok(Self {
             embed_tokens,
             layers,
@@ -594,6 +682,8 @@ impl TextModel {
             dtype: vb.dtype(),
             hidden_size: cfg.hidden_size,
             sliding_window: cfg.sliding_window,
+
+            ple,
         })
     }
 
@@ -633,11 +723,12 @@ impl TextModel {
     pub fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
         let (b_size, seq_len) = input_ids.dims2()?;
         let xs = self.embed_tokens(input_ids)?;
-        self.forward_embeds(&xs, seqlen_offset, b_size, seq_len)
+        self.forward_embeds(input_ids, &xs, seqlen_offset, b_size, seq_len)
     }
 
     pub fn forward_embeds(
         &mut self,
+        input_ids: &Tensor,
         xs: &Tensor,
         seqlen_offset: usize,
         batch_size: usize,
@@ -646,13 +737,47 @@ impl TextModel {
         let (attention_mask, sliding_attention_mask) =
             self.create_attention_masks(batch_size, seq_len, seqlen_offset)?;
 
+        let per_layer_inputs = self
+            .ple
+            .as_ref()
+            .map(|ple| {
+                let inputs_embeds = xs;
+
+                let per_layer_projection = (xs.apply(&ple.per_layer_model_projection)?
+                    * (1.0 / (self.hidden_size as f64).sqrt()))?;
+
+                let mut shape = inputs_embeds.dims().to_vec();
+                shape.pop().unwrap();
+                shape.extend([self.layers.len(), ple.hidden_size_per_layer_input]);
+                let per_layer_projection = per_layer_projection.reshape(shape)?;
+                let per_layer_projection =
+                    per_layer_projection.apply(&ple.per_layer_projection_norm)?;
+
+                let per_layer_inputs = (input_ids.apply(&ple.embed_tokens_per_layer)?
+                    * (ple.hidden_size_per_layer_input as f64).sqrt())?
+                .reshape(
+                    input_ids
+                        .shape()
+                        .clone()
+                        .extend(&[self.layers.len(), ple.hidden_size_per_layer_input]),
+                )?;
+
+                (per_layer_projection + per_layer_inputs)? * (1.0 / 2.0f64.sqrt())
+            })
+            .transpose()?;
+
         let mut xs = xs.clone();
-        for layer in self.layers.iter_mut() {
+        for (i, layer) in self.layers.iter_mut().enumerate() {
             xs = layer.forward(
                 &xs,
                 attention_mask.as_ref(),
                 sliding_attention_mask.as_ref(),
                 seqlen_offset,
+                per_layer_inputs
+                    .as_ref()
+                    .map(|per_layer_inputs| per_layer_inputs.get_on_dim(2, i))
+                    .transpose()?
+                    .as_ref(),
             )?
         }
         let logits = xs

--- a/candle-transformers/src/models/gemma4/text.rs
+++ b/candle-transformers/src/models/gemma4/text.rs
@@ -406,6 +406,8 @@ struct DecoderLayer {
     post_feedforward_layernorm: RmsNorm,
     #[allow(dead_code)]
     is_sliding: bool,
+
+    layer_scalar: Tensor,
 }
 
 impl DecoderLayer {
@@ -456,6 +458,8 @@ impl DecoderLayer {
             pre_feedforward_layernorm,
             post_feedforward_layernorm,
             is_sliding,
+
+            layer_scalar: vb.get(1, "layer_scalar")?,
         })
     }
 
@@ -477,7 +481,9 @@ impl DecoderLayer {
         let xs = xs.apply(&self.pre_feedforward_layernorm)?;
         let xs = xs.apply(&self.mlp)?;
         let xs = xs.apply(&self.post_feedforward_layernorm)?;
-        residual + xs
+        let xs = (residual + xs)?;
+
+        xs.broadcast_mul(&self.layer_scalar)
     }
 
     fn clear_kv_cache(&mut self) {

--- a/candle-transformers/src/models/gemma4/text.rs
+++ b/candle-transformers/src/models/gemma4/text.rs
@@ -529,7 +529,7 @@ pub struct TextModel {
 
 impl TextModel {
     pub fn new(cfg: &Gemma4TextConfig, vb: VarBuilder) -> Result<Self> {
-        let vb_m = vb.pp("model");
+        let vb_m = vb.clone();
         let embed_tokens =
             candle_nn::embedding(cfg.vocab_size, cfg.hidden_size, vb_m.pp("embed_tokens"))?;
 

--- a/candle-transformers/src/models/gemma4/text.rs
+++ b/candle-transformers/src/models/gemma4/text.rs
@@ -369,11 +369,9 @@ impl Attention {
             let q = q.transpose(1, 2)?;
             let k = k.transpose(1, 2)?;
             let v = v.transpose(1, 2)?;
-            let scale = 1f32 / (self.head_dim as f32).sqrt();
-            flash_attn(&q, &k, &v, scale, mask.is_some())?.transpose(1, 2)?
+            flash_attn(&q, &k, &v, 1.0, mask.is_some())?.transpose(1, 2)?
         } else {
-            let scale = 1f64 / f64::sqrt(self.head_dim as f64);
-            let attn_weights = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
+            let attn_weights = q.matmul(&k.transpose(2, 3)?)?;
 
             let attn_weights = match mask {
                 None => attn_weights,

--- a/candle-transformers/src/models/gemma4/vision.rs
+++ b/candle-transformers/src/models/gemma4/vision.rs
@@ -204,14 +204,26 @@ impl VisionAttention {
         let num_heads = cfg.num_attention_heads;
         let num_kv_heads = cfg.num_key_value_heads;
         let head_dim = cfg.head_dim;
-        let q_proj =
-            candle_nn::linear_no_bias(cfg.hidden_size, num_heads * head_dim, vb.pp("q_proj"))?;
-        let k_proj =
-            candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("k_proj"))?;
-        let v_proj =
-            candle_nn::linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("v_proj"))?;
-        let o_proj =
-            candle_nn::linear_no_bias(num_heads * head_dim, cfg.hidden_size, vb.pp("o_proj"))?;
+        let q_proj = candle_nn::linear_no_bias(
+            cfg.hidden_size,
+            num_heads * head_dim,
+            vb.pp("q_proj").pp("linear"),
+        )?;
+        let k_proj = candle_nn::linear_no_bias(
+            cfg.hidden_size,
+            num_kv_heads * head_dim,
+            vb.pp("k_proj").pp("linear"),
+        )?;
+        let v_proj = candle_nn::linear_no_bias(
+            cfg.hidden_size,
+            num_kv_heads * head_dim,
+            vb.pp("v_proj").pp("linear"),
+        )?;
+        let o_proj = candle_nn::linear_no_bias(
+            num_heads * head_dim,
+            cfg.hidden_size,
+            vb.pp("o_proj").pp("linear"),
+        )?;
         let q_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
         let k_norm = RmsNorm::new(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
         Ok(Self {
@@ -284,12 +296,21 @@ struct VisionMlp {
 
 impl VisionMlp {
     fn new(cfg: &Gemma4VisionConfig, vb: VarBuilder) -> Result<Self> {
-        let gate_proj =
-            candle_nn::linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("gate_proj"))?;
-        let up_proj =
-            candle_nn::linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("up_proj"))?;
-        let down_proj =
-            candle_nn::linear_no_bias(cfg.intermediate_size, cfg.hidden_size, vb.pp("down_proj"))?;
+        let gate_proj = candle_nn::linear_no_bias(
+            cfg.hidden_size,
+            cfg.intermediate_size,
+            vb.pp("gate_proj").pp("linear"),
+        )?;
+        let up_proj = candle_nn::linear_no_bias(
+            cfg.hidden_size,
+            cfg.intermediate_size,
+            vb.pp("up_proj").pp("linear"),
+        )?;
+        let down_proj = candle_nn::linear_no_bias(
+            cfg.intermediate_size,
+            cfg.hidden_size,
+            vb.pp("down_proj").pp("linear"),
+        )?;
         Ok(Self {
             gate_proj,
             up_proj,


### PR DESCRIPTION
See individual commits for specific changes - 12B/31B need only the first two commits to start loading (and the first 5 commits to stop outputting gibberish), but E2B/E4B have several atypical features that required extra implementation work.

Some of the initial fixes were based on https://github.com/huggingface/candle/issues/3448#issuecomment-4322047232 (thanks, @PCfVW!).

But for the most part, I had to reference the Python `transformers` implementation, and ended up debugging individual `Tensor`s for a while - for which I ended up using the `.sum_all()` as a proxy, e.g.:
```rust
// Rust
if self.layer_idx <= 1 {
    println!(
        "layer {} hidden_states={} per_layer_input={}",
        self.layer_idx,
        xs.to_dtype(DType::F64).unwrap().sum_all().unwrap().to_scalar::<f64>().unwrap(),
        per_layer_input.unwrap().to_dtype(DType::F64).unwrap().sum_all().unwrap().to_scalar::<f64>().unwrap(),
    );
}
```
```python
# Python
if self.layer_idx <= 1:
    print(f"layer {self.layer_idx} hidden_states={hidden_states.double().sum()} per_layer_input={per_layer_input.double().sum()}")
```
(this isn't foolproof, but if these sums differ, the `Tensor`s must differ too)

---

The MoE model (26B-A4B) should also be possible to get working, but requires some extra porting I haven't tried doing yet, and this has been sitting around long enough.

---

Since starting on this, I've noticed some overlap with:
- https://github.com/huggingface/candle/pull/3488

It's possible that there are still subtle differences that only that PR, or neither of them, actually addresses (I've been meaning to test against the Python `transformers` implementation with random input vectors, haven't done that yet).