### PR TITLE
Fix Qwen3 causal mask for batch_size > 1

### DIFF
--- a/candle-transformers/src/models/qwen3.rs
+++ b/candle-transformers/src/models/qwen3.rs
@@ -462,7 +462,7 @@ impl Model {
                 })
             })
             .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
+        Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
     }
 
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {


### PR DESCRIPTION
## Summary

Fixes #3582 

The  function in Qwen3 was incorrectly shaping the attention mask, causing wrong outputs when .

## Problem

The mask buffer was generated with  elements (independent of batch size), but was shaped as . This caused:
- Batch index 0: correct masking ✅
- Batch indices > 0: incorrect mask values, breaking causal attention ❌

When processing multiple identical sequences in a batch, outputs differed between batch indices, which should not happen.

## Solution

Changed the mask shape from  to .

The existing  in  (line 343) automatically broadcasts the mask across all batch elements, ensuring correct causal masking for every sequence.

## Benefits

- ✅ Fixes incorrect attention for batched inference
- ✅ More memory efficient (one mask for all batches)
- ✅ Leverages tensor broadcasting mechanism
- ✅ One-line change, minimal risk

## Testing

The issue reporter verified that with this change, batched forwards match per-sequence forwards to ~5 decimal places.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>