### PR TITLE
Fix Qwen3 causal mask for batch size > 1

### DIFF
--- a/candle-transformers/src/models/qwen3.rs
+++ b/candle-transformers/src/models/qwen3.rs
@@ -461,7 +461,9 @@ impl Model {
                 })
             })
             .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
+        Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), &self.device)?
+            .to_dtype(self.dtype)?
+            .expand((b, 1, tgt, tgt + offset))
     }
 
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
@@ -514,5 +516,44 @@ impl ModelForCausalLM {
 
     pub fn clear_kv_cache(&mut self) {
         self.base.clear_kv_cache();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn causal_mask_is_correct_for_every_batch_row() -> Result<()> {
+        let cfg = Config {
+            vocab_size: 16,
+            hidden_size: 8,
+            intermediate_size: 16,
+            num_hidden_layers: 1,
+            num_attention_heads: 2,
+            head_dim: 4,
+            attention_bias: false,
+            num_key_value_heads: 2,
+            max_position_embeddings: 32,
+            sliding_window: None,
+            max_window_layers: 1,
+            tie_word_embeddings: false,
+            rope_theta: 10_000.,
+            rms_norm_eps: 1e-6,
+            use_sliding_window: false,
+            hidden_act: Activation::Silu,
+        };
+        let vb = VarBuilder::zeros(DType::F32, &Device::Cpu);
+        let model = Model::new(&cfg, vb)?;
+
+        let (b, tgt, offset) = (3, 2, 1);
+        let mask = model.causal_mask(b, tgt, offset, None)?;
+        assert_eq!(mask.dims(), [b, 1, tgt, tgt + offset]);
+        let rows = mask.reshape((b, tgt, tgt + offset))?.to_vec3::<f32>()?;
+        let expected = vec![vec![0., 0., f32::NEG_INFINITY], vec![0., 0., 0.]];
+        for (batch_idx, row) in rows.iter().enumerate() {
+            assert_eq!(row, &expected, "wrong mask for batch row {batch_idx}");
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
`Model::causal_mask` filled `tgt * (tgt + offset)` elements but declared the shape `(b, 1, tgt, tgt + offset)`, so only batch row 0 carried a valid mask and rows >= 1 attended over a corrupt, effectively non-causal pattern — two identical sequences in one batch produce different outputs (row 0 correct, row 1 garbage).

Build the mask as `(1, 1, tgt, tgt + offset)` and `expand` it across the batch (a zero-copy view). Adds a unit test asserting every batch row gets the correct causal pattern; it fails on the previous behavior.

Related to #3609 (Qwen2 mask fix); this one is the batch-dimension variant in Qwen3.

Fixes #3582

🤖 Generated with [Claude Code](https://claude.com/claude-code)