### PR TITLE
Add backward pass to fused layer_norm

### DIFF
--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -864,6 +864,49 @@ impl candle::CustomOp3 for LayerNorm {
         let newstorage = candle::MetalStorage::new(output, device.clone(), elem_count, s1.dtype());
         Ok((newstorage, l1.shape().clone()))
     }
+
+    fn bwd(
+        &self,
+        xs: &Tensor,
+        alpha: &Tensor,
+        beta: &Tensor,
+        _res: &Tensor,
+        grad_res: &Tensor,
+    ) -> Result<(Option<Tensor>, Option<Tensor>, Option<Tensor>)> {
+        // y = (x - mean) / sqrt(var + eps) * alpha + beta, statistics over the last dim.
+        let x_dtype = xs.dtype();
+        let internal_dtype = match x_dtype {
+            DType::F16 | DType::BF16 => DType::F32,
+            d => d,
+        };
+        let n = xs.dim(D::Minus1)?;
+        let xs = xs.to_dtype(internal_dtype)?;
+        let grad = grad_res.to_dtype(internal_dtype)?;
+        let alpha_i = alpha.to_dtype(internal_dtype)?;
+
+        let mean = (xs.sum_keepdim(D::Minus1)? / n as f64)?;
+        let centered = xs.broadcast_sub(&mean)?;
+        let var = (centered.sqr()?.sum_keepdim(D::Minus1)? / n as f64)?;
+        let std = (var + self.eps as f64)?.sqrt()?;
+        let x_hat = centered.broadcast_div(&std)?;
+
+        // g is the gradient with respect to the normalized activations:
+        // grad_x = (g - mean(g) - x_hat * mean(g * x_hat)) / std
+        let g = grad.broadcast_mul(&alpha_i)?;
+        let g_mean = (g.sum_keepdim(D::Minus1)? / n as f64)?;
+        let gx_mean = ((&g * &x_hat)?.sum_keepdim(D::Minus1)? / n as f64)?;
+        let grad_x = ((g.broadcast_sub(&g_mean)? - x_hat.broadcast_mul(&gx_mean)?)?
+            .broadcast_div(&std)?)
+        .to_dtype(x_dtype)?;
+
+        let grad_alpha = (&grad * &x_hat)?
+            .reshape(((), n))?
+            .sum(0)?
+            .to_dtype(alpha.dtype())?;
+        let grad_beta = grad.reshape(((), n))?.sum(0)?.to_dtype(beta.dtype())?;
+
+        Ok((Some(grad_x), Some(grad_alpha), Some(grad_beta)))
+    }
 }
 
 pub fn layer_norm_slow(x: &Tensor, alpha: &Tensor, beta: &Tensor, eps: f32) -> Result<Tensor> {
@@ -898,7 +941,7 @@ pub fn layer_norm(xs: &Tensor, alpha: &Tensor, beta: &Tensor, eps: f32) -> Resul
             beta.shape()
         )
     }
-    xs.apply_op3_no_bwd(alpha, beta, &LayerNorm { eps })
+    xs.apply_op3(alpha, beta, LayerNorm { eps })
 }
 
 // https://pytorch.org/docs/stable/generated/torch.nn.PixelShuffle.html

--- a/candle-nn/tests/layer_norm.rs
+++ b/candle-nn/tests/layer_norm.rs
@@ -61,3 +61,64 @@ fn layer_norm() -> Result<()> {
 
     Ok(())
 }
+
+/// Gradients must flow through the fused layer_norm and match the gradients of
+/// the pure-tensor layer_norm_slow implementation, for x, alpha, and beta.
+#[test]
+fn layer_norm_grad() -> Result<()> {
+    use candle::{Device, Var};
+
+    let device = &Device::Cpu;
+    let (rows, n) = (4, 6);
+    let xs: Vec<f32> = (0..rows * n)
+        .map(|i| (i as f32 * 0.37).sin() * 3.0)
+        .collect();
+    let alpha: Vec<f32> = (0..n).map(|i| 0.5 + (i as f32 * 0.11).cos()).collect();
+    let beta: Vec<f32> = (0..n).map(|i| (i as f32 * 0.23).sin()).collect();
+    let weight: Vec<f32> = (0..rows * n).map(|i| (i as f32 * 0.53).cos()).collect();
+    let xs = Tensor::from_vec(xs, (rows, n), device)?;
+    let alpha = Tensor::from_vec(alpha, n, device)?;
+    let beta = Tensor::from_vec(beta, n, device)?;
+    let weight = Tensor::from_vec(weight, (rows, n), device)?;
+
+    let grads_of = |fused: bool| -> Result<(Tensor, Tensor, Tensor)> {
+        let x_var = Var::from_tensor(&xs)?;
+        let a_var = Var::from_tensor(&alpha)?;
+        let b_var = Var::from_tensor(&beta)?;
+        let y = if fused {
+            candle_nn::ops::layer_norm(
+                x_var.as_tensor(),
+                a_var.as_tensor(),
+                b_var.as_tensor(),
+                1e-5,
+            )?
+        } else {
+            candle_nn::ops::layer_norm_slow(
+                x_var.as_tensor(),
+                a_var.as_tensor(),
+                b_var.as_tensor(),
+                1e-5,
+            )?
+        };
+        let loss = (y * &weight)?.sum_all()?;
+        let grads = loss.backward()?;
+        let err = || candle::Error::Msg("missing gradient".to_string());
+        Ok((
+            grads.get(&x_var).cloned().ok_or_else(err)?,
+            grads.get(&a_var).cloned().ok_or_else(err)?,
+            grads.get(&b_var).cloned().ok_or_else(err)?,
+        ))
+    };
+
+    let (gx_f, ga_f, gb_f) = grads_of(true)?;
+    let (gx_s, ga_s, gb_s) = grads_of(false)?;
+    for (name, f, s) in [
+        ("x", gx_f, gx_s),
+        ("alpha", ga_f, ga_s),
+        ("beta", gb_f, gb_s),
+    ] {
+        let diff = (&f - &s)?.abs()?.max_all()?.to_vec0::<f32>()?;
+        assert!(diff < 1e-4, "grad mismatch for {name}: {diff}");
+    }
+    Ok(())
+}


### PR DESCRIPTION
`candle_nn::ops::layer_norm` used `apply_op3_no_bwd`, so `loss.backward()` silently returned no gradient for any `Var` upstream of it, while `layer_norm_slow` is differentiable. Same naming footgun as rms_norm (#3526), softmax_last_dim (#3591), and rope (#3568).

Implements the standard layernorm backward with backend-agnostic tensor ops (computed in f32 for f16/bf16 inputs, matching the forward kernels), returning gradients for x, alpha, and beta. Adds a gradient test comparing the fused path against `layer_norm_slow` autograd; it fails on the previous behavior with a missing gradient.

Fixes #3011

🤖 Generated with [Claude Code](https://claude.com/claude-code)