### PR TITLE
Fix Qwen3 causal mask for batch size > 1 (#3582)

### DIFF
--- a/candle-transformers/src/models/qwen3.rs
+++ b/candle-transformers/src/models/qwen3.rs
@@ -461,7 +461,9 @@ impl Model {
                 })
             })
             .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
+        Tensor::from_slice(&mask, (tgt, tgt + offset), &self.device)?
+            .expand((b, 1, tgt, tgt + offset))?
+            .to_dtype(self.dtype)
     }
 
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
@@ -514,5 +516,57 @@ impl ModelForCausalLM {
 
     pub fn clear_kv_cache(&mut self) {
         self.base.clear_kv_cache();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::IndexOp;
+    use candle_nn::VarMap;
+
+    fn tiny_config() -> Config {
+        Config {
+            vocab_size: 16,
+            hidden_size: 8,
+            intermediate_size: 16,
+            num_hidden_layers: 1,
+            num_attention_heads: 2,
+            head_dim: 4,
+            attention_bias: false,
+            num_key_value_heads: 1,
+            max_position_embeddings: 32,
+            sliding_window: None,
+            max_window_layers: 0,
+            tie_word_embeddings: false,
+            rope_theta: 10000.0,
+            rms_norm_eps: 1e-6,
+            use_sliding_window: false,
+            hidden_act: Activation::Silu,
+        }
+    }
+
+    // Regression test for https://github.com/huggingface/candle/issues/3582:
+    // the causal mask is batch-independent, so every batch row must be the exact
+    // same mask. Before the fix the buffer held only `tgt * (tgt + offset)`
+    // values but was shaped `(b, 1, tgt, tgt + offset)`, leaving rows >= 1 backed
+    // by out-of-range data and corrupting attention for batch size > 1.
+    #[test]
+    fn causal_mask_is_batch_independent() -> Result<()> {
+        let device = Device::Cpu;
+        let vb = VarBuilder::from_varmap(&VarMap::new(), DType::F32, &device);
+        let model = Model::new(&tiny_config(), vb)?;
+        let (b, tgt) = (3, 5);
+        let mask = model.causal_mask(b, tgt, 0, None)?;
+        assert_eq!(mask.dims(), &[b, 1, tgt, tgt]);
+        let row0 = mask.i(0)?.flatten_all()?.to_vec1::<f32>()?;
+        for r in 1..b {
+            let row = mask.i(r)?.flatten_all()?.to_vec1::<f32>()?;
+            assert_eq!(
+                row, row0,
+                "batch row {r} of the causal mask differs from row 0"
+            );
+        }
+        Ok(())
     }
 }

--- a/candle-transformers/src/models/qwen3_moe.rs
+++ b/candle-transformers/src/models/qwen3_moe.rs
@@ -323,7 +323,9 @@ impl Model {
                 })
             })
             .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
+        Tensor::from_slice(&mask, (tgt, tgt + offset), &self.device)?
+            .expand((b, 1, tgt, tgt + offset))?
+            .to_dtype(self.dtype)
     }
 
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
@@ -370,5 +372,62 @@ impl ModelForCausalLM {
 
     pub fn clear_kv_cache(&mut self) {
         self.base.clear_kv_cache();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::IndexOp;
+    use candle_nn::VarMap;
+
+    fn tiny_config() -> Config {
+        Config {
+            vocab_size: 16,
+            hidden_size: 8,
+            intermediate_size: 16,
+            num_hidden_layers: 1,
+            num_attention_heads: 2,
+            head_dim: 4,
+            attention_bias: false,
+            num_key_value_heads: 1,
+            max_position_embeddings: 32,
+            sliding_window: None,
+            max_window_layers: 0,
+            tie_word_embeddings: false,
+            rope_theta: 10000.0,
+            rms_norm_eps: 1e-6,
+            use_sliding_window: false,
+            hidden_act: Activation::Silu,
+            decoder_sparse_step: 1,
+            moe_intermediate_size: 16,
+            num_experts_per_tok: 2,
+            num_experts: 4,
+            norm_topk_prob: true,
+        }
+    }
+
+    // Regression test for https://github.com/huggingface/candle/issues/3582:
+    // the causal mask is batch-independent, so every batch row must be the exact
+    // same mask. Before the fix the buffer held only `tgt * (tgt + offset)`
+    // values but was shaped `(b, 1, tgt, tgt + offset)`, leaving rows >= 1 backed
+    // by out-of-range data and corrupting attention for batch size > 1.
+    #[test]
+    fn causal_mask_is_batch_independent() -> Result<()> {
+        let device = Device::Cpu;
+        let vb = VarBuilder::from_varmap(&VarMap::new(), DType::F32, &device);
+        let model = Model::new(&tiny_config(), vb)?;
+        let (b, tgt) = (3, 5);
+        let mask = model.causal_mask(b, tgt, 0, None)?;
+        assert_eq!(mask.dims(), &[b, 1, tgt, tgt]);
+        let row0 = mask.i(0)?.flatten_all()?.to_vec1::<f32>()?;
+        for r in 1..b {
+            let row = mask.i(r)?.flatten_all()?.to_vec1::<f32>()?;
+            assert_eq!(
+                row, row0,
+                "batch row {r} of the causal mask differs from row 0"
+            );
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
Fixes #3582.

`Model::causal_mask` in `qwen3.rs` (and the identical code in `qwen3_moe.rs`) builds a mask buffer of `tgt * (tgt + offset)` elements — independent of the batch size — but shapes it `(b, 1, tgt, tgt + offset)`. `Tensor::from_slice` does not validate the element count against the requested shape (`ShapeWithOneHole::into_shape` ignores the slice length for a fully specified shape), so for `b > 1` the mask tensor is backed by an undersized buffer. Batch rows `>= 1` then read out-of-range data, silently corrupting attention — `forward` on two identical sequences yields different outputs for row 0 vs row 1. Batch size 1 is unaffected.

The causal mask is batch-independent, so build it at its natural `(tgt, tgt + offset)` shape and `expand` it across the batch, matching how `qwen2.rs` already does it. The mask is only consumed by the standard-attention `broadcast_add` path (the flash paths mask internally via the `causal` flag), so broadcasting is sufficient.

Added a regression test in each model asserting the mask is identical across batch rows. Without the fix the test fails (out-of-range slice access on CPU); with it the rows match.
