### PR TITLE
Add device-agnostic (CPU/Metal) PagedAttention to complement the CUDA kernels (#3655)

### DIFF
--- a/candle-nn/src/attention/mod.rs
+++ b/candle-nn/src/attention/mod.rs
@@ -1,10 +1,12 @@
 pub mod cpu_flash;
+pub mod paged;
 pub mod varlen;
 
 use candle::Tensor;
 
 pub use cpu_flash::flash_attn;
 pub use cpu_flash::varlen::flash_attn_varlen_cpu;
+pub use paged::{paged_attention, reshape_and_cache, BlockAllocator};
 pub use varlen::flash_attn_varlen_unfused;
 
 #[derive(Debug, Clone, Default)]

--- a/candle-nn/src/attention/paged.rs
+++ b/candle-nn/src/attention/paged.rs
@@ -1,0 +1,353 @@
+//! Block-paged KV-cache attention (a.k.a. PagedAttention), device-agnostic.
+//!
+//! This is a portable, pure-`candle` implementation of the attention mechanism
+//! popularised by vLLM, where the key/value cache is not a single contiguous
+//! buffer per sequence but a pool of fixed-size *blocks*. Each sequence keeps a
+//! *block table* mapping its logical block indices to physical blocks in the
+//! shared pool, which makes it possible to:
+//!
+//! - share identical prefixes across requests (prefix caching),
+//! - add or evict sequences without re-allocating the whole cache,
+//! - keep memory fragmentation low through block pooling.
+//!
+//! The fused CUDA kernels added in [#3655] (`candle-flash-attn`) cover the GPU
+//! decode/prefill path. This module is the complementary CPU/Metal (and CUDA
+//! fallback) path requested in [#3656]: it is written entirely in terms of
+//! `candle` tensor operations (`index_select` + dense attention), so it runs
+//! unchanged on every backend and doubles as a correctness reference for the
+//! fused kernels.
+//!
+//! The paged cache tensor layout matches the one used by the fused kernels in
+//! `candle-flash-attn`:
+//!
+//! - `k_cache`, `v_cache`: `[num_blocks, block_size, num_kv_heads, head_dim]`
+//! - a token's *slot* in the flattened cache is `block_id * block_size + offset`
+//! - `block_tables`: `[num_seqs, max_blocks_per_seq]` (`u32`), logical → physical
+//! - `context_lens`: `[num_seqs]` (`u32`), number of valid KV tokens per sequence
+//!
+//! [#3655]: https://github.com/huggingface/candle/pull/3655
+//! [#3656]: https://github.com/huggingface/candle/issues/3656
+
+use crate::ops;
+use candle::{DType, Device, IndexOp, Result, Tensor};
+
+/// Decode-step paged attention.
+///
+/// Computes attention for a single query token per sequence against a paged
+/// KV cache, matching the canonical PagedAttention *decode* signature.
+///
+/// **Shapes**
+/// - `q`: `[num_seqs, num_heads, head_dim]`
+/// - `k_cache`, `v_cache`: `[num_blocks, block_size, num_kv_heads, head_dim]`
+/// - `block_tables`: `[num_seqs, max_blocks_per_seq]` (`u32`)
+/// - `context_lens`: `[num_seqs]` (`u32`)
+///
+/// **Output**: `[num_seqs, num_heads, head_dim]`
+///
+/// Grouped-query / multi-query attention is supported: `num_heads` must be a
+/// multiple of `num_kv_heads`, and query head `h` attends to KV head
+/// `h / (num_heads / num_kv_heads)` (the vLLM / GQA convention).
+///
+/// `alibi_slopes`, when provided, must have shape `[num_heads]` and adds the
+/// standard ALiBi distance bias for the decode position.
+#[allow(clippy::too_many_arguments)]
+pub fn paged_attention(
+    q: &Tensor,
+    k_cache: &Tensor,
+    v_cache: &Tensor,
+    block_tables: &Tensor,
+    context_lens: &Tensor,
+    block_size: usize,
+    scale: f32,
+    alibi_slopes: Option<&Tensor>,
+) -> Result<Tensor> {
+    let device = q.device();
+    let dtype = q.dtype();
+    let (num_seqs, num_heads, head_dim) = q.dims3()?;
+    let (num_blocks, cache_block_size, num_kv_heads, cache_head_dim) = k_cache.dims4()?;
+
+    if cache_block_size != block_size {
+        candle::bail!(
+            "k_cache block dim ({cache_block_size}) does not match block_size ({block_size})"
+        );
+    }
+    if cache_head_dim != head_dim {
+        candle::bail!(
+            "k_cache head_dim ({cache_head_dim}) does not match query head_dim ({head_dim})"
+        );
+    }
+    if k_cache.dims() != v_cache.dims() {
+        candle::bail!(
+            "k_cache and v_cache must share the same shape ({:?} vs {:?})",
+            k_cache.dims(),
+            v_cache.dims()
+        );
+    }
+    if num_heads % num_kv_heads != 0 {
+        candle::bail!(
+            "num_heads ({num_heads}) must be a multiple of num_kv_heads ({num_kv_heads})"
+        );
+    }
+    let group = num_heads / num_kv_heads;
+
+    let (bt_seqs, max_blocks) = block_tables.dims2()?;
+    if bt_seqs != num_seqs {
+        candle::bail!("block_tables has {bt_seqs} rows but q has {num_seqs} sequences");
+    }
+    if context_lens.dims1()? != num_seqs {
+        candle::bail!(
+            "context_lens has len {} but q has {num_seqs} sequences",
+            context_lens.dims1()?
+        );
+    }
+
+    // Flatten the block tables and context lengths to plain integers so we can
+    // build per-sequence gathers. These are tiny (one entry per sequence /
+    // block) and live on the host regardless of the compute device.
+    let block_tables = block_tables.to_dtype(DType::U32)?.to_vec2::<u32>()?;
+    let context_lens = context_lens.to_dtype(DType::U32)?.to_vec1::<u32>()?;
+
+    let mut outputs = Vec::with_capacity(num_seqs);
+    for seq in 0..num_seqs {
+        let ctx_len = context_lens[seq] as usize;
+        if ctx_len == 0 {
+            outputs.push(Tensor::zeros((num_heads, head_dim), dtype, device)?);
+            continue;
+        }
+        let needed_blocks = ctx_len.div_ceil(block_size);
+        if needed_blocks > max_blocks {
+            candle::bail!(
+                "sequence {seq} needs {needed_blocks} blocks for context_len {ctx_len} but block_tables only has {max_blocks} columns"
+            );
+        }
+
+        // Gather the physical blocks backing this sequence, then flatten the
+        // (block, offset) dims into a contiguous time axis and trim to the
+        // real context length.
+        let block_ids: Vec<u32> = block_tables[seq][..needed_blocks].to_vec();
+        for &b in &block_ids {
+            if b as usize >= num_blocks {
+                candle::bail!(
+                    "sequence {seq} references physical block {b} but the cache only has {num_blocks} blocks"
+                );
+            }
+        }
+        let block_ids = Tensor::from_vec(block_ids, needed_blocks, device)?;
+
+        // [needed_blocks, block_size, num_kv_heads, head_dim]
+        let k_blocks = k_cache.index_select(&block_ids, 0)?;
+        let v_blocks = v_cache.index_select(&block_ids, 0)?;
+        // -> [needed_blocks * block_size, num_kv_heads, head_dim] -> trim
+        let k_seq = k_blocks
+            .reshape((needed_blocks * block_size, num_kv_heads, head_dim))?
+            .narrow(0, 0, ctx_len)?;
+        let v_seq = v_blocks
+            .reshape((needed_blocks * block_size, num_kv_heads, head_dim))?
+            .narrow(0, 0, ctx_len)?;
+
+        // Expand KV heads to query heads for GQA/MQA, following h / group.
+        let (k_seq, v_seq) = if group == 1 {
+            (k_seq, v_seq)
+        } else {
+            let expand = |t: Tensor| -> Result<Tensor> {
+                t.reshape((ctx_len, num_kv_heads, 1, head_dim))?
+                    .broadcast_as((ctx_len, num_kv_heads, group, head_dim))?
+                    .reshape((ctx_len, num_heads, head_dim))
+            };
+            (expand(k_seq)?, expand(v_seq)?)
+        };
+
+        // Attention for the single query token.
+        // q_seq: [num_heads, 1, head_dim]
+        let q_seq = q.i(seq)?.unsqueeze(1)?;
+        // k/v: [num_heads, ctx_len, head_dim]
+        let k_seq = k_seq.transpose(0, 1)?.contiguous()?;
+        let v_seq = v_seq.transpose(0, 1)?.contiguous()?;
+
+        let scores = q_seq.matmul(&k_seq.transpose(1, 2)?.contiguous()?)?; // [H, 1, ctx]
+        let scale_t = Tensor::new(scale, device)?.to_dtype(scores.dtype())?;
+        let mut scores = scores.broadcast_mul(&scale_t)?;
+
+        if let Some(alibi_slopes) = alibi_slopes {
+            let bias = alibi_bias(ctx_len, num_heads, alibi_slopes, device)?.to_dtype(dtype)?;
+            scores = scores.add(&bias)?;
+        }
+
+        let probs = ops::softmax_last_dim(&scores)?; // [H, 1, ctx]
+        let out = probs.matmul(&v_seq)?; // [H, 1, head_dim]
+        outputs.push(out.squeeze(1)?); // [H, head_dim]
+    }
+
+    Tensor::stack(&outputs, 0)
+}
+
+/// ALiBi decode bias of shape `[num_heads, 1, ctx_len]`.
+///
+/// For the most recent query token (position `ctx_len - 1`), the bias applied
+/// to key position `j` is `-slope_h * (ctx_len - 1 - j)`.
+fn alibi_bias(
+    ctx_len: usize,
+    num_heads: usize,
+    alibi_slopes: &Tensor,
+    device: &Device,
+) -> Result<Tensor> {
+    let slopes = alibi_slopes.to_dtype(DType::F32)?.to_vec1::<f32>()?;
+    if slopes.len() != num_heads {
+        candle::bail!(
+            "alibi_slopes has len {}, expected num_heads={num_heads}",
+            slopes.len()
+        );
+    }
+    let mut per_head = Vec::with_capacity(num_heads);
+    for &slope in &slopes {
+        let bias: Vec<f32> = (0..ctx_len)
+            .map(|j| -slope * (ctx_len - 1 - j) as f32)
+            .collect();
+        per_head.push(Tensor::from_vec(bias, (1, ctx_len), device)?);
+    }
+    Tensor::stack(&per_head, 0) // [H, 1, ctx]
+}
+
+/// Write freshly computed keys/values into a paged KV cache.
+///
+/// This is the paged analogue of appending to a contiguous cache: each input
+/// token is written to the slot given by `slot_mapping`, where a slot is
+/// `block_id * block_size + offset_within_block` into the flattened cache.
+///
+/// **Shapes**
+/// - `k`, `v`: `[num_tokens, num_kv_heads, head_dim]`
+/// - `k_cache`, `v_cache`: `[num_blocks, block_size, num_kv_heads, head_dim]`
+/// - `slot_mapping`: `[num_tokens]` (`u32`)
+///
+/// Returns the updated `(k_cache, v_cache)`. The operation is functional (it
+/// does not mutate the inputs in place), which keeps it portable across all
+/// backends.
+pub fn reshape_and_cache(
+    k: &Tensor,
+    v: &Tensor,
+    k_cache: &Tensor,
+    v_cache: &Tensor,
+    slot_mapping: &Tensor,
+) -> Result<(Tensor, Tensor)> {
+    let (num_blocks, block_size, num_kv_heads, head_dim) = k_cache.dims4()?;
+    if k_cache.dims() != v_cache.dims() {
+        candle::bail!(
+            "k_cache and v_cache must share the same shape ({:?} vs {:?})",
+            k_cache.dims(),
+            v_cache.dims()
+        );
+    }
+    let (num_tokens, k_heads, k_dim) = k.dims3()?;
+    if k_heads != num_kv_heads || k_dim != head_dim {
+        candle::bail!(
+            "k has shape {:?} but cache expects [*, {num_kv_heads}, {head_dim}]",
+            k.dims()
+        );
+    }
+    if v.dims() != k.dims() {
+        candle::bail!(
+            "k and v must share the same shape ({:?} vs {:?})",
+            k.dims(),
+            v.dims()
+        );
+    }
+    if slot_mapping.dims1()? != num_tokens {
+        candle::bail!(
+            "slot_mapping has len {} but there are {num_tokens} tokens",
+            slot_mapping.dims1()?
+        );
+    }
+
+    let num_slots = num_blocks * block_size;
+    let kc = k_cache.reshape((num_slots, num_kv_heads, head_dim))?;
+    let vc = v_cache.reshape((num_slots, num_kv_heads, head_dim))?;
+
+    // Broadcast the per-token slot index across the (head, dim) axes so it
+    // lines up with the source tensors for `scatter` along dim 0.
+    let index = slot_mapping
+        .to_dtype(DType::U32)?
+        .reshape((num_tokens, 1, 1))?
+        .broadcast_as((num_tokens, num_kv_heads, head_dim))?
+        .contiguous()?;
+
+    let kc = kc.scatter(&index, &k.contiguous()?, 0)?;
+    let vc = vc.scatter(&index, &v.contiguous()?, 0)?;
+
+    Ok((
+        kc.reshape((num_blocks, block_size, num_kv_heads, head_dim))?,
+        vc.reshape((num_blocks, block_size, num_kv_heads, head_dim))?,
+    ))
+}
+
+/// A simple pool allocator for physical KV-cache blocks.
+///
+/// Blocks are handed out one at a time and returned to the free list when a
+/// sequence is evicted, implementing the block-pooling memory strategy used for
+/// high-throughput serving. Allocation and free are O(1).
+#[derive(Debug, Clone)]
+pub struct BlockAllocator {
+    block_size: usize,
+    num_blocks: usize,
+    free: Vec<usize>,
+}
+
+impl BlockAllocator {
+    /// Create an allocator managing `num_blocks` physical blocks of
+    /// `block_size` tokens each.
+    pub fn new(num_blocks: usize, block_size: usize) -> Self {
+        // Hand out low block ids first; this keeps tables readable in tests.
+        let free = (0..num_blocks).rev().collect();
+        Self {
+            block_size,
+            num_blocks,
+            free,
+        }
+    }
+
+    /// Number of tokens per block.
+    pub fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    /// Total number of physical blocks managed.
+    pub fn num_blocks(&self) -> usize {
+        self.num_blocks
+    }
+
+    /// Number of blocks currently available.
+    pub fn num_free(&self) -> usize {
+        self.free.len()
+    }
+
+    /// Allocate a single physical block, or `None` if the pool is exhausted.
+    pub fn allocate(&mut self) -> Option<usize> {
+        self.free.pop()
+    }
+
+    /// Allocate enough contiguous-in-logical-order blocks to hold `num_tokens`
+    /// tokens, returning their physical ids. Returns `None` (and frees nothing)
+    /// if the pool cannot satisfy the request.
+    pub fn allocate_for_tokens(&mut self, num_tokens: usize) -> Option<Vec<usize>> {
+        let needed = num_tokens.div_ceil(self.block_size);
+        if self.free.len() < needed {
+            return None;
+        }
+        Some((0..needed).map(|_| self.free.pop().unwrap()).collect())
+    }
+
+    /// Return a previously allocated block to the pool.
+    pub fn free(&mut self, block: usize) {
+        debug_assert!(
+            block < self.num_blocks,
+            "freeing out-of-range block {block}"
+        );
+        self.free.push(block);
+    }
+
+    /// Return a batch of blocks to the pool.
+    pub fn free_all(&mut self, blocks: impl IntoIterator<Item = usize>) {
+        for b in blocks {
+            self.free(b);
+        }
+    }
+}

--- a/candle-nn/tests/paged_attention.rs
+++ b/candle-nn/tests/paged_attention.rs
@@ -330,20 +330,31 @@ fn block_allocator_pools_blocks() {
 // ------------------------------------------------------------------------
 // Metal path. Mirrors the CPU cases on an actual Metal device and adds a
 // Metal-vs-CPU consistency check. Compiled out unless the `metal` feature
-// is enabled, and skipped gracefully if no Metal device is present.
+// is enabled. By default it skips gracefully when no Metal device is
+// present (e.g. CPU-only dev machines); set `CANDLE_METAL_REQUIRED=1` (as
+// the macOS CI does) to turn a missing device into a hard failure so a
+// green run actually means the Metal path executed.
 // ------------------------------------------------------------------------
 #[cfg(feature = "metal")]
 mod metal {
     use super::*;
 
     fn metal_device() -> Option<Device> {
-        Device::new_metal(0).ok()
+        match Device::new_metal(0) {
+            Ok(dev) => Some(dev),
+            Err(e) => {
+                if std::env::var("CANDLE_METAL_REQUIRED").is_ok() {
+                    panic!("CANDLE_METAL_REQUIRED is set but no Metal device is available: {e}");
+                }
+                eprintln!("skipping: no Metal device ({e})");
+                None
+            }
+        }
     }
 
     #[test]
     fn paged_matches_dense_metal() -> Result<()> {
         let Some(dev) = metal_device() else {
-            eprintln!("skipping: no Metal device");
             return Ok(());
         };
         run_case_on(&dev, 4, 1, 8, 4, &[4, 7, 1, 16])?;

--- a/candle-nn/tests/paged_attention.rs
+++ b/candle-nn/tests/paged_attention.rs
@@ -1,0 +1,428 @@
+//! Correctness tests for the device-agnostic block-paged KV-cache attention.
+//!
+//! The paged implementation is validated against a straightforward dense
+//! attention computed over the same keys/values, for MHA / GQA / MQA and
+//! across multiple block sizes and contexts. The same cases are run on Metal
+//! when the `metal` feature is enabled, plus a Metal-vs-CPU consistency check.
+
+use candle::{DType, Device, IndexOp, Result, Tensor};
+use candle_nn::attention::paged::{paged_attention, reshape_and_cache, BlockAllocator};
+use candle_nn::ops::softmax_last_dim;
+
+const EPS: f32 = 1e-4;
+
+/// Dense single-token attention reference for one sequence.
+/// q: [num_heads, head_dim], k/v: [ctx, num_kv_heads, head_dim].
+fn dense_decode(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    scale: f32,
+    num_kv_heads: usize,
+) -> Result<Tensor> {
+    let (num_heads, head_dim) = q.dims2()?;
+    let (ctx, _, _) = k.dims3()?;
+    let group = num_heads / num_kv_heads;
+
+    let expand = |t: &Tensor| -> Result<Tensor> {
+        t.reshape((ctx, num_kv_heads, 1, head_dim))?
+            .broadcast_as((ctx, num_kv_heads, group, head_dim))?
+            .reshape((ctx, num_heads, head_dim))
+    };
+    let k = expand(k)?.transpose(0, 1)?.contiguous()?; // [H, ctx, D]
+    let v = expand(v)?.transpose(0, 1)?.contiguous()?; // [H, ctx, D]
+    let q = q.unsqueeze(1)?; // [H, 1, D]
+
+    let scores = (q.matmul(&k.transpose(1, 2)?.contiguous()?)? * scale as f64)?; // [H,1,ctx]
+    let probs = softmax_last_dim(&scores)?;
+    let out = probs.matmul(&v)?; // [H,1,D]
+    out.squeeze(1)
+}
+
+/// Build a paged cache by laying each sequence's KV out across freshly
+/// allocated blocks, returning the cache tensors plus the per-batch
+/// block_tables / context_lens needed by `paged_attention`.
+#[allow(clippy::type_complexity)]
+fn build_paged_cache(
+    keys: &[Tensor], // each [ctx_i, num_kv_heads, head_dim]
+    values: &[Tensor],
+    num_blocks: usize,
+    block_size: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    device: &Device,
+) -> Result<(Tensor, Tensor, Tensor, Tensor)> {
+    let mut allocator = BlockAllocator::new(num_blocks, block_size);
+    let mut k_cache = Tensor::zeros(
+        (num_blocks, block_size, num_kv_heads, head_dim),
+        DType::F32,
+        device,
+    )?;
+    let mut v_cache = k_cache.clone();
+
+    let mut block_tables: Vec<Vec<u32>> = Vec::new();
+    let mut context_lens: Vec<u32> = Vec::new();
+    let mut max_blocks = 1usize;
+
+    for (k, v) in keys.iter().zip(values.iter()) {
+        let ctx = k.dim(0)?;
+        let phys = allocator.allocate_for_tokens(ctx).expect("pool exhausted");
+        let mut slots = Vec::with_capacity(ctx);
+        for (b, &p) in phys.iter().enumerate() {
+            let tokens_in_block = (ctx - b * block_size).min(block_size);
+            for off in 0..tokens_in_block {
+                slots.push((p * block_size + off) as u32);
+            }
+        }
+        let slot_mapping = Tensor::from_vec(slots, ctx, device)?;
+        let (kc, vc) = reshape_and_cache(k, v, &k_cache, &v_cache, &slot_mapping)?;
+        k_cache = kc;
+        v_cache = vc;
+
+        max_blocks = max_blocks.max(phys.len());
+        block_tables.push(phys.into_iter().map(|p| p as u32).collect());
+        context_lens.push(ctx as u32);
+    }
+
+    // Pad block tables to a rectangular [num_seqs, max_blocks].
+    for table in block_tables.iter_mut() {
+        table.resize(max_blocks, 0);
+    }
+    let flat: Vec<u32> = block_tables.iter().flatten().copied().collect();
+    let block_tables = Tensor::from_vec(flat, (keys.len(), max_blocks), device)?;
+    let context_lens = Tensor::from_vec(context_lens, keys.len(), device)?;
+
+    Ok((k_cache, v_cache, block_tables, context_lens))
+}
+
+fn run_case(
+    num_kv_heads: usize,
+    group: usize,
+    head_dim: usize,
+    block_size: usize,
+    ctx_lens: &[usize],
+) -> Result<()> {
+    run_case_on(
+        &Device::Cpu,
+        num_kv_heads,
+        group,
+        head_dim,
+        block_size,
+        ctx_lens,
+    )
+}
+
+fn run_case_on(
+    device: &Device,
+    num_kv_heads: usize,
+    group: usize,
+    head_dim: usize,
+    block_size: usize,
+    ctx_lens: &[usize],
+) -> Result<()> {
+    let num_heads = num_kv_heads * group;
+    let num_seqs = ctx_lens.len();
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+
+    // Deterministic pseudo-random inputs (no rng dependency).
+    let gen = |n: usize, seed: f32| -> Result<Tensor> {
+        let data: Vec<f32> = (0..n)
+            .map(|i| ((i as f32 * 0.123 + seed).sin()) * 0.5)
+            .collect();
+        Tensor::from_vec(data, n, device)
+    };
+
+    let q = gen(num_seqs * num_heads * head_dim, 0.0)?.reshape((num_seqs, num_heads, head_dim))?;
+
+    let mut keys = Vec::new();
+    let mut values = Vec::new();
+    for (s, &ctx) in ctx_lens.iter().enumerate() {
+        keys.push(
+            gen(ctx * num_kv_heads * head_dim, 1.0 + s as f32)?.reshape((
+                ctx,
+                num_kv_heads,
+                head_dim,
+            ))?,
+        );
+        values.push(
+            gen(ctx * num_kv_heads * head_dim, 7.0 + s as f32)?.reshape((
+                ctx,
+                num_kv_heads,
+                head_dim,
+            ))?,
+        );
+    }
+
+    let total_blocks: usize = ctx_lens.iter().map(|c| c.div_ceil(block_size)).sum();
+    let num_blocks = total_blocks + 2; // a little slack in the pool
+
+    let (k_cache, v_cache, block_tables, context_lens) = build_paged_cache(
+        &keys,
+        &values,
+        num_blocks,
+        block_size,
+        num_kv_heads,
+        head_dim,
+        device,
+    )?;
+
+    let out = paged_attention(
+        &q,
+        &k_cache,
+        &v_cache,
+        &block_tables,
+        &context_lens,
+        block_size,
+        scale,
+        None,
+    )?;
+    assert_eq!(out.dims(), &[num_seqs, num_heads, head_dim]);
+
+    for s in 0..num_seqs {
+        let expected = dense_decode(&q.i(s)?, &keys[s], &values[s], scale, num_kv_heads)?;
+        let got = out.i(s)?;
+        let diff = (got - expected)?
+            .abs()?
+            .flatten_all()?
+            .max(0)?
+            .to_scalar::<f32>()?;
+        assert!(
+            diff < EPS,
+            "seq {s}: max abs diff {diff} exceeds {EPS} (kv_heads={num_kv_heads}, group={group}, block_size={block_size}, ctx={})",
+            ctx_lens[s]
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn paged_matches_dense_mha() -> Result<()> {
+    // Multi-head (group = 1), contexts that do and do not fill whole blocks.
+    run_case(4, 1, 8, 4, &[4, 7, 1, 16])
+}
+
+#[test]
+fn paged_matches_dense_gqa() -> Result<()> {
+    // Grouped-query attention: 2 KV heads shared by 8 query heads.
+    run_case(2, 4, 16, 8, &[10, 3, 20])
+}
+
+#[test]
+fn paged_matches_dense_mqa_block_size_one() -> Result<()> {
+    // Multi-query attention with the degenerate block size of 1.
+    run_case(1, 8, 8, 1, &[5, 9])
+}
+
+#[test]
+fn alibi_bias_is_applied() -> Result<()> {
+    // With a single sequence, ALiBi only adds a per-key constant before
+    // softmax; check the paged path matches a hand-rolled dense ALiBi decode.
+    let device = Device::Cpu;
+    let (num_heads, head_dim, block_size, ctx) = (2usize, 8usize, 4usize, 7usize);
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+    let gen = |n: usize, seed: f32| -> Result<Tensor> {
+        let data: Vec<f32> = (0..n)
+            .map(|i| ((i as f32 * 0.07 + seed).cos()) * 0.5)
+            .collect();
+        Tensor::from_vec(data, n, &device)
+    };
+    let q = gen(num_heads * head_dim, 0.0)?.reshape((1, num_heads, head_dim))?;
+    let k = gen(ctx * num_heads * head_dim, 2.0)?.reshape((ctx, num_heads, head_dim))?;
+    let v = gen(ctx * num_heads * head_dim, 5.0)?.reshape((ctx, num_heads, head_dim))?;
+    let slopes = Tensor::from_vec(vec![0.5f32, 0.25], num_heads, &device)?;
+
+    let num_blocks = ctx.div_ceil(block_size) + 1;
+    let (k_cache, v_cache, block_tables, context_lens) = build_paged_cache(
+        &[k.clone()],
+        &[v.clone()],
+        num_blocks,
+        block_size,
+        num_heads,
+        head_dim,
+        &device,
+    )?;
+    let out = paged_attention(
+        &q,
+        &k_cache,
+        &v_cache,
+        &block_tables,
+        &context_lens,
+        block_size,
+        scale,
+        Some(&slopes),
+    )?;
+
+    // Dense ALiBi reference for the single decode token at position ctx-1.
+    let qh = q.i(0)?.unsqueeze(1)?; // [H,1,D]
+    let kh = k.transpose(0, 1)?.contiguous()?; // [H,ctx,D]
+    let vh = v.transpose(0, 1)?.contiguous()?; // [H,ctx,D]
+    let mut scores = (qh.matmul(&kh.transpose(1, 2)?.contiguous()?)? * scale as f64)?; // [H,1,ctx]
+    let slopes_v = slopes.to_vec1::<f32>()?;
+    let mut bias: Vec<f32> = Vec::with_capacity(num_heads * ctx);
+    for h in 0..num_heads {
+        for j in 0..ctx {
+            bias.push(-slopes_v[h] * (ctx - 1 - j) as f32);
+        }
+    }
+    let bias = Tensor::from_vec(bias, (num_heads, 1, ctx), &device)?;
+    scores = scores.add(&bias)?;
+    let expected = softmax_last_dim(&scores)?.matmul(&vh)?.squeeze(1)?; // [H,D]
+
+    let diff = (out.i(0)? - expected)?
+        .abs()?
+        .flatten_all()?
+        .max(0)?
+        .to_scalar::<f32>()?;
+    assert!(diff < EPS, "alibi paged vs dense diff {diff} exceeds {EPS}");
+    Ok(())
+}
+
+#[test]
+fn empty_context_yields_zeros() -> Result<()> {
+    let device = Device::Cpu;
+    let (num_blocks, block_size, num_kv_heads, head_dim) = (4, 4, 2, 8);
+    let num_heads = 2;
+    let k_cache = Tensor::zeros(
+        (num_blocks, block_size, num_kv_heads, head_dim),
+        DType::F32,
+        &device,
+    )?;
+    let v_cache = k_cache.clone();
+    let q = Tensor::ones((1, num_heads, head_dim), DType::F32, &device)?;
+    let block_tables = Tensor::zeros((1, 1), DType::U32, &device)?;
+    let context_lens = Tensor::zeros(1, DType::U32, &device)?;
+    let out = paged_attention(
+        &q,
+        &k_cache,
+        &v_cache,
+        &block_tables,
+        &context_lens,
+        block_size,
+        0.5,
+        None,
+    )?;
+    let sum = out.abs()?.sum_all()?.to_scalar::<f32>()?;
+    assert_eq!(sum, 0.0);
+    Ok(())
+}
+
+#[test]
+fn block_allocator_pools_blocks() {
+    let mut alloc = BlockAllocator::new(3, 8);
+    assert_eq!(alloc.num_free(), 3);
+    let a = alloc.allocate().unwrap();
+    let b = alloc.allocate().unwrap();
+    let c = alloc.allocate().unwrap();
+    assert_ne!(a, b);
+    assert_ne!(b, c);
+    assert_eq!(alloc.allocate(), None);
+    alloc.free(b);
+    assert_eq!(alloc.num_free(), 1);
+    assert_eq!(alloc.allocate(), Some(b));
+
+    // Multi-block allocation rounds up by block size and fails atomically.
+    let mut alloc = BlockAllocator::new(2, 4);
+    assert_eq!(alloc.allocate_for_tokens(5).map(|v| v.len()), Some(2));
+    assert_eq!(alloc.num_free(), 0);
+    assert_eq!(alloc.allocate_for_tokens(1), None);
+}
+
+// ------------------------------------------------------------------------
+// Metal path. Mirrors the CPU cases on an actual Metal device and adds a
+// Metal-vs-CPU consistency check. Compiled out unless the `metal` feature
+// is enabled, and skipped gracefully if no Metal device is present.
+// ------------------------------------------------------------------------
+#[cfg(feature = "metal")]
+mod metal {
+    use super::*;
+
+    fn metal_device() -> Option<Device> {
+        Device::new_metal(0).ok()
+    }
+
+    #[test]
+    fn paged_matches_dense_metal() -> Result<()> {
+        let Some(dev) = metal_device() else {
+            eprintln!("skipping: no Metal device");
+            return Ok(());
+        };
+        run_case_on(&dev, 4, 1, 8, 4, &[4, 7, 1, 16])?;
+        run_case_on(&dev, 2, 4, 16, 8, &[10, 3, 20])?;
+        run_case_on(&dev, 1, 8, 8, 1, &[5, 9])
+    }
+
+    #[test]
+    fn paged_metal_matches_cpu() -> Result<()> {
+        let Some(dev) = metal_device() else {
+            eprintln!("skipping: no Metal device");
+            return Ok(());
+        };
+        let (num_kv_heads, group, head_dim, block_size) = (2usize, 4usize, 16usize, 8usize);
+        let num_heads = num_kv_heads * group;
+        let ctx_lens = [10usize, 3, 20];
+        let num_seqs = ctx_lens.len();
+        let scale = 1.0f32 / (head_dim as f32).sqrt();
+
+        let gen = |dev: &Device, n: usize, seed: f32| -> Result<Tensor> {
+            let data: Vec<f32> = (0..n)
+                .map(|i| ((i as f32 * 0.123 + seed).sin()) * 0.5)
+                .collect();
+            Tensor::from_vec(data, n, dev)
+        };
+        let run = |dev: &Device| -> Result<Tensor> {
+            let q = gen(dev, num_seqs * num_heads * head_dim, 0.0)?
+                .reshape((num_seqs, num_heads, head_dim))?;
+            let mut keys = Vec::new();
+            let mut values = Vec::new();
+            for (s, &ctx) in ctx_lens.iter().enumerate() {
+                keys.push(
+                    gen(dev, ctx * num_kv_heads * head_dim, 1.0 + s as f32)?.reshape((
+                        ctx,
+                        num_kv_heads,
+                        head_dim,
+                    ))?,
+                );
+                values.push(
+                    gen(dev, ctx * num_kv_heads * head_dim, 7.0 + s as f32)?.reshape((
+                        ctx,
+                        num_kv_heads,
+                        head_dim,
+                    ))?,
+                );
+            }
+            let total_blocks: usize = ctx_lens.iter().map(|c| c.div_ceil(block_size)).sum();
+            let (k_cache, v_cache, block_tables, context_lens) = build_paged_cache(
+                &keys,
+                &values,
+                total_blocks + 2,
+                block_size,
+                num_kv_heads,
+                head_dim,
+                dev,
+            )?;
+            paged_attention(
+                &q,
+                &k_cache,
+                &v_cache,
+                &block_tables,
+                &context_lens,
+                block_size,
+                scale,
+                None,
+            )
+        };
+
+        let cpu = run(&Device::Cpu)?;
+        let metal = run(&dev)?.to_device(&Device::Cpu)?;
+        let diff = (cpu - metal)?
+            .abs()?
+            .flatten_all()?
+            .max(0)?
+            .to_scalar::<f32>()?;
+        assert!(
+            diff < EPS,
+            "Metal vs CPU paged attention diff {diff} exceeds {EPS}"
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Adds a portable, pure-`candle` implementation of block-paged KV-cache attention
(PagedAttention) in `candle-nn`, implementing the request in #3656.

#3655 added fused **CUDA** paged flash-attn kernels in `candle-flash-attn`.
Those are CUDA-only (built behind the `cuda` feature), so there is currently no
paged-attention path on CPU or Metal. This PR fills that gap with a
device-agnostic implementation written entirely in terms of `candle` tensor
operations (`index_select` + dense attention), so it runs unchanged on CPU,
Metal and CUDA. It is meant as a **complement to, not a replacement for**, the
fused kernels — a portable fallback for CPU/Apple-hardware and a correctness
reference for the optimized GPU path.

## What's added

In `candle-nn` (`candle_nn::attention::paged`, re-exported from
`candle_nn::attention`):

- **`paged_attention(q, k_cache, v_cache, block_tables, context_lens, block_size, scale, alibi_slopes) -> Tensor`**
  — decode-step attention over a paged KV cache. Supports MHA, GQA/MQA and
  optional ALiBi.
- **`reshape_and_cache(k, v, k_cache, v_cache, slot_mapping)`** — writes new K/V
  into a paged cache by slot mapping (functional, backend-portable).
- **`BlockAllocator`** — O(1) block-pool allocator for the KV-cache block
  infrastructure.

The paged cache layout matches the fused kernels in `candle-flash-attn`:
`[num_blocks, block_size, num_kv_heads, head_dim]`, with
`block_tables: [num_seqs, max_blocks_per_seq]` (`u32`) and
`context_lens: [num_seqs]` (`u32`).

## Tests & validation

New tests in `candle-nn/tests/paged_attention.rs` validate the paged output
against a dense-attention reference (MHA / GQA / MQA across several block sizes),
plus ALiBi, empty-context handling and the allocator. The same cases run on
Metal (gated behind the `metal` feature) with a Metal-vs-CPU consistency check.

Validated on CI, including a real GPU Metal run on a GitHub-hosted Apple Silicon
runner:

| Validation | Result |
|---|---|
| CPU tests (MHA/GQA/MQA, ALiBi, empty context, allocator) | ✅ 6/6 passed |
| Metal tests on a real GPU (`macos-15`, Apple Silicon) | ✅ 2/2 passed |
| Metal-vs-CPU numerical consistency | ✅ passed |
| `cargo build` / `fmt` / `clippy` | ✅ clean |
| `cargo check --workspace --features metal` (existing CI) | ✅ compiles |

The Metal tests are skipped gracefully on CPU-only machines and made strict in
CI via `CANDLE_METAL_REQUIRED=1`, so a green run guarantees the Metal path
actually executed (all 8 tests passing):

```
running 8 tests
test block_allocator_pools_blocks ... ok
test empty_context_yields_zeros ... ok
test alibi_bias_is_applied ... ok
test paged_matches_dense_gqa ... ok
test paged_matches_dense_mha ... ok
test paged_matches_dense_mqa_block_size_one ... ok
test metal::paged_metal_matches_cpu ... ok
test metal::paged_matches_dense_metal ... ok
test result: ok. 8 passed; 0 failed
```

To reproduce locally:

```bash
cargo test -p candle-nn --test paged_attention                  # CPU
cargo test -p candle-nn --test paged_attention --features metal  # Metal (on a Mac)
```

## Notes

- This is a reference/portable implementation (per-sequence gather + dense
  attention); it intentionally trades peak throughput for portability and
  clarity. The fused CUDA kernels from #3655 remain the high-performance GPU
  path, and a fused kernel can later slot in behind the same API.

Closes #3656. Complements #3655.