### PR TITLE
Fix Metal device creation panic with bounds check (fixes #3566)

### DIFF
--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -2023,7 +2023,15 @@ impl BackendDevice for MetalDevice {
     type Storage = MetalStorage;
 
     fn new(ordinal: usize) -> Result<Self> {
-        let device = Device::all().swap_remove(ordinal);
+        let mut devices = Device::all();
+        if ordinal >= devices.len() {
+            return Err(MetalError::Message(format!(
+                "no Metal device at ordinal {ordinal} (MTLCopyAllDevices returned {} devices)",
+                devices.len()
+            ))
+            .into());
+        }
+        let device = devices.swap_remove(ordinal);
         let command_queue = device.new_command_queue().map_err(MetalError::from)?;
         #[cfg(feature = "metal-debug-labels")]
         command_queue.setLabel(Some(&NSString::from_str("candle-metal")));

--- a/candle-core/tests/metal_device_tests.rs
+++ b/candle-core/tests/metal_device_tests.rs
@@ -1,0 +1,42 @@
+#[cfg(feature = "metal")]
+#[test]
+fn test_metal_device_ordinal_bounds() {
+    use candle_core::Device;
+
+    // This test verifies that creating a Metal device with an invalid ordinal
+    // returns a proper error instead of panicking.
+    // See issue #3566: https://github.com/huggingface/candle/issues/3566
+
+    // Try to create a device with a very large ordinal that definitely doesn't exist
+    let result = Device::new_metal(999);
+
+    match result {
+        Ok(_) => {
+            // This is unexpected unless the system actually has 1000+ Metal devices
+            println!("Unexpectedly created Metal device with ordinal 999");
+        }
+        Err(e) => {
+            // This is the expected behavior - should return an error, not panic
+            let error_msg = e.to_string();
+            assert!(
+                error_msg.contains("no Metal device at ordinal") ||
+                error_msg.contains("MTLCopyAllDevices"),
+                "Error message should mention device ordinal or MTLCopyAllDevices, got: {}",
+                error_msg
+            );
+            println!("✓ Correctly returned error: {}", error_msg);
+        }
+    }
+
+    // Also test ordinal 0 - it might fail if no Metal devices are available,
+    // but it should return an error, not panic
+    let result = Device::new_metal(0);
+    match result {
+        Ok(device) => {
+            println!("✓ Successfully created Metal device: {:?}", device);
+        }
+        Err(e) => {
+            println!("✓ Metal device creation failed with error (this is OK): {}", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR fixes issue #3566 where `MetalDevice::new(ordinal)` would panic instead of returning a proper error when no Metal devices are available.

## Problem
When `MTLCopyAllDevices()` returns an empty vector (which can happen in SSH sessions, unsigned binaries, headless environments, or sandboxed contexts), the code called `swap_remove(ordinal)` without bounds checking, causing a panic:
```
thread 'tokio-runtime-worker' panicked at library/alloc/src/vec/mod.rs:1981:13:
swap_remove index (is 0) should be < len (is 0)
```

This prevented downstream code from gracefully handling the absence of Metal devices using `if let Ok(device) = Device::new_metal(0)`.

## Solution
Added a bounds check before `swap_remove` that returns a descriptive error when the ordinal is out of range:
```rust
let mut devices = Device::all();
if ordinal >= devices.len() {
    return Err(MetalError::Message(format!(
        "no Metal device at ordinal {ordinal} (MTLCopyAllDevices returned {} devices)",
        devices.len()
    ))
    .into());
}
let device = devices.swap_remove(ordinal);
```

## Testing
Added a new test `candle-core/tests/metal_device_tests.rs` that verifies the fix works correctly.

### Before fix (panic ❌):
```
thread 'test_metal_device_ordinal_bounds' panicked at swap_remove index (is 999) should be < len (is 1)
test test_metal_device_ordinal_bounds ... FAILED
```

### After fix (proper error handling ✅):
```
✓ Correctly returned error: Metal error no Metal device at ordinal 999 (MTLCopyAllDevices returned 1 devices)
✓ Successfully created Metal device: Metal(MetalDevice(DeviceId(1)))
test test_metal_device_ordinal_bounds ... ok
```

The test demonstrates that:
1. **Without the fix**: Attempting to create a Metal device with an invalid ordinal causes a panic
2. **With the fix**: The same operation returns a proper error that can be handled gracefully

Fixes #3566