### PR TITLE
Reject oversized Long1 in pickle reader instead of panicking (fixes #3619)

### DIFF
--- a/candle-core/src/pickle.rs
+++ b/candle-core/src/pickle.rs
@@ -603,6 +603,11 @@ impl Stack {
             }
             OpCode::Long1 => {
                 let n_bytes = r.read_u8()?;
+                // Values wider than an i64 cannot be represented and shifting by >= 64
+                // bits would panic, so reject them rather than crash on crafted input.
+                if n_bytes > 8 {
+                    crate::bail!("Long1 with {n_bytes} bytes cannot be represented as an i64")
+                }
                 let mut v = 0;
                 // Decode the next n bytes in little endian
                 for i in 0..n_bytes {
@@ -838,4 +843,23 @@ pub fn read_all_with_key<P: AsRef<std::path::Path>>(
 /// * `path` - Path to the pth file.
 pub fn read_all<P: AsRef<std::path::Path>>(path: P) -> Result<Vec<(String, Tensor)>> {
     read_all_with_key(path, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Stack;
+    use std::io::Cursor;
+
+    // A crafted Long1 opcode advertising more bytes than fit in an i64 used to
+    // panic with "attempt to shift left with overflow" (a shift by >= 64 bits),
+    // a deterministic DoS reachable from a malicious pickle/.pth stream. It must
+    // now return an error instead of panicking.
+    #[test]
+    fn long1_oversized_byte_count_errors_instead_of_panicking() {
+        // Long1 (0x8a) | n_bytes = 9 | 9 payload bytes
+        let data = [0x8a_u8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let mut stack = Stack::empty();
+        let res = stack.read_loop(&mut Cursor::new(&data[..]));
+        assert!(res.is_err());
+    }
 }


### PR DESCRIPTION
Fixes #3619.

`candle-core`'s pickle reader decodes the `Long1` opcode by reading an attacker-controlled byte count `n_bytes` (0–255) and shifting each subsequent byte into an `i64`:

```rust
let n_bytes = r.read_u8()?;
for i in 0..n_bytes {
    v |= (r.read_u8()? as i64) << (i * 8);
}
```

For `n_bytes >= 9` the loop reaches `i == 8` and evaluates `<< 64`, which panics unconditionally in Rust ("attempt to shift left with overflow") in all build profiles. That's a deterministic panic / DoS reachable from a crafted pickle stream embedded in a `.pth` / `.pt` model file, and it can't be recovered by the caller's error handling.

Values needing more than 8 bytes can't be represented as an `i64` anyway, so this rejects `n_bytes > 8` with an error instead of panicking. Added a regression test that feeds an oversized `Long1` stream and asserts it returns an error rather than crashing.
