### PR TITLE
Metal SDPA: support combining an additive mask with causal masking

### DIFF
--- a/candle-metal-kernels/src/kernels/sdpa.rs
+++ b/candle-metal-kernels/src/kernels/sdpa.rs
@@ -109,11 +109,12 @@ pub fn call_sdpa_full(
     let align_k = (kl % bk) == 0;
     let has_mask = mask_buffer.is_some();
 
-    // When an explicit additive mask is supplied it already encodes causality.
-    // Also enabling the in-kernel `do_causal` path double-applies causality and,
-    // at periodic sequence lengths, leaves a query row fully masked -> softmax
-    // normalizer sum(exp) == 0 -> final divide computes 0/0 = NaN logits.
-    let do_causal = do_causal && !has_mask;
+    // `mask` (additive bias / padding) and `do_causal` are independent inputs and
+    // the kernel applies both. A fully-masked query row no longer produces NaN
+    // (the kernel clamps the softmax normalizer before the final divide), so we
+    // must not silently drop causal masking when a mask is also supplied --
+    // otherwise a padding/bias mask combined with `do_causal` would attend to
+    // future keys and corrupt the output.
 
     let itype_repr = match itype {
         SdpaDType::BF16 => "bfloat16",

--- a/candle-metal-kernels/src/metal_src/scaled_dot_product_attention.metal
+++ b/candle-metal-kernels/src/metal_src/scaled_dot_product_attention.metal
@@ -2275,7 +2275,18 @@ template <
     loader_v.next();
   }
 
-  // Normalize output
+  // Normalize output. A fully-masked query row (every key excluded by the
+  // additive mask and/or causal masking) ends the loop with sum_score == 0 and
+  // an all-zero Otile. The ExpSubOp/rescale guards above keep that row NaN-free
+  // during accumulation, but the final divide would still compute 0/0 = NaN.
+  // Clamp a zero normalizer to 1 so the row stays zeroed instead of poisoning
+  // the output (this is what lets `has_mask` and `do_causal` be combined).
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < kRowsPT; ++i) {
+    if (sum_score[i] == AccumType(0)) {
+      sum_score[i] = AccumType(1);
+    }
+  }
   Otile.template row_bin_op<DivOp>(sum_score);
   threadgroup_barrier(mem_flags::mem_none);
 

--- a/candle-nn/tests/sdpa.rs
+++ b/candle-nn/tests/sdpa.rs
@@ -184,4 +184,131 @@ mod metal_sdpa_tests {
         assert!(error <= 0.0013, "{}", error);
         Ok(())
     }
+
+    #[test]
+    fn sdpa_full_causal_with_mask() -> Result<()> {
+        // Regression test: a non-causal additive mask (padding/bias) combined
+        // with `do_causal = true` must apply BOTH maskings. The wrapper used to
+        // drop causal masking whenever any mask was present, which let queries
+        // attend to future keys and corrupted prefill/training outputs.
+        const BS: usize = 2;
+        const H: usize = 3;
+        const R: usize = 16; // q_seq > 8 -> full kernel
+        const L: usize = 16;
+        const DK: usize = 64;
+
+        let scale: f64 = f64::from(DK as u32).sqrt().recip();
+        let device = Device::new_metal(0)?;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0xC0FFEE);
+        let q = randn(&mut rng, (BS, H, R, DK), &device)?;
+        let k = randn(&mut rng, (BS, H, L, DK), &device)?;
+        let v = randn(&mut rng, (BS, H, L, DK), &device)?;
+
+        // Non-causal additive padding mask: drop the last two key positions for
+        // every query (0.0 = keep, -inf = drop). No row is fully masked, since
+        // causal masking still leaves key 0 visible to every query.
+        let neg_inf = f32::NEG_INFINITY;
+        let mut mask_data = vec![0f32; BS * H * R * L];
+        for b in 0..BS {
+            for h in 0..H {
+                for r in 0..R {
+                    for c in (L - 2)..L {
+                        mask_data[((b * H + h) * R + r) * L + c] = neg_inf;
+                    }
+                }
+            }
+        }
+        let mask = Tensor::from_vec(mask_data, (BS, H, R, L), &device)?;
+
+        // Reference: apply BOTH causal masking and the additive mask to scores.
+        let mut causal = vec![0f32; R * L];
+        for i in 0..R {
+            for j in 0..L {
+                if j > i {
+                    causal[i * L + j] = neg_inf;
+                }
+            }
+        }
+        let causal =
+            Tensor::from_vec(causal, (1, 1, R, L), &device)?.broadcast_as((BS, H, R, L))?;
+
+        let ground_truth = {
+            let att = (q.clone() * scale)?
+                .matmul(&k.clone().t()?)?
+                .to_dtype(DType::F32)?;
+            let att = att.broadcast_add(&causal)?.broadcast_add(&mask)?;
+            let att = candle_nn::ops::softmax_last_dim(&att)?.to_dtype(q.dtype())?;
+            att.matmul(&v.clone())?
+        };
+
+        let sdpa_output = candle_nn::ops::sdpa(&q, &k, &v, Some(&mask), true, scale as f32, 1.)?;
+        assert_eq!(ground_truth.shape(), sdpa_output.shape());
+
+        // No NaNs/infs leaked from the combined mask + causal path.
+        let flat = sdpa_output.flatten_all()?.to_vec1::<f32>()?;
+        assert!(
+            flat.iter().all(|x| x.is_finite()),
+            "sdpa output has non-finite values"
+        );
+
+        let denom = ground_truth.abs()?.affine(1.0, 1e-3)?;
+        let error: f32 = ((&ground_truth - &sdpa_output)?.abs()? / denom)?
+            .sum_all()?
+            .to_scalar()?;
+        assert!(error <= 0.1, "{}", error);
+        Ok(())
+    }
+
+    #[test]
+    fn sdpa_full_fully_masked_row_is_finite() -> Result<()> {
+        // Regression test for the softmax-normalizer guard: a query row whose
+        // keys are all excluded by the mask must yield a finite (zero) row
+        // instead of 0/0 = NaN.
+        const BS: usize = 1;
+        const H: usize = 2;
+        const R: usize = 16; // q_seq > 8 -> full kernel
+        const L: usize = 16;
+        const DK: usize = 64;
+
+        let scale: f64 = f64::from(DK as u32).sqrt().recip();
+        let device = Device::new_metal(0)?;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0x1234);
+        let q = randn(&mut rng, (BS, H, R, DK), &device)?;
+        let k = randn(&mut rng, (BS, H, L, DK), &device)?;
+        let v = randn(&mut rng, (BS, H, L, DK), &device)?;
+
+        // Additive mask: fully mask query row 0 (all keys), keep the rest.
+        let neg_inf = f32::NEG_INFINITY;
+        let mut mask_data = vec![0f32; BS * H * R * L];
+        for b in 0..BS {
+            for h in 0..H {
+                for c in 0..L {
+                    mask_data[((b * H + h) * R) * L + c] = neg_inf;
+                }
+            }
+        }
+        let mask = Tensor::from_vec(mask_data, (BS, H, R, L), &device)?;
+
+        let out = candle_nn::ops::sdpa(&q, &k, &v, Some(&mask), false, scale as f32, 1.)?;
+        let flat = out.flatten_all()?.to_vec1::<f32>()?;
+        assert!(
+            flat.iter().all(|x| x.is_finite()),
+            "fully-masked row produced non-finite values"
+        );
+
+        // The fully-masked query row (row 0) must be zero.
+        for b in 0..BS {
+            for h in 0..H {
+                let base = ((b * H + h) * R) * DK;
+                for d in 0..DK {
+                    assert!(
+                        flat[base + d].abs() < 1e-5,
+                        "masked row should be zero, got {}",
+                        flat[base + d]
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
call_sdpa_full previously forced do_causal=false whenever a mask buffer was present, to avoid a 0/0 = NaN when a fully-masked query row reached the final softmax divide. That silently dropped causal masking for callers passing a padding/bias mask together with do_causal=true, letting queries attend to future keys.

Fix the NaN at its source instead: clamp a zero softmax normalizer to 1 before the final divide in the steel attention kernel, so a fully-masked row yields a zeroed output row. With that guard in place, the additive mask and do_causal can be applied together, so the wrapper no longer needs to drop causal masking.

Add regression tests covering (1) a non-causal padding mask combined with do_causal, and (2) a fully-masked query row staying finite (zero).


Claude-Session: https://claude.ai/code/session_01BB5dWNeZGmPzWtyRpBEdMM