### PR TITLE
Validate from_slice/from_vec shapes and add stepped slice_assign

### DIFF
--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -522,6 +522,13 @@ impl Tensor {
         is_variable: bool,
     ) -> Result<Self> {
         let shape = shape.into_shape(data.len())?;
+        if shape.elem_count() != data.len() {
+            return Err(Error::ShapeMismatch {
+                buffer_size: data.len(),
+                shape,
+            }
+            .bt());
+        }
         let storage = device.storage_owned(data)?;
         let none = BackpropOp::none();
         Ok(from_storage(storage, shape, none, is_variable))
@@ -567,6 +574,13 @@ impl Tensor {
         device: &Device,
     ) -> Result<Self> {
         let shape = shape.into_shape(array.len())?;
+        if shape.elem_count() != array.len() {
+            return Err(Error::ShapeMismatch {
+                buffer_size: array.len(),
+                shape,
+            }
+            .bt());
+        }
         let storage = device.storage_from_slice(array)?;
         let none = BackpropOp::none();
         Ok(from_storage(storage, shape, none, false))
@@ -2873,6 +2887,84 @@ impl Tensor {
             }
             src = src.pad_with_zeros(i, start_included, self_dims[i] - end_excluded)?;
             mask = mask.pad_with_zeros(i, start_included, self_dims[i] - end_excluded)?
+        }
+        mask.where_cond(/* on_true= */ &src, /* on_false= */ self)
+    }
+
+    /// Returns a copy of `self` where the values within the stepped `ranges` have been replaced
+    /// with the content of `src`. Each range comes with a step: element `k` of `src` along dim
+    /// `i` is written at position `start + k * step`, like Python's `dst[start:end:step] = src`.
+    pub fn slice_assign_with_step<D: std::ops::RangeBounds<usize>>(
+        &self,
+        ranges: &[(D, usize)],
+        src: &Tensor,
+    ) -> Result<Self> {
+        let src_dims = src.dims();
+        let self_dims = self.dims();
+        if self_dims.len() != src_dims.len() {
+            bail!(
+                "slice-assign requires input with the same rank {} <> {}",
+                self_dims.len(),
+                src_dims.len()
+            )
+        }
+        if self_dims.len() != ranges.len() {
+            bail!(
+                "slice-assign requires input with the same rank as there are ranges {} <> {}",
+                self_dims.len(),
+                ranges.len()
+            )
+        }
+        let mut src = src.clone();
+        let mut mask = Self::ones(src.shape(), DType::U8, src.device())?;
+        for (i, (range, step)) in ranges.iter().enumerate() {
+            let step = *step;
+            if step == 0 {
+                bail!("slice-assign: step must be non-zero for dim {i}")
+            }
+            let start_included = match range.start_bound() {
+                std::ops::Bound::Unbounded => 0,
+                std::ops::Bound::Included(v) => *v,
+                std::ops::Bound::Excluded(v) => *v + 1,
+            };
+            let end_excluded = match range.end_bound() {
+                std::ops::Bound::Unbounded => self_dims[i],
+                std::ops::Bound::Included(v) => *v + 1,
+                std::ops::Bound::Excluded(v) => *v,
+            };
+            if end_excluded <= start_included {
+                bail!("slice-assign: empty range for dim {i}, {start_included} {end_excluded}")
+            }
+            if self_dims[i] < end_excluded {
+                bail!(
+                    "slice-assign: upper bound is out of range for dim {i}, {end_excluded} {}",
+                    self_dims[i]
+                )
+            }
+            let covered = (end_excluded - start_included).div_ceil(step);
+            if covered != src_dims[i] {
+                bail!(
+                    "slice-assign: the range for dim {i} ({start_included}..{end_excluded} step {step}) covers {covered} positions but src has {}",
+                    src_dims[i]
+                )
+            }
+            if step > 1 {
+                // Dilate src and mask along dim i: element k moves to position k * step.
+                let dilate = |t: &Tensor| -> Result<Tensor> {
+                    let n = t.dim(i)?;
+                    let mut dims = t.dims().to_vec();
+                    dims[i] = n * step;
+                    t.unsqueeze(i + 1)?
+                        .pad_with_zeros(i + 1, 0, step - 1)?
+                        .reshape(dims)?
+                        .narrow(i, 0, n * step - (step - 1))
+                };
+                src = dilate(&src)?;
+                mask = dilate(&mask)?;
+            }
+            let len = src.dim(i)?;
+            src = src.pad_with_zeros(i, start_included, self_dims[i] - start_included - len)?;
+            mask = mask.pad_with_zeros(i, start_included, self_dims[i] - start_included - len)?;
         }
         mask.where_cond(/* on_true= */ &src, /* on_false= */ self)
     }

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -2094,3 +2094,51 @@ fn allocates_twice_when_transferring_to_same_device() -> Result<()> {
     assert_ne!(id1, id2);
     Ok(())
 }
