### PR TITLE
Box the Config field in smollm3's model enum

### DIFF
--- a/candle-examples/examples/smollm3/main.rs
+++ b/candle-examples/examples/smollm3/main.rs
@@ -27,7 +27,7 @@ const DEFAULT_PROMPT: &str = "Write a Rust function to calculate the factorial o
 
 enum SmolLM3Model {
     Quantized(QuantizedModelForCausalLM),
-    Full(ModelForCausalLM, Config), // Store config alongside model
+    Full(ModelForCausalLM, Box<Config>), // Store config alongside model
 }
 
 impl SmolLM3Model {
@@ -310,7 +310,7 @@ fn load_full_model(args: &Args, device: &Device) -> Result<SmolLM3Model> {
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&filenames, dtype, device)? };
     let model = ModelForCausalLM::new(&config, vb)?;
 
-    Ok(SmolLM3Model::Full(model, config))
+    Ok(SmolLM3Model::Full(model, Box::new(config)))
 }
 
 // ==================== Text Generation ====================


### PR DESCRIPTION
clippy 1.96 (current `stable`) flags `SmolLM3Model` with `large_enum_variant`:

```
error: large size difference between variants
  --> candle-examples/examples/smollm3/main.rs:28:1
   = the largest variant contains at least 456 bytes
   = the second-largest variant contains at least 216 bytes
```

This fails `cargo clippy --workspace --tests --examples --benches -- -D warnings` on any PR. Box the `Config` field in the `Full` variant, as clippy's machine-applicable suggestion proposes; the only construction site and the `cfg` field accesses are unaffected.
