### PR TITLE
Metal apple silicon fixes

### DIFF
--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -261,7 +261,14 @@ impl Tensor {
 
                         let grad_kernel = arg
                             .transpose(0, 1)?
-                            .conv1d(&grad.transpose(0, 1)?, *padding, *dilation, *stride, 1)?
+                            .contiguous()?
+                            .conv1d(
+                                &grad.transpose(0, 1)?.contiguous()?,
+                                *padding,
+                                *dilation,
+                                *stride,
+                                1,
+                            )?
                             .transpose(0, 1)?;
                         let sum_grad = grads.or_insert(kernel)?;
                         let (_, _, k0) = kernel.dims3()?;
@@ -299,7 +306,14 @@ impl Tensor {
 
                         let grad_kernel = arg
                             .transpose(0, 1)?
-                            .conv2d(&grad.transpose(0, 1)?, *padding, *dilation, *stride, 1)?
+                            .contiguous()?
+                            .conv2d(
+                                &grad.transpose(0, 1)?.contiguous()?,
+                                *padding,
+                                *dilation,
+                                *stride,
+                                1,
+                            )?
                             .transpose(0, 1)?;
                         let sum_grad = grads.or_insert(kernel)?;
                         let (_, _, k0, k1) = kernel.dims4()?;
@@ -328,7 +342,14 @@ impl Tensor {
 
                         let grad_kernel = grad
                             .transpose(0, 1)?
-                            .conv2d(&arg.transpose(0, 1)?, *padding, *dilation, *stride, 1)?
+                            .contiguous()?
+                            .conv2d(
+                                &arg.transpose(0, 1)?.contiguous()?,
+                                *padding,
+                                *dilation,
+                                *stride,
+                                1,
+                            )?
                             .transpose(0, 1)?;
                         let sum_grad = grads.or_insert(kernel)?;
                         let (_, _, k0, k1) = kernel.dims4()?;

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -2023,7 +2023,21 @@ impl BackendDevice for MetalDevice {
     type Storage = MetalStorage;
 
     fn new(ordinal: usize) -> Result<Self> {
-        let device = Device::all().swap_remove(ordinal);
+        // `Device::all()` (MTLCopyAllDevices) returns no devices on Apple Silicon.
+        // Use `system_default()` (MTLCreateSystemDefaultDevice) for the default
+        // device and fall back to `all()` for explicit additional GPUs.
+        let device = if ordinal == 0 {
+            Device::system_default()
+                .ok_or_else(|| MetalError::from("no Metal device found".to_string()))?
+        } else {
+            let mut devices = Device::all();
+            if ordinal >= devices.len() {
+                return Err(
+                    MetalError::Message(format!("Metal device {ordinal} not found")).into(),
+                );
+            }
+            devices.swap_remove(ordinal)
+        };
         let command_queue = device.new_command_queue().map_err(MetalError::from)?;
         #[cfg(feature = "metal-debug-labels")]
         command_queue.setLabel(Some(&NSString::from_str("candle-metal")));


### PR DESCRIPTION
Two independent Apple-Silicon Metal fixes, one commit each:

## 1. `MetalDevice::new` panics on Apple Silicon

`MetalDevice::new` does `Device::all().swap_remove(ordinal)`. On Apple Silicon, `MTLCopyAllDevices` returns **no** devices, so `swap_remove(0)` panics on an empty vec — Metal is unusable on M-series:

```
thread 'main' panicked: swap_remove index (is 0) should be < len (is 0)
```

Fix: use `Device::system_default()` (`MTLCreateSystemDefaultDevice`) for the default device, falling back to `all()` with a bounds check for explicit additional-GPU ordinals.

## 2. conv weight-gradient is wrong on Metal — training silently diverges

The `conv1d` / `conv2d` / `conv_transpose2d` backward computes the kernel gradient by convolving a **transposed (non-contiguous)** input:

```rust
let grad_kernel = arg.transpose(0, 1)?.conv2d(&grad.transpose(0, 1)?, ...)?...
```

The Metal `im2col` reads its input as if contiguous, so the **weight gradient is incorrect on Metal**. The forward pass and the *input* gradient are correct — so inference works fine, but **training diverges**: every conv kernel is updated in the wrong direction and the loss climbs.

Fix: force the transposed operands contiguous before the conv. No-op on CPU.

### Verification

Minimal CPU-vs-Metal check of `conv2d` through `loss.backward()` (max abs diff):

| | forward | input-grad | **weight-grad** |
|---|---|---|---|
| before | 2e-7 | 2e-6 | **2.95e1** |
| after  | 2e-7 | 2e-6 | **7.6e-6** |

A small residual U-Net that **diverged** when trained on Metal (loss climbing, PSNR going negative) trains normally after this change, matching the CPU result step-for-step. `group_norm`, `reshape`/`permute`, and the conv *input* gradient were all already correct on Metal — only the conv *weight* gradient was affected.