+
+/// `from_vec`/`from_slice` must reject shapes whose element count does not
+/// match the data length instead of building a tensor whose shape lies about
+/// its storage (#3534). `from_raw_buffer` routes through `from_slice`.
+#[test]
+fn from_data_shape_mismatch_errors() -> Result<()> {
+    let dev = &Device::Cpu;
+    assert!(Tensor::from_slice(&[0f32], 10, dev).is_err());
+    assert!(Tensor::from_vec(vec![0f32; 4], (2, 3), dev).is_err());
+    // Exact matches and one-hole inference keep working.
+    let t = Tensor::from_slice(&[0f32, 1., 2., 3.], (2, 2), dev)?;
+    assert_eq!(t.dims(), [2, 2]);
+    let t = Tensor::from_vec(vec![0f32; 6], ((), 3), dev)?;
+    assert_eq!(t.dims(), [2, 3]);
+    Ok(())
+}
+
+/// Stepped slice assignment matches the equivalent Python `dst[s:e:step] = src` semantics.
+#[test]
+fn slice_assign_with_step() -> Result<()> {
+    let dev = &Device::Cpu;
+    // 1-D: dst[1..8 step 3] = [10, 20, 30]
+    let dst = Tensor::zeros(8, DType::F32, dev)?;
+    let src = Tensor::from_vec(vec![10f32, 20., 30.], 3, dev)?;
+    let out = dst.slice_assign_with_step(&[(1..8, 3)], &src)?;
+    assert_eq!(out.to_vec1::<f32>()?, [0., 10., 0., 0., 20., 0., 0., 30.]);
+
+    // 2-D mixed steps: rows step 2, cols step 1.
+    let dst = Tensor::zeros((4, 3), DType::F32, dev)?;
+    let src = Tensor::from_vec(vec![1f32, 2., 3., 4., 5., 6.], (2, 3), dev)?;
+    let out = dst.slice_assign_with_step(&[(0..4, 2), (0..3, 1)], &src)?;
+    assert_eq!(
+        out.to_vec2::<f32>()?,
+        [[1., 2., 3.], [0., 0., 0.], [4., 5., 6.], [0., 0., 0.]]
+    );
+
+    // step 1 behaves exactly like slice_assign.
+    let dst = Tensor::zeros(4, DType::F32, dev)?;
+    let src = Tensor::from_vec(vec![7f32, 8.], 2, dev)?;
+    let a = dst.slice_assign_with_step(&[(1..3, 1)], &src)?;
+    let b = dst.slice_assign(&[1..3], &src)?;
+    assert_eq!(a.to_vec1::<f32>()?, b.to_vec1::<f32>()?);
+
+    // step 0 and src-length mismatches are errors.
+    assert!(dst.slice_assign_with_step(&[(1..3, 0)], &src).is_err());
+    assert!(dst.slice_assign_with_step(&[(0..4, 4)], &src).is_err());
+    Ok(())
+}


### PR DESCRIPTION
`from_slice` and `from_vec` accepted shapes whose element count does not match the data length, building tensors whose shape lies about their storage; reads past the data then fail or silently misbehave later (#3534). Both now return `Error::ShapeMismatch`, while one-hole shape inference keeps working. This also turns silent mask-construction bugs of the #3582 family into immediate errors.

Adds `slice_assign_with_step`, the stepped counterpart of `slice_assign` matching Python's `dst[start:end:step] = src` semantics (#3095), built on the same mask/pad approach with zero-dilation along stepped dims; tests cover 1-D/2-D mixed steps, step-1 equivalence with `slice_assign`, and error cases.

Note: this implements the validation approach @pjdurden outlined on #3534 last month; happy to defer if that work is still in flight.

Fixes #3534
Fixes #3095

🤖 Generated with [Claude Code](https://claude.com/claude-code)
