### PR TITLE
candle-onnx: add pipeline-parallel evaluation via simple_eval_with_placement

### DIFF
--- a/candle-examples/examples/onnx-llm/main.rs
+++ b/candle-examples/examples/onnx-llm/main.rs
@@ -170,7 +170,7 @@ pub fn main() -> Result<()> {
             }
         }
 
-        let outputs = candle_onnx::simple_eval(&model, inputs)?;
+        let outputs = candle_onnx::simple_eval(&model, inputs, &device)?;
 
         let logits = outputs.get("logits").unwrap();
 

--- a/candle-examples/examples/onnx/main.rs
+++ b/candle-examples/examples/onnx/main.rs
@@ -66,9 +66,10 @@ pub fn main() -> anyhow::Result<()> {
 
     let model = candle_onnx::read_file(model)?;
     let graph = model.graph.as_ref().unwrap();
+    let device = image.device().clone();
     let mut inputs = std::collections::HashMap::new();
     inputs.insert(graph.input[0].name.to_string(), image.unsqueeze(0)?);
-    let mut outputs = candle_onnx::simple_eval(&model, inputs)?;
+    let mut outputs = candle_onnx::simple_eval(&model, inputs, &device)?;
     let output = outputs.remove(&graph.output[0].name).unwrap();
     let prs = match args.which {
         Which::SqueezeNet => candle_nn::ops::softmax(&output, D::Minus1)?,

--- a/candle-examples/examples/onnx_basics.rs
+++ b/candle-examples/examples/onnx_basics.rs
@@ -77,7 +77,7 @@ pub fn main() -> Result<()> {
                 println!("input {}: {value:?}", input.name);
                 inputs.insert(input.name.clone(), value);
             }
-            let outputs = candle_onnx::simple_eval(&model, inputs)?;
+            let outputs = candle_onnx::simple_eval(&model, inputs, &Device::Cpu)?;
             for (name, value) in outputs.iter() {
                 println!("output {name}: {value:?}")
             }

--- a/candle-examples/examples/silero-vad/main.rs
+++ b/candle-examples/examples/silero-vad/main.rs
@@ -177,7 +177,7 @@ fn main() -> Result<()> {
             ("sr".to_string(), state.sample_rate.clone()),
             ("state".to_string(), state.state.clone()),
         ]);
-        let out = candle_onnx::simple_eval(&model, inputs).unwrap();
+        let out = candle_onnx::simple_eval(&model, inputs, &device).unwrap();
         let out_names = &model.graph.as_ref().unwrap().output;
         let output = out.get(&out_names[0].name).unwrap().clone();
         state.state = out.get(&out_names[1].name).unwrap().clone();

--- a/candle-onnx/Cargo.toml
+++ b/candle-onnx/Cargo.toml
@@ -20,3 +20,7 @@ prost-build = "0.14.1"
 [dev-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 clap = { version = "4.5.49", features = ["derive"] }
+
+[features]
+cuda = ["candle/cuda"]
+metal = ["candle/metal"]

--- a/candle-onnx/README.md
+++ b/candle-onnx/README.md
@@ -2,6 +2,26 @@
 
 This crate adds ONNX support to candle
 
+## Multi-device evaluation (pipeline parallelism)
+
+`simple_eval` runs the whole graph on a single device. To split one graph across
+several devices (e.g. the first transformer blocks on `cuda:0` and the rest on
+`cuda:1`, so a model that does not fit on one GPU still runs), use
+`simple_eval_with_placement` with a `Placement`:
+
+```rust
+let placement = candle_onnx::Placement::new(&cuda0)
+    .with_prefix("/model/layers.16/", &cuda1);
+let outputs = candle_onnx::simple_eval_with_placement(&model, inputs, &placement)?;
+```
+
+A node runs on the device of the longest matching node-name prefix, otherwise it
+inherits the device of its first input, otherwise the fallback device. Weights
+are materialized lazily on the device that first consumes them and cross-device
+copies are inserted automatically at stage boundaries. This is pipeline
+parallelism (not tensor/expert parallelism), and cross-device transfers
+currently require CUDA (Metal-to-Metal copies are unimplemented in candle-core).
+
 ## FAQ
 
 #### Missing protoc installation when compiling candle-onnx

--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -28,7 +28,7 @@ trait Attr {
 
 trait AttrOwned: Sized {
     const TYPE: AttributeType;
-    fn get(attr: &onnx::AttributeProto) -> Result<Self>;
+    fn get(attr: &onnx::AttributeProto, device: &Device) -> Result<Self>;
 }
 
 impl Attr for i64 {
@@ -70,7 +70,7 @@ impl Attr for GraphProto {
 
 impl AttrOwned for Vec<String> {
     const TYPE: AttributeType = AttributeType::Strings;
-    fn get(attr: &onnx::AttributeProto) -> Result<Self> {
+    fn get(attr: &onnx::AttributeProto, _device: &Device) -> Result<Self> {
         let mut ret = vec![];
         for bytes in attr.strings.iter() {
             let s = String::from_utf8(bytes.clone()).map_err(candle::Error::wrap)?;
@@ -82,7 +82,7 @@ impl AttrOwned for Vec<String> {
 
 impl AttrOwned for Tensor {
     const TYPE: AttributeType = AttributeType::Tensor;
-    fn get(attr: &onnx::AttributeProto) -> Result<Self> {
+    fn get(attr: &onnx::AttributeProto, device: &Device) -> Result<Self> {
         let tensor_proto = match &attr.t {
             Some(value) => value,
             None => bail!(
@@ -120,7 +120,7 @@ impl AttrOwned for Tensor {
             dims.push(*dim as usize)
         }
 
-        Tensor::from_raw_buffer(&tensor_proto.raw_data, dtype, &dims, &Device::Cpu)
+        Tensor::from_raw_buffer(&tensor_proto.raw_data, dtype, &dims, device)
     }
 }
 
@@ -171,7 +171,11 @@ fn get_attr_opt<'a, T: Attr + ?Sized>(
     }
 }
 
-fn get_attr_opt_owned<T: AttrOwned>(node: &onnx::NodeProto, name: &str) -> Result<Option<T>> {
+fn get_attr_opt_owned<T: AttrOwned>(
+    node: &onnx::NodeProto,
+    name: &str,
+    device: &Device,
+) -> Result<Option<T>> {
     match node.attribute.iter().find(|attr| attr.name == name) {
         None => Ok(None),
         Some(attr) => {
@@ -183,13 +187,13 @@ fn get_attr_opt_owned<T: AttrOwned>(node: &onnx::NodeProto, name: &str) -> Resul
                     node.name
                 )
             }
-            let val = T::get(attr)?;
+            let val = T::get(attr, device)?;
             Ok(Some(val))
         }
     }
 }
 
-pub fn get_tensor(t: &onnx::TensorProto, name: &str) -> Result<Tensor> {
+pub fn get_tensor(t: &onnx::TensorProto, name: &str, device: &Device) -> Result<Tensor> {
     let dims: Vec<usize> = t.dims.iter().map(|&x| x as usize).collect();
     match DataType::try_from(t.data_type) {
         Ok(DataType::Int32) => {
@@ -198,27 +202,22 @@ pub fn get_tensor(t: &onnx::TensorProto, name: &str) -> Result<Tensor> {
                 let data: &[i32] =
                     unsafe { std::slice::from_raw_parts(t.raw_data.as_ptr() as *const i32, len) };
                 let data = data.iter().map(|v| *v as i64).collect::<Vec<_>>();
-                Tensor::from_vec(data, len, &Device::Cpu)
+                Tensor::from_vec(data, len, device)
             } else {
                 let data = t.int32_data.iter().map(|v| *v as i64).collect::<Vec<_>>();
-                Tensor::from_vec(data, t.int32_data.len(), &Device::Cpu)
+                Tensor::from_vec(data, t.int32_data.len(), device)
             }
         }
         Ok(dt) => match dtype(dt) {
             Some(dt) => {
                 if dt == DType::F32 && !t.float_data.is_empty() {
-                    Tensor::from_slice(&t.float_data, dims.as_slice(), &Device::Cpu)
+                    Tensor::from_slice(&t.float_data, dims.as_slice(), device)
                 } else if dt == DType::F64 && !t.double_data.is_empty() {
-                    Tensor::from_slice(&t.double_data, dims.as_slice(), &Device::Cpu)
+                    Tensor::from_slice(&t.double_data, dims.as_slice(), device)
                 } else if dt == DType::I64 && !t.int64_data.is_empty() {
-                    Tensor::from_slice(&t.int64_data, dims.as_slice(), &Device::Cpu)
+                    Tensor::from_slice(&t.int64_data, dims.as_slice(), device)
                 } else {
-                    Tensor::from_raw_buffer(
-                        t.raw_data.as_slice(),
-                        dt,
-                        dims.as_slice(),
-                        &Device::Cpu,
-                    )
+                    Tensor::from_raw_buffer(t.raw_data.as_slice(), dt, dims.as_slice(), device)
                 }
             }
             None => {
@@ -239,20 +238,22 @@ pub fn get_tensor(t: &onnx::TensorProto, name: &str) -> Result<Tensor> {
 pub fn simple_eval(
     model: &onnx::ModelProto,
     mut inputs: HashMap<String, Value>,
+    device: &Device,
 ) -> Result<HashMap<String, Value>> {
     let graph = match &model.graph {
         None => bail!("no graph defined in proto"),
         Some(graph) => graph,
     };
-    simple_eval_(graph, &mut inputs)
+    simple_eval_(graph, &mut inputs, device)
 }
 
 fn simple_eval_(
     graph: &onnx::GraphProto,
     values: &mut HashMap<String, Value>,
+    device: &Device,
 ) -> Result<HashMap<String, Value>> {
     for t in graph.initializer.iter() {
-        let tensor = get_tensor(t, t.name.as_str())?;
+        let tensor = get_tensor(t, t.name.as_str(), device)?;
         values.insert(t.name.to_string(), tensor);
     }
     for input in graph.input.iter() {
@@ -577,11 +578,8 @@ fn simple_eval_(
             // https://github.com/onnx/onnx/blob/main/docs/Operators.md#ConstantOfShape
             "ConstantOfShape" => {
                 let input = get(&node.input[0])?;
-                let value = get_attr_opt_owned::<Tensor>(node, "value")?.unwrap_or(Tensor::zeros(
-                    (),
-                    DType::F32,
-                    &Device::Cpu,
-                )?);
+                let value = get_attr_opt_owned::<Tensor>(node, "value", device)?
+                    .unwrap_or(Tensor::zeros((), DType::F32, device)?);
 
                 let shape_vec: Vec<usize> = input
                     .to_vec1::<i64>()?
@@ -760,7 +758,7 @@ fn simple_eval_(
                             to_vec0_flexible::<$t>(start)?,
                             to_vec0_flexible::<$t>(limit)?,
                             to_vec0_flexible::<$t>(delta)?,
-                            &Device::Cpu,
+                            start.device(),
                         )?
                     };
                 }
@@ -1085,7 +1083,7 @@ fn simple_eval_(
                 let output = match value.r#type() {
                     AttributeType::Tensor => {
                         let t = value.t.as_ref().unwrap();
-                        get_tensor(t, &node.name)?
+                        get_tensor(t, &node.name, device)?
                     }
                     rtype => bail!("unsupported 'value' type {rtype:?} for {}", node.name),
                 };
@@ -1161,7 +1159,7 @@ fn simple_eval_(
                         node.output.len()
                     );
                 }
-                let branch_out = simple_eval_(sub_graph, values)?;
+                let branch_out = simple_eval_(sub_graph, values, device)?;
                 for (i, out) in node.output.iter().enumerate() {
                     values.insert(
                         out.clone(),
@@ -1695,11 +1693,11 @@ fn simple_eval_(
                 let output = if random_type == "RandomUniform" {
                     let low: f32 = get_attr_opt(node, "low")?.copied().unwrap_or(0.0);
                     let high: f32 = get_attr_opt(node, "high")?.copied().unwrap_or(1.0);
-                    Tensor::rand(low, high, shape, &Device::Cpu)?.to_dtype(dtype)?
+                    Tensor::rand(low, high, shape, device)?.to_dtype(dtype)?
                 } else {
                     let mean: f32 = get_attr_opt(node, "mean")?.copied().unwrap_or(0.0);
                     let scale: f32 = get_attr_opt(node, "scale")?.copied().unwrap_or(1.0);
-                    Tensor::randn(mean, scale, shape, &Device::Cpu)?.to_dtype(dtype)?
+                    Tensor::randn(mean, scale, shape, device)?.to_dtype(dtype)?
                 };
                 values.insert(node.output[0].clone(), output);
             }
@@ -1793,8 +1791,8 @@ fn simple_eval_(
                 let alpha = get_attr_opt::<f32>(node, "alpha")?.copied().unwrap_or(1.0);
                 let beta = get_attr_opt::<f32>(node, "beta")?.copied().unwrap_or(1.0);
 
-                let alpha = Tensor::full(alpha, a.shape(), &Device::Cpu)?;
-                let beta = Tensor::full(beta, c.shape(), &Device::Cpu)?;
+                let alpha = Tensor::full(alpha, a.shape(), a.device())?;
+                let beta = Tensor::full(beta, c.shape(), c.device())?;
 
                 let trans_a = get_attr_opt::<i64>(node, "transA")?.copied().unwrap_or(0);
                 let trans_b = get_attr_opt::<i64>(node, "transB")?.copied().unwrap_or(0);
@@ -1824,7 +1822,7 @@ fn simple_eval_(
                     "Tanh".to_string(),
                     "Tanh".to_string(),
                 ];
-                let activations = get_attr_opt_owned::<Vec<String>>(node, "activations")?
+                let activations = get_attr_opt_owned::<Vec<String>>(node, "activations", device)?
                     .unwrap_or(activations_default.clone());
                 if activations != activations_default {
                     bail!("LSTM currently only supports default activations ({activations_default:?})");
@@ -2031,7 +2029,7 @@ fn simple_eval_(
             "RNN" => {
                 // activation_alpha and activation_beta don't apply to (Tanh, Tanh) so ignoring them is okay
                 let activations_default = vec!["Tanh".to_string(), "Tanh".to_string()];
-                let activations = get_attr_opt_owned::<Vec<String>>(node, "activations")?
+                let activations = get_attr_opt_owned::<Vec<String>>(node, "activations", device)?
                     .unwrap_or(activations_default.clone());
                 let clip = get_attr_opt::<f32>(node, "clip")?.copied();
                 if clip.is_some() {

--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -230,6 +230,77 @@ pub fn get_tensor(t: &onnx::TensorProto, name: &str, device: &Device) -> Result<
     }
 }
 
+/// Describes which [`Device`] each node of an ONNX graph should be evaluated on,
+/// enabling pipeline-parallel execution of a single graph across several devices
+/// (e.g. the first transformer blocks on one GPU and the rest on another).
+///
+/// A node's device is resolved as:
+/// 1. the device of the longest matching node-name prefix rule, if any;
+/// 2. otherwise the device of the node's first already-computed input, so a
+///    stage's device flows along the graph and only the first node of each stage
+///    needs an explicit rule;
+/// 3. otherwise the fallback device.
+///
+/// Initializers (weights/constants) are materialized lazily, directly on the
+/// device of the node that first consumes them, so a model that does not fit on
+/// a single device can be split across several. Cross-device copies are inserted
+/// automatically at stage boundaries via [`Tensor::to_device`].
+///
+/// Notes / current limitations:
+/// - Transfers rely on `candle`'s `to_device`, which supports CPU<->CUDA and
+///   CUDA<->CUDA copies; Metal-to-Metal transfers are not implemented in
+///   candle-core, so multi-GPU placement is CUDA-only for now.
+/// - The placement is expected to be monotone along the topological order: a
+///   value moved to a later stage must not be read again by an earlier stage.
+///   A by-depth pipeline split satisfies this.
+#[derive(Clone, Debug)]
+pub struct Placement {
+    fallback: Device,
+    // Kept sorted by descending prefix length so the first match is the longest.
+    rules: Vec<(String, Device)>,
+}
+
+impl Placement {
+    /// Evaluate every node on a single device. This reproduces the behavior of
+    /// [`simple_eval`].
+    pub fn uniform(device: &Device) -> Self {
+        Self {
+            fallback: device.clone(),
+            rules: Vec::new(),
+        }
+    }
+
+    /// Start a placement whose default (fallback) device is `fallback`; attach
+    /// per-stage rules with [`Placement::with_prefix`].
+    pub fn new(fallback: &Device) -> Self {
+        Self {
+            fallback: fallback.clone(),
+            rules: Vec::new(),
+        }
+    }
+
+    /// Place every node whose name starts with `node_name_prefix` on `device`.
+    /// When several rules match a node, the one with the longest prefix wins.
+    pub fn with_prefix(mut self, node_name_prefix: &str, device: &Device) -> Self {
+        self.rules
+            .push((node_name_prefix.to_string(), device.clone()));
+        self.rules.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+        self
+    }
+
+    fn fallback(&self) -> &Device {
+        &self.fallback
+    }
+
+    /// The device explicitly assigned to `node_name` by the prefix rules, if any.
+    fn explicit_device(&self, node_name: &str) -> Option<&Device> {
+        self.rules
+            .iter()
+            .find(|(prefix, _)| node_name.starts_with(prefix.as_str()))
+            .map(|(_, device)| device)
+    }
+}
+
 // This function provides a direct evaluation of the proto.
 // Longer-term, we should first convert the proto to an intermediate representation of the compute
 // graph so as to make multiple evaluations more efficient.
@@ -237,25 +308,41 @@ pub fn get_tensor(t: &onnx::TensorProto, name: &str, device: &Device) -> Result<
 // anymore.
 pub fn simple_eval(
     model: &onnx::ModelProto,
-    mut inputs: HashMap<String, Value>,
+    inputs: HashMap<String, Value>,
     device: &Device,
+) -> Result<HashMap<String, Value>> {
+    simple_eval_with_placement(model, inputs, &Placement::uniform(device))
+}
+
+/// Like [`simple_eval`] but spreads the graph across the devices described by
+/// `placement`, inserting cross-device copies at stage boundaries. See
+/// [`Placement`] for how each node's device is resolved.
+pub fn simple_eval_with_placement(
+    model: &onnx::ModelProto,
+    mut inputs: HashMap<String, Value>,
+    placement: &Placement,
 ) -> Result<HashMap<String, Value>> {
     let graph = match &model.graph {
         None => bail!("no graph defined in proto"),
         Some(graph) => graph,
     };
-    simple_eval_(graph, &mut inputs, device)
+    simple_eval_(graph, &mut inputs, placement)
 }
 
 fn simple_eval_(
     graph: &onnx::GraphProto,
     values: &mut HashMap<String, Value>,
-    device: &Device,
+    placement: &Placement,
 ) -> Result<HashMap<String, Value>> {
-    for t in graph.initializer.iter() {
-        let tensor = get_tensor(t, t.name.as_str(), device)?;
-        values.insert(t.name.to_string(), tensor);
-    }
+    // Initializers (weights/constants) are materialized lazily, directly on the
+    // device of the node that first consumes them (see the node loop below). This
+    // lets a model that does not fit on a single device be split across several.
+    let initializers: HashMap<&str, &onnx::TensorProto> = graph
+        .initializer
+        .iter()
+        .map(|t| (t.name.as_str(), t))
+        .collect();
+
     for input in graph.input.iter() {
         let input_type = match &input.r#type {
             Some(input_type) => input_type,
@@ -271,8 +358,15 @@ fn simple_eval_(
         };
 
         let tensor = match values.get(&input.name) {
-            None => bail!("missing input {}", input.name),
             Some(tensor) => tensor,
+            None => {
+                // Initializer defaults are materialized lazily on their
+                // consumer's device, so they may legitimately be absent here.
+                if initializers.contains_key(input.name.as_str()) {
+                    continue;
+                }
+                bail!("missing input {}", input.name)
+            }
         };
         let dt = match DataType::try_from(tensor_type.elem_type) {
             Ok(dt) => match dtype(dt) {
@@ -322,6 +416,35 @@ fn simple_eval_(
     }
     // The nodes are topologically sorted so we can just process them in order.
     for node in graph.node.iter() {
+        // Resolve the device this node runs on, then make sure all of its inputs
+        // live there: lazily materialize initializer inputs and move
+        // previously-computed inputs across stage boundaries when needed.
+        let node_device = match placement.explicit_device(&node.name) {
+            Some(d) => d.clone(),
+            None => node
+                .input
+                .iter()
+                .filter(|s| !s.is_empty())
+                .find_map(|name| values.get(name).map(|t| t.device().clone()))
+                .unwrap_or_else(|| placement.fallback().clone()),
+        };
+        for name in node.input.iter().filter(|s| !s.is_empty()) {
+            let name = name.as_str();
+            let needs_move = match values.get(name) {
+                Some(tensor) => !tensor.device().same_device(&node_device),
+                None => false,
+            };
+            if needs_move {
+                let moved = values.get(name).unwrap().to_device(&node_device)?;
+                values.insert(name.to_string(), moved);
+            } else if !values.contains_key(name) {
+                if let Some(&proto) = initializers.get(name) {
+                    let tensor = get_tensor(proto, name, &node_device)?;
+                    values.insert(name.to_string(), tensor);
+                }
+            }
+        }
+
         let get = |input_name: &str| match values.get(input_name) {
             Some(value) => Ok(value),
             None => bail!("cannot find {input_name} for op '{}'", node.name),
@@ -578,8 +701,8 @@ fn simple_eval_(
             // https://github.com/onnx/onnx/blob/main/docs/Operators.md#ConstantOfShape
             "ConstantOfShape" => {
                 let input = get(&node.input[0])?;
-                let value = get_attr_opt_owned::<Tensor>(node, "value", device)?
-                    .unwrap_or(Tensor::zeros((), DType::F32, device)?);
+                let value = get_attr_opt_owned::<Tensor>(node, "value", &node_device)?
+                    .unwrap_or(Tensor::zeros((), DType::F32, &node_device)?);
 
                 let shape_vec: Vec<usize> = input
                     .to_vec1::<i64>()?
@@ -1083,7 +1206,7 @@ fn simple_eval_(
                 let output = match value.r#type() {
                     AttributeType::Tensor => {
                         let t = value.t.as_ref().unwrap();
-                        get_tensor(t, &node.name, device)?
+                        get_tensor(t, &node.name, &node_device)?
                     }
                     rtype => bail!("unsupported 'value' type {rtype:?} for {}", node.name),
                 };
@@ -1159,7 +1282,7 @@ fn simple_eval_(
                         node.output.len()
                     );
                 }
-                let branch_out = simple_eval_(sub_graph, values, device)?;
+                let branch_out = simple_eval_(sub_graph, values, placement)?;
                 for (i, out) in node.output.iter().enumerate() {
                     values.insert(
                         out.clone(),
@@ -1693,11 +1816,11 @@ fn simple_eval_(
                 let output = if random_type == "RandomUniform" {
                     let low: f32 = get_attr_opt(node, "low")?.copied().unwrap_or(0.0);
                     let high: f32 = get_attr_opt(node, "high")?.copied().unwrap_or(1.0);
-                    Tensor::rand(low, high, shape, device)?.to_dtype(dtype)?
+                    Tensor::rand(low, high, shape, &node_device)?.to_dtype(dtype)?
                 } else {
                     let mean: f32 = get_attr_opt(node, "mean")?.copied().unwrap_or(0.0);
                     let scale: f32 = get_attr_opt(node, "scale")?.copied().unwrap_or(1.0);
-                    Tensor::randn(mean, scale, shape, device)?.to_dtype(dtype)?
+                    Tensor::randn(mean, scale, shape, &node_device)?.to_dtype(dtype)?
                 };
                 values.insert(node.output[0].clone(), output);
             }
@@ -1822,8 +1945,9 @@ fn simple_eval_(
                     "Tanh".to_string(),
                     "Tanh".to_string(),
                 ];
-                let activations = get_attr_opt_owned::<Vec<String>>(node, "activations", device)?
-                    .unwrap_or(activations_default.clone());
+                let activations =
+                    get_attr_opt_owned::<Vec<String>>(node, "activations", &node_device)?
+                        .unwrap_or(activations_default.clone());
                 if activations != activations_default {
                     bail!("LSTM currently only supports default activations ({activations_default:?})");
                 }
@@ -2029,8 +2153,9 @@ fn simple_eval_(
             "RNN" => {
                 // activation_alpha and activation_beta don't apply to (Tanh, Tanh) so ignoring them is okay
                 let activations_default = vec!["Tanh".to_string(), "Tanh".to_string()];
-                let activations = get_attr_opt_owned::<Vec<String>>(node, "activations", device)?
-                    .unwrap_or(activations_default.clone());
+                let activations =
+                    get_attr_opt_owned::<Vec<String>>(node, "activations", &node_device)?
+                        .unwrap_or(activations_default.clone());
                 let clip = get_attr_opt::<f32>(node, "clip")?.copied();
                 if clip.is_some() {
                     bail!("RNN does not currently support clip attribute");
@@ -2546,6 +2671,16 @@ fn simple_eval_(
                 values.insert(node.output[0].clone(), output);
             }
             op_type => bail!("unsupported op_type {op_type} for op {node:?}"),
+        }
+    }
+    // A graph output may be an initializer that no node consumed; materialize
+    // any such leftover (on the fallback device) before collecting results.
+    for output in graph.output.iter() {
+        if !values.contains_key(&output.name) {
+            if let Some(&proto) = initializers.get(output.name.as_str()) {
+                let tensor = get_tensor(proto, &output.name, placement.fallback())?;
+                values.insert(output.name.clone(), tensor);
+            }
         }
     }
     graph

--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -236,10 +236,12 @@ pub fn get_tensor(t: &onnx::TensorProto, name: &str, device: &Device) -> Result<
 ///
 /// A node's device is resolved as:
 /// 1. the device of the longest matching node-name prefix rule, if any;
-/// 2. otherwise the device of the node's first already-computed input, so a
-///    stage's device flows along the graph and only the first node of each stage
-///    needs an explicit rule;
-/// 3. otherwise the fallback device.
+/// 2. otherwise, when at least one prefix rule is configured, the device of the
+///    node's first already-computed input, so a stage's device flows along the
+///    graph and only the first node of each stage needs an explicit rule;
+/// 3. otherwise the fallback device. In particular, [`Placement::uniform`] has no
+///    rules, so every node unconditionally runs on the fallback device, matching
+///    the documented behavior of [`simple_eval`].
 ///
 /// Initializers (weights/constants) are materialized lazily, directly on the
 /// device of the node that first consumes them, so a model that does not fit on
@@ -292,6 +294,13 @@ impl Placement {
         &self.fallback
     }
 
+    /// Whether at least one prefix rule is configured. [`Placement::uniform`]
+    /// has none, in which case every node must use the fallback device
+    /// unconditionally rather than inheriting an input's device.
+    fn has_rules(&self) -> bool {
+        !self.rules.is_empty()
+    }
+
     /// The device explicitly assigned to `node_name` by the prefix rules, if any.
     fn explicit_device(&self, node_name: &str) -> Option<&Device> {
         self.rules
@@ -326,22 +335,23 @@ pub fn simple_eval_with_placement(
         None => bail!("no graph defined in proto"),
         Some(graph) => graph,
     };
-    simple_eval_(graph, &mut inputs, placement)
+    simple_eval_(graph, &mut inputs, placement, &HashMap::new())
 }
 
-fn simple_eval_(
-    graph: &onnx::GraphProto,
+fn simple_eval_<'a>(
+    graph: &'a onnx::GraphProto,
     values: &mut HashMap<String, Value>,
     placement: &Placement,
+    parent_initializers: &HashMap<&'a str, &'a onnx::TensorProto>,
 ) -> Result<HashMap<String, Value>> {
     // Initializers (weights/constants) are materialized lazily, directly on the
     // device of the node that first consumes them (see the node loop below). This
     // lets a model that does not fit on a single device be split across several.
-    let initializers: HashMap<&str, &onnx::TensorProto> = graph
-        .initializer
-        .iter()
-        .map(|t| (t.name.as_str(), t))
-        .collect();
+    // Subgraphs (e.g. `If` branches) inherit their enclosing graph's initializers,
+    // matching ONNX's lexical scoping rules for control-flow ops; a name declared
+    // locally shadows one of the same name from an outer scope.
+    let mut initializers: HashMap<&'a str, &'a onnx::TensorProto> = parent_initializers.clone();
+    initializers.extend(graph.initializer.iter().map(|t| (t.name.as_str(), t)));
 
     for input in graph.input.iter() {
         let input_type = match &input.r#type {
@@ -421,12 +431,13 @@ fn simple_eval_(
         // previously-computed inputs across stage boundaries when needed.
         let node_device = match placement.explicit_device(&node.name) {
             Some(d) => d.clone(),
-            None => node
+            None if placement.has_rules() => node
                 .input
                 .iter()
                 .filter(|s| !s.is_empty())
                 .find_map(|name| values.get(name).map(|t| t.device().clone()))
                 .unwrap_or_else(|| placement.fallback().clone()),
+            None => placement.fallback().clone(),
         };
         for name in node.input.iter().filter(|s| !s.is_empty()) {
             let name = name.as_str();
@@ -1282,7 +1293,7 @@ fn simple_eval_(
                         node.output.len()
                     );
                 }
-                let branch_out = simple_eval_(sub_graph, values, placement)?;
+                let branch_out = simple_eval_(sub_graph, values, placement, &initializers)?;
                 for (i, out) in node.output.iter().enumerate() {
                     values.insert(
                         out.clone(),

--- a/candle-onnx/src/lib.rs
+++ b/candle-onnx/src/lib.rs
@@ -6,7 +6,7 @@ pub mod onnx {
 }
 
 pub mod eval;
-pub use eval::{dtype, simple_eval};
+pub use eval::{dtype, simple_eval, simple_eval_with_placement, Placement};
 
 pub fn read_file<P: AsRef<std::path::Path>>(p: P) -> Result<onnx::ModelProto> {
     let buf = std::fs::read(p)?;

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -1794,11 +1794,9 @@ fn test_gelu_operation() -> Result<()> {
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
 
-    let results = z.to_vec2::<f32>()?;
-
     assert_eq!(
-        results,
-        vec![vec![0.0, 0.8413448], vec![1.9544997, 2.9959502]]
+        to_vec2_round(z, 6)?,
+        [[0.0, 0.841345], [1.9545, 2.99595]]
     );
 
     Ok(())

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -5,7 +5,7 @@ use candle_onnx::onnx::tensor_proto::DataType;
 use candle_onnx::onnx::tensor_shape_proto::{dimension, Dimension};
 use candle_onnx::onnx::{type_proto, TensorProto, TensorShapeProto, TypeProto};
 use candle_onnx::onnx::{AttributeProto, GraphProto, ModelProto, NodeProto, ValueInfoProto};
-use candle_onnx::simple_eval;
+use candle_onnx::{simple_eval, simple_eval_with_placement, Placement};
 use std::collections::HashMap;
 
 const INPUT_X: &str = "x";
@@ -7509,3 +7509,175 @@ test_device!(
     simple_eval_gemm_device_gpu,
     simple_eval_gemm_device_metal
 );
+
+// Pipeline-parallelism tests for `simple_eval_with_placement`
+// (follow-up to https://github.com/huggingface/candle/issues/3491).
+//
+// They check that a single ONNX graph can be evaluated with its nodes spread
+// across several devices, with cross-device copies inserted automatically at
+// stage boundaries. The CPU-only tests exercise placement resolution and the
+// lazy-initializer logic; the CUDA tests (feature-gated) exercise the actual
+// cross-device transfers.
+
+// A two-stage graph: z = (x + w0) * w1, with the two compute nodes named so they
+// can be assigned to different stages/devices:
+//   node "stage0/add": t = x + w0
+//   node "stage1/mul": z = t * w1
+fn two_stage_graph() -> ModelProto {
+    create_model_proto_with_graph(Some(GraphProto {
+        node: vec![
+            NodeProto {
+                op_type: "Add".to_string(),
+                name: "stage0/add".to_string(),
+                input: vec![INPUT_X.to_string(), "w0".to_string()],
+                output: vec!["t".to_string()],
+                ..Default::default()
+            },
+            NodeProto {
+                op_type: "Mul".to_string(),
+                name: "stage1/mul".to_string(),
+                input: vec!["t".to_string(), "w1".to_string()],
+                output: vec![OUTPUT_Z.to_string()],
+                ..Default::default()
+            },
+        ],
+        initializer: vec![
+            TensorProto {
+                data_type: DataType::Float.into(),
+                dims: vec![3],
+                float_data: vec![1.0, 1.0, 1.0],
+                name: "w0".to_string(),
+                ..Default::default()
+            },
+            TensorProto {
+                data_type: DataType::Float.into(),
+                dims: vec![3],
+                float_data: vec![2.0, 2.0, 2.0],
+                name: "w1".to_string(),
+                ..Default::default()
+            },
+        ],
+        output: vec![ValueInfoProto {
+            name: OUTPUT_Z.to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }))
+}
+
+// `Placement::uniform(device)` must behave exactly like `simple_eval(.., device)`.
+#[test]
+fn placement_uniform_matches_simple_eval() -> Result<()> {
+    let graph = two_stage_graph();
+    let device = Device::Cpu;
+    let x = Tensor::new(&[10f32, 20., 30.], &device)?;
+
+    let mut inputs = HashMap::new();
+    inputs.insert(INPUT_X.to_string(), x.clone());
+    let baseline = simple_eval(&graph, inputs, &device)?;
+
+    let mut inputs = HashMap::new();
+    inputs.insert(INPUT_X.to_string(), x);
+    let placed = simple_eval_with_placement(&graph, inputs, &Placement::uniform(&device))?;
+
+    let baseline_z = baseline.get(OUTPUT_Z).unwrap().to_vec1::<f32>()?;
+    let placed_z = placed.get(OUTPUT_Z).unwrap().to_vec1::<f32>()?;
+    assert_eq!(baseline_z, placed_z);
+    assert_eq!(placed_z, vec![22f32, 42., 62.]);
+    Ok(())
+}
+
+// Prefix rules + data-flow inheritance, exercised on CPU (so the devices compare
+// equal, but the resolution, lazy-init and input pre-staging code paths all run).
+#[test]
+fn placement_prefix_resolution_cpu() -> Result<()> {
+    let graph = two_stage_graph();
+    let cpu = Device::Cpu;
+    // "stage1/mul" is matched explicitly; "stage0/add" inherits cpu from `x`.
+    let placement = Placement::new(&cpu).with_prefix("stage1", &cpu);
+
+    let mut inputs = HashMap::new();
+    inputs.insert(INPUT_X.to_string(), Tensor::new(&[10f32, 20., 30.], &cpu)?);
+    let eval = simple_eval_with_placement(&graph, inputs, &placement)?;
+
+    let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+    assert!(z.device().same_device(&cpu));
+    assert_eq!(z.to_vec1::<f32>()?, vec![22f32, 42., 62.]);
+    Ok(())
+}
+
+// A graph output that is an initializer consumed by no node must still be
+// returned (the lazy-initializer path materializes it on the fallback device).
+#[test]
+fn placement_initializer_only_output_cpu() -> Result<()> {
+    let graph = create_model_proto_with_graph(Some(GraphProto {
+        node: vec![],
+        initializer: vec![TensorProto {
+            data_type: DataType::Float.into(),
+            dims: vec![3],
+            float_data: vec![1.0, 2.0, 3.0],
+            name: OUTPUT_Z.to_string(),
+            ..Default::default()
+        }],
+        output: vec![ValueInfoProto {
+            name: OUTPUT_Z.to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }));
+
+    let eval =
+        simple_eval_with_placement(&graph, HashMap::new(), &Placement::uniform(&Device::Cpu))?;
+    let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+    assert_eq!(z.to_vec1::<f32>()?, vec![1f32, 2., 3.]);
+    Ok(())
+}
+
+// Real cross-device execution on a single CUDA GPU: stage0 runs on the CPU and
+// stage1 on cuda:0, so the run exercises both cuda->cpu and cpu->cuda boundary
+// copies as well as lazy initializer materialization on each device.
+#[cfg(feature = "cuda")]
+#[test]
+fn simple_eval_placement_cpu_to_cuda() -> Result<()> {
+    let cuda = Device::new_cuda(0)?;
+    let graph = two_stage_graph();
+    let placement = Placement::new(&cuda)
+        .with_prefix("stage0", &Device::Cpu)
+        .with_prefix("stage1", &cuda);
+
+    let mut inputs = HashMap::new();
+    inputs.insert(INPUT_X.to_string(), Tensor::new(&[10f32, 20., 30.], &cuda)?);
+    let eval = simple_eval_with_placement(&graph, inputs, &placement)?;
+
+    let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+    assert!(z.device().same_device(&cuda));
+    assert_eq!(z.to_vec1::<f32>()?, vec![22f32, 42., 62.]);
+    Ok(())
+}
+
+// Pipeline split across two physical GPUs (the homelab use case): the boundary
+// inserts a genuine cuda:0 -> cuda:1 device-to-device copy. Ignored by default
+// since CI machines rarely have two GPUs; run with:
+//   cargo test --features cuda -- --ignored simple_eval_placement_two_cuda_gpus
+#[cfg(feature = "cuda")]
+#[test]
+#[ignore = "requires two CUDA GPUs"]
+fn simple_eval_placement_two_cuda_gpus() -> Result<()> {
+    let cuda0 = Device::new_cuda(0)?;
+    let cuda1 = Device::new_cuda(1)?;
+    let graph = two_stage_graph();
+    // stage0 inherits cuda:0 from the input; stage1 is pinned to cuda:1.
+    let placement = Placement::new(&cuda0).with_prefix("stage1", &cuda1);
+
+    let mut inputs = HashMap::new();
+    inputs.insert(
+        INPUT_X.to_string(),
+        Tensor::new(&[10f32, 20., 30.], &cuda0)?,
+    );
+    let eval = simple_eval_with_placement(&graph, inputs, &placement)?;
+
+    let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+    assert!(z.device().same_device(&cuda1));
+    assert_eq!(z.to_vec1::<f32>()?, vec![22f32, 42., 62.]);
+    Ok(())
+}

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -1,5 +1,5 @@
 use candle::test_utils::to_vec2_round;
-use candle::{DType, Device, NdArray, Result, Tensor};
+use candle::{test_device, DType, Device, NdArray, Result, Tensor};
 use candle_onnx::onnx::attribute_proto::AttributeType;
 use candle_onnx::onnx::tensor_proto::DataType;
 use candle_onnx::onnx::tensor_shape_proto::{dimension, Dimension};
@@ -33,7 +33,7 @@ fn create_model_proto_with_graph(graph: Option<GraphProto>) -> ModelProto {
 fn test_evaluation_fails_without_defined_graph() -> Result<()> {
     let manual_graph = create_model_proto_with_graph(None);
     let inputs: HashMap<String, Tensor> = HashMap::new();
-    match candle_onnx::simple_eval(&manual_graph, inputs) {
+    match candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu) {
         Err(err) => assert_eq!(err.to_string(), "no graph defined in proto"),
         Ok(_) => panic!("Expected an error due to undefined graph"),
     }
@@ -71,7 +71,7 @@ fn test_add_operation() -> Result<()> {
     inputs.insert(INPUT_X.to_string(), Tensor::new(&[2.], &Device::Cpu)?);
     inputs.insert(INPUT_Y.to_string(), Tensor::new(&[2.], &Device::Cpu)?);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -111,7 +111,7 @@ fn test_sub_operation() -> Result<()> {
     inputs.insert(INPUT_X.to_string(), Tensor::new(&[2.], &Device::Cpu)?);
     inputs.insert(INPUT_Y.to_string(), Tensor::new(&[2.], &Device::Cpu)?);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -151,7 +151,7 @@ fn test_mul_operation() -> Result<()> {
     inputs.insert(INPUT_X.to_string(), Tensor::new(&[2.], &Device::Cpu)?);
     inputs.insert(INPUT_Y.to_string(), Tensor::new(&[2.], &Device::Cpu)?);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -191,7 +191,7 @@ fn test_div_operation() -> Result<()> {
     inputs.insert(INPUT_X.to_string(), Tensor::new(&[2.], &Device::Cpu)?);
     inputs.insert(INPUT_Y.to_string(), Tensor::new(&[2.], &Device::Cpu)?);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -232,7 +232,7 @@ fn test_exp_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -277,7 +277,7 @@ fn test_equal_operation() -> Result<()> {
     inputs.insert(INPUT_X.to_string(), Tensor::new(&[2.], &Device::Cpu)?);
     inputs.insert(INPUT_Y.to_string(), Tensor::new(&[2.], &Device::Cpu)?);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -317,7 +317,7 @@ fn test_not_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), Tensor::new(&[0.], &Device::Cpu)?);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -374,7 +374,7 @@ fn test_matmul_operation() -> Result<()> {
         )?,
     );
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -439,7 +439,7 @@ fn test_reshape_operation() -> Result<()> {
     inputs.insert(INPUT_X.to_string(), x);
     inputs.insert(INPUT_Y.to_string(), y);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -499,7 +499,7 @@ fn test_logsoftmax_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -562,7 +562,7 @@ fn test_softmax_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -625,7 +625,7 @@ fn test_transpose_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -684,7 +684,7 @@ fn test_dropout_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -764,7 +764,7 @@ fn test_flatten_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs.clone())?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs.clone(), &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -809,7 +809,7 @@ fn test_flatten_operation() -> Result<()> {
         quantization_annotation: vec![],
     }));
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -958,7 +958,7 @@ fn test_constant_of_shape() -> Result<()> {
         let mut inputs: HashMap<String, Tensor> = HashMap::new();
         inputs.insert(INPUT_X.to_string(), Tensor::new(input, &Device::Cpu)?);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval
@@ -1022,7 +1022,7 @@ fn test_unsqueeze() -> Result<()> {
 
     let inputs = HashMap::from_iter([(INPUT_X.to_string(), x.clone()), (INPUT_Y.to_string(), y)]);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -1149,7 +1149,7 @@ fn test_gather_operation() -> Result<()> {
         inputs.insert(INPUT_X.to_string(), Tensor::new(data, &Device::Cpu)?);
         inputs.insert(INPUT_Y.to_string(), Tensor::new(indices, &Device::Cpu)?);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -1306,7 +1306,7 @@ fn test_gather_elements() -> Result<()> {
         inputs.insert(INPUT_X.to_string(), Tensor::new(data, &Device::Cpu)?);
         inputs.insert(INPUT_Y.to_string(), Tensor::new(indices, &Device::Cpu)?);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -1360,7 +1360,7 @@ fn test_size_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -1405,7 +1405,7 @@ fn test_shape_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -1467,7 +1467,7 @@ fn test_abs_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -1521,7 +1521,7 @@ fn test_cos_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -1569,7 +1569,7 @@ fn test_sin_operation() -> Result<()> {
     let x = Tensor::from_vec(vec![0.0f32, 1.0f32, 2.0f32, 3.0f32], &[2, 2], &Device::Cpu)?;
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
     assert_eq!(to_vec2_round(z, 4)?, [[0.0, 0.8415], [0.9093, 0.1411]]);
@@ -1618,7 +1618,7 @@ fn test_neg_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -1675,7 +1675,7 @@ fn test_tanh_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -1732,7 +1732,7 @@ fn test_sigmoid_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -1789,7 +1789,7 @@ fn test_gelu_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -1843,7 +1843,7 @@ fn test_relu_operation() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -1904,7 +1904,7 @@ fn test_prelu_operation() -> Result<()> {
     inputs.insert(INPUT_X.to_string(), x);
     inputs.insert(INPUT_Y.to_string(), y);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -2394,7 +2394,7 @@ fn test_reduce_max() -> Result<()> {
             }
         }
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -2913,7 +2913,7 @@ fn test_reduce_min() -> Result<()> {
             }
         }
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -3114,7 +3114,7 @@ fn test_reduce_mean() -> Result<()> {
         let mut inputs: HashMap<String, Tensor> = HashMap::new();
         inputs.insert(INPUT_X.to_string(), Tensor::new(data, &Device::Cpu)?);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -3168,7 +3168,7 @@ fn test_sqrt() -> Result<()> {
         let mut inputs: HashMap<String, Tensor> = HashMap::new();
         inputs.insert(INPUT_X.to_string(), Tensor::new(data, &Device::Cpu)?);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -3310,7 +3310,7 @@ fn test_random_uniform() -> Result<()> {
             sparse_initializer: vec![],
             quantization_annotation: vec![],
         }));
-        let eval = candle_onnx::simple_eval(&manual_graph, HashMap::new())?;
+        let eval = candle_onnx::simple_eval(&manual_graph, HashMap::new(), &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
         let min = z
@@ -3456,7 +3456,7 @@ fn test_random_normal() -> Result<()> {
             sparse_initializer: vec![],
             quantization_annotation: vec![],
         }));
-        let eval = candle_onnx::simple_eval(&manual_graph, HashMap::new())?;
+        let eval = candle_onnx::simple_eval(&manual_graph, HashMap::new(), &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -3526,7 +3526,7 @@ fn test_range() -> Result<()> {
         inputs.insert(INPUT_Y.to_string(), Tensor::new(limit, &Device::Cpu)?);
         inputs.insert(INPUT_A.to_string(), Tensor::new(delta, &Device::Cpu)?);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval
@@ -3587,7 +3587,7 @@ fn test_greater() -> Result<()> {
         inputs.insert(INPUT_X.to_string(), Tensor::new(a, &Device::Cpu)?);
         inputs.insert(INPUT_Y.to_string(), Tensor::new(b, &Device::Cpu)?);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval
@@ -3648,7 +3648,7 @@ fn test_less() -> Result<()> {
         inputs.insert(INPUT_X.to_string(), Tensor::new(a, &Device::Cpu)?);
         inputs.insert(INPUT_Y.to_string(), Tensor::new(b, &Device::Cpu)?);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval
@@ -3705,7 +3705,7 @@ fn test_log() -> Result<()> {
         let mut inputs: HashMap<String, Tensor> = HashMap::new();
         inputs.insert(INPUT_X.to_string(), Tensor::new(data, &Device::Cpu)?);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -3770,7 +3770,7 @@ fn test_min() -> Result<()> {
         inputs.insert(INPUT_Y.to_string(), Tensor::new(b, &Device::Cpu)?);
         inputs.insert(INPUT_A.to_string(), Tensor::new(c, &Device::Cpu)?);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -3848,7 +3848,7 @@ fn test_where() -> Result<()> {
         inputs.insert(INPUT_Y.to_string(), Tensor::new(x, &Device::Cpu)?);
         inputs.insert(INPUT_A.to_string(), Tensor::new(y, &Device::Cpu)?);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval
@@ -3921,7 +3921,7 @@ fn test_floor() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -3997,7 +3997,7 @@ fn test_ceil() -> Result<()> {
     let mut inputs: HashMap<String, Tensor> = HashMap::new();
     inputs.insert(INPUT_X.to_string(), x);
 
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
     assert_eq!(eval.len(), 1);
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -4189,7 +4189,7 @@ fn test_argmin() -> Result<()> {
         }));
         let mut inputs: HashMap<String, Tensor> = HashMap::new();
         inputs.insert(INPUT_X.to_string(), Tensor::new(data, &Device::Cpu)?);
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
 
         let expected = Tensor::new(expected, &Device::Cpu)?;
@@ -4371,7 +4371,7 @@ fn test_argmax() -> Result<()> {
         }));
         let mut inputs: HashMap<String, Tensor> = HashMap::new();
         inputs.insert(INPUT_X.to_string(), Tensor::new(data, &Device::Cpu)?);
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
 
         let expected = Tensor::new(expected, &Device::Cpu)?;
@@ -4446,7 +4446,7 @@ fn test_leakyrelu() -> Result<()> {
         }));
         let mut inputs: HashMap<String, Tensor> = HashMap::new();
         inputs.insert(INPUT_X.to_string(), Tensor::new(data, &Device::Cpu)?);
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
 
         let expected = Tensor::new(expected, &Device::Cpu)?;
@@ -4565,7 +4565,7 @@ fn test_if() -> Result<()> {
     for cond in [1u8, 0] {
         let inputs =
             HashMap::from_iter([("cond".to_string(), Tensor::full(cond, (1,), &Device::Cpu)?)]);
-        let outputs = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let outputs = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         let expected = if cond != 0 { &x } else { &y };
         let Some(res) = outputs.get("res") else {
             candle::bail!("outputs didn't contain expected key `res`: {outputs:?}");
@@ -4628,7 +4628,7 @@ fn test_pad() -> Result<()> {
     }));
 
     let inputs = HashMap::from_iter([("data".to_string(), data), ("pads".to_string(), pads)]);
-    let res = candle_onnx::simple_eval(&model, inputs)?;
+    let res = candle_onnx::simple_eval(&model, inputs, &Device::Cpu)?;
     let Some(actual) = res.get("output") else {
         candle::bail!("outputs didn't contain expected key `output`: {res:?}");
     };
@@ -4709,6 +4709,7 @@ fn test_slice() -> Result<()> {
                 Tensor::from_vec(vec![1i64, 2], (2,), &Device::Cpu)?,
             ),
         ]),
+        &Device::Cpu,
     )?;
     let actual = outputs.get("result").unwrap().to_vec2::<i64>()?;
     assert_eq!(actual, vec![vec![5i64, 7]]);
@@ -4765,6 +4766,7 @@ fn test_slice() -> Result<()> {
                 Tensor::from_vec(vec![-1i64, 1000], (2,), &Device::Cpu)?,
             ),
         ]),
+        &Device::Cpu,
     )?;
     let actual = outputs.get("result").unwrap().to_vec2::<i64>()?;
     assert_eq!(actual, vec![vec![2i64, 3, 4]]);
@@ -5209,6 +5211,7 @@ fn test_lstm() -> Result<()> {
             ("h".to_string(), h0),
             ("c".to_string(), c0),
         ]),
+        &Device::Cpu,
     )?;
     let actual_output = result.get("output").unwrap();
     assert_eq!(output.dims(), actual_output.dims());
@@ -5489,6 +5492,7 @@ fn test_rnn() -> Result<()> {
             ("b".to_string(), b),
             ("h".to_string(), h),
         ]),
+        &Device::Cpu,
     )?;
     let actual_output = result.get("output").unwrap();
     assert_eq!(output.dims(), actual_output.dims());
@@ -5561,7 +5565,7 @@ fn test_expand_dim_changed() -> Result<()> {
         ("data".to_string(), data),
         ("new_shape".to_string(), new_shape),
     ]);
-    let result = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let result = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
 
     // Retrieve and compare the result
     let expanded = result.get("expanded").expect("Output 'expanded' not found");
@@ -5631,7 +5635,7 @@ fn test_expand_dim_unchanged() -> Result<()> {
         ("data".to_string(), data),
         ("new_shape".to_string(), new_shape),
     ]);
-    let result = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let result = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
 
     // Retrieve and compare the result
     let expanded = result.get("expanded").expect("Output 'expanded' not found");
@@ -5664,7 +5668,7 @@ fn test_split_equal_parts_1d_opset13() -> Result<()> {
     {
         let manual_graph =
             make_split_graph_helper(&["input"], &["output_1", "output_2", "output_3"], 0);
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs.clone())?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs.clone(), &Device::Cpu)?;
         assert_eq!(eval.len(), 3);
 
         let out1 = eval.get("output_1").expect("Output 'output_1' not found");
@@ -5682,7 +5686,7 @@ fn test_split_equal_parts_1d_opset13() -> Result<()> {
 
         let manual_graph =
             make_split_graph_helper(&["input", "split"], &["output_1", "output_2"], 0);
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 2);
 
         let out1 = eval.get("output_1").expect("Output 'output_1' not found");
@@ -5739,7 +5743,7 @@ fn test_reduce_sum_default_axes_keepdims() -> Result<()> {
         inputs.insert("data".to_string(), data);
         // inputs.insert("axes".to_string(), axes);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let reduced = eval.get("reduced").expect("Output 'reduced' not found");
@@ -5760,7 +5764,7 @@ fn test_reduce_sum_default_axes_keepdims() -> Result<()> {
         let mut inputs = HashMap::new();
         inputs.insert("data".to_string(), data.clone());
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let reduced = eval.get("reduced").expect("Output 'reduced' not found");
@@ -5791,7 +5795,7 @@ fn test_reduce_sum_do_not_keep_dims() -> Result<()> {
         inputs.insert("data".to_string(), data);
         inputs.insert("axes".to_string(), axes);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let reduced = eval.get("reduced").expect("Output 'reduced' not found");
@@ -5820,7 +5824,7 @@ fn test_reduce_sum_do_not_keep_dims() -> Result<()> {
         inputs.insert("data".to_string(), data.clone());
         inputs.insert("axes".to_string(), axes);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let reduced = eval.get("reduced").expect("Output 'reduced' not found");
@@ -6170,7 +6174,7 @@ fn test_xor() -> Result<()> {
             (INPUT_Y.to_string(), Tensor::new(other, &Device::Cpu)?),
         ]);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -6237,7 +6241,7 @@ fn test_sign_operation() -> Result<()> {
         INPUT_X.to_string(),
         Tensor::new(vec![-2f32, -1., 0., 1., 2.], &Device::Cpu)?,
     );
-    let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
     assert_eq!(
@@ -6275,7 +6279,7 @@ fn test_selu_operator() -> Result<()> {
         let mut inputs = HashMap::new();
         inputs.insert("input".to_string(), input);
 
-        let eval = simple_eval(&default_graph, inputs)?;
+        let eval = simple_eval(&default_graph, inputs, &Device::Cpu)?;
         let output = eval.get("output").unwrap();
         let out_vec = to_vec2_round(output, 4)?;
         assert_eq!(out_vec, vec![vec![-1.1113, 0.0], vec![1.0507, 2.1014]]);
@@ -6318,7 +6322,7 @@ fn test_selu_operator() -> Result<()> {
         let input = Tensor::from_vec(vec![-1.0f32, 0.0, 1.0, 2.0], (2, 2), &Device::Cpu)?;
         let mut inputs = HashMap::new();
         inputs.insert("input".to_string(), input);
-        let eval = simple_eval(&custom_graph, inputs)?;
+        let eval = simple_eval(&custom_graph, inputs, &Device::Cpu)?;
         let output = eval.get("output").unwrap();
         let out_vec = to_vec2_round(output, 4)?;
         assert_eq!(out_vec, vec![vec![-0.6321, 0.0], vec![0.5, 1.0]]);
@@ -6350,7 +6354,7 @@ fn test_selu_operator() -> Result<()> {
         let input = Tensor::from_vec(vec![-10.0f32, -5.0, 0.0, 10.0], (2, 2), &Device::Cpu)?;
         let mut inputs = HashMap::new();
         inputs.insert("input".to_string(), input);
-        let eval = simple_eval(&manual_graph, inputs)?;
+        let eval = simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         let output = eval.get("output").unwrap();
         let out_vec = to_vec2_round(output, 4)?;
         assert_eq!(
@@ -6400,7 +6404,7 @@ fn test_selu_operator() -> Result<()> {
         let mut inputs = HashMap::new();
         inputs.insert("input".to_string(), input);
 
-        let eval = simple_eval(&graph, inputs)?;
+        let eval = simple_eval(&graph, inputs, &Device::Cpu)?;
         let output = eval.get("output").unwrap();
         let out_vec = output.to_vec1::<f32>()?;
         let expected = vec![-3.7927232, 0.0, 3.0];
@@ -6434,7 +6438,7 @@ fn test_selu_operator() -> Result<()> {
         let input = Tensor::from_vec(vec![] as Vec<f32>, (0, 2), &Device::Cpu)?;
         let mut inputs = HashMap::new();
         inputs.insert("input".to_string(), input);
-        let eval = simple_eval(&manual_graph, inputs)?;
+        let eval = simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         let output = eval.get("output").unwrap();
         assert_eq!(output.dims(), &[0, 2]);
     }
@@ -6467,7 +6471,7 @@ fn test_hard_swish() -> candle::Result<()> {
         let mut inputs = HashMap::new();
         inputs.insert(INPUT_X.to_string(), input_tensor);
 
-        let outputs = simple_eval(&manual_graph, inputs)?;
+        let outputs = simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         let output = outputs.get(OUTPUT_Z).expect("missing output Z");
         let output_vec = output.to_vec1::<f32>()?;
 
@@ -6504,7 +6508,7 @@ fn test_hard_swish() -> candle::Result<()> {
         let mut inputs = HashMap::new();
         inputs.insert(INPUT_X.to_string(), input_tensor);
 
-        let outputs = simple_eval(&manual_graph, inputs)?;
+        let outputs = simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         let output = outputs.get(OUTPUT_Z).expect("missing output Z");
         let output_vec = output.to_vec1::<f32>()?;
 
@@ -6594,7 +6598,7 @@ fn test_scatternd_operation() -> Result<()> {
         inputs.insert(INPUT_Y.to_string(), Tensor::new(indices, &Device::Cpu)?);
         inputs.insert(INPUT_A.to_string(), Tensor::new(updates, &Device::Cpu)?);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -6656,7 +6660,7 @@ fn test_trilu_operation() -> Result<()> {
         let mut inputs: HashMap<String, Tensor> = HashMap::new();
         inputs.insert(INPUT_X.to_string(), x);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -6722,7 +6726,7 @@ fn test_trilu_operation() -> Result<()> {
         inputs.insert(INPUT_X.to_string(), x);
         inputs.insert(INPUT_Y.to_string(), k);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -6778,7 +6782,7 @@ fn test_trilu_operation() -> Result<()> {
         inputs.insert(INPUT_X.to_string(), x);
         inputs.insert(INPUT_Y.to_string(), k);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -6853,7 +6857,7 @@ fn test_trilu_operation() -> Result<()> {
         let mut inputs: HashMap<String, Tensor> = HashMap::new();
         inputs.insert(INPUT_X.to_string(), x);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -6932,7 +6936,7 @@ fn test_trilu_operation() -> Result<()> {
         inputs.insert(INPUT_X.to_string(), x);
         inputs.insert(INPUT_Y.to_string(), k);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -7010,7 +7014,7 @@ fn test_trilu_operation() -> Result<()> {
         inputs.insert(INPUT_X.to_string(), x);
         inputs.insert(INPUT_Y.to_string(), k);
 
-        let eval = candle_onnx::simple_eval(&manual_graph, inputs)?;
+        let eval = candle_onnx::simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         assert_eq!(eval.len(), 1);
 
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
@@ -7077,7 +7081,7 @@ fn test_one_hot() -> Result<()> {
         inputs.insert("depth".to_string(), depth_value);
         inputs.insert("values".to_string(), values_tensor);
 
-        let eval = simple_eval(&manual_graph, inputs)?;
+        let eval = simple_eval(&manual_graph, inputs, &Device::Cpu)?;
         let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
 
         let expected = vec![
@@ -7120,7 +7124,7 @@ fn test_one_hot() -> Result<()> {
         inputs.insert("depth".into(), depth);
         inputs.insert("values".into(), values);
 
-        let eval = simple_eval(&graph, inputs)?;
+        let eval = simple_eval(&graph, inputs, &Device::Cpu)?;
         let y = eval.get("y").unwrap();
         assert_eq!(y.dims(), &[2, 10, 2]);
     }
@@ -7155,7 +7159,7 @@ fn test_one_hot() -> Result<()> {
         inputs.insert("depth".into(), depth);
         inputs.insert("values".into(), values);
 
-        let eval = simple_eval(&graph, inputs)?;
+        let eval = simple_eval(&graph, inputs, &Device::Cpu)?;
         let y = eval.get("y").unwrap();
         assert_eq!(y.dims(), &[2, 10, 2]);
     }
@@ -7190,7 +7194,7 @@ fn test_one_hot() -> Result<()> {
         inputs.insert("depth".into(), depth);
         inputs.insert("values".into(), values);
 
-        let eval = simple_eval(&graph, inputs)?;
+        let eval = simple_eval(&graph, inputs, &Device::Cpu)?;
         let y = eval.get("y").unwrap();
         assert_eq!(y.dims(), &[3, 10]);
     }
@@ -7219,10 +7223,291 @@ fn test_one_hot() -> Result<()> {
         inputs.insert("depth".into(), depth);
         inputs.insert("values".into(), values);
 
-        let eval = simple_eval(&graph, inputs)?;
+        let eval = simple_eval(&graph, inputs, &Device::Cpu)?;
         let y = eval.get("y").unwrap();
         assert_eq!(y.dims(), &[3, 12]);
     }
 
     Ok(())
 }
+
+// Regression tests for https://github.com/huggingface/candle/issues/3491
+//
+// `simple_eval` used to hard-code `Device::Cpu` for initializers, `Constant`
+// values, `ConstantOfShape` defaults, `RandomUniform`/`RandomNormal` outputs
+// and the `Gemm` alpha/beta scalars. This meant that running a model on a
+// non-CPU device failed with a device-mismatch error as soon as a user input
+// was combined with one of those values. Each test below builds a tiny graph
+// that exercises one of the previously hard-coded code paths and checks that
+// the result lives on the device that was passed to `simple_eval`.
+
+// "Add" between a user input and a graph initializer (i.e. a model weight),
+// which is exactly the scenario from the linked issue.
+fn simple_eval_initializer_device(device: &Device) -> Result<()> {
+    let graph = create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "Add".to_string(),
+            input: vec![INPUT_X.to_string(), "weight".to_string()],
+            output: vec![OUTPUT_Z.to_string()],
+            ..Default::default()
+        }],
+        initializer: vec![TensorProto {
+            data_type: DataType::Float.into(),
+            dims: vec![3],
+            float_data: vec![1.0, 2.0, 3.0],
+            name: "weight".to_string(),
+            ..Default::default()
+        }],
+        output: vec![ValueInfoProto {
+            name: OUTPUT_Z.to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }));
+
+    let mut inputs: HashMap<String, Tensor> = HashMap::new();
+    inputs.insert(
+        INPUT_X.to_string(),
+        Tensor::new(&[10f32, 20., 30.], device)?,
+    );
+
+    let eval = simple_eval(&graph, inputs, device)?;
+    let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+    assert!(z.device().same_device(device));
+    assert_eq!(z.to_vec1::<f32>()?, vec![11f32, 22., 33.]);
+    Ok(())
+}
+test_device!(
+    simple_eval_initializer_device,
+    simple_eval_initializer_device_cpu,
+    simple_eval_initializer_device_gpu,
+    simple_eval_initializer_device_metal
+);
+
+// "Constant" node whose value comes from an attribute tensor.
+fn simple_eval_constant_device(device: &Device) -> Result<()> {
+    let tensor = TensorProto {
+        data_type: DataType::Float.into(),
+        dims: vec![3],
+        float_data: vec![1.0, 2.0, 3.0],
+        ..Default::default()
+    };
+    let graph = create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "Constant".to_string(),
+            attribute: vec![AttributeProto {
+                name: "value".to_string(),
+                r#type: AttributeType::Tensor.into(),
+                t: Some(tensor),
+                ..Default::default()
+            }],
+            output: vec![OUTPUT_Z.to_string()],
+            ..Default::default()
+        }],
+        output: vec![ValueInfoProto {
+            name: OUTPUT_Z.to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }));
+
+    let eval = simple_eval(&graph, HashMap::new(), device)?;
+    let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+    assert!(z.device().same_device(device));
+    assert_eq!(z.to_vec1::<f32>()?, vec![1f32, 2., 3.]);
+    Ok(())
+}
+test_device!(
+    simple_eval_constant_device,
+    simple_eval_constant_device_cpu,
+    simple_eval_constant_device_gpu,
+    simple_eval_constant_device_metal
+);
+
+// "ConstantOfShape" without a "value" attribute, which falls back to a
+// default tensor that used to be pinned to the CPU.
+fn simple_eval_constant_of_shape_device(device: &Device) -> Result<()> {
+    let graph = create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "ConstantOfShape".to_string(),
+            input: vec![INPUT_X.to_string()],
+            output: vec![OUTPUT_Z.to_string()],
+            ..Default::default()
+        }],
+        output: vec![ValueInfoProto {
+            name: OUTPUT_Z.to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }));
+
+    let mut inputs: HashMap<String, Tensor> = HashMap::new();
+    inputs.insert(INPUT_X.to_string(), Tensor::new(&[2i64, 3], device)?);
+
+    let eval = simple_eval(&graph, inputs, device)?;
+    let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+    assert!(z.device().same_device(device));
+    assert_eq!(
+        z.to_vec2::<f32>()?,
+        vec![vec![0f32, 0., 0.], vec![0f32, 0., 0.]]
+    );
+    Ok(())
+}
+test_device!(
+    simple_eval_constant_of_shape_device,
+    simple_eval_constant_of_shape_device_cpu,
+    simple_eval_constant_of_shape_device_gpu,
+    simple_eval_constant_of_shape_device_metal
+);
+
+// "RandomUniform" has no tensor inputs at all, so its output device only
+// ever came from the (previously hard-coded) device argument.
+fn simple_eval_random_uniform_device(device: &Device) -> Result<()> {
+    let graph = create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "RandomUniform".to_string(),
+            attribute: vec![AttributeProto {
+                name: "shape".to_string(),
+                r#type: AttributeType::Ints.into(),
+                ints: vec![2, 2],
+                ..Default::default()
+            }],
+            output: vec![OUTPUT_Z.to_string()],
+            ..Default::default()
+        }],
+        output: vec![ValueInfoProto {
+            name: OUTPUT_Z.to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }));
+
+    let eval = simple_eval(&graph, HashMap::new(), device)?;
+    let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+    assert!(z.device().same_device(device));
+    assert_eq!(z.dims(), &[2, 2]);
+    Ok(())
+}
+test_device!(
+    simple_eval_random_uniform_device,
+    simple_eval_random_uniform_device_cpu,
+    simple_eval_random_uniform_device_gpu,
+    simple_eval_random_uniform_device_metal
+);
+
+// Same as above but for "RandomNormal".
+fn simple_eval_random_normal_device(device: &Device) -> Result<()> {
+    let graph = create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "RandomNormal".to_string(),
+            attribute: vec![AttributeProto {
+                name: "shape".to_string(),
+                r#type: AttributeType::Ints.into(),
+                ints: vec![2, 2],
+                ..Default::default()
+            }],
+            output: vec![OUTPUT_Z.to_string()],
+            ..Default::default()
+        }],
+        output: vec![ValueInfoProto {
+            name: OUTPUT_Z.to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }));
+
+    let eval = simple_eval(&graph, HashMap::new(), device)?;
+    let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+    assert!(z.device().same_device(device));
+    assert_eq!(z.dims(), &[2, 2]);
+    Ok(())
+}
+test_device!(
+    simple_eval_random_normal_device,
+    simple_eval_random_normal_device_cpu,
+    simple_eval_random_normal_device_gpu,
+    simple_eval_random_normal_device_metal
+);
+
+// "Range" derives its output device from the "start" input tensor, which
+// must therefore stay on the device the caller asked for.
+fn simple_eval_range_device(device: &Device) -> Result<()> {
+    let graph = create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "Range".to_string(),
+            input: vec![
+                "start".to_string(),
+                "limit".to_string(),
+                "delta".to_string(),
+            ],
+            output: vec![OUTPUT_Z.to_string()],
+            ..Default::default()
+        }],
+        output: vec![ValueInfoProto {
+            name: OUTPUT_Z.to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }));
+
+    let mut inputs: HashMap<String, Tensor> = HashMap::new();
+    inputs.insert("start".to_string(), Tensor::new(0i64, device)?);
+    inputs.insert("limit".to_string(), Tensor::new(5i64, device)?);
+    inputs.insert("delta".to_string(), Tensor::new(1i64, device)?);
+
+    let eval = simple_eval(&graph, inputs, device)?;
+    let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+    assert!(z.device().same_device(device));
+    assert_eq!(z.to_vec1::<i64>()?, vec![0i64, 1, 2, 3, 4]);
+    Ok(())
+}
+test_device!(
+    simple_eval_range_device,
+    simple_eval_range_device_cpu,
+    simple_eval_range_device_gpu,
+    simple_eval_range_device_metal
+);
+
+// "Gemm" without explicit alpha/beta attributes builds internal scalar
+// tensors that used to be pinned to the CPU regardless of the operands.
+fn simple_eval_gemm_device(device: &Device) -> Result<()> {
+    let graph = create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "Gemm".to_string(),
+            input: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            output: vec![OUTPUT_Z.to_string()],
+            ..Default::default()
+        }],
+        output: vec![ValueInfoProto {
+            name: OUTPUT_Z.to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }));
+
+    let mut inputs: HashMap<String, Tensor> = HashMap::new();
+    inputs.insert(
+        "a".to_string(),
+        Tensor::from_vec(vec![1f32, 2., 3., 4.], (2, 2), device)?,
+    );
+    inputs.insert(
+        "b".to_string(),
+        Tensor::from_vec(vec![1f32, 0., 0., 1.], (2, 2), device)?,
+    );
+    inputs.insert(
+        "c".to_string(),
+        Tensor::from_vec(vec![0f32, 0., 0., 0.], (2, 2), device)?,
+    );
+
+    let eval = simple_eval(&graph, inputs, device)?;
+    let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+    assert!(z.device().same_device(device));
+    assert_eq!(z.to_vec2::<f32>()?, vec![vec![1f32, 2.], vec![3., 4.]]);
+    Ok(())
+}
+test_device!(
+    simple_eval_gemm_device,
+    simple_eval_gemm_device_cpu,
+    simple_eval_gemm_device_gpu,
+    simple_eval_gemm_device_metal
+);

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -7681,3 +7681,132 @@ fn simple_eval_placement_two_cuda_gpus() -> Result<()> {
     assert_eq!(z.to_vec1::<f32>()?, vec![22f32, 42., 62.]);
     Ok(())
 }
+
+// Regression test: under `Placement::uniform` (no prefix rules, used by plain
+// `simple_eval`), a node must always run on the fallback device, even when one
+// of its inputs is already present on a different device (e.g. a caller-supplied
+// input tensor). Inheriting the input's device in that case would silently
+// defeat the device argument that `simple_eval` is documented to honor.
+#[cfg(feature = "cuda")]
+#[test]
+fn simple_eval_placement_uniform_overrides_input_device() -> Result<()> {
+    let cuda = Device::new_cuda(0)?;
+    let graph = create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "Identity".to_string(),
+            name: "identity".to_string(),
+            input: vec![INPUT_X.to_string()],
+            output: vec![OUTPUT_Z.to_string()],
+            ..Default::default()
+        }],
+        output: vec![ValueInfoProto {
+            name: OUTPUT_Z.to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }));
+
+    // `x` lives on the CPU, but the requested fallback device is cuda:0.
+    let mut inputs = HashMap::new();
+    inputs.insert(
+        INPUT_X.to_string(),
+        Tensor::new(&[1f32, 2., 3.], &Device::Cpu)?,
+    );
+    let eval = simple_eval(&graph, inputs, &cuda)?;
+
+    let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+    assert!(z.device().same_device(&cuda));
+    assert_eq!(z.to_vec1::<f32>()?, vec![1f32, 2., 3.]);
+    Ok(())
+}
+
+// Regression test: an `If` branch must be able to reference an initializer
+// declared on an enclosing (parent) graph even when no node of the parent graph
+// consumes that initializer directly. Since initializers are materialized
+// lazily on first use, the parent's initializer map must be inherited by the
+// subgraph rather than rebuilt from scratch, mirroring ONNX's lexical scoping
+// rules for control-flow subgraphs.
+#[test]
+fn placement_if_subgraph_uses_parent_initializer() -> Result<()> {
+    let then_branch = GraphProto {
+        node: vec![NodeProto {
+            op_type: "Identity".to_string(),
+            input: vec!["w".to_string()],
+            output: vec!["then_out".to_string()],
+            ..Default::default()
+        }],
+        output: vec![ValueInfoProto {
+            name: "then_out".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let else_branch = GraphProto {
+        node: vec![NodeProto {
+            op_type: "Constant".to_string(),
+            output: vec!["else_out".to_string()],
+            attribute: vec![AttributeProto {
+                name: "value".to_string(),
+                r#type: AttributeType::Tensor.into(),
+                t: Some(TensorProto {
+                    dims: vec![3],
+                    float_data: vec![0.0, 0.0, 0.0],
+                    data_type: DataType::Float.into(),
+                    ..TensorProto::default()
+                }),
+                ..AttributeProto::default()
+            }],
+            ..Default::default()
+        }],
+        output: vec![ValueInfoProto {
+            name: "else_out".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    // `w` is declared on the parent graph but is only ever read from inside the
+    // `then_branch` subgraph: no parent-level node consumes it directly, so it
+    // is never eagerly materialized into `values` before the `If` node runs.
+    let graph = create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "If".to_string(),
+            input: vec!["cond".to_string()],
+            output: vec![OUTPUT_Z.to_string()],
+            attribute: vec![
+                AttributeProto {
+                    name: "then_branch".to_string(),
+                    r#type: AttributeType::Graph.into(),
+                    g: Some(then_branch),
+                    ..AttributeProto::default()
+                },
+                AttributeProto {
+                    name: "else_branch".to_string(),
+                    r#type: AttributeType::Graph.into(),
+                    g: Some(else_branch),
+                    ..AttributeProto::default()
+                },
+            ],
+            ..Default::default()
+        }],
+        initializer: vec![TensorProto {
+            data_type: DataType::Float.into(),
+            dims: vec![3],
+            float_data: vec![1.0, 2.0, 3.0],
+            name: "w".to_string(),
+            ..Default::default()
+        }],
+        output: vec![ValueInfoProto {
+            name: OUTPUT_Z.to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }));
+
+    let mut inputs = HashMap::new();
+    inputs.insert("cond".to_string(), Tensor::full(1u8, (1,), &Device::Cpu)?);
+    let eval = simple_eval(&graph, inputs, &Device::Cpu)?;
+
+    let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+    assert_eq!(z.to_vec1::<f32>()?, vec![1f32, 2., 3.]);
+    Ok(())
+}

--- a/candle-pyo3/src/onnx.rs
+++ b/candle-pyo3/src/onnx.rs
@@ -207,10 +207,15 @@ impl PyONNXModel {
     fn run(&self, inputs: HashMap<String, PyTensor>) -> PyResult<HashMap<String, PyTensor>> {
         let unwrapped_tensors: HashMap<_, _> =
             inputs.into_iter().map(|(k, v)| (k.clone(), v.0)).collect();
+        // Prefer a non-CPU device if any input lives on one, so that a CPU-only
+        // metadata tensor (e.g. a shape/axis input) can't arbitrarily win over a
+        // GPU data tensor depending on HashMap iteration order.
         let device = unwrapped_tensors
             .values()
-            .next()
-            .map_or(Device::Cpu, |t| t.device().clone());
+            .map(|t| t.device())
+            .find(|d| !d.is_cpu())
+            .cloned()
+            .unwrap_or(Device::Cpu);
 
         let result = simple_eval(&self.0, unwrapped_tensors, &device).map_err(wrap_err)?;
 

--- a/candle-pyo3/src/onnx.rs
+++ b/candle-pyo3/src/onnx.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::utils::wrap_err;
 use crate::{PyDType, PyTensor};
+use candle::Device;
 use candle_onnx::eval::{dtype, get_tensor, simple_eval};
 use candle_onnx::onnx::tensor_proto::DataType;
 use candle_onnx::onnx::tensor_shape_proto::dimension::Value;
@@ -168,8 +169,12 @@ impl PyONNXModel {
         let mut map = HashMap::new();
         if let Some(graph) = self.0.graph.as_ref() {
             for tensor_description in graph.initializer.iter() {
-                let tensor = get_tensor(tensor_description, tensor_description.name.as_str())
-                    .map_err(wrap_err)?;
+                let tensor = get_tensor(
+                    tensor_description,
+                    tensor_description.name.as_str(),
+                    &Device::Cpu,
+                )
+                .map_err(wrap_err)?;
                 map.insert(tensor_description.name.to_string(), PyTensor(tensor));
             }
         }
@@ -200,9 +205,14 @@ impl PyONNXModel {
     /// Run the model on the given inputs.
     /// &RETURNS&: Dict[str,Tensor]
     fn run(&self, inputs: HashMap<String, PyTensor>) -> PyResult<HashMap<String, PyTensor>> {
-        let unwrapped_tensors = inputs.into_iter().map(|(k, v)| (k.clone(), v.0)).collect();
+        let unwrapped_tensors: HashMap<_, _> =
+            inputs.into_iter().map(|(k, v)| (k.clone(), v.0)).collect();
+        let device = unwrapped_tensors
+            .values()
+            .next()
+            .map_or(Device::Cpu, |t| t.device().clone());
 
-        let result = simple_eval(&self.0, unwrapped_tensors).map_err(wrap_err)?;
+        let result = simple_eval(&self.0, unwrapped_tensors, &device).map_err(wrap_err)?;
 
         Ok(result
             .into_iter()


### PR DESCRIPTION
Depends on #3647 (must merge first; this branch is stacked on top of it).

## Motivation

`simple_eval` runs a whole ONNX graph on a single device. For models that
don't fit on one GPU, this adds an additive, non-breaking API to spread a
single graph across several devices (pipeline parallelism) — e.g. running
the first transformer blocks on `cuda:0` and the rest on `cuda:1`.

## API

- New `Placement` type: resolves each node's device from the longest
  matching node-name prefix rule, otherwise the device of the node's first
  already-computed input (so a stage's device flows along the graph and
  only the first node of each stage needs an explicit rule), otherwise a
  fallback device.
- New `simple_eval_with_placement`; `simple_eval` now delegates to it with
  a uniform placement, preserving its exact existing behavior.
- Initializers are materialized lazily on the device of the node that first
  consumes them (instead of all up front on a single device), which is what
  makes real memory splitting possible. Graph outputs that are unconsumed
  initializers are still materialized before returning.
- Inputs are pre-staged onto each node's device, so cross-device copies are
  inserted automatically at stage boundaries via `Tensor::to_device`.

Cross-device transfers currently require CUDA (CPU<->CUDA and CUDA<->CUDA);
Metal-to-Metal copies are not implemented in candle-core. Placement is
expected to be monotone along the topological order, which a by-depth
pipeline split satisfies.

## Fixes folded in from review

- `Placement::uniform` (used by plain `simple_eval`) now always resolves a
  node's device to the fallback, instead of inheriting an already-present
  input's device when no prefix rule matches. With zero rules,
  input-device inheritance was taking priority over the requested device,
  letting `simple_eval` silently run on the wrong device.
- `If` subgraphs now inherit their enclosing graph's initializers instead
  of only seeing their own. Lazy initializer materialization only
  populates `values` when a node directly consumes an initializer, so a
  parent-scope initializer referenced solely inside an `If` branch was
  never visible to that branch and evaluation failed with "cannot find
  ... for op".

## Testing

- CPU tests cover placement resolution, lazy-initializer handling, and
  uniform-placement equivalence with `simple_eval`.
- Feature-gated CUDA tests cover a real CPU<->cuda:0 round-trip (one GPU)
  and a cuda:0 -> cuda:1 split (two GPUs, `--include-ignored`), both
  passing on real dual-GPU hardware (2x RTX 3060).
- A CPU-runnable regression test for the `If`/initializer fix and a
  cuda-gated regression test for the uniform-placement fix are included,
  both verified to fail without their respective fix.
- README documents the new API and its limitations.