### PR TITLE
Fix batch>1 causal masks in GLM4 and Qwen3 model variants

### DIFF
--- a/candle-transformers/src/models/glm4_new.rs
+++ b/candle-transformers/src/models/glm4_new.rs
@@ -329,33 +329,6 @@ impl Model {
         }
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| {
-                    let past_ok = j <= i + offset;
-                    let sw_ok = match sw {
-                        Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
-                        None => true,
-                    };
-                    if past_ok && sw_ok {
-                        0.
-                    } else {
-                        minf
-                    }
-                })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
         let (b, l) = input.dims2()?;
         let mut h = self.embed_tokens.forward(input)?;
@@ -363,7 +336,14 @@ impl Model {
         let causal = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(crate::utils::additive_causal_mask(
+                b,
+                l,
+                offset,
+                None,
+                &self.device,
+                self.dtype,
+            )?)
         };
 
         for layer in &mut self.layers {

--- a/candle-transformers/src/models/quantized_glm4.rs
+++ b/candle-transformers/src/models/quantized_glm4.rs
@@ -427,33 +427,6 @@ impl ModelWeights {
         })
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| {
-                    let past_ok = j <= i + offset;
-                    let sw_ok = match sw {
-                        Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
-                        None => true,
-                    };
-                    if past_ok && sw_ok {
-                        0.
-                    } else {
-                        minf
-                    }
-                })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
         let _enter = self.span.enter();
         let (b, l) = input.dims2()?;
@@ -462,7 +435,14 @@ impl ModelWeights {
         let causal_mask = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(crate::utils::additive_causal_mask(
+                b,
+                l,
+                offset,
+                None,
+                &self.device,
+                self.dtype,
+            )?)
         };
 
         for layer in &mut self.layers {

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -536,33 +536,6 @@ impl ModelWeights {
         })
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| {
-                    let past_ok = j <= i + offset;
-                    let sw_ok = match sw {
-                        Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
-                        None => true,
-                    };
-                    if past_ok && sw_ok {
-                        0.
-                    } else {
-                        minf
-                    }
-                })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
         let _enter = self.span.enter();
         let (b, l) = input.dims2()?;
@@ -571,7 +544,14 @@ impl ModelWeights {
         let causal_mask = if l == 1 || self.device.is_cpu() {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(crate::utils::additive_causal_mask(
+                b,
+                l,
+                offset,
+                None,
+                &self.device,
+                self.dtype,
+            )?)
         };
         for layer in &mut self.layers {
             h = layer.forward(&h, causal_mask.as_ref(), offset)?;

--- a/candle-transformers/src/models/quantized_qwen3_moe.rs
+++ b/candle-transformers/src/models/quantized_qwen3_moe.rs
@@ -391,33 +391,6 @@ impl GGUFQWenMoE {
         })
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| {
-                    let past_ok = j <= i + offset;
-                    let sw_ok = match sw {
-                        Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
-                        None => true,
-                    };
-                    if past_ok && sw_ok {
-                        0.
-                    } else {
-                        minf
-                    }
-                })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     pub fn forward(&mut self, x: &Tensor, offset: usize) -> Result<Tensor> {
         let mut xs = self.tok_embeddings.forward(x)?;
         let (b, l) = x.dims2()?;
@@ -425,7 +398,14 @@ impl GGUFQWenMoE {
         let causal_mask = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(crate::utils::additive_causal_mask(
+                b,
+                l,
+                offset,
+                None,
+                &self.device,
+                self.dtype,
+            )?)
         };
 
         for layer in self.layers.iter_mut() {

--- a/candle-transformers/src/models/qwen3_moe.rs
+++ b/candle-transformers/src/models/qwen3_moe.rs
@@ -299,33 +299,6 @@ impl Model {
         }
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| {
-                    let past_ok = j <= i + offset;
-                    let sw_ok = match sw {
-                        Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
-                        None => true,
-                    };
-                    if past_ok && sw_ok {
-                        0.
-                    } else {
-                        minf
-                    }
-                })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
         let (b, l) = input.dims2()?;
         let mut h = self.embed_tokens.forward(input)?;
@@ -333,7 +306,14 @@ impl Model {
         let causal = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(crate::utils::additive_causal_mask(
+                b,
+                l,
+                offset,
+                None,
+                &self.device,
+                self.dtype,
+            )?)
         };
 
         for layer in &mut self.layers {

--- a/candle-transformers/src/utils.rs
+++ b/candle-transformers/src/utils.rs
@@ -1,6 +1,6 @@
 //! Shared utilities: repeat_kv, repeat_penalty, causal mask.
 
-use candle::{Device, Result, Tensor};
+use candle::{DType, Device, Result, Tensor};
 
 /// Build a causal attention mask of shape `(seq_len, kv_len)` where
 /// `kv_len = index_pos + seq_len`.
@@ -20,6 +20,43 @@ pub fn build_causal_mask(seq_len: usize, index_pos: usize, device: &Device) -> R
         .flat_map(|i| (0..kv_len).map(move |j| u8::from(j > index_pos + i)))
         .collect();
     Tensor::from_slice(&mask, (seq_len, kv_len), device)
+}
+
+/// Build an additive causal attention bias of shape `(b, 1, tgt, tgt + offset)`:
+/// `0.` where attention is allowed and `-inf` where it is masked, for use with
+/// `broadcast_add` on attention scores. Queries attend to keys `j <= i + offset`,
+/// optionally restricted to a sliding window of `sw` positions back.
+///
+/// Unlike [`build_causal_mask`], the data is built once and expanded across the
+/// batch (a zero-copy view), so every batch row carries the same valid mask.
+pub fn additive_causal_mask(
+    b: usize,
+    tgt: usize,
+    offset: usize,
+    sw: Option<usize>,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    let minf = f32::NEG_INFINITY;
+    let mask: Vec<_> = (0..tgt)
+        .flat_map(|i| {
+            (0..(tgt + offset)).map(move |j| {
+                let past_ok = j <= i + offset;
+                let sw_ok = match sw {
+                    Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
+                    None => true,
+                };
+                if past_ok && sw_ok {
+                    0.
+                } else {
+                    minf
+                }
+            })
+        })
+        .collect();
+    Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), device)?
+        .to_dtype(dtype)?
+        .expand((b, 1, tgt, tgt + offset))
 }
 
 pub fn apply_repeat_penalty(logits: &Tensor, penalty: f32, context: &[u32]) -> Result<Tensor> {
@@ -54,5 +91,42 @@ pub fn repeat_kv(xs: Tensor, n_rep: usize) -> Result<Tensor> {
         // strided copy.
         // https://github.com/huggingface/candle/pull/2043
         Tensor::cat(&vec![&xs; n_rep], 2)?.reshape((b_sz, n_kv_head * n_rep, seq_len, head_dim))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::additive_causal_mask;
+    use candle::{DType, Device};
+
+    const NI: f32 = f32::NEG_INFINITY;
+
+    /// Regression test for the per-model `causal_mask` helpers this replaces: the
+    /// data was built batch-independent but declared with a batched shape, so
+    /// batch rows >= 1 read garbage (see #3582).
+    #[test]
+    fn batched_rows_are_all_valid_with_offset() -> candle::Result<()> {
+        let m = additive_causal_mask(3, 2, 1, None, &Device::Cpu, DType::F32)?;
+        assert_eq!(m.dims(), [3, 1, 2, 3]);
+        let rows = m.reshape((3, 2, 3))?.to_vec3::<f32>()?;
+        let expected = vec![vec![0., 0., NI], vec![0., 0., 0.]];
+        for (b, row) in rows.iter().enumerate() {
+            assert_eq!(row, &expected, "wrong mask for batch row {b}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn sliding_window_limits_lookback() -> candle::Result<()> {
+        let m = additive_causal_mask(1, 4, 0, Some(1), &Device::Cpu, DType::F32)?;
+        let rows = m.reshape((4, 4))?.to_vec2::<f32>()?;
+        let expected = vec![
+            vec![0., NI, NI, NI],
+            vec![0., 0., NI, NI],
+            vec![NI, 0., 0., NI],
+            vec![NI, NI, 0., 0.],
+        ];
+        assert_eq!(rows, expected);
+        Ok(())
     }
 }


### PR DESCRIPTION
Five models (glm4_new, quantized_glm4, quantized_qwen3, qwen3_moe, quantized_qwen3_moe) carried byte-identical copies of qwen3's `causal_mask` helper, sharing its bug: the mask data is built independent of the batch size but declared with shape `(b, 1, tgt, tgt + offset)`, so only batch row 0 is valid and rows >= 1 attend over a corrupt pattern. Same bug as #3582, fixed for qwen3 in #3610.

Replaces the copies with a shared `utils::additive_causal_mask` that builds the data once and expands it across the batch (zero-copy view), with unit tests covering batching, KV offset, and sliding window. Net -26 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)