### PR TITLE
Add GPTQ quantized linear layer support for Qwen2 (#3650)

### DIFF
--- a/.github/workflows/ci_cuda.yaml
+++ b/.github/workflows/ci_cuda.yaml
@@ -33,3 +33,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Test (cuda)
         run: cargo test --features cuda
+      - name: Build+test (cuda) - fused GPTQ dequant+GEMM kernel
+        run: cargo test -p candle-transformers --features cuda,gptq-cuda
+      - name: Test (cuda) - GPTQ tensor-core kernel correctness
+        run: cargo test --manifest-path candle-gptq-kernels/Cargo.toml

--- a/.github/workflows/ci_metal.yaml
+++ b/.github/workflows/ci_metal.yaml
@@ -1,0 +1,37 @@
+name: CI / metal
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_ref:
+        description: 'Branch/tag/SHA to checkout and test (defaults to the dispatched ref)'
+        required: false
+        type: string
+  pull_request:
+
+jobs:
+  test-metal:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+    # GitHub-hosted Apple Silicon runner (free for public repos), exposes a
+    # real Metal GPU. macOS 15 is required: candle's Metal backend uses the
+    # MTLResidencySet API (Metal 3.2), which is absent on macos-14.
+    runs-on: macos-15
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+    env:
+      # Turn a missing Metal device into a hard failure so a green run
+      # guarantees the Metal path actually executed (see the metal tests).
+      CANDLE_METAL_REQUIRED: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.test_ref || github.ref }}
+      - name: Remove cargo config (macOS ring crate fix)
+        run: rm -f .cargo/config.toml
+      - name: Install Rust Stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Test (metal) - GPTQ fused dequant+GEMM kernel
+        run: cargo test --manifest-path candle-gptq-kernels/Cargo.toml --no-default-features --features metal -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [
     "candle-book",
     "candle-flash-attn",
     "candle-flash-attn-v3",
+    "candle-gptq-kernels",
     "candle-kernels",
     "candle-metal-kernels",
     "candle-onnx",
@@ -39,6 +40,7 @@ candle = { path = "./candle-core", package = "candle-core", version = "0.10.2" }
 candle-datasets = { path = "./candle-datasets", version = "0.10.2" }
 candle-flash-attn = { path = "./candle-flash-attn", version = "0.10.2" }
 candle-flash-attn-v3 = { path = "./candle-flash-attn-v3", version = "0.10.2" }
+candle-gptq-kernels = { path = "./candle-gptq-kernels", version = "0.10.2", default-features = false }
 candle-kernels = { path = "./candle-kernels", version = "0.10.2" }
 candle-metal-kernels = { path = "./candle-metal-kernels", version = "0.10.2" }
 candle-nn = { path = "./candle-nn", version = "0.10.2" }

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ We also provide some command line based examples using state of the art models:
   the LLaMA model using the same quantization techniques as
   [llama.cpp](https://github.com/ggerganov/llama.cpp).
 - [Quantized Qwen3 MoE](./candle-examples/examples/quantized-qwen3-moe/): support gguf quantized models of Qwen3 MoE models.
+- [Quantized GPTQ Qwen2](./candle-examples/examples/quantized-gptq-qwen2/): load
+  GPTQ-quantized Qwen2 checkpoints directly from the Hugging Face Hub.
 
 <img src="https://github.com/huggingface/candle/raw/main/candle-examples/examples/quantized/assets/aoc.gif" width="600">
   
@@ -292,6 +294,9 @@ Cheatsheet:
 - [candle-transformers](./candle-transformers): transformers-related utilities.
 - [candle-flash-attn](./candle-flash-attn): Flash attention v2 layer.
 - [candle-onnx](./candle-onnx/): ONNX model evaluation.
+- [candle-gptq-kernels](./candle-gptq-kernels/): fused dequantize+GEMM CUDA/Metal
+  kernel for GPTQ-quantized linear layers, used by `candle-transformers` when the
+  `gptq-cuda`/`gptq-metal` feature is enabled.
 
 ## FAQ
 

--- a/candle-examples/examples/quantized-gptq-qwen2/README.md
+++ b/candle-examples/examples/quantized-gptq-qwen2/README.md
@@ -1,0 +1,36 @@
+# candle-quantized-gptq-qwen2: GPTQ-quantized Qwen2 from the Hugging Face Hub
+
+End-to-end example that downloads a GPTQ-quantized Qwen2 checkpoint (in the AutoGPTQ /
+GPTQModel safetensors layout: packed `qweight`/`qzeros`/`scales`/`g_idx` tensors per linear
+layer) from the Hugging Face Hub and runs text generation through it, using
+[`candle_transformers::models::gptq_qwen2`] and the GPTQ kernels in `candle-gptq-kernels` /
+[`candle_transformers::quantized_gptq`].
+
+The model architecture mirrors the dense [`qwen2`](../qwen2) model, but every attention and MLP
+projection (`q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`, `up_proj`, `down_proj`) is
+dequantized from the checkpoint's packed GPTQ tensors via `gptq_linear` at load time, instead of
+being read as plain dense weights.
+
+## Running the example
+
+```bash
+$ cargo run --example quantized-gptq-qwen2 --release -- \
+    --prompt "Give me three tips for staying focused while studying."
+```
+
+By default this downloads
+[`Qwen/Qwen2-0.5B-Instruct-GPTQ-Int4`](https://huggingface.co/Qwen/Qwen2-0.5B-Instruct-GPTQ-Int4).
+A different GPTQ-quantized Qwen2 checkpoint can be selected with `--model-id`:
+
+```bash
+$ cargo run --example quantized-gptq-qwen2 --release -- \
+    --model-id "<org>/<some-other-qwen2-gptq-checkpoint>" \
+    --prompt "Hello there "
+```
+
+This example always uses the portable CPU dequantize-at-load path (`gptq_linear`), which runs on
+CPU, CUDA, and Metal without requiring the `gptq-cuda`/`gptq-metal` feature flags. For the fused
+dequantize+GEMM kernels (which keep the checkpoint packed and dequantize on every forward pass
+instead of once at load time), see `candle_transformers::quantized_gptq::cuda::GptqLinearCuda` /
+`metal::GptqLinearMetal`, gated behind the `gptq-cuda`/`gptq-metal` features on
+`candle-transformers`.

--- a/candle-examples/examples/quantized-gptq-qwen2/main.rs
+++ b/candle-examples/examples/quantized-gptq-qwen2/main.rs
@@ -1,0 +1,254 @@
+//! End-to-end example: download a GPTQ-quantized Qwen2 checkpoint from the Hugging Face Hub
+//! (e.g. `Qwen/Qwen2-0.5B-Instruct-GPTQ-Int4`) and run text generation through the fused/CPU
+//! GPTQ kernels in `candle-gptq-kernels` / `candle_transformers::quantized_gptq`.
+//!
+//! The checkpoint's `config.json` carries a `quantization_config` block (`bits`, `group_size`,
+//! ...) produced by AutoGPTQ/GPTQModel; this example reads it to build a
+//! [`candle_transformers::quantized_gptq::GptqConfig`] and constructs the model with
+//! [`candle_transformers::models::gptq_qwen2::ModelForCausalLM`], which mirrors the dense Qwen2
+//! model but routes every attention/MLP projection through the GPTQ dequantized linear layer.
+
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use anyhow::{Error as E, Result};
+use clap::Parser;
+
+use candle::{DType, Tensor};
+use candle_examples::token_output_stream::TokenOutputStream;
+use candle_nn::VarBuilder;
+use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::models::gptq_qwen2::{Config, ModelForCausalLM};
+use candle_transformers::quantized_gptq::GptqConfig;
+use hf_hub::{api::sync::Api, Repo, RepoType};
+use tokenizers::Tokenizer;
+
+#[derive(serde::Deserialize)]
+struct QuantizationConfig {
+    bits: usize,
+    group_size: usize,
+}
+
+#[derive(serde::Deserialize)]
+struct ConfigFile {
+    quantization_config: QuantizationConfig,
+}
+
+struct TextGeneration {
+    model: ModelForCausalLM,
+    device: candle::Device,
+    tokenizer: TokenOutputStream,
+    logits_processor: LogitsProcessor,
+    repeat_penalty: f32,
+    repeat_last_n: usize,
+}
+
+impl TextGeneration {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        model: ModelForCausalLM,
+        tokenizer: Tokenizer,
+        seed: u64,
+        temp: Option<f64>,
+        top_p: Option<f64>,
+        repeat_penalty: f32,
+        repeat_last_n: usize,
+        device: &candle::Device,
+    ) -> Self {
+        let logits_processor = LogitsProcessor::new(seed, temp, top_p);
+        Self {
+            model,
+            tokenizer: TokenOutputStream::new(tokenizer),
+            logits_processor,
+            repeat_penalty,
+            repeat_last_n,
+            device: device.clone(),
+        }
+    }
+
+    fn run(&mut self, prompt: &str, sample_len: usize) -> Result<()> {
+        use std::io::Write;
+        self.tokenizer.clear();
+        let mut tokens = self
+            .tokenizer
+            .tokenizer()
+            .encode(prompt, true)
+            .map_err(E::msg)?
+            .get_ids()
+            .to_vec();
+        for &t in tokens.iter() {
+            if let Some(t) = self.tokenizer.next_token(t)? {
+                print!("{t}")
+            }
+        }
+        std::io::stdout().flush()?;
+
+        let mut generated_tokens = 0usize;
+        let eos_token = match self.tokenizer.get_token("<|endoftext|>") {
+            Some(token) => token,
+            None => anyhow::bail!("cannot find the <|endoftext|> token"),
+        };
+        let eos_token2 = match self.tokenizer.get_token("<|im_end|>") {
+            Some(token) => token,
+            None => anyhow::bail!("cannot find the <|im_end|> token"),
+        };
+        let start_gen = std::time::Instant::now();
+        for index in 0..sample_len {
+            let context_size = if index > 0 { 1 } else { tokens.len() };
+            let start_pos = tokens.len().saturating_sub(context_size);
+            let ctxt = &tokens[start_pos..];
+            let input = Tensor::new(ctxt, &self.device)?.unsqueeze(0)?;
+            let logits = self.model.forward(&input, start_pos)?;
+            let logits = logits.squeeze(0)?.squeeze(0)?.to_dtype(DType::F32)?;
+            let logits = if self.repeat_penalty == 1. {
+                logits
+            } else {
+                let start_at = tokens.len().saturating_sub(self.repeat_last_n);
+                candle_transformers::utils::apply_repeat_penalty(
+                    &logits,
+                    self.repeat_penalty,
+                    &tokens[start_at..],
+                )?
+            };
+
+            let next_token = self.logits_processor.sample(&logits)?;
+            tokens.push(next_token);
+            generated_tokens += 1;
+            if next_token == eos_token || next_token == eos_token2 {
+                break;
+            }
+            if let Some(t) = self.tokenizer.next_token(next_token)? {
+                print!("{t}");
+                std::io::stdout().flush()?;
+            }
+        }
+        let dt = start_gen.elapsed();
+        if let Some(rest) = self.tokenizer.decode_rest().map_err(E::msg)? {
+            print!("{rest}");
+        }
+        std::io::stdout().flush()?;
+        println!(
+            "\n{generated_tokens} tokens generated ({:.2} token/s)",
+            generated_tokens as f64 / dt.as_secs_f64(),
+        );
+        Ok(())
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Run on CPU rather than on GPU.
+    #[arg(long)]
+    cpu: bool,
+
+    #[arg(long)]
+    prompt: String,
+
+    /// The temperature used to generate samples.
+    #[arg(long)]
+    temperature: Option<f64>,
+
+    /// Nucleus sampling probability cutoff.
+    #[arg(long)]
+    top_p: Option<f64>,
+
+    /// The seed to use when generating random samples.
+    #[arg(long, default_value_t = 299792458)]
+    seed: u64,
+
+    /// The length of the sample to generate (in tokens).
+    #[arg(long, short = 'n', default_value_t = 1000)]
+    sample_len: usize,
+
+    /// The GPTQ-quantized model repo on the Hugging Face Hub.
+    #[arg(long, default_value = "Qwen/Qwen2-0.5B-Instruct-GPTQ-Int4")]
+    model_id: String,
+
+    #[arg(long, default_value = "main")]
+    revision: String,
+
+    /// Penalty to be applied for repeating tokens, 1. means no penalty.
+    #[arg(long, default_value_t = 1.1)]
+    repeat_penalty: f32,
+
+    /// The context size to consider for the repeat penalty.
+    #[arg(long, default_value_t = 64)]
+    repeat_last_n: usize,
+
+    /// Skip chat template formatting (use the raw prompt, like a base model).
+    #[arg(long)]
+    no_chat_template: bool,
+}
+
+fn format_prompt(prompt: &str, use_chat_template: bool) -> String {
+    if !use_chat_template {
+        return prompt.to_string();
+    }
+    format!("<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n")
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    println!(
+        "avx: {}, neon: {}, simd128: {}, f16c: {}",
+        candle::utils::with_avx(),
+        candle::utils::with_neon(),
+        candle::utils::with_simd128(),
+        candle::utils::with_f16c()
+    );
+
+    let start = std::time::Instant::now();
+    let api = Api::new()?;
+    let repo = api.repo(Repo::with_revision(
+        args.model_id,
+        RepoType::Model,
+        args.revision,
+    ));
+
+    let tokenizer_filename = repo.get("tokenizer.json")?;
+    let config_filename = repo.get("config.json")?;
+    // GPTQ exports on the Hub are typically a single `model.safetensors` file (no shard index).
+    let weights_filename = if repo.get("model.safetensors.index.json").is_ok() {
+        candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?
+    } else {
+        vec![repo.get("model.safetensors")?]
+    };
+    println!("retrieved the files in {:?}", start.elapsed());
+
+    let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
+    let config_bytes = std::fs::read(&config_filename)?;
+    let config: Config = serde_json::from_slice(&config_bytes)?;
+    let quant_config: ConfigFile = serde_json::from_slice(&config_bytes)?;
+    let gptq_config = GptqConfig {
+        bits: quant_config.quantization_config.bits,
+        group_size: quant_config.quantization_config.group_size,
+    };
+
+    let start = std::time::Instant::now();
+    let device = candle_examples::device(args.cpu)?;
+    // The packed `qweight`/`qzeros`/`g_idx` tensors are always read as i32 regardless of this
+    // dtype (see `gptq_linear`); this only controls the dense embed/norm/lm_head tensors and the
+    // dequantized GPTQ weights, which are converted to it.
+    let dtype = DType::F32;
+    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&weights_filename, dtype, &device)? };
+    let model = ModelForCausalLM::new(&config, gptq_config, vb)?;
+    println!("loaded the model in {:?}", start.elapsed());
+
+    let mut pipeline = TextGeneration::new(
+        model,
+        tokenizer,
+        args.seed,
+        args.temperature,
+        args.top_p,
+        args.repeat_penalty,
+        args.repeat_last_n,
+        &device,
+    );
+    let prompt = format_prompt(&args.prompt, !args.no_chat_template);
+    pipeline.run(&prompt, args.sample_len)?;
+    Ok(())
+}

--- a/candle-gptq-kernels/Cargo.toml
+++ b/candle-gptq-kernels/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "candle-gptq-kernels"
+version = "0.10.2"
+edition = "2021"
+
+description = "Fused dequantize+GEMM CUDA kernel for GPTQ-quantized linear layers, for the candle ML framework."
+repository = "https://github.com/huggingface/candle"
+keywords = ["blas", "tensor", "machine-learning"]
+categories = ["science"]
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+candle = { path = "../candle-core", package = "candle-core", version = "0.10.2" }
+half = { version = "2.5.0", features = ["num-traits"] }
+candle-metal-kernels = { path = "../candle-metal-kernels", version = "0.10.2", optional = true }
+objc2-metal = { version = "0.3.2", optional = true }
+
+[features]
+default = ["cuda"]
+# Fused dequant+GEMM CUDA kernels (GPTQ scalar/tensor-core + vendored Marlin FFI).
+cuda = ["candle/cuda"]
+# Fused dequant+GEMM Metal kernel (GPTQ scalar tiled GEMM) for Apple Silicon.
+metal = ["candle/metal", "dep:candle-metal-kernels", "dep:objc2-metal"]
+
+[build-dependencies]
+cudaforge = "0.1.2"
+anyhow = { version = "1", features = ["backtrace"] }
+
+[dev-dependencies]
+anyhow = { version = "1", features = ["backtrace"] }
+candle-nn = { path = "../candle-nn" }

--- a/candle-gptq-kernels/README.md
+++ b/candle-gptq-kernels/README.md
@@ -1,0 +1,33 @@
+# candle-gptq-kernels
+
+Fused dequantize+GEMM CUDA/Metal kernels for GPTQ-quantized linear layers, used from
+[`candle_transformers::quantized_gptq`](../candle-transformers/src/quantized_gptq.rs) when the
+`gptq-cuda`/`gptq-metal` feature is enabled on `candle-transformers`.
+
+## Why a separate crate instead of living in `candle-kernels`
+
+[`candle-kernels`](../candle-kernels) holds the original CUDA kernels candle ships with (elementwise
+ops, reductions, the GGUF quantized matmul types, etc.), built via `nvcc` through `build.rs` and
+consumed unconditionally by `candle-core`'s `cuda` feature.
+
+GPTQ/AWQ/FP8 support is split into its own crate per format (this one, plus
+[`candle-awq-kernels`](../candle-awq-kernels) and [`candle-fp8-kernels`](../candle-fp8-kernels))
+instead of being added as more `.cu` files inside `candle-kernels`, for a few reasons:
+
+- **Optionality**: these kernels are only needed by checkpoints in that specific quantization
+  format. Folding them into `candle-kernels` would mean every `candle-core` consumer with the
+  `cuda` feature compiles GPTQ/AWQ/FP8 kernels (and links against `cudaforge`'s codegen for them)
+  whether or not they ever load such a checkpoint. As separate crates, they're only built when
+  `candle-transformers` is built with the corresponding `{gptq,awq,fp8}-cuda`/`-metal` feature.
+- **No `candle-core` dependency edge**: `candle-kernels` is a dependency of `candle-core` itself
+  (used to build the base CUDA backend). These crates instead depend *on* `candle-core` (for
+  `Tensor`/`DType` glue, vendored Marlin repacking, etc.) and sit at the `candle-transformers`
+  layer, alongside the format's CPU dequantization logic in `quantized_{gptq,awq,fp8}.rs`.
+- **Independent CUDA/Metal feature gating**: each crate has its own `cuda`/`metal` Cargo features
+  and `build.rs`, so e.g. enabling `gptq-metal` doesn't require pulling in AWQ's or FP8's kernel
+  sources at all.
+- **Vendored third-party code**: this crate also vendors the upstream Marlin CUDA kernel
+  (`kernels/marlin/marlin_cuda_kernel.cu`) for the fast 4-bit tensor-core GEMM path, which is kept
+  isolated from candle's own kernel sources rather than mixed into `candle-kernels`.
+
+See each crate's top-level module doc comment (`src/lib.rs`) for what each one implements.

--- a/candle-gptq-kernels/build.rs
+++ b/candle-gptq-kernels/build.rs
@@ -1,0 +1,50 @@
+// Build script compiling the GPTQ fused dequant+GEMM CUDA kernel into a static lib.
+//
+// The CUDA compile only runs when the `cuda` feature is enabled (i.e. `CARGO_FEATURE_CUDA` is
+// set). With `--features metal` and no CUDA the crate has no native build step: the Metal kernel
+// source is compiled at runtime from the embedded `.metal` string, so this script is a no-op.
+use std::path::PathBuf;
+
+fn main() -> anyhow::Result<()> {
+    println!("cargo::rerun-if-changed=build.rs");
+
+    if std::env::var("CARGO_FEATURE_CUDA").is_err() {
+        // No CUDA requested (e.g. a Metal-only build): nothing to compile or link.
+        return Ok(());
+    }
+
+    use cudaforge::KernelBuilder;
+
+    println!("cargo::rerun-if-changed=kernels/gptq_gemm.cu");
+    println!("cargo::rerun-if-changed=kernels/gptq_gemm_tc.cu");
+    println!("cargo::rerun-if-changed=kernels/marlin/marlin_cuda_kernel.cu");
+    println!("cargo::rerun-if-changed=kernels/marlin/marlin_shim.cu");
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR not set"));
+
+    let builder = KernelBuilder::new()
+        .source_files(vec![
+            "kernels/gptq_gemm.cu",
+            "kernels/gptq_gemm_tc.cu",
+            "kernels/marlin/marlin_cuda_kernel.cu",
+            "kernels/marlin/marlin_shim.cu",
+        ])
+        .out_dir(&out_dir)
+        .arg("-std=c++17")
+        .arg("-O3")
+        .arg("-Xcompiler")
+        .arg("-fPIC")
+        // The vendored Marlin kernel (kernels/marlin/marlin_cuda_kernel.cu) calls the constexpr
+        // __host__ helper `ceildiv` from __global__/__device__ code; recent nvcc rejects this
+        // without relaxing the constexpr rules. Passed as a build flag rather than editing the
+        // vendored kernel, which must stay an unmodified copy of upstream IST-DASLab/marlin.
+        .arg("--expt-relaxed-constexpr");
+
+    let out_file = out_dir.join("libgptqkernels.a");
+    builder.build_lib(out_file)?;
+
+    println!("cargo::rustc-link-search={}", out_dir.display());
+    println!("cargo::rustc-link-lib=gptqkernels");
+    println!("cargo::rustc-link-lib=dylib=cudart");
+    Ok(())
+}

--- a/candle-gptq-kernels/kernels/gptq_gemm.cu
+++ b/candle-gptq-kernels/kernels/gptq_gemm.cu
@@ -1,0 +1,72 @@
+// Fused dequantize + GEMM kernel for GPTQ (AutoGPTQ/GPTQModel) "old" CUDA layout.
+//
+// Computes Y[M,N] = X[M,K] @ dequant(qweight,qzeros,scales,g_idx)[K,N] using a
+// shared-memory-tiled GEMM, dequantizing each weight element on the fly while it is staged
+// into shared memory. Accumulation is scalar FP32 (no tensor cores): a correct,
+// reasonably cache-friendly fused kernel, one step above "dequantize then call cuBLAS".
+#include <cstdint>
+
+#define TILE 32
+
+extern "C" __global__ void gptq_gemm_f32(
+    const float *__restrict__ x,        // [M, K]
+    const int32_t *__restrict__ qweight, // [K / pack_factor, N]
+    const int32_t *__restrict__ qzeros,  // [n_groups, N / pack_factor]
+    const float *__restrict__ scales,    // [n_groups, N]
+    const int32_t *__restrict__ g_idx,   // [K], group index per input row
+    float *__restrict__ y,               // [M, N]
+    int M, int K, int N,
+    int bits, int pack_factor, int n_groups_out /* N / pack_factor */) {
+  __shared__ float As[TILE][TILE];
+  __shared__ float Bs[TILE][TILE];
+
+  const int row = blockIdx.y * TILE + threadIdx.y; // index into M
+  const int col = blockIdx.x * TILE + threadIdx.x; // index into N
+  const int32_t mask = (1 << bits) - 1;
+
+  float acc = 0.0f;
+  const int n_tiles = (K + TILE - 1) / TILE;
+  for (int t = 0; t < n_tiles; ++t) {
+    const int a_col = t * TILE + threadIdx.x;
+    As[threadIdx.y][threadIdx.x] =
+        (row < M && a_col < K) ? x[row * K + a_col] : 0.0f;
+
+    const int k = t * TILE + threadIdx.y;
+    if (k < K && col < N) {
+      const int g = g_idx[k];
+      const int32_t w_word = qweight[(k / pack_factor) * N + col];
+      const int shift_q = (k % pack_factor) * bits;
+      const int32_t q = (w_word >> shift_q) & mask;
+
+      const int32_t z_word = qzeros[g * n_groups_out + col / pack_factor];
+      const int shift_z = (col % pack_factor) * bits;
+      const int32_t z = ((z_word >> shift_z) & mask) + 1;
+
+      const float s = scales[g * N + col];
+      Bs[threadIdx.y][threadIdx.x] = (float)(q - z) * s;
+    } else {
+      Bs[threadIdx.y][threadIdx.x] = 0.0f;
+    }
+    __syncthreads();
+
+#pragma unroll
+    for (int i = 0; i < TILE; ++i) {
+      acc += As[threadIdx.y][i] * Bs[i][threadIdx.x];
+    }
+    __syncthreads();
+  }
+
+  if (row < M && col < N) {
+    y[row * N + col] = acc;
+  }
+}
+
+extern "C" void run_gptq_gemm_f32(
+    const float *x, const int32_t *qweight, const int32_t *qzeros,
+    const float *scales, const int32_t *g_idx, float *y, int M, int K, int N,
+    int bits, int pack_factor, int n_groups_out) {
+  dim3 block(TILE, TILE);
+  dim3 grid((N + TILE - 1) / TILE, (M + TILE - 1) / TILE);
+  gptq_gemm_f32<<<grid, block>>>(x, qweight, qzeros, scales, g_idx, y, M, K, N,
+                                  bits, pack_factor, n_groups_out);
+}

--- a/candle-gptq-kernels/kernels/gptq_gemm.metal
+++ b/candle-gptq-kernels/kernels/gptq_gemm.metal
@@ -1,0 +1,80 @@
+// Fused dequantize + GEMM kernel for GPTQ (AutoGPTQ/GPTQModel) "old" layout, Metal port.
+//
+// Computes Y[M,N] = X[M,K] @ dequant(qweight,qzeros,scales,g_idx)[K,N] using a
+// threadgroup-memory-tiled GEMM, dequantizing each weight element on the fly while it is staged
+// into threadgroup memory. Accumulation is scalar FP32. This is a straight port of
+// `kernels/gptq_gemm.cu` (CUDA), with TILE reduced to 16 so 16x16=256 threads fit comfortably in
+// a Metal threadgroup.
+#include <metal_stdlib>
+using namespace metal;
+
+#define TILE 16
+
+struct GptqParams {
+    int M;
+    int K;
+    int N;
+    int bits;
+    int pack_factor;
+    int n_groups_out; // N / pack_factor
+};
+
+kernel void gptq_gemm_f32(
+    device const float *x         [[buffer(0)]], // [M, K]
+    device const int   *qweight   [[buffer(1)]], // [K / pack_factor, N]
+    device const int   *qzeros    [[buffer(2)]], // [n_groups, N / pack_factor]
+    device const float *scales    [[buffer(3)]], // [n_groups, N]
+    device const int   *g_idx     [[buffer(4)]], // [K]
+    device float       *y         [[buffer(5)]], // [M, N]
+    constant GptqParams &p        [[buffer(6)]],
+    uint2 tid [[thread_position_in_threadgroup]],
+    uint2 gid [[threadgroup_position_in_grid]])
+{
+    threadgroup float As[TILE][TILE];
+    threadgroup float Bs[TILE][TILE];
+
+    const int M = p.M;
+    const int K = p.K;
+    const int N = p.N;
+    const int bits = p.bits;
+    const int pack_factor = p.pack_factor;
+    const int n_groups_out = p.n_groups_out;
+    const int mask = (1 << bits) - 1;
+
+    const int row = int(gid.y) * TILE + int(tid.y); // index into M
+    const int col = int(gid.x) * TILE + int(tid.x); // index into N
+
+    float acc = 0.0f;
+    const int n_tiles = (K + TILE - 1) / TILE;
+    for (int t = 0; t < n_tiles; ++t) {
+        const int a_col = t * TILE + int(tid.x);
+        As[tid.y][tid.x] = (row < M && a_col < K) ? x[row * K + a_col] : 0.0f;
+
+        const int k = t * TILE + int(tid.y);
+        if (k < K && col < N) {
+            const int g = g_idx[k];
+            const int w_word = qweight[(k / pack_factor) * N + col];
+            const int shift_q = (k % pack_factor) * bits;
+            const int q = (w_word >> shift_q) & mask;
+
+            const int z_word = qzeros[g * n_groups_out + col / pack_factor];
+            const int shift_z = (col % pack_factor) * bits;
+            const int z = ((z_word >> shift_z) & mask) + 1;
+
+            const float s = scales[g * N + col];
+            Bs[tid.y][tid.x] = (float)(q - z) * s;
+        } else {
+            Bs[tid.y][tid.x] = 0.0f;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (int i = 0; i < TILE; ++i) {
+            acc += As[tid.y][i] * Bs[i][tid.x];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (row < M && col < N) {
+        y[row * N + col] = acc;
+    }
+}

--- a/candle-gptq-kernels/kernels/gptq_gemm_tc.cu
+++ b/candle-gptq-kernels/kernels/gptq_gemm_tc.cu
@@ -1,0 +1,113 @@
+// Tensor-core fused dequantize+GEMM kernel for GPTQ 4-bit weights (bits=4 only).
+//
+// Same numerical semantics as the scalar kernel in `gptq_gemm.cu` (AutoGPTQ/GPTQModel "old"
+// CUDA layout: qweight/qzeros/scales/g_idx, zero point stored as `value - 1`), but the GEMM
+// inner product is computed on the SM's tensor cores via the WMMA API instead of scalar FMAs:
+// each 16x16x16 partial product runs through `wmma::mma_sync` on FP16 operands with FP32
+// accumulation, after dequantizing the relevant 16x16 weight tile into shared memory as FP16.
+//
+// This is a from-scratch tensor-core kernel, not a port of Neural Magic's Marlin: it reads the
+// standard AutoGPTQ tensor layout directly (no offline weight repacking step) and uses a simple
+// one-warp-per-output-tile schedule (no `cp.async` pipelining, no Stream-K decomposition). It is
+// nonetheless a genuine tensor-core kernel, unlike the scalar-FMA kernel in `gptq_gemm.cu`.
+#include <cstdint>
+#include <mma.h>
+
+using namespace nvcuda;
+
+#define GPTQ_TC_BITS 4
+#define GPTQ_TC_PACK_FACTOR 8
+#define GPTQ_TC_MASK 0xF
+#define WMMA_M 16
+#define WMMA_N 16
+#define WMMA_K 16
+
+extern "C" __global__ void gptq_gemm_tc_f32(
+    const float *__restrict__ x,         // [M, K]
+    const int32_t *__restrict__ qweight, // [K / pack_factor, N]
+    const int32_t *__restrict__ qzeros,  // [n_groups, N / pack_factor]
+    const float *__restrict__ scales,    // [n_groups, N]
+    const int32_t *__restrict__ g_idx,   // [K], group index per input row
+    float *__restrict__ y,               // [M, N]
+    int M, int K, int N, int n_groups_out /* N / pack_factor */) {
+  __shared__ __align__(16) half As[WMMA_M][WMMA_K];
+  __shared__ __align__(16) half Bs[WMMA_K][WMMA_N];
+  __shared__ __align__(16) float Cs[WMMA_M][WMMA_N];
+
+  const int tile_row = blockIdx.y * WMMA_M; // base row into M
+  const int tile_col = blockIdx.x * WMMA_N; // base col into N
+  const int tid = threadIdx.x;              // 0..31, one warp per block
+
+  wmma::fragment<wmma::matrix_a, WMMA_M, WMMA_N, WMMA_K, half, wmma::row_major>
+      a_frag;
+  wmma::fragment<wmma::matrix_b, WMMA_M, WMMA_N, WMMA_K, half, wmma::row_major>
+      b_frag;
+  wmma::fragment<wmma::accumulator, WMMA_M, WMMA_N, WMMA_K, float> c_frag;
+  wmma::fill_fragment(c_frag, 0.0f);
+
+  for (int k0 = 0; k0 < K; k0 += WMMA_K) {
+    // Stage the activation tile into shared memory as half, zero-padding out-of-bounds.
+    for (int i = tid; i < WMMA_M * WMMA_K; i += 32) {
+      const int r = i / WMMA_K;
+      const int c = i % WMMA_K;
+      const int row = tile_row + r;
+      const int k = k0 + c;
+      As[r][c] = (row < M && k < K) ? __float2half(x[row * K + k])
+                                     : __float2half(0.0f);
+    }
+
+    // Stage the dequantized weight tile into shared memory as half, zero-padding OOB.
+    for (int i = tid; i < WMMA_K * WMMA_N; i += 32) {
+      const int r = i / WMMA_N; // local k index
+      const int c = i % WMMA_N; // local col index
+      const int k = k0 + r;
+      const int col = tile_col + c;
+      if (k < K && col < N) {
+        const int g = g_idx[k];
+        const int32_t w_word = qweight[(k / GPTQ_TC_PACK_FACTOR) * N + col];
+        const int shift_q = (k % GPTQ_TC_PACK_FACTOR) * GPTQ_TC_BITS;
+        const int32_t q = (w_word >> shift_q) & GPTQ_TC_MASK;
+
+        const int32_t z_word =
+            qzeros[g * n_groups_out + col / GPTQ_TC_PACK_FACTOR];
+        const int shift_z = (col % GPTQ_TC_PACK_FACTOR) * GPTQ_TC_BITS;
+        const int32_t z = ((z_word >> shift_z) & GPTQ_TC_MASK) + 1;
+
+        const float s = scales[g * N + col];
+        Bs[r][c] = __float2half((float)(q - z) * s);
+      } else {
+        Bs[r][c] = __float2half(0.0f);
+      }
+    }
+    __syncthreads();
+
+    wmma::load_matrix_sync(a_frag, &As[0][0], WMMA_K);
+    wmma::load_matrix_sync(b_frag, &Bs[0][0], WMMA_N);
+    wmma::mma_sync(c_frag, a_frag, b_frag, c_frag);
+    __syncthreads();
+  }
+
+  wmma::store_matrix_sync(&Cs[0][0], c_frag, WMMA_N, wmma::mem_row_major);
+  __syncthreads();
+
+  for (int i = tid; i < WMMA_M * WMMA_N; i += 32) {
+    const int r = i / WMMA_N;
+    const int c = i % WMMA_N;
+    const int row = tile_row + r;
+    const int col = tile_col + c;
+    if (row < M && col < N) {
+      y[row * N + col] = Cs[r][c];
+    }
+  }
+}
+
+extern "C" void run_gptq_gemm_tc_f32(const float *x, const int32_t *qweight,
+                                      const int32_t *qzeros,
+                                      const float *scales,
+                                      const int32_t *g_idx, float *y, int M,
+                                      int K, int N, int n_groups_out) {
+  dim3 block(32, 1);
+  dim3 grid((N + WMMA_N - 1) / WMMA_N, (M + WMMA_M - 1) / WMMA_M);
+  gptq_gemm_tc_f32<<<grid, block>>>(x, qweight, qzeros, scales, g_idx, y, M, K,
+                                     N, n_groups_out);
+}

--- a/candle-gptq-kernels/kernels/marlin/ATTRIBUTION.md
+++ b/candle-gptq-kernels/kernels/marlin/ATTRIBUTION.md
@@ -1,0 +1,19 @@
+# Vendored Marlin kernel
+
+`marlin_cuda_kernel.cu` is vendored verbatim from the Marlin project:
+
+- Source: https://github.com/IST-DASLab/marlin (`marlin/marlin_cuda_kernel.cu`)
+- Author: Elias Frantar (IST-DASLab)
+- License: Apache License 2.0 (see `LICENSE` in this directory)
+
+It is the real Marlin FP16xINT4 tensor-core GEMM kernel; this crate compiles it and drives it
+over FFI (`marlin_shim.cu` -> `run_marlin_gemm`, bound in `src/ffi.rs` / `src/marlin.rs`) rather
+than reimplementing it.
+
+Not vendored: upstream's `marlin/marlin_cuda.cpp` (a torch/PyBind wrapper) and `marlin/__init__.py`
+(the Python repack). The repack is reimplemented host-side in Rust in `src/marlin.rs`, ported from
+`__init__.py`'s `Layer.pack` / `_get_perms`.
+
+Constraints inherited from the upstream kernel: 4-bit, symmetric (no per-output zero point), FP16
+operands, group size 128 or -1 (per-channel), no act-order (`g_idx` must be sequential), and
+`infeatures % 128 == 0`, `outfeatures % 256 == 0`.

--- a/candle-gptq-kernels/kernels/marlin/LICENSE
+++ b/candle-gptq-kernels/kernels/marlin/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/candle-gptq-kernels/kernels/marlin/marlin_cuda_kernel.cu
+++ b/candle-gptq-kernels/kernels/marlin/marlin_cuda_kernel.cu
@@ -1,0 +1,822 @@
+/*
+ * Copyright (C) Marlin.2024 Elias Frantar (elias.frantar@ist.ac.at)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef MARLIN_CUDA_KERNEL_CUH
+#define MARLIN_CUDA_KERNEL_CUH
+
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <iostream>
+
+
+constexpr int ceildiv(int a, int b) {
+  return (a + b - 1) / b;
+}
+
+// Instances of `Vec` are used to organize groups of >>registers<<, as needed for instance as inputs to tensor core
+// operations. Consequently, all corresponding index accesses must be compile-time constants, which is why we
+// extensively use `#pragma unroll` throughout the kernel code to guarantee this.
+template <typename T, int n>
+struct Vec {
+  T elems[n];
+  __device__ T& operator[](int i) {
+    return elems[i];
+  }
+};
+
+using I4 = Vec<int, 4>;
+
+// Matrix fragments for tensor core instructions; their precise layout is documented here: 
+// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
+using FragA = Vec<half2, 4>;
+using FragB = Vec<half2, 2>;
+using FragC = Vec<float, 4>;
+using FragS = Vec<half2, 1>; // quantization scales
+
+// Predicated asynchronous global->shared copy; used for inputs A where we apply predication to handle batchsizes that
+// are not multiples of 16.
+__device__ inline void cp_async4_pred(void* smem_ptr, const void* glob_ptr, bool pred = true) {
+  const int BYTES = 16;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+    "{\n"
+    "   .reg .pred p;\n"
+    "   setp.ne.b32 p, %0, 0;\n"
+    "   @p cp.async.cg.shared.global [%1], [%2], %3;\n"
+    "}\n" :: "r"((int) pred), "r"(smem), "l"(glob_ptr), "n"(BYTES)
+  );
+}
+
+// Asynchronous global->shared copy with a cache hint indicating that the values may be evicted immediately; used for
+// quantized weights B, which are only accessed precisely once and should thus not pollute the L2 cache which we need
+// for inputs A and outputs C. 
+__device__ inline void cp_async4_stream(void* smem_ptr, const void* glob_ptr) {
+  const int BYTES = 16;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+    "{\n"
+    "   .reg .b64 p;\n"
+    "   createpolicy.fractional.L2::evict_first.b64 p, 1.0;"
+    "   cp.async.cg.shared.global.L2::cache_hint [%0], [%1], %2, p;\n"
+    "}\n" :: "r"(smem), "l"(glob_ptr), "n"(BYTES)
+  );
+}
+
+// Async copy fence.
+__device__ inline void cp_async_fence() {
+  asm volatile("cp.async.commit_group;\n" ::);
+}
+
+// Wait until at most `n` async copy stages are still pending.
+template <int n>
+__device__ inline void cp_async_wait() {
+  asm volatile("cp.async.wait_group %0;\n" :: "n"(n));
+}
+
+// m16n8k16 tensor core mma instruction with fp16 inputs and fp32 output/accumulation.
+__device__ inline void mma(const FragA& a_frag, const FragB& frag_b, FragC& frag_c) {
+  const uint32_t* a = reinterpret_cast<const uint32_t*>(&a_frag);
+  const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
+  float* c = reinterpret_cast<float*>(&frag_c);
+  asm volatile(
+    "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+    "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+    : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+    :  "r"(a[0]),  "r"(a[1]),  "r"(a[2]),  "r"(a[3]),  "r"(b[0]),  "r"(b[1]),
+       "f"(c[0]),  "f"(c[1]),  "f"(c[2]),  "f"(c[3])
+  );
+}
+
+// Instruction for loading a full 16x16 matrix fragment of operand A from shared memory, directly in tensor core layout.
+__device__ inline void ldsm4(FragA& frag_a, const void* smem_ptr) {
+  uint32_t* a = reinterpret_cast<uint32_t*>(&frag_a);
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+    "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+    : "=r"(a[0]), "=r"(a[1]), "=r"(a[2]), "=r"(a[3]) : "r"(smem)
+  );
+}
+
+// Lookup-table based 3-input logical operation; explicitly used for dequantization as the compiler does not seem to
+// automatically recognize it in all cases. 
+template <int lut>
+__device__ inline int lop3(int a, int b, int c) {
+  int res;
+  asm volatile(
+    "lop3.b32 %0, %1, %2, %3, %4;\n"
+    : "=r"(res) : "r"(a), "r"(b), "r"(c), "n"(lut)
+  );
+  return res;
+}
+
+// Efficiently dequantize an int32 value into a full B-fragment of 4 fp16 values.
+// We mostly follow the strategy in the link below, with some small changes:
+// https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
+__device__ inline FragB dequant(int q) {
+  const int LO = 0x000f000f;
+  const int HI = 0x00f000f0;
+  const int EX = 0x64006400;
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, LO, EX);
+  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, HI, EX);
+  // We want signed int4 outputs, hence we fuse the `-8` symmetric zero point directly into `SUB` and `ADD`.
+  const int SUB = 0x64086408;
+  const int MUL = 0x2c002c00;
+  const int ADD = 0xd480d480;
+  FragB frag_b;
+  frag_b[0] = __hsub2(
+    *reinterpret_cast<half2*>(&lo),
+    *reinterpret_cast<const half2*>(&SUB)
+  );
+  frag_b[1] = __hfma2(
+    *reinterpret_cast<half2*>(&hi),
+    *reinterpret_cast<const half2*>(&MUL), *reinterpret_cast<const half2*>(&ADD)
+  );
+  return frag_b;
+}
+
+// Multiply dequantized values by the corresponding quantization scale; used only for grouped quantization.
+__device__ inline void scale(FragB& frag_b, FragS& frag_s, int i) {
+  half2 s = __half2half2(reinterpret_cast<__half*>(&frag_s)[i]);
+  frag_b[0] = __hmul2(frag_b[0], s);
+  frag_b[1] = __hmul2(frag_b[1], s);
+}
+
+// Wait until barrier reaches `count`, then lock for current threadblock.
+__device__ inline void barrier_acquire(int* lock, int count) {
+  if (threadIdx.x == 0) {
+    int state = -1;
+    do
+      // Guarantee that subsequent writes by this threadblock will be visible globally.
+      asm volatile ("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
+    while (state != count);
+  }
+  __syncthreads();
+}
+
+// Release barrier and increment visitation count.
+__device__ inline void barrier_release(int* lock, bool reset = false) {
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    if (reset) {
+      lock[0] = 0;
+      return;
+    }
+    int val = 1;
+    // Make sure that all writes since acquiring this barrier are visible globally, while releasing the barrier. 
+    asm volatile ("fence.acq_rel.gpu;\n");
+    asm volatile ("red.relaxed.gpu.global.add.s32 [%0], %1;\n" : : "l"(lock), "r"(val)); 
+  }
+}
+
+
+template <
+  const int threads, // number of threads in a threadblock
+  const int thread_m_blocks, // number of 16x16 blocks in the m dimension (batchsize) of the threadblock 
+  const int thread_n_blocks, // same for n dimension (output) 
+  const int thread_k_blocks, // same for k dimension (reduction)
+  const int stages, // number of stages for the async global->shared fetch pipeline
+  const int group_blocks = -1 // number of consecutive 16x16 blocks with a separate quantization scale
+>
+__global__ void Marlin(
+  const int4* __restrict__ A, // fp16 input matrix of shape mxk 
+  const int4* __restrict__ B, // 4bit quantized weight matrix of shape kxn 
+        int4* __restrict__ C, // fp16 output buffer of shape mxn
+  const int4* __restrict__ s, // fp16 quantization scales of shape (k/groupsize)xn 
+  int  prob_m, // batch dimension m
+  int  prob_n, // output dimension n
+  int  prob_k, // reduction dimension k
+  int* locks // extra global storage for barrier synchronization 
+) {
+  // Each threadblock processes one "stripe" of the B matrix with (roughly) the same size, which might involve multiple 
+  // column "slices" (of width 16 * `thread_n_blocks`). Stripes are defined as shown in the 3x3 matrix 5 SM example: 
+  //   0 1 3 
+  //   0 2 3
+  //   1 2 4
+  // While this kind of partitioning makes things somewhat more complicated, it ensures good utilization of all SMs
+  // for many kinds of shape and GPU configurations, while requiring as few slow global cross-threadblock reductions as 
+  // possible.
+  
+  // For larger GEMMs we run multiple batchsize 64 versions in parallel for a better partitioning with less reductions
+  int parallel = 1;
+  if (prob_m > 16 * thread_m_blocks) {
+    parallel = prob_m / (16 * thread_m_blocks);
+    prob_m = 16 * thread_m_blocks;
+  }
+
+  int k_tiles = prob_k / 16 / thread_k_blocks;
+  int n_tiles = prob_n / 16 / thread_n_blocks;
+  int iters = ceildiv(k_tiles * n_tiles * parallel, gridDim.x);
+  // Ensure that the number of tiles in each stripe is a multiple of the groupsize; this avoids an annoying special case
+  // where a stripe starts in the middle of group.
+  if (group_blocks != -1)
+    iters = (group_blocks / thread_k_blocks) * ceildiv(iters, (group_blocks / thread_k_blocks));
+
+  int slice_row = (iters * blockIdx.x) % k_tiles;
+  int slice_col_par = (iters * blockIdx.x) / k_tiles;
+  int slice_col = slice_col_par;
+  int slice_iters; // number of threadblock tiles in the current slice
+  int slice_count = 0; // total number of active threadblocks in the current slice
+  int slice_idx; // index of threadblock in current slice; numbered bottom to top
+
+  // We can easily implement parallel problem execution by just remapping indices and advancing global pointers
+  if (slice_col_par >= n_tiles) {
+    A += (slice_col_par / n_tiles) * 16 * thread_m_blocks * prob_k / 8;
+    C += (slice_col_par / n_tiles) * 16 * thread_m_blocks * prob_n / 8;
+    locks += (slice_col_par / n_tiles) * n_tiles;
+    slice_col = slice_col_par % n_tiles;
+  }
+
+  // Compute all information about the current slice which is required for synchronization.
+  auto init_slice = [&] () {
+    slice_iters = iters * (blockIdx.x + 1) - (k_tiles * slice_col_par + slice_row);
+    if (slice_iters < 0 || slice_col_par >= n_tiles * parallel)
+      slice_iters = 0;
+    if (slice_iters == 0)
+      return;
+    if (slice_row + slice_iters > k_tiles) 
+      slice_iters = k_tiles - slice_row;
+    slice_count = 1;
+    slice_idx = 0;
+    int col_first = iters * ceildiv(k_tiles * slice_col_par, iters);
+    if (col_first <= k_tiles * (slice_col_par + 1)) {
+      int col_off = col_first - k_tiles * slice_col_par;
+      slice_count = ceildiv(k_tiles - col_off, iters);
+      if (col_off > 0)
+        slice_count++;
+      int delta_first = iters * blockIdx.x - col_first;
+      if (delta_first < 0 || (col_off == 0 && delta_first == 0))
+        slice_idx = slice_count - 1;
+      else {
+        slice_idx = slice_count - 1 - delta_first / iters;
+        if (col_off > 0)
+          slice_idx--;
+      }
+    }
+    if (slice_col == n_tiles) {
+      A += 16 * thread_m_blocks * prob_k / 8;
+      C += 16 * thread_m_blocks * prob_n / 8;
+      locks += n_tiles;
+      slice_col = 0;
+    }
+  };
+  init_slice();
+
+  int a_gl_stride = prob_k / 8; // stride of the A matrix in global memory
+  // We typically use `constexpr` to indicate that this value is a compile-time constant
+  constexpr int a_sh_stride = 16 * thread_k_blocks / 8; // stride of an A matrix tile in shared memory
+  constexpr int a_gl_rd_delta_o = 16 * thread_k_blocks / 8; // delta between subsequent A tiles in global memory
+  int a_gl_rd_delta_i = a_gl_stride * (threads / a_gl_rd_delta_o); // between subsequent accesses within a tile
+  constexpr int a_sh_wr_delta = a_sh_stride * (threads / a_gl_rd_delta_o); // between shared memory writes
+  constexpr int a_sh_rd_delta_o = 2 * ((threads / 32) / (thread_n_blocks / 4)); // between shared memory tile reads
+  constexpr int a_sh_rd_delta_i = a_sh_stride * 16; // within a shared memory tile
+  constexpr int a_sh_stage = a_sh_stride * (16 * thread_m_blocks); // overall size of a tile
+  constexpr int a_sh_wr_iters = ceildiv(a_sh_stage, a_sh_wr_delta); // number of shared write iterations for a tile
+
+  int b_gl_stride = 16 * prob_n / 32;
+  constexpr int b_sh_stride = 32 * thread_n_blocks / 4;
+  int b_gl_rd_delta_o = b_gl_stride * thread_k_blocks;
+  int b_gl_rd_delta_i = b_gl_stride * (threads / b_sh_stride);
+  constexpr int b_sh_wr_delta = threads;
+  constexpr int b_sh_rd_delta = threads;
+  constexpr int b_sh_stage = b_sh_stride * thread_k_blocks;
+  constexpr int b_sh_wr_iters = b_sh_stage / b_sh_wr_delta;
+
+  int s_gl_stride = prob_n / 8;
+  constexpr int s_sh_stride = 16 * thread_n_blocks / 8;
+  constexpr int s_sh_stage = s_sh_stride;
+  int s_gl_rd_delta = s_gl_stride;
+
+  // Global A read index of current thread.
+  int a_gl_rd = a_gl_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
+  a_gl_rd += a_gl_rd_delta_o * slice_row;
+  // Shared write index of current thread.
+  int a_sh_wr = a_sh_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
+  // Shared read index.
+  int a_sh_rd = a_sh_stride * ((threadIdx.x % 32) % 16) + (threadIdx.x % 32) / 16;
+  a_sh_rd += 2 * ((threadIdx.x / 32) / (thread_n_blocks / 4));
+
+  int b_gl_rd = b_gl_stride * (threadIdx.x / b_sh_stride) + (threadIdx.x % b_sh_stride);
+  b_gl_rd += b_sh_stride * slice_col;
+  b_gl_rd += b_gl_rd_delta_o * slice_row;
+  int b_sh_wr = threadIdx.x;
+  int b_sh_rd = threadIdx.x;
+
+  int s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) + s_sh_stride * slice_col + threadIdx.x;
+  int s_sh_wr = threadIdx.x;
+  int s_sh_rd;
+  // We use a different scale layout for grouped and column-wise quantization as we scale a `half2` tile in column-major
+  // layout in the former and in row-major in the latter case.
+  if (group_blocks != -1)
+    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) / 4;
+  else
+    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) % 4;
+  
+  // Precompute which thread should not read memory in which iterations; this is needed if there are more threads than
+  // required for a certain tilesize or when the batchsize is not a multiple of 16.
+  bool a_sh_wr_pred[a_sh_wr_iters];
+  #pragma unroll
+  for (int i = 0; i < a_sh_wr_iters; i++)
+    a_sh_wr_pred[i] = a_sh_wr_delta * i + a_sh_wr < a_sh_stride * prob_m;
+  bool s_sh_wr_pred = threadIdx.x < s_sh_stride;
+
+  // To ensure that writing and reading A tiles to/from shared memory, the latter in fragment format, is fully bank
+  // conflict free, we need to use a rather fancy XOR-based layout. The key here is that neither reads nor writes of 
+  // the 16-byte `int4` blocks of 8 consecutive threads involve the same shared memory banks. Further, it seems (based
+  // on NSight-Compute) that each warp must also write a consecutive memory segment?
+  auto transform_a = [&] (int i) {
+    int row = i / a_gl_rd_delta_o;
+    return a_gl_rd_delta_o * row + (i % a_gl_rd_delta_o) ^ row;
+  };
+  // Since the computation of this remapping is non-trivial and, due to our main loop unrolls, all shared memory 
+  // accesses are static, we simply precompute both transformed reads and writes.
+  int a_sh_wr_trans[a_sh_wr_iters];
+  #pragma unroll
+  for (int i = 0; i < a_sh_wr_iters; i++)
+    a_sh_wr_trans[i] = transform_a(a_sh_wr_delta * i + a_sh_wr);
+  int a_sh_rd_trans[b_sh_wr_iters][thread_m_blocks];
+  #pragma unroll
+  for (int i = 0; i < b_sh_wr_iters; i++) {
+    #pragma unroll
+    for (int j = 0; j < thread_m_blocks; j++)
+      a_sh_rd_trans[i][j] = transform_a(a_sh_rd_delta_o * i + a_sh_rd_delta_i * j + a_sh_rd); 
+  }
+
+  // Since B-accesses have non-constant stride they have to be computed at runtime; we break dependicies between
+  // subsequent accesses with a tile by maintining multiple pointers (we have enough registers), a tiny optimization.
+  const int4* B_ptr[b_sh_wr_iters];
+  #pragma unroll
+  for (int i = 0; i < b_sh_wr_iters; i++)
+    B_ptr[i] = B + b_gl_rd_delta_i * i + b_gl_rd;
+
+  extern __shared__ int4 sh[];
+  // Shared memory storage for global fetch pipelines. 
+  int4* sh_a = sh;
+  int4* sh_b = sh_a + (stages * a_sh_stage);
+  int4* sh_s = sh_b + (stages * b_sh_stage);
+  // Register storage for double buffer of shared memory reads. 
+  FragA frag_a[2][thread_m_blocks];
+  I4 frag_b_quant[2];
+  FragC frag_c[thread_m_blocks][4][2];
+  FragS frag_s[2][4];
+
+  // Zero accumulators.
+  auto zero_accums = [&] () {
+    #pragma unroll
+    for (int i = 0; i < thread_m_blocks * 4 * 2 * 4; i++)
+      reinterpret_cast<float*>(frag_c)[i] = 0;
+  };
+
+  // Asynchronously fetch the next A, B and s tile from global to the next shared memory pipeline location.
+  auto fetch_to_shared = [&] (int pipe, int a_off, bool pred = true) {
+    if (pred) {
+      int4* sh_a_stage = sh_a + a_sh_stage * pipe;
+      #pragma unroll
+      for (int i = 0; i < a_sh_wr_iters; i++) {
+        cp_async4_pred(
+          &sh_a_stage[a_sh_wr_trans[i]],
+          &A[a_gl_rd_delta_i * i + a_gl_rd + a_gl_rd_delta_o * a_off],
+          a_sh_wr_pred[i]
+        );
+      }
+      int4* sh_b_stage = sh_b + b_sh_stage * pipe;
+      #pragma unroll
+      for (int i = 0; i < b_sh_wr_iters; i++) {
+        cp_async4_stream(&sh_b_stage[b_sh_wr_delta * i + b_sh_wr], B_ptr[i]);
+        B_ptr[i] += b_gl_rd_delta_o;
+      }
+      // Only fetch scales if this tile starts a new group
+      if (group_blocks != -1 && pipe % (group_blocks / thread_k_blocks) == 0) {
+        int4* sh_s_stage = sh_s + s_sh_stage * pipe;
+        if (s_sh_wr_pred)
+          cp_async4_stream(&sh_s_stage[s_sh_wr], &s[s_gl_rd]);
+        s_gl_rd += s_gl_rd_delta;
+      }
+    }
+    // Insert a fence even when we are winding down the pipeline to ensure that waiting is also correct at this point.
+    cp_async_fence();
+  };
+
+  // Wait until the next thread tile has been loaded to shared memory.
+  auto wait_for_stage = [&] () {
+    // We only have `stages - 2` active fetches since we are double buffering and can only issue the next fetch when
+    // it is guaranteed that the previous shared memory load is fully complete (as it may otherwise be overwritten).
+    cp_async_wait<stages - 2>();
+    __syncthreads();
+  };
+
+  // Load the next sub-tile from the current location in the shared memory pipe into the current register buffer.
+  auto fetch_to_registers = [&] (int k, int pipe) {
+    // It may seem inefficient that we reload the groups for every sub-tile; however, this does not seem to be a
+    // significant bottleneck, while some theoretically better attempts have lead to bad instruction ordering by the
+    // compiler and correspondingly a noticable drop in performance.
+    if (group_blocks != -1) {
+      int4* sh_s_stage = sh_s + s_sh_stage * ((group_blocks / thread_k_blocks) * (pipe / (group_blocks / thread_k_blocks)));
+      reinterpret_cast<int4*>(&frag_s[k % 2])[0] = sh_s_stage[s_sh_rd];
+    }
+    int4* sh_a_stage = sh_a + a_sh_stage * pipe;
+    #pragma unroll
+    for (int i = 0; i < thread_m_blocks; i++)
+      ldsm4(frag_a[k % 2][i], &sh_a_stage[a_sh_rd_trans[k % b_sh_wr_iters][i]]);
+    int4* sh_b_stage = sh_b + b_sh_stage * pipe;
+    frag_b_quant[k % 2] = *reinterpret_cast<I4*>(&sh_b_stage[b_sh_rd_delta * (k % b_sh_wr_iters) + b_sh_rd]);
+  };
+
+  // Execute the actual tensor core matmul of a sub-tile. 
+  auto matmul = [&] (int k) {
+    // We have the m dimension as the inner loop in order to encourage overlapping dequantization and matmul operations.
+    #pragma unroll
+    for (int j = 0; j < 4; j++) {
+      int b_quant = frag_b_quant[k % 2][j];
+      int b_quant_shift = b_quant >> 8;
+      FragB frag_b0 = dequant(b_quant);
+      // If there are no groups, we can just scale the final output once and can avoid doing so for each weight.
+      if (group_blocks != -1)
+        scale(frag_b0, frag_s[k % 2][j], 0);
+      FragB frag_b1 = dequant(b_quant_shift);
+      if (group_blocks != -1)
+        scale(frag_b1, frag_s[k % 2][j], 1);
+      #pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+        mma(frag_a[k % 2][i], frag_b0, frag_c[i][j][0]);
+        mma(frag_a[k % 2][i], frag_b1, frag_c[i][j][1]);
+      }
+    }
+  };
+
+  // Since we slice across the k dimension of a tile in order to increase the number of warps while keeping the n
+  // dimension of a tile reasonable, we have multiple warps that accumulate their partial sums of the same output
+  // location; which we have to reduce over in the end. We do in shared memory.
+  auto thread_block_reduce = [&] () {
+    constexpr int red_off = threads / b_sh_stride / 2;
+    if (red_off >= 1) {
+      int red_idx = threadIdx.x / b_sh_stride;
+      constexpr int red_sh_stride = b_sh_stride * 4 * 2;
+      constexpr int red_sh_delta = b_sh_stride; 
+      int red_sh_rd = red_sh_stride * (threadIdx.x / b_sh_stride) + (threadIdx.x % b_sh_stride);
+
+      // Parallel logarithmic shared memory reduction. We make sure to avoid any unnecessary read or write iterations,
+      // e.g., for two warps we write only once by warp 1 and read only once by warp 0. 
+
+      #pragma unroll
+      for (int m_block = 0; m_block < thread_m_blocks; m_block++) {
+        #pragma unroll
+        for (int i = red_off; i > 0; i /= 2) {
+          if (i <= red_idx && red_idx < 2 * i) {
+            #pragma unroll
+            for (int j = 0; j < 4 * 2; j++) {
+              int red_sh_wr = red_sh_delta * j + (red_sh_rd - red_sh_stride * i);
+              if (i < red_off) {
+                float* c_rd = reinterpret_cast<float*>(&sh[red_sh_delta * j + red_sh_rd]);
+                float* c_wr = reinterpret_cast<float*>(&sh[red_sh_wr]);
+                #pragma unroll
+                for (int k = 0; k < 4; k++)
+                  reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + j][k] += c_rd[k] + c_wr[k];
+              }
+              sh[red_sh_wr] = reinterpret_cast<int4*>(&frag_c)[4 * 2 * m_block + j];
+            }
+          }
+          __syncthreads();
+        }
+        if (red_idx == 0) {
+          #pragma unroll
+          for (int i = 0; i < 4 * 2; i++) {
+            float* c_rd = reinterpret_cast<float*>(&sh[red_sh_delta * i + red_sh_rd]);
+            #pragma unroll
+            for (int j = 0; j < 4; j++)
+              reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + i][j] += c_rd[j];
+          }
+        }
+        __syncthreads();
+      }
+    }
+  };
+
+  // Since multiple threadblocks may process parts of the same column slice, we finally have to globally reduce over
+  // the results. As the striped partioning minimizes the number of such reductions and our outputs are usually rather
+  // small, we perform this reduction serially in L2 cache.
+  auto global_reduce = [&] (bool first = false, bool last = false) {
+    // We are very careful here to reduce directly in the output buffer to maximize L2 cache utilization in this step. 
+    // To do this, we write out results in FP16 (but still reduce with FP32 compute).
+    constexpr int active_threads = 32 * thread_n_blocks / 4;
+    if (threadIdx.x < active_threads) {
+      int c_gl_stride = prob_n / 8;
+      int c_gl_wr_delta_o = 8 * c_gl_stride;
+      int c_gl_wr_delta_i = 4 * (active_threads / 32);
+      int c_gl_wr = c_gl_stride * ((threadIdx.x % 32) / 4) + 4 * (threadIdx.x / 32) + threadIdx.x % 4;
+      c_gl_wr += (2 * thread_n_blocks) * slice_col;
+      constexpr int c_sh_wr_delta = active_threads;
+      int c_sh_wr = threadIdx.x;
+
+      int row = (threadIdx.x % 32) / 4;
+
+      if (!first) {
+        // Interestingly, doing direct global accesses here really seems to mess up the compiler and lead to slowdowns,
+        // hence we also use async-copies even though these fetches are not actually asynchronous.
+        #pragma unroll
+        for (int i = 0; i < thread_m_blocks * 4; i++) {
+          cp_async4_pred(
+            &sh[c_sh_wr + c_sh_wr_delta * i],
+            &C[c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2)],
+            i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m
+          );
+        }
+        cp_async_fence();
+        cp_async_wait<0>();
+      }
+
+      #pragma unroll
+      for (int i = 0; i < thread_m_blocks * 4; i++) {
+        if (i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m) {
+          if (!first) {
+            int4 c_red = sh[c_sh_wr + i * c_sh_wr_delta];
+            #pragma unroll
+            for (int j = 0; j < 2 * 4; j++) {
+              reinterpret_cast<float*>(&frag_c)[4 * 2 * 4 * (i / 4) + 4 * j + (i % 4)] += __half2float(
+                reinterpret_cast<__half*>(&c_red)[j]
+              );
+            }
+          }
+          if (!last) {
+            int4 c;
+            #pragma unroll
+            for (int j = 0; j < 2 * 4; j++) {
+              reinterpret_cast<__half*>(&c)[j] = __float2half(
+                reinterpret_cast<float*>(&frag_c)[4 * 2 * 4 * (i / 4) + 4 * j + (i % 4)]
+              );
+            }
+            C[c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2)] = c;
+          }
+        }
+      }
+    }
+  };
+
+  // Write out the reduce final result in the correct layout. We only actually reshuffle matrix fragments in this step,
+  // the reduction above is performed in fragment layout. 
+  auto write_result = [&] () {
+    int c_gl_stride = prob_n / 8;
+    constexpr int c_sh_stride = 2 * thread_n_blocks + 1;
+    int c_gl_wr_delta = c_gl_stride * (threads / (2 * thread_n_blocks));
+    constexpr int c_sh_rd_delta = c_sh_stride * (threads / (2 * thread_n_blocks));
+
+    int c_gl_wr = c_gl_stride * (threadIdx.x / (2 * thread_n_blocks)) + (threadIdx.x % (2 * thread_n_blocks));
+    c_gl_wr += (2 * thread_n_blocks) * slice_col;
+    int c_sh_wr = (4 * c_sh_stride) * ((threadIdx.x % 32) / 4) + (threadIdx.x % 32) % 4;
+    c_sh_wr += 32 * (threadIdx.x / 32);
+    int c_sh_rd = c_sh_stride * (threadIdx.x / (2 * thread_n_blocks)) + (threadIdx.x % (2 * thread_n_blocks));
+
+    int c_gl_wr_end = c_gl_stride * prob_m;
+
+    // We first reorder in shared memory to guarantee the most efficient final global write patterns
+    auto write = [&] (int idx, float c0, float c1, FragS& s) {
+      half2 res = __halves2half2(__float2half(c0), __float2half(c1));
+      if (group_blocks == -1) // for per-column quantization we finally apply the scale here
+        res = __hmul2(res, s[0]);
+      ((half2*) sh)[idx] = res;
+    };
+    if (threadIdx.x / 32 < thread_n_blocks / 4) {
+      #pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+          int wr = c_sh_wr + 8 * j;
+          write(wr + (4 * c_sh_stride) * 0 + 0, frag_c[i][j][0][0], frag_c[i][j][0][1], frag_s[j / 2][2 * (j % 2) + 0]);
+          write(wr + (4 * c_sh_stride) * 8 + 0, frag_c[i][j][0][2], frag_c[i][j][0][3], frag_s[j / 2][2 * (j % 2) + 0]);
+          write(wr + (4 * c_sh_stride) * 0 + 4, frag_c[i][j][1][0], frag_c[i][j][1][1], frag_s[j / 2][2 * (j % 2) + 1]);
+          write(wr + (4 * c_sh_stride) * 8 + 4, frag_c[i][j][1][2], frag_c[i][j][1][3], frag_s[j / 2][2 * (j % 2) + 1]);
+        }
+        c_sh_wr += 16 * (4 * c_sh_stride);
+      }
+    }
+    __syncthreads();
+
+    #pragma unroll
+    for (int i = 0; i < ceildiv(16 * thread_m_blocks, threads / (2 * thread_n_blocks)); i++) {
+      if (c_gl_wr < c_gl_wr_end) {
+        C[c_gl_wr] = sh[c_sh_rd];
+        c_gl_wr += c_gl_wr_delta;
+        c_sh_rd += c_sh_rd_delta;
+      }
+    }
+  };
+
+  // Start global fetch and register load pipelines. 
+  auto start_pipes = [&] () {
+    #pragma unroll
+    for (int i = 0; i < stages - 1; i++)
+      fetch_to_shared(i, i, i < slice_iters);
+    zero_accums();
+    wait_for_stage();
+    fetch_to_registers(0, 0);
+    a_gl_rd += a_gl_rd_delta_o * (stages - 1);
+  };
+  start_pipes();
+
+  // Main loop.
+  while (slice_iters) {
+    // We unroll over both the global fetch and the register load pipeline to ensure all shared memory accesses are
+    // static. Note that both pipelines have even length meaning that the next iteration will always start at index 0.
+    #pragma unroll
+    for (int pipe = 0; pipe < stages;) {
+      #pragma unroll
+      for (int k = 0; k < b_sh_wr_iters; k++) {
+        fetch_to_registers(k + 1, pipe % stages);
+        if (k == b_sh_wr_iters - 2) {
+          fetch_to_shared((pipe + stages - 1) % stages, pipe, slice_iters >= stages);
+          pipe++;
+          wait_for_stage();
+        }
+        matmul(k);
+      }
+      slice_iters--;
+      if (slice_iters == 0)
+        break;
+    }
+    a_gl_rd += a_gl_rd_delta_o * stages;
+
+    // Process results and, if necessary, proceed to the next column slice. While this pattern may not be the most
+    // readable, other ways of writing the loop seemed to noticeably worse performance after compliation.
+    if (slice_iters == 0) {
+      cp_async_wait<0>();
+      bool last = slice_idx == slice_count - 1;
+      // For per-column scales, we only fetch them here in the final step before write-out
+      if (group_blocks == -1 && last) {
+        if (s_sh_wr_pred)
+          cp_async4_stream(&sh_s[s_sh_wr], &s[s_gl_rd]);
+        cp_async_fence();
+      }
+      thread_block_reduce();
+      if (group_blocks == -1 && last) {
+        cp_async_wait<0>();
+        __syncthreads();
+        if (threadIdx.x / 32 < thread_n_blocks / 4) {
+          reinterpret_cast<int4*>(&frag_s)[0] = sh_s[s_sh_rd + 0];
+          reinterpret_cast<int4*>(&frag_s)[1] = sh_s[s_sh_rd + 4];
+        }
+      }
+      if (slice_count > 1) { // only globally reduce if there is more than one block in a slice
+        barrier_acquire(&locks[slice_col], slice_idx);
+        global_reduce(slice_idx == 0, last);
+        barrier_release(&locks[slice_col], last);
+      }
+      if (last) // only the last block in a slice actually writes the result
+        write_result();
+      slice_row = 0;
+      slice_col_par++;
+      slice_col++;
+      init_slice();
+      if (slice_iters) {
+        a_gl_rd = a_gl_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
+        #pragma unroll
+        for (int i = 0; i < b_sh_wr_iters; i++)
+          B_ptr[i] += b_sh_stride - b_gl_rd_delta_o * k_tiles;
+        if (slice_col == 0) {
+          #pragma unroll
+          for (int i = 0; i < b_sh_wr_iters; i++)
+            B_ptr[i] -= b_gl_stride;
+        }
+        s_gl_rd = s_sh_stride * slice_col + threadIdx.x;
+        start_pipes();
+      }
+    }
+  }
+}
+
+
+// 8 warps are a good choice since every SM has 4 schedulers and having more than 1 warp per schedule allows some more
+// latency hiding. At the same time, we want relatively few warps to have many registers per warp and small tiles.
+const int THREADS = 256;
+const int STAGES = 4; // 4 pipeline stages fit into shared memory
+const int SHARED_MEM = 96 * 1024; // max shared memory on compute capability 8.6 (< 8.0)
+
+#define CALL_IF(THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, GROUP_BLOCKS) \
+  else if ( \
+    thread_m_blocks == THREAD_M_BLOCKS && thread_n_blocks == THREAD_N_BLOCKS && thread_k_blocks == THREAD_K_BLOCKS && \
+    group_blocks == GROUP_BLOCKS \
+  ) { \
+    cudaFuncSetAttribute( \
+      Marlin<THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS>, \
+      cudaFuncAttributeMaxDynamicSharedMemorySize, \
+      SHARED_MEM \
+    ); \
+    Marlin< \
+      THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS \
+    ><<<blocks, THREADS, SHARED_MEM, stream>>>( \
+      A_ptr, B_ptr, C_ptr, s_ptr, \
+      prob_m, prob_n, prob_k, \
+      locks \
+    ); \
+  }
+
+const int ERR_PROB_SHAPE = 1;
+const int ERR_KERN_SHAPE = 2;
+
+int marlin_cuda(
+  const void* A,
+  const void* B,
+        void* C,
+        void* s,
+  int prob_m,
+  int prob_n,
+  int prob_k,
+  void* workspace,
+  int groupsize = -1,
+  int dev = 0,
+  cudaStream_t stream = 0,
+  int thread_k = -1,
+  int thread_n = -1,
+  int sms = -1,
+  int max_par = 16
+) {
+  int tot_m = prob_m;
+  int tot_m_blocks = ceildiv(tot_m, 16);
+  int pad = 16 * tot_m_blocks - tot_m;
+
+  if (sms == -1)
+    cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, dev);
+  if (thread_k == -1 || thread_n == -1) {
+    if (prob_m <= 16) {
+      // For small batchizes, better partioning is slightly more important than better compute utilization
+      thread_k = 128;
+      thread_n = 128;
+    } else {
+      thread_k = 64;
+      thread_n = 256;
+    }
+  }
+
+  int thread_k_blocks = thread_k / 16;
+  int thread_n_blocks = thread_n / 16;
+  int group_blocks = (groupsize == -1) ? -1 : groupsize / 16;
+  int blocks = sms;
+
+  if (prob_n % thread_n != 0 || prob_k % thread_k != 0 || (group_blocks != -1 && prob_k % group_blocks != 0))
+    return ERR_PROB_SHAPE;
+  if (prob_m == 0 || prob_n == 0 || prob_k == 0)
+    return 0;
+
+  const int4* A_ptr = (const int4*) A;
+  const int4* B_ptr = (const int4*) B;
+  int4* C_ptr = (int4*) C;
+  const int4* s_ptr = (const int4*) s;
+
+  int cols = prob_n / thread_n;
+  int* locks = (int*) workspace;
+
+  int ret = 0;
+  for (int i = 0; i < tot_m_blocks; i += 4) {
+    int thread_m_blocks = tot_m_blocks - i;
+    prob_m = tot_m - 16 * i;
+    int par = 1;
+    if (thread_m_blocks > 4) {
+      // Note that parallel > 1 currently only works for inputs without any padding
+      par = (16 * thread_m_blocks - pad) / 64;
+      if (par > max_par)
+        par = max_par;
+      prob_m = 64 * par;
+      i += 4 * (par - 1);
+      thread_m_blocks = 4;
+    }
+    
+    // For compilation speed, we only define the kernel configurations that have seemed useful (in terms of performance)
+    // in our testing, however many more are, in principle, possible.
+    if (false) {}
+    CALL_IF(1,  8,  8, -1)
+    CALL_IF(1,  8,  8,  8)
+    CALL_IF(1, 16,  4, -1)
+    CALL_IF(1, 16,  4,  8)
+    CALL_IF(2, 16,  4, -1)
+    CALL_IF(2, 16,  4,  8)
+    CALL_IF(3, 16,  4, -1)
+    CALL_IF(3, 16,  4,  8)
+    CALL_IF(4, 16,  4, -1)
+    CALL_IF(4, 16,  4,  8)
+    else
+      ret = ERR_KERN_SHAPE;
+
+    A_ptr += 16 * thread_m_blocks * (prob_k / 8) * par;
+    C_ptr += 16 * thread_m_blocks * (prob_n / 8) * par;
+  }
+
+  return ret;
+}
+
+
+#endif

--- a/candle-gptq-kernels/kernels/marlin/marlin_shim.cu
+++ b/candle-gptq-kernels/kernels/marlin/marlin_shim.cu
@@ -1,0 +1,68 @@
+/*
+ * extern "C" shim around the vendored Marlin FP16xINT4 kernel so it can be driven over FFI
+ * from Rust (see `src/marlin.rs`). The kernel itself lives in `marlin_cuda_kernel.cu` and is
+ * vendored verbatim from https://github.com/IST-DASLab/marlin (Apache-2.0); the upstream entry
+ * point `marlin_cuda(...)` has C++ linkage and takes raw `void*`/`cudaStream_t`, so we just
+ * forward-declare it and wrap it in an `extern "C"` function with a stable name.
+ *
+ * We deliberately do NOT vendor upstream's `marlin_cuda.cpp` PyBind/torch wrapper; this shim
+ * replaces it.
+ */
+
+#include <cuda_runtime.h>
+
+// Defined in marlin_cuda_kernel.cu (C++ linkage; signature must match exactly so the mangled
+// names line up at link time).
+int marlin_cuda(
+  const void* A,
+  const void* B,
+        void* C,
+        void* s,
+  int prob_m,
+  int prob_n,
+  int prob_k,
+  void* workspace,
+  int groupsize,
+  int dev,
+  cudaStream_t stream,
+  int thread_k,
+  int thread_n,
+  int sms,
+  int max_par
+);
+
+// Returns the upstream status code: 0 = ok, 1 = ERR_PROB_SHAPE, 2 = ERR_KERN_SHAPE.
+//   A:         fp16 activations, row-major [prob_m, prob_k]
+//   B:         repacked int4 weights in Marlin layout, int32 [prob_k/16, prob_n*2]
+//   C:         fp16 output, row-major [prob_m, prob_n]
+//   s:         fp16 scales in Marlin layout [prob_k/groupsize, prob_n]
+//   workspace: int32 scratch, at least prob_n/128*max_par entries, zero-initialized
+//   groupsize: -1 (per-output-channel) or 128
+extern "C" int run_marlin_gemm(
+  const void* A,
+  const void* B,
+        void* C,
+  const void* s,
+  int prob_m,
+  int prob_n,
+  int prob_k,
+  void* workspace,
+  int groupsize,
+  int dev,
+  int max_par
+) {
+  // thread_k/thread_n/sms = -1 lets Marlin pick its auto-tuned tiling; default stream (0) keeps
+  // the same convention as the other kernels in this crate.
+  return marlin_cuda(
+    A, B, C, const_cast<void*>(s),
+    prob_m, prob_n, prob_k,
+    workspace,
+    groupsize,
+    dev,
+    /*stream=*/0,
+    /*thread_k=*/-1,
+    /*thread_n=*/-1,
+    /*sms=*/-1,
+    max_par
+  );
+}

--- a/candle-gptq-kernels/src/ffi.rs
+++ b/candle-gptq-kernels/src/ffi.rs
@@ -1,0 +1,51 @@
+use core::ffi::c_int;
+
+extern "C" {
+    pub(crate) fn run_gptq_gemm_f32(
+        x: *const f32,
+        qweight: *const i32,
+        qzeros: *const i32,
+        scales: *const f32,
+        g_idx: *const i32,
+        y: *mut f32,
+        m: c_int,
+        k: c_int,
+        n: c_int,
+        bits: c_int,
+        pack_factor: c_int,
+        n_groups_out: c_int,
+    );
+
+    /// Tensor-core (WMMA `mma.sync`) variant, 4-bit only: `bits`/`pack_factor` are fixed at 4/8
+    /// in the kernel itself, so they are not parameters here.
+    pub(crate) fn run_gptq_gemm_tc_f32(
+        x: *const f32,
+        qweight: *const i32,
+        qzeros: *const i32,
+        scales: *const f32,
+        g_idx: *const i32,
+        y: *mut f32,
+        m: c_int,
+        k: c_int,
+        n: c_int,
+        n_groups_out: c_int,
+    );
+
+    /// Drive the vendored Marlin FP16xINT4 tensor-core GEMM (see `kernels/marlin/`).
+    /// `a`/`c`/`s` are fp16 (`half`) device pointers, `b`/`workspace` are int32. `workspace` must
+    /// hold at least `n / 128 * max_par` zero-initialized entries. Returns 0 on success, 1 for a
+    /// problem-shape error, 2 for an unsupported kernel-shape combination.
+    pub(crate) fn run_marlin_gemm(
+        a: *const core::ffi::c_void,
+        b: *const core::ffi::c_void,
+        c: *mut core::ffi::c_void,
+        s: *const core::ffi::c_void,
+        prob_m: c_int,
+        prob_n: c_int,
+        prob_k: c_int,
+        workspace: *mut core::ffi::c_void,
+        groupsize: c_int,
+        dev: c_int,
+        max_par: c_int,
+    ) -> c_int;
+}

--- a/candle-gptq-kernels/src/lib.rs
+++ b/candle-gptq-kernels/src/lib.rs
@@ -1,0 +1,600 @@
+//! Fused dequantize+GEMM CUDA kernel for GPTQ (AutoGPTQ/GPTQModel "old" CUDA layout)
+//! quantized linear layers.
+//!
+//! Unlike `candle_transformers::quantized_gptq`, which dequantizes a GPTQ checkpoint into a
+//! dense `f32` weight once at load time and then runs the regular matmul, this crate fuses the
+//! per-element dequantization into the GEMM kernel itself so the dense weight is never
+//! materialized. Two kernels are provided: [`gptq_gemm`], a shared-memory-tiled kernel with
+//! scalar FP32 accumulation (any `bits` dividing 32), and [`gptq_gemm_tensor_core`], a 4-bit-only
+//! kernel that runs the GEMM inner product on tensor cores via the WMMA API instead.
+//!
+//! For the common 4-bit symmetric case there is also [`marlin_gemm`], an FFI binding to the real
+//! Marlin tensor-core kernel (vendored CUDA C++ under `kernels/marlin/`); use
+//! [`marlin_repack_gptq`] once at load time to convert a checkpoint into Marlin's layout.
+//!
+//! With the `metal` feature the same [`gptq_gemm`] entry point runs a Metal port of the scalar
+//! tiled kernel on Apple Silicon (see `src/metal.rs` / `kernels/gptq_gemm.metal`); the tensor-core
+//! and Marlin paths remain CUDA-only.
+
+#[cfg(feature = "cuda")]
+mod ffi;
+#[cfg(feature = "cuda")]
+mod marlin;
+
+#[cfg(feature = "metal")]
+mod metal;
+
+#[cfg(feature = "cuda")]
+pub use marlin::{marlin_gemm, marlin_repack_gptq};
+
+#[cfg(feature = "cuda")]
+use candle::{
+    backend::BackendStorage,
+    cuda_backend::cudarc::driver::{DevicePtr, DevicePtrMut},
+    CudaStorage, DType,
+};
+use candle::{CpuStorage, Layout, Result, Shape, Tensor};
+
+/// `x.apply_op3(qweight, qzeros, op)`: `scales` and `g_idx` ride along as extra fields, mirroring
+/// the pattern `candle-flash-attn` uses for `alibi_slopes` (CustomOp only supports 3 tensors).
+pub struct GptqGemm {
+    pub scales: Tensor,
+    pub g_idx: Tensor,
+    pub bits: usize,
+    pub pack_factor: usize,
+}
+
+#[cfg(feature = "cuda")]
+impl GptqGemm {
+    fn extra_cuda_slice<'a, T: candle::cuda_backend::CudaDType>(
+        storage: &'a candle::Storage,
+        layout: &Layout,
+        name: &'static str,
+    ) -> Result<candle::cuda_backend::cudarc::driver::CudaView<'a, T>> {
+        let slice = match storage {
+            candle::Storage::Cuda(c) => c.as_cuda_slice::<T>()?,
+            _ => candle::bail!("{name} must be a cuda tensor"),
+        };
+        match layout.contiguous_offsets() {
+            Some((o1, o2)) => Ok(slice.slice(o1..o2)),
+            None => candle::bail!("{name} has to be contiguous"),
+        }
+    }
+}
+
+impl candle::CustomOp3 for GptqGemm {
+    fn name(&self) -> &'static str {
+        "gptq-gemm"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+    ) -> Result<(CpuStorage, Shape)> {
+        candle::bail!("no cpu support for the fused gptq-gemm kernel, use candle_transformers::quantized_gptq instead")
+    }
+
+    #[cfg(feature = "metal")]
+    fn metal_fwd(
+        &self,
+        x: &candle::MetalStorage,
+        x_l: &Layout,
+        qweight: &candle::MetalStorage,
+        qweight_l: &Layout,
+        qzeros: &candle::MetalStorage,
+        qzeros_l: &Layout,
+    ) -> Result<(candle::MetalStorage, Shape)> {
+        metal::gptq_gemm_metal_fwd(self, x, x_l, qweight, qweight_l, qzeros, qzeros_l)
+    }
+
+    #[cfg(feature = "cuda")]
+    fn cuda_fwd(
+        &self,
+        x: &CudaStorage,
+        x_l: &Layout,
+        qweight: &CudaStorage,
+        qweight_l: &Layout,
+        qzeros: &CudaStorage,
+        qzeros_l: &Layout,
+    ) -> Result<(CudaStorage, Shape)> {
+        if x.dtype() != DType::F32 {
+            candle::bail!(
+                "gptq-gemm only supports f32 activations, got {:?}",
+                x.dtype()
+            );
+        }
+        let (m, k) = x_l.shape().dims2()?;
+        let (packed_k, n) = qweight_l.shape().dims2()?;
+        if packed_k * self.pack_factor != k {
+            candle::bail!(
+                "gptq-gemm: qweight rows {packed_k} * pack_factor {} != x cols {k}",
+                self.pack_factor
+            );
+        }
+        let (_n_groups, n_packed) = qzeros_l.shape().dims2()?;
+        if n_packed * self.pack_factor != n {
+            candle::bail!(
+                "gptq-gemm: qzeros cols {n_packed} * pack_factor {} != out dim {n}",
+                self.pack_factor
+            );
+        }
+
+        let dev = x.device();
+        let stream = dev.cuda_stream();
+
+        let x_slice = x.as_cuda_slice::<f32>()?;
+        let x_slice = match x_l.contiguous_offsets() {
+            Some((o1, o2)) => x_slice.slice(o1..o2),
+            None => candle::bail!("gptq-gemm: x must be contiguous"),
+        };
+        let qweight_slice = qweight.as_cuda_slice::<i32>()?;
+        let qweight_slice = match qweight_l.contiguous_offsets() {
+            Some((o1, o2)) => qweight_slice.slice(o1..o2),
+            None => candle::bail!("gptq-gemm: qweight must be contiguous"),
+        };
+        let qzeros_slice = qzeros.as_cuda_slice::<i32>()?;
+        let qzeros_slice = match qzeros_l.contiguous_offsets() {
+            Some((o1, o2)) => qzeros_slice.slice(o1..o2),
+            None => candle::bail!("gptq-gemm: qzeros must be contiguous"),
+        };
+        let (scales_storage, scales_layout) = self.scales.storage_and_layout();
+        let scales_slice = Self::extra_cuda_slice::<f32>(&scales_storage, scales_layout, "scales")?;
+        let (g_idx_storage, g_idx_layout) = self.g_idx.storage_and_layout();
+        let g_idx_slice = Self::extra_cuda_slice::<i32>(&g_idx_storage, g_idx_layout, "g_idx")?;
+
+        let mut dst = unsafe { dev.alloc::<f32>(m * n)? };
+
+        unsafe {
+            let (x_ptr, _guard) = x_slice.device_ptr(&stream);
+            let (qweight_ptr, _guard) = qweight_slice.device_ptr(&stream);
+            let (qzeros_ptr, _guard) = qzeros_slice.device_ptr(&stream);
+            let (scales_ptr, _guard) = scales_slice.device_ptr(&stream);
+            let (g_idx_ptr, _guard) = g_idx_slice.device_ptr(&stream);
+            let (dst_ptr, _guard) = dst.device_ptr_mut(&stream);
+            ffi::run_gptq_gemm_f32(
+                x_ptr as *const f32,
+                qweight_ptr as *const i32,
+                qzeros_ptr as *const i32,
+                scales_ptr as *const f32,
+                g_idx_ptr as *const i32,
+                dst_ptr as *mut f32,
+                m as i32,
+                k as i32,
+                n as i32,
+                self.bits as i32,
+                self.pack_factor as i32,
+                n_packed as i32,
+            );
+        }
+
+        let dst = CudaStorage::wrap_cuda_slice(dst, dev.clone());
+        Ok((dst, Shape::from((m, n))))
+    }
+}
+
+/// Run the fused GPTQ dequant+GEMM kernel: `y = x @ dequant(qweight, qzeros, scales, g_idx)`.
+///
+/// * `x` - activations, `f32`, shape `[m, k]`.
+/// * `qweight` - packed weight, `i32`, shape `[k / pack_factor, n]`.
+/// * `qzeros` - packed zero points, `i32`, shape `[n_groups, n / pack_factor]`.
+/// * `scales` - per-group scales, `f32`, shape `[n_groups, n]`.
+/// * `g_idx` - per-row group index, `i32`, shape `[k]`.
+pub fn gptq_gemm(
+    x: &Tensor,
+    qweight: &Tensor,
+    qzeros: &Tensor,
+    scales: &Tensor,
+    g_idx: &Tensor,
+    bits: usize,
+    group_size: usize,
+) -> Result<Tensor> {
+    let _ = group_size;
+    let pack_factor = 32 / bits;
+    let op = GptqGemm {
+        scales: scales.clone(),
+        g_idx: g_idx.clone(),
+        bits,
+        pack_factor,
+    };
+    x.apply_op3(qweight, qzeros, op)
+}
+
+/// `x.apply_op3(qweight, qzeros, op)`: `scales` and `g_idx` ride along as extra fields, same
+/// pattern as [`GptqGemm`]. CUDA-only (tensor cores / WMMA have no Metal equivalent here).
+#[cfg(feature = "cuda")]
+pub struct GptqGemmTensorCore {
+    pub scales: Tensor,
+    pub g_idx: Tensor,
+}
+
+#[cfg(feature = "cuda")]
+const GPTQ_TC_BITS: usize = 4;
+#[cfg(feature = "cuda")]
+const GPTQ_TC_PACK_FACTOR: usize = 32 / GPTQ_TC_BITS;
+
+#[cfg(feature = "cuda")]
+impl candle::CustomOp3 for GptqGemmTensorCore {
+    fn name(&self) -> &'static str {
+        "gptq-gemm-tensor-core"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+    ) -> Result<(CpuStorage, Shape)> {
+        candle::bail!("no cpu support for the fused gptq-gemm-tensor-core kernel, use candle_transformers::quantized_gptq instead")
+    }
+
+    fn cuda_fwd(
+        &self,
+        x: &CudaStorage,
+        x_l: &Layout,
+        qweight: &CudaStorage,
+        qweight_l: &Layout,
+        qzeros: &CudaStorage,
+        qzeros_l: &Layout,
+    ) -> Result<(CudaStorage, Shape)> {
+        if x.dtype() != DType::F32 {
+            candle::bail!(
+                "gptq-gemm-tensor-core only supports f32 activations, got {:?}",
+                x.dtype()
+            );
+        }
+        let (m, k) = x_l.shape().dims2()?;
+        let (packed_k, n) = qweight_l.shape().dims2()?;
+        if packed_k * GPTQ_TC_PACK_FACTOR != k {
+            candle::bail!(
+                "gptq-gemm-tensor-core: qweight rows {packed_k} * pack_factor {GPTQ_TC_PACK_FACTOR} != x cols {k}"
+            );
+        }
+        let (_n_groups, n_packed) = qzeros_l.shape().dims2()?;
+        if n_packed * GPTQ_TC_PACK_FACTOR != n {
+            candle::bail!(
+                "gptq-gemm-tensor-core: qzeros cols {n_packed} * pack_factor {GPTQ_TC_PACK_FACTOR} != out dim {n}"
+            );
+        }
+
+        let dev = x.device();
+        let stream = dev.cuda_stream();
+
+        let x_slice = x.as_cuda_slice::<f32>()?;
+        let x_slice = match x_l.contiguous_offsets() {
+            Some((o1, o2)) => x_slice.slice(o1..o2),
+            None => candle::bail!("gptq-gemm-tensor-core: x must be contiguous"),
+        };
+        let qweight_slice = qweight.as_cuda_slice::<i32>()?;
+        let qweight_slice = match qweight_l.contiguous_offsets() {
+            Some((o1, o2)) => qweight_slice.slice(o1..o2),
+            None => candle::bail!("gptq-gemm-tensor-core: qweight must be contiguous"),
+        };
+        let qzeros_slice = qzeros.as_cuda_slice::<i32>()?;
+        let qzeros_slice = match qzeros_l.contiguous_offsets() {
+            Some((o1, o2)) => qzeros_slice.slice(o1..o2),
+            None => candle::bail!("gptq-gemm-tensor-core: qzeros must be contiguous"),
+        };
+        let (scales_storage, scales_layout) = self.scales.storage_and_layout();
+        let scales_slice =
+            GptqGemm::extra_cuda_slice::<f32>(&scales_storage, scales_layout, "scales")?;
+        let (g_idx_storage, g_idx_layout) = self.g_idx.storage_and_layout();
+        let g_idx_slice = GptqGemm::extra_cuda_slice::<i32>(&g_idx_storage, g_idx_layout, "g_idx")?;
+
+        let mut dst = unsafe { dev.alloc::<f32>(m * n)? };
+
+        unsafe {
+            let (x_ptr, _guard) = x_slice.device_ptr(&stream);
+            let (qweight_ptr, _guard) = qweight_slice.device_ptr(&stream);
+            let (qzeros_ptr, _guard) = qzeros_slice.device_ptr(&stream);
+            let (scales_ptr, _guard) = scales_slice.device_ptr(&stream);
+            let (g_idx_ptr, _guard) = g_idx_slice.device_ptr(&stream);
+            let (dst_ptr, _guard) = dst.device_ptr_mut(&stream);
+            ffi::run_gptq_gemm_tc_f32(
+                x_ptr as *const f32,
+                qweight_ptr as *const i32,
+                qzeros_ptr as *const i32,
+                scales_ptr as *const f32,
+                g_idx_ptr as *const i32,
+                dst_ptr as *mut f32,
+                m as i32,
+                k as i32,
+                n as i32,
+                n_packed as i32,
+            );
+        }
+
+        let dst = CudaStorage::wrap_cuda_slice(dst, dev.clone());
+        Ok((dst, Shape::from((m, n))))
+    }
+}
+
+/// Run the tensor-core (WMMA `mma.sync`) fused GPTQ dequant+GEMM kernel, 4-bit only:
+/// `y = x @ dequant(qweight, qzeros, scales, g_idx)`.
+///
+/// Same checkpoint layout as [`gptq_gemm`], but the GEMM itself runs on tensor cores instead
+/// of scalar FMAs (see `kernels/gptq_gemm_tc.cu`). Only `bits == 4` is supported; use
+/// [`gptq_gemm`] for other bit widths.
+#[cfg(feature = "cuda")]
+pub fn gptq_gemm_tensor_core(
+    x: &Tensor,
+    qweight: &Tensor,
+    qzeros: &Tensor,
+    scales: &Tensor,
+    g_idx: &Tensor,
+    bits: usize,
+) -> Result<Tensor> {
+    if bits != GPTQ_TC_BITS {
+        candle::bail!(
+            "gptq-gemm-tensor-core only supports 4-bit weights, got {bits}-bit; use gptq_gemm instead"
+        );
+    }
+    let op = GptqGemmTensorCore {
+        scales: scales.clone(),
+        g_idx: g_idx.clone(),
+    };
+    x.apply_op3(qweight, qzeros, op)
+}
+
+#[cfg(all(test, feature = "cuda"))]
+mod tests {
+    use super::*;
+    use candle::Device;
+
+    /// Plain-Rust reference, computed independently of either CUDA kernel: dequantize on the
+    /// fly and accumulate in `f64` to get a value both fused kernels should agree with.
+    #[allow(clippy::too_many_arguments)]
+    fn dequant_matmul_ref(
+        x: &[f32],
+        qweight: &[i32],
+        qzeros: &[i32],
+        scales: &[f32],
+        g_idx: &[i32],
+        m: usize,
+        k: usize,
+        n: usize,
+        pack_factor: usize,
+        bits: usize,
+    ) -> Vec<f32> {
+        let mask = (1i32 << bits) - 1;
+        let n_packed = n / pack_factor;
+        let mut y = vec![0f32; m * n];
+        for row in 0..m {
+            for col in 0..n {
+                let mut acc = 0f64;
+                for kk in 0..k {
+                    let g = g_idx[kk] as usize;
+                    let w_word = qweight[(kk / pack_factor) * n + col];
+                    let shift_q = (kk % pack_factor) * bits;
+                    let q = (w_word >> shift_q) & mask;
+                    let z_word = qzeros[g * n_packed + col / pack_factor];
+                    let shift_z = (col % pack_factor) * bits;
+                    let z = ((z_word >> shift_z) & mask) + 1;
+                    let s = scales[g * n + col];
+                    let w = (q - z) as f32 * s;
+                    acc += x[row * k + kk] as f64 * w as f64;
+                }
+                y[row * n + col] = acc as f32;
+            }
+        }
+        y
+    }
+
+    /// Numeric correctness test for the 4-bit tensor-core kernel (`gptq_gemm_tensor_core`),
+    /// cross-checked against both a plain-Rust reference and the scalar fused kernel
+    /// (`gptq_gemm`). Dimensions are deliberately not multiples of the kernel's 16x16x16 tile
+    /// to exercise the zero-padding paths for `M`, `K`, and `N`. Requires a CUDA device; this
+    /// is run on real GPU CI (see `.github/workflows/ci_cuda.yaml`), not locally.
+    #[test]
+    fn gptq_gemm_tensor_core_matches_reference() -> Result<()> {
+        let device = Device::new_cuda(0)?;
+        let bits = 4;
+        let pack_factor = 32 / bits;
+        let m = 17; // not a multiple of WMMA_M=16
+        let k: usize = 48; // multiple of pack_factor=8, not a multiple of WMMA_K=16
+        let n = 24; // not a multiple of WMMA_N=16
+        let group_size = 16;
+        let n_groups = k.div_ceil(group_size);
+
+        let x: Vec<f32> = (0..m * k).map(|i| ((i % 13) as f32 - 6.0) * 0.1).collect();
+        let qweight: Vec<i32> = (0..(k / pack_factor) * n)
+            .map(|i| {
+                let mut packed = 0i32;
+                for sub in 0..pack_factor {
+                    let v = ((i * 7 + sub * 3) % 16) as i32;
+                    packed |= v << (sub * bits);
+                }
+                packed
+            })
+            .collect();
+        let qzeros: Vec<i32> = (0..n_groups * (n / pack_factor))
+            .map(|i| {
+                let mut packed = 0i32;
+                for sub in 0..pack_factor {
+                    let v = ((i * 5 + sub) % 16) as i32;
+                    packed |= v << (sub * bits);
+                }
+                packed
+            })
+            .collect();
+        let scales: Vec<f32> = (0..n_groups * n)
+            .map(|i| 0.05 + (i % 7) as f32 * 0.01)
+            .collect();
+        let g_idx: Vec<i32> = (0..k as i32).map(|i| i / group_size as i32).collect();
+
+        let expected = dequant_matmul_ref(
+            &x,
+            &qweight,
+            &qzeros,
+            &scales,
+            &g_idx,
+            m,
+            k,
+            n,
+            pack_factor,
+            bits,
+        );
+
+        let x_t = Tensor::from_vec(x, (m, k), &device)?;
+        let qweight_t = Tensor::from_vec(qweight, (k / pack_factor, n), &device)?;
+        let qzeros_t = Tensor::from_vec(qzeros, (n_groups, n / pack_factor), &device)?;
+        let scales_t = Tensor::from_vec(scales, (n_groups, n), &device)?;
+        let g_idx_t = Tensor::from_vec(g_idx, k, &device)?;
+
+        let y_tc = gptq_gemm_tensor_core(&x_t, &qweight_t, &qzeros_t, &scales_t, &g_idx_t, bits)?
+            .to_vec2::<f32>()?;
+        let y_scalar = gptq_gemm(
+            &x_t, &qweight_t, &qzeros_t, &scales_t, &g_idx_t, bits, group_size,
+        )?
+        .to_vec2::<f32>()?;
+
+        for row in 0..m {
+            for col in 0..n {
+                let exp = expected[row * n + col];
+                // The tensor-core path rounds operands to fp16 before `mma.sync`, so allow a
+                // wider tolerance than the fp32 scalar kernel; this still catches indexing /
+                // layout bugs, which produce errors far larger than fp16 rounding noise.
+                let tc_tol = 0.05 + 0.02 * exp.abs();
+                assert!(
+                    (y_tc[row][col] - exp).abs() < tc_tol,
+                    "tensor-core mismatch at ({row},{col}): {} vs {exp}",
+                    y_tc[row][col]
+                );
+                assert!(
+                    (y_scalar[row][col] - exp).abs() < 1e-3 + 1e-5 * exp.abs(),
+                    "scalar mismatch at ({row},{col}): {} vs {exp}",
+                    y_scalar[row][col]
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "metal"))]
+mod metal_tests {
+    use super::*;
+    use candle::Device;
+
+    /// Plain-Rust reference (f64 accumulation), independent of the Metal kernel.
+    #[allow(clippy::too_many_arguments)]
+    fn dequant_matmul_ref(
+        x: &[f32],
+        qweight: &[i32],
+        qzeros: &[i32],
+        scales: &[f32],
+        g_idx: &[i32],
+        m: usize,
+        k: usize,
+        n: usize,
+        pack_factor: usize,
+        bits: usize,
+    ) -> Vec<f32> {
+        let mask = (1i32 << bits) - 1;
+        let n_packed = n / pack_factor;
+        let mut y = vec![0f32; m * n];
+        for row in 0..m {
+            for col in 0..n {
+                let mut acc = 0f64;
+                for kk in 0..k {
+                    let g = g_idx[kk] as usize;
+                    let w_word = qweight[(kk / pack_factor) * n + col];
+                    let shift_q = (kk % pack_factor) * bits;
+                    let q = (w_word >> shift_q) & mask;
+                    let z_word = qzeros[g * n_packed + col / pack_factor];
+                    let shift_z = (col % pack_factor) * bits;
+                    let z = ((z_word >> shift_z) & mask) + 1;
+                    let s = scales[g * n + col];
+                    let w = (q - z) as f32 * s;
+                    acc += x[row * k + kk] as f64 * w as f64;
+                }
+                y[row * n + col] = acc as f32;
+            }
+        }
+        y
+    }
+
+    /// Numeric correctness test for the Metal scalar kernel. Dimensions are deliberately not
+    /// multiples of the 16x16 tile to exercise the zero-padding paths. Requires a Metal device;
+    /// run on the macOS GPU CI runner (see `.github/workflows/ci_metal.yaml`).
+    #[test]
+    fn gptq_gemm_metal_matches_reference() -> Result<()> {
+        let device = Device::new_metal(0)?;
+        let bits = 4;
+        let pack_factor = 32 / bits;
+        let m = 17; // not a multiple of TILE=16
+        let k: usize = 48; // multiple of pack_factor=8, not a multiple of TILE=16
+        let n = 24; // not a multiple of TILE=16
+        let group_size = 16;
+        let n_groups = k.div_ceil(group_size);
+
+        let x: Vec<f32> = (0..m * k).map(|i| ((i % 13) as f32 - 6.0) * 0.1).collect();
+        let qweight: Vec<i32> = (0..(k / pack_factor) * n)
+            .map(|i| {
+                let mut packed = 0i32;
+                for sub in 0..pack_factor {
+                    let v = ((i * 7 + sub * 3) % 16) as i32;
+                    packed |= v << (sub * bits);
+                }
+                packed
+            })
+            .collect();
+        let qzeros: Vec<i32> = (0..n_groups * (n / pack_factor))
+            .map(|i| {
+                let mut packed = 0i32;
+                for sub in 0..pack_factor {
+                    let v = ((i * 5 + sub) % 16) as i32;
+                    packed |= v << (sub * bits);
+                }
+                packed
+            })
+            .collect();
+        let scales: Vec<f32> = (0..n_groups * n)
+            .map(|i| 0.05 + (i % 7) as f32 * 0.01)
+            .collect();
+        let g_idx: Vec<i32> = (0..k as i32).map(|i| i / group_size as i32).collect();
+
+        let expected = dequant_matmul_ref(
+            &x,
+            &qweight,
+            &qzeros,
+            &scales,
+            &g_idx,
+            m,
+            k,
+            n,
+            pack_factor,
+            bits,
+        );
+
+        let x_t = Tensor::from_vec(x, (m, k), &device)?;
+        let qweight_t = Tensor::from_vec(qweight, (k / pack_factor, n), &device)?;
+        let qzeros_t = Tensor::from_vec(qzeros, (n_groups, n / pack_factor), &device)?;
+        let scales_t = Tensor::from_vec(scales, (n_groups, n), &device)?;
+        let g_idx_t = Tensor::from_vec(g_idx, k, &device)?;
+
+        let y = gptq_gemm(
+            &x_t, &qweight_t, &qzeros_t, &scales_t, &g_idx_t, bits, group_size,
+        )?
+        .to_vec2::<f32>()?;
+
+        for row in 0..m {
+            for col in 0..n {
+                let exp = expected[row * n + col];
+                assert!(
+                    (y[row][col] - exp).abs() < 1e-3 + 1e-5 * exp.abs(),
+                    "metal mismatch at ({row},{col}): {} vs {exp}",
+                    y[row][col]
+                );
+            }
+        }
+        Ok(())
+    }
+}

--- a/candle-gptq-kernels/src/marlin.rs
+++ b/candle-gptq-kernels/src/marlin.rs
@@ -1,0 +1,566 @@
+//! FFI binding to the real Marlin FP16xINT4 tensor-core GEMM kernel (vendored under
+//! `kernels/marlin/`, Apache-2.0, from <https://github.com/IST-DASLab/marlin>).
+//!
+//! This module does NOT reimplement Marlin's GEMM: the CUDA C++ kernel is compiled as-is and
+//! driven over FFI (`ffi::run_marlin_gemm`). What is reimplemented here, host-side in Rust, is the
+//! offline weight *repack* (ported from upstream's `marlin/__init__.py` `Layer.pack` /
+//! `_get_perms`), which converts a GPTQ checkpoint into the permuted layout the kernel expects.
+//!
+//! Marlin only handles a restricted (but very common) case, so [`marlin_repack_gptq`] returns
+//! `Ok(None)` for checkpoints it cannot serve and the caller falls back to the generic kernels:
+//! 4-bit, symmetric (per-output zero point fixed at 8), FP16 operands, group size 128 or -1
+//! (per-channel), sequential `g_idx` (no act-order), `in_dim % 128 == 0`, `out_dim % 256 == 0`.
+
+use candle::backend::BackendStorage;
+use candle::cuda_backend::cudarc::driver::{DevicePtr, DevicePtrMut};
+use candle::{CpuStorage, CudaStorage, DType, Layout, Result, Shape, Tensor};
+use half::f16;
+
+use crate::ffi;
+
+const TILE: usize = 16;
+const PERM_LEN: usize = 1024;
+const SCALE_PERM_LEN: usize = 64;
+const SCALE_PERM_SINGLE_LEN: usize = 32;
+const MAX_PAR: i32 = 16;
+/// 4-bit symmetric GPTQ stores `zero_point - 1`, and a symmetric checkpoint fixes the zero point
+/// at `2^(4-1) = 8`, so every packed `qzeros` word is `0x7777_7777`.
+const SYM_QZERO_WORD: i32 = 0x7777_7777u32 as i32;
+
+/// Port of upstream `_get_perms()`: the weight tile permutation (`perm`, 1024 entries) and the two
+/// scale-column permutations (grouped: 64 entries; per-channel: 32 entries).
+fn marlin_perms() -> (Vec<usize>, Vec<usize>, Vec<usize>) {
+    let mut perm: Vec<usize> = Vec::with_capacity(PERM_LEN);
+    for i in 0..32usize {
+        let mut perm1: Vec<usize> = Vec::with_capacity(8);
+        let col = i / 4;
+        for block in [0usize, 1] {
+            for row in [
+                2 * (i % 4),
+                2 * (i % 4) + 1,
+                2 * (i % 4 + 4),
+                2 * (i % 4 + 4) + 1,
+            ] {
+                perm1.push(16 * row + col + 8 * block);
+            }
+        }
+        for j in 0..4usize {
+            for &p in perm1.iter() {
+                perm.push(p + 256 * j);
+            }
+        }
+    }
+    // `perm.reshape(-1, 8)[:, [0,2,4,6,1,3,5,7]].ravel()`
+    let interleave = [0usize, 2, 4, 6, 1, 3, 5, 7];
+    let mut perm_i = Vec::with_capacity(PERM_LEN);
+    for chunk in perm.chunks_exact(8) {
+        for &idx in interleave.iter() {
+            perm_i.push(chunk[idx]);
+        }
+    }
+
+    let mut scale_perm: Vec<usize> = Vec::with_capacity(SCALE_PERM_LEN);
+    for i in 0..8usize {
+        for j in 0..8usize {
+            scale_perm.push(i + 8 * j);
+        }
+    }
+    let mut scale_perm_single: Vec<usize> = Vec::with_capacity(SCALE_PERM_SINGLE_LEN);
+    for i in 0..4usize {
+        for j in [0usize, 1, 8, 9, 16, 17, 24, 25] {
+            scale_perm_single.push(2 * i + j);
+        }
+    }
+    (perm_i, scale_perm, scale_perm_single)
+}
+
+/// Repack already-unpacked 4-bit levels `q` (row-major `[k, n]`, values 0..15) into Marlin's
+/// `B` layout, returning a flat `[k/16, n*2]` `i32` buffer. Pure function of `q`; ported from
+/// `Layer.pack` (the weight half).
+fn pack_weights(q: &[i32], k: usize, n: usize) -> Vec<i32> {
+    let (perm, _, _) = marlin_perms();
+    // w.reshape(k/16,16,n/16,16).transpose(0,2,1,3).reshape(k/16, n*16)
+    let row_len = n * TILE; // columns per `k/16` row after the tile transpose
+    let mut tmp = vec![0i32; (k / TILE) * row_len];
+    for ko in 0..k / TILE {
+        for no in 0..n / TILE {
+            for i in 0..TILE {
+                for j in 0..TILE {
+                    let src = (ko * TILE + i) * n + (no * TILE + j);
+                    let dst = ko * row_len + no * 256 + i * TILE + j;
+                    tmp[dst] = q[src];
+                }
+            }
+        }
+    }
+    // res = tmp.reshape(-1, 1024)[:, perm] applied per flat 1024-block.
+    let mut res = vec![0i32; tmp.len()];
+    for (b, block) in tmp.chunks_exact(PERM_LEN).enumerate() {
+        let base = b * PERM_LEN;
+        for i in 0..PERM_LEN {
+            res[base + i] = block[perm[i]];
+        }
+    }
+    // Bit-pack 8 nibbles per i32: B[r,p] = OR_i (res[r, 8p+i] & 0xF) << 4i
+    let packed_cols = n * 2; // n*16/8
+    let mut out = vec![0i32; (k / TILE) * packed_cols];
+    for r in 0..k / TILE {
+        for p in 0..packed_cols {
+            let mut acc: u32 = 0;
+            for i in 0..8usize {
+                let v = (res[r * row_len + 8 * p + i] as u32) & 0xF;
+                acc |= v << (4 * i);
+            }
+            out[r * packed_cols + p] = acc as i32;
+        }
+    }
+    out
+}
+
+/// Repack GPTQ scales `[n_groups, n]` into Marlin's permuted scale layout (same shape). `grouped`
+/// selects the 64-wide group permutation vs the 32-wide per-channel one. Ported from `Layer.pack`
+/// (the scale half).
+fn pack_scales(scales: &[f32], n_groups: usize, n: usize, grouped: bool) -> Vec<f32> {
+    let (_, scale_perm, scale_perm_single) = marlin_perms();
+    let (perm, block) = if grouped {
+        (&scale_perm, SCALE_PERM_LEN)
+    } else {
+        (&scale_perm_single, SCALE_PERM_SINGLE_LEN)
+    };
+    let mut out = vec![0f32; n_groups * n];
+    // reshape(-1, block)[:, perm]: each contiguous `block` of columns is permuted; blocks never
+    // cross a group row because `n` is a multiple of `block`.
+    for g in 0..n_groups {
+        for b in 0..n / block {
+            let base = g * n + b * block;
+            for i in 0..block {
+                out[base + i] = scales[base + perm[i]];
+            }
+        }
+    }
+    out
+}
+
+/// Marlin's groupsize convention: `-1` means a single per-output-channel scale.
+fn marlin_groupsize(group_size: usize, k: usize) -> i32 {
+    if group_size >= k {
+        -1
+    } else {
+        group_size as i32
+    }
+}
+
+/// Repack a GPTQ-quantized weight into Marlin's `(B, s)` layout if (and only if) the checkpoint is
+/// Marlin-eligible; otherwise return `Ok(None)` so the caller can fall back to the generic kernels.
+///
+/// * `qweight` - packed GPTQ weight, `i32`, shape `[k / 8, n]`.
+/// * `qzeros`  - packed GPTQ zero points, `i32`, shape `[n_groups, n / 8]`.
+/// * `scales`  - per-group scales, `f32`, shape `[n_groups, n]`.
+///
+/// On success returns `(B, s)` where `B` is `i32 [k/16, n*2]` and `s` is `f16 [n_groups, n]`, both
+/// on the same device as `qweight`.
+pub fn marlin_repack_gptq(
+    qweight: &Tensor,
+    qzeros: &Tensor,
+    scales: &Tensor,
+    bits: usize,
+    group_size: usize,
+) -> Result<Option<(Tensor, Tensor)>> {
+    if bits != 4 {
+        return Ok(None);
+    }
+    let device = qweight.device().clone();
+    let (packed_k, n) = qweight.dims2()?;
+    let k = packed_k * 8;
+    let (n_groups, n_packed_z) = qzeros.dims2()?;
+    let (scale_groups, scale_n) = scales.dims2()?;
+
+    // Shape eligibility (Marlin tiling + our repack assumptions).
+    if k % 128 != 0
+        || n % 256 != 0
+        || n_packed_z * 8 != n
+        || scale_n != n
+        || scale_groups != n_groups
+    {
+        return Ok(None);
+    }
+    let gs = marlin_groupsize(group_size, k);
+    let grouped = gs != -1;
+    if grouped {
+        if gs != 128 || n_groups != k / 128 {
+            return Ok(None);
+        }
+    } else if n_groups != 1 {
+        return Ok(None);
+    }
+
+    // Pull the packed tensors to host. Repack is a one-time, load-time cost.
+    let qweight_host = qweight.to_dtype(DType::I32)?.to_vec2::<i32>()?;
+    let qzeros_host = qzeros.to_dtype(DType::I32)?.to_vec2::<i32>()?;
+    let scales_host = scales.to_dtype(DType::F32)?.to_vec2::<f32>()?;
+
+    // Symmetric-only: every packed zero word must be 0x77777777 (zero point == 8 everywhere).
+    for row in qzeros_host.iter() {
+        for &w in row.iter() {
+            if w != SYM_QZERO_WORD {
+                return Ok(None);
+            }
+        }
+    }
+
+    // Unpack GPTQ qweight -> q[k, n] in 0..15.
+    let mut q = vec![0i32; k * n];
+    for row in 0..k {
+        let word_row = &qweight_host[row / 8];
+        let shift = (row % 8) * 4;
+        for col in 0..n {
+            q[row * n + col] = (word_row[col] >> shift) & 0xF;
+        }
+    }
+    let b_flat = pack_weights(&q, k, n);
+
+    let scales_flat: Vec<f32> = scales_host.into_iter().flatten().collect();
+    let s_flat = pack_scales(&scales_flat, n_groups, n, grouped);
+    let s_flat_f16: Vec<f16> = s_flat.into_iter().map(f16::from_f32).collect();
+
+    let b =
+        Tensor::from_vec(b_flat, (k / TILE, n * 2), &candle::Device::Cpu)?.to_device(&device)?;
+    let s =
+        Tensor::from_vec(s_flat_f16, (n_groups, n), &candle::Device::Cpu)?.to_device(&device)?;
+    Ok(Some((b, s)))
+}
+
+/// `a.apply_op3(b, s, MarlinGemm)`: drives the vendored Marlin kernel. `a`/`s` are `f16`, `b` is
+/// `i32` (already in Marlin layout, see [`marlin_repack_gptq`]). Output is `f16 [m, n]`.
+struct MarlinGemm;
+
+impl candle::CustomOp3 for MarlinGemm {
+    fn name(&self) -> &'static str {
+        "marlin-gemm"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+    ) -> Result<(CpuStorage, Shape)> {
+        candle::bail!("no cpu support for the Marlin kernel; use the dense path instead")
+    }
+
+    fn cuda_fwd(
+        &self,
+        a: &CudaStorage,
+        a_l: &Layout,
+        b: &CudaStorage,
+        b_l: &Layout,
+        s: &CudaStorage,
+        s_l: &Layout,
+    ) -> Result<(CudaStorage, Shape)> {
+        if a.dtype() != DType::F16 {
+            candle::bail!("marlin: activations must be f16, got {:?}", a.dtype());
+        }
+        if s.dtype() != DType::F16 {
+            candle::bail!("marlin: scales must be f16, got {:?}", s.dtype());
+        }
+        let (m, k) = a_l.shape().dims2()?;
+        let (k_tiles, n2) = b_l.shape().dims2()?;
+        let n = n2 / 2;
+        if k_tiles * TILE != k {
+            candle::bail!("marlin: B rows {k_tiles} * 16 != k {k}");
+        }
+        let (n_groups, s_n) = s_l.shape().dims2()?;
+        if s_n != n {
+            candle::bail!("marlin: scales cols {s_n} != n {n}");
+        }
+        if n % 256 != 0 || k % 128 != 0 {
+            candle::bail!("marlin: unsupported shape m={m} n={n} k={k}");
+        }
+        // Mirror upstream `mul`: groupsize == -1 for a single scale row, else k / n_groups.
+        let groupsize: i32 = if n_groups == 1 {
+            -1
+        } else {
+            (k / n_groups) as i32
+        };
+
+        let dev = a.device();
+        let stream = dev.cuda_stream();
+
+        let a_slice = a.as_cuda_slice::<f16>()?;
+        let a_slice = match a_l.contiguous_offsets() {
+            Some((o1, o2)) => a_slice.slice(o1..o2),
+            None => candle::bail!("marlin: activations must be contiguous"),
+        };
+        let b_slice = b.as_cuda_slice::<i32>()?;
+        let b_slice = match b_l.contiguous_offsets() {
+            Some((o1, o2)) => b_slice.slice(o1..o2),
+            None => candle::bail!("marlin: B must be contiguous"),
+        };
+        let s_slice = s.as_cuda_slice::<f16>()?;
+        let s_slice = match s_l.contiguous_offsets() {
+            Some((o1, o2)) => s_slice.slice(o1..o2),
+            None => candle::bail!("marlin: scales must be contiguous"),
+        };
+
+        let mut dst = unsafe { dev.alloc::<f16>(m * n)? };
+        // Marlin's Stream-K reduction needs a zero-initialized lock buffer of n/128*max_par ints.
+        let mut workspace = dev.alloc_zeros::<i32>((n / 128) * MAX_PAR as usize)?;
+
+        let ret = unsafe {
+            let (a_ptr, _g0) = a_slice.device_ptr(&stream);
+            let (b_ptr, _g1) = b_slice.device_ptr(&stream);
+            let (s_ptr, _g2) = s_slice.device_ptr(&stream);
+            let (dst_ptr, _g3) = dst.device_ptr_mut(&stream);
+            let (ws_ptr, _g4) = workspace.device_ptr_mut(&stream);
+            ffi::run_marlin_gemm(
+                a_ptr as *const core::ffi::c_void,
+                b_ptr as *const core::ffi::c_void,
+                dst_ptr as *mut core::ffi::c_void,
+                s_ptr as *const core::ffi::c_void,
+                m as i32,
+                n as i32,
+                k as i32,
+                ws_ptr as *mut core::ffi::c_void,
+                groupsize,
+                // Single-GPU CI runner: device ordinal 0. Marlin only uses `dev` to query the SM
+                // count when `sms == -1`.
+                0,
+                MAX_PAR,
+            )
+        };
+        if ret != 0 {
+            candle::bail!(
+                "marlin kernel returned error {ret} (1=problem shape, 2=unsupported kernel shape) \
+                 for m={m} n={n} k={k} groupsize={groupsize}"
+            );
+        }
+
+        let dst = CudaStorage::wrap_cuda_slice(dst, dev.clone());
+        Ok((dst, Shape::from((m, n))))
+    }
+}
+
+/// Run the vendored Marlin FP16xINT4 GEMM: `y = a @ dequant(b, s)`, where `b`/`s` come from
+/// [`marlin_repack_gptq`]. `a` is `f16 [m, k]`; the result is `f16 [m, n]`.
+pub fn marlin_gemm(a: &Tensor, b: &Tensor, s: &Tensor) -> Result<Tensor> {
+    a.apply_op3(b, s, MarlinGemm)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Deterministic q/scale formulas, mirrored from the numpy reference used to generate the
+    // golden values below (k=128, n=256, group size -1).
+    fn golden_q(k: usize, n: usize) -> Vec<i32> {
+        let mut q = vec![0i32; k * n];
+        for i in 0..k {
+            for j in 0..n {
+                q[i * n + j] = ((i * 7 + j * 3) % 16) as i32;
+            }
+        }
+        q
+    }
+    fn golden_scales(n_groups: usize, n: usize) -> Vec<f32> {
+        let mut s = vec![0f32; n_groups * n];
+        for g in 0..n_groups {
+            for j in 0..n {
+                s[g * n + j] = 0.01 + 0.001 * ((g * 5 + j) % 7) as f32;
+            }
+        }
+        s
+    }
+
+    #[test]
+    fn perms_are_permutations() {
+        let (perm, scale_perm, scale_perm_single) = marlin_perms();
+        assert_eq!(perm.len(), PERM_LEN);
+        assert_eq!(scale_perm.len(), SCALE_PERM_LEN);
+        assert_eq!(scale_perm_single.len(), SCALE_PERM_SINGLE_LEN);
+        let mut sorted = perm.clone();
+        sorted.sort_unstable();
+        assert!(
+            sorted.iter().copied().eq(0..PERM_LEN),
+            "perm not a bijection"
+        );
+        assert_eq!(perm.iter().sum::<usize>(), 523776);
+        assert_eq!(&perm[..8], &[0, 128, 8, 136, 16, 144, 24, 152]);
+        assert_eq!(
+            scale_perm_single,
+            vec![
+                0, 1, 8, 9, 16, 17, 24, 25, 2, 3, 10, 11, 18, 19, 26, 27, 4, 5, 12, 13, 20, 21, 28,
+                29, 6, 7, 14, 15, 22, 23, 30, 31
+            ]
+        );
+    }
+
+    // Cross-check the pure repack against values produced by the upstream-equivalent numpy port
+    // (see the session's marlin_ref.py). Catches sign/shift/transpose mistakes that a self-
+    // consistent round-trip alone could miss.
+    #[test]
+    fn pack_weights_matches_golden() {
+        let (k, n) = (128usize, 256usize);
+        let b = pack_weights(&golden_q(k, n), k, n);
+        assert_eq!(b.len(), (k / 16) * (n * 2)); // 8 * 512
+        let cols = n * 2;
+        assert_eq!(b[0], 2146896000);
+        assert_eq!(b[1], 2146896000);
+        assert_eq!(b[511], 1860630399);
+        assert_eq!(b[7 * cols], 2146896000);
+        assert_eq!(b[7 * cols + 511], 1860630399);
+        let sum: i64 = b.iter().map(|&x| x as i64).sum();
+        assert_eq!(sum, 586128816128);
+    }
+
+    #[test]
+    fn pack_scales_matches_golden() {
+        let (n_groups, n) = (1usize, 256usize);
+        let s = pack_scales(&golden_scales(n_groups, n), n_groups, n, false);
+        assert!((s[0] - 0.01).abs() < 1e-6);
+        assert!((s[255] - 0.013).abs() < 1e-6);
+        let sum: f64 = s.iter().map(|&x| x as f64).sum();
+        assert!((sum - 3.322).abs() < 1e-3, "scale sum {sum}");
+    }
+
+    // Round-trip: packing then unpacking with the inverse permutation must recover q exactly,
+    // for both the grouped and per-channel layouts.
+    fn unpack_weights(b: &[i32], k: usize, n: usize) -> Vec<i32> {
+        let (perm, _, _) = marlin_perms();
+        let row_len = n * TILE;
+        let packed_cols = n * 2;
+        // invert bit packing
+        let mut res = vec![0i32; (k / TILE) * row_len];
+        for r in 0..k / TILE {
+            for p in 0..packed_cols {
+                let word = b[r * packed_cols + p] as u32;
+                for i in 0..8usize {
+                    res[r * row_len + 8 * p + i] = ((word >> (4 * i)) & 0xF) as i32;
+                }
+            }
+        }
+        // invert perm: the forward direction computed `res[i] = tmp[perm[i]]`, so recovering
+        // `tmp` from `res` means scattering by `perm[i]` (not by the inverse permutation, which
+        // would only be correct if `perm` were self-inverse).
+        let mut tmp = vec![0i32; res.len()];
+        for (bk, block) in res.chunks_exact(PERM_LEN).enumerate() {
+            let base = bk * PERM_LEN;
+            for i in 0..PERM_LEN {
+                tmp[base + perm[i]] = block[i];
+            }
+        }
+        // invert tile transpose
+        let mut q = vec![0i32; k * n];
+        for ko in 0..k / TILE {
+            for no in 0..n / TILE {
+                for i in 0..TILE {
+                    for j in 0..TILE {
+                        let src = ko * row_len + no * 256 + i * TILE + j;
+                        let dst = (ko * TILE + i) * n + (no * TILE + j);
+                        q[dst] = tmp[src];
+                    }
+                }
+            }
+        }
+        q
+    }
+
+    #[test]
+    fn pack_weights_roundtrips() {
+        for (k, n) in [(128usize, 256usize), (256, 256), (128, 512)] {
+            let mut q = vec![0i32; k * n];
+            for (idx, v) in q.iter_mut().enumerate() {
+                *v = ((idx * 1103515245 + 12345) % 16) as i32;
+            }
+            let b = pack_weights(&q, k, n);
+            let q2 = unpack_weights(&b, k, n);
+            assert_eq!(q, q2, "roundtrip failed for k={k} n={n}");
+        }
+    }
+
+    // End-to-end GPU test: repack a synthetic symmetric 4-bit GPTQ weight into Marlin layout, run
+    // the vendored Marlin kernel over FFI, and check the output against a dense `A @ W` reference.
+    // This validates the whole binding (repack + FFI + kernel) on real Ampere hardware; it is run
+    // by the `candle-gptq-kernels` test step in ci_cuda.yaml, not locally.
+    #[test]
+    fn marlin_gemm_matches_dense() -> Result<()> {
+        let device = candle::Device::new_cuda(0)?;
+        // Marlin-eligible: k % 128 == 0, n % 256 == 0, group size 128.
+        let (m, k, n, group_size) = (16usize, 256usize, 256usize, 128usize);
+        let n_groups = k / group_size;
+
+        // Symmetric 4-bit levels (0..15) and per-group scales.
+        let mut q = vec![0i32; k * n];
+        for i in 0..k {
+            for j in 0..n {
+                q[i * n + j] = ((i * 3 + j * 7) % 16) as i32;
+            }
+        }
+        let mut scales = vec![0f32; n_groups * n];
+        for g in 0..n_groups {
+            for j in 0..n {
+                scales[g * n + j] = 0.01 + 0.002 * ((g * 3 + j) % 5) as f32;
+            }
+        }
+
+        // Dense reference weight W[k,n] = (q - 8) * scale[group(row), col].
+        let mut w = vec![0f32; k * n];
+        for i in 0..k {
+            let g = i / group_size;
+            for j in 0..n {
+                w[i * n + j] = (q[i * n + j] - 8) as f32 * scales[g * n + j];
+            }
+        }
+        // Activations and expected A @ W (f32 accumulation).
+        let a: Vec<f32> = (0..m * k).map(|i| ((i % 11) as f32 - 5.0) * 0.05).collect();
+        let mut expected = vec![0f32; m * n];
+        for row in 0..m {
+            for col in 0..n {
+                let mut acc = 0f64;
+                for kk in 0..k {
+                    acc += a[row * k + kk] as f64 * w[kk * n + col] as f64;
+                }
+                expected[row * n + col] = acc as f32;
+            }
+        }
+
+        // Pack a GPTQ checkpoint: qweight [k/8, n], qzeros [n_groups, n/8] (all 0x77777777 = sym).
+        let mut qweight = vec![0i32; (k / 8) * n];
+        for i in 0..k {
+            let shift = (i % 8) * 4;
+            for j in 0..n {
+                qweight[(i / 8) * n + j] |= q[i * n + j] << shift;
+            }
+        }
+        let qzeros = vec![SYM_QZERO_WORD; n_groups * (n / 8)];
+
+        let qweight_t = Tensor::from_vec(qweight, (k / 8, n), &device)?;
+        let qzeros_t = Tensor::from_vec(qzeros, (n_groups, n / 8), &device)?;
+        let scales_t = Tensor::from_vec(scales, (n_groups, n), &device)?;
+
+        let (b, s) = marlin_repack_gptq(&qweight_t, &qzeros_t, &scales_t, 4, group_size)?
+            .expect("checkpoint should be Marlin-eligible");
+
+        let a_t = Tensor::from_vec(a, (m, k), &device)?.to_dtype(DType::F16)?;
+        let y = marlin_gemm(&a_t, &b, &s)?
+            .to_dtype(DType::F32)?
+            .to_vec2::<f32>()?;
+
+        for row in 0..m {
+            for col in 0..n {
+                let exp = expected[row * n + col];
+                // fp16 operands + fp16 accumulation in the scale step: allow a relative tolerance
+                // wide enough for fp16 noise but tight enough to catch layout/repack bugs.
+                let tol = 0.05 + 0.03 * exp.abs();
+                assert!(
+                    (y[row][col] - exp).abs() < tol,
+                    "marlin mismatch at ({row},{col}): {} vs {exp}",
+                    y[row][col]
+                );
+            }
+        }
+        Ok(())
+    }
+}

--- a/candle-gptq-kernels/src/metal.rs
+++ b/candle-gptq-kernels/src/metal.rs
@@ -1,0 +1,175 @@
+//! Metal backend for the fused GPTQ dequant+GEMM kernel.
+//!
+//! Mirrors the CUDA scalar path (`gptq_gemm.cu`) on Apple Silicon: the kernel source
+//! (`kernels/gptq_gemm.metal`) is compiled at runtime the first time it runs on a given device and
+//! the resulting pipeline is cached, then dispatched as a threadgroup-tiled GEMM that dequantizes
+//! each weight on the fly. There is no Metal equivalent of the tensor-core / Marlin paths, so
+//! `gptq_gemm` is the only entry point routed here.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use candle::backend::BackendStorage;
+use candle::metal_backend::DeviceId;
+use candle::{DType, Layout, MetalStorage, Result, Shape, Storage};
+use candle_metal_kernels::metal::{ComputeCommandEncoder, ComputePipeline};
+use objc2_metal::MTLSize;
+
+use crate::GptqGemm;
+
+const KERNEL_SRC: &str = include_str!("../kernels/gptq_gemm.metal");
+const FUNCTION_NAME: &str = "gptq_gemm_f32";
+const TILE: usize = 16;
+
+/// Scalar arguments, laid out to match `struct GptqParams` in `gptq_gemm.metal` (6 × i32).
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct GptqParams {
+    m: i32,
+    k: i32,
+    n: i32,
+    bits: i32,
+    pack_factor: i32,
+    n_groups_out: i32,
+}
+
+/// One compiled pipeline per Metal device, compiled on first use. `ComputePipeline` is `Send`/`Sync`
+/// in `candle-metal-kernels`, so a process-wide cache is sound.
+fn pipeline_for(device: &candle::MetalDevice) -> Result<ComputePipeline> {
+    static CACHE: OnceLock<Mutex<HashMap<DeviceId, ComputePipeline>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let id = device.id();
+    {
+        let guard = cache.lock().unwrap();
+        if let Some(p) = guard.get(&id) {
+            return Ok(p.clone());
+        }
+    }
+    let mdev = device.metal_device();
+    let lib = mdev
+        .new_library_with_source(KERNEL_SRC, None)
+        .map_err(candle::Error::wrap)?;
+    let func = lib
+        .get_function(FUNCTION_NAME, None)
+        .map_err(candle::Error::wrap)?;
+    let pipeline = mdev
+        .new_compute_pipeline_state_with_function(&func)
+        .map_err(candle::Error::wrap)?;
+    cache.lock().unwrap().insert(id, pipeline.clone());
+    Ok(pipeline)
+}
+
+/// Byte offset of a contiguous tensor's data within its backing buffer.
+fn offset_bytes(layout: &Layout, dtype: DType) -> usize {
+    layout.start_offset() * dtype.size_in_bytes()
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn gptq_gemm_metal_fwd(
+    op: &GptqGemm,
+    x: &MetalStorage,
+    x_l: &Layout,
+    qweight: &MetalStorage,
+    qweight_l: &Layout,
+    qzeros: &MetalStorage,
+    qzeros_l: &Layout,
+) -> Result<(MetalStorage, Shape)> {
+    if x.dtype() != DType::F32 {
+        candle::bail!(
+            "gptq-gemm (metal) only supports f32 activations, got {:?}",
+            x.dtype()
+        );
+    }
+    if qweight.dtype() != DType::I32 || qzeros.dtype() != DType::I32 {
+        candle::bail!(
+            "gptq-gemm (metal): qweight/qzeros must be i32, got {:?}/{:?}",
+            qweight.dtype(),
+            qzeros.dtype()
+        );
+    }
+    let (m, k) = x_l.shape().dims2()?;
+    let (packed_k, n) = qweight_l.shape().dims2()?;
+    if packed_k * op.pack_factor != k {
+        candle::bail!(
+            "gptq-gemm (metal): qweight rows {packed_k} * pack_factor {} != x cols {k}",
+            op.pack_factor
+        );
+    }
+    let (_n_groups, n_packed) = qzeros_l.shape().dims2()?;
+    if n_packed * op.pack_factor != n {
+        candle::bail!(
+            "gptq-gemm (metal): qzeros cols {n_packed} * pack_factor {} != out dim {n}",
+            op.pack_factor
+        );
+    }
+
+    let device = x.device().clone();
+
+    // Extra ride-along tensors (scales: f32, g_idx: i32).
+    let (scales_storage, scales_l) = op.scales.storage_and_layout();
+    let scales_metal = match &*scales_storage {
+        Storage::Metal(s) => s,
+        _ => candle::bail!("gptq-gemm (metal): scales must be a metal tensor"),
+    };
+    let (g_idx_storage, g_idx_l) = op.g_idx.storage_and_layout();
+    let g_idx_metal = match &*g_idx_storage {
+        Storage::Metal(s) => s,
+        _ => candle::bail!("gptq-gemm (metal): g_idx must be a metal tensor"),
+    };
+
+    let pipeline = pipeline_for(&device)?;
+    let output = device.new_buffer(m * n, DType::F32, "gptq-metal-out")?;
+
+    let params = GptqParams {
+        m: m as i32,
+        k: k as i32,
+        n: n as i32,
+        bits: op.bits as i32,
+        pack_factor: op.pack_factor as i32,
+        n_groups_out: n_packed as i32,
+    };
+
+    let encoder = device.command_encoder()?;
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_label("gptq-gemm-metal");
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    encoder.set_input_buffer(0, Some(x.buffer()), offset_bytes(x_l, x.dtype()));
+    encoder.set_input_buffer(
+        1,
+        Some(qweight.buffer()),
+        offset_bytes(qweight_l, qweight.dtype()),
+    );
+    encoder.set_input_buffer(
+        2,
+        Some(qzeros.buffer()),
+        offset_bytes(qzeros_l, qzeros.dtype()),
+    );
+    encoder.set_input_buffer(
+        3,
+        Some(scales_metal.buffer()),
+        offset_bytes(scales_l, scales_metal.dtype()),
+    );
+    encoder.set_input_buffer(
+        4,
+        Some(g_idx_metal.buffer()),
+        offset_bytes(g_idx_l, g_idx_metal.dtype()),
+    );
+    encoder.set_output_buffer(5, Some(output.as_ref()), 0);
+    encoder.set_bytes(6, &params);
+
+    let groups = MTLSize {
+        width: n.div_ceil(TILE),
+        height: m.div_ceil(TILE),
+        depth: 1,
+    };
+    let threads = MTLSize {
+        width: TILE,
+        height: TILE,
+        depth: 1,
+    };
+    encoder.dispatch_thread_groups(groups, threads);
+
+    let out = MetalStorage::new(output, device.clone(), m * n, DType::F32);
+    Ok((out, Shape::from((m, n))))
+}

--- a/candle-transformers/Cargo.toml
+++ b/candle-transformers/Cargo.toml
@@ -14,6 +14,7 @@ accelerate-src = { workspace = true, optional = true }
 byteorder = { workspace = true }
 candle = { workspace = true }
 candle-flash-attn = { workspace = true, optional = true }
+candle-gptq-kernels = { workspace = true, optional = true }
 candle-nn = { workspace = true }
 fancy-regex = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
@@ -31,6 +32,8 @@ accelerate = ["dep:accelerate-src", "candle/accelerate", "candle-nn/accelerate"]
 cuda = ["candle/cuda", "candle-nn/cuda"]
 cudnn = ["candle/cudnn", "candle-nn/cudnn"]
 flash-attn = ["cuda", "dep:candle-flash-attn"]
+gptq-cuda = ["cuda", "dep:candle-gptq-kernels", "candle-gptq-kernels/cuda"]
+gptq-metal = ["metal", "dep:candle-gptq-kernels", "candle-gptq-kernels/metal"]
 mkl = ["dep:intel-mkl-src", "candle/mkl", "candle-nn/mkl"]
 metal = ["candle/metal", "candle-nn/metal"]
 metal-debug-labels = ["metal", "candle/metal-debug-labels", "candle-nn/metal-debug-labels"]

--- a/candle-transformers/src/lib.rs
+++ b/candle-transformers/src/lib.rs
@@ -3,6 +3,7 @@ pub mod generation;
 pub mod models;
 pub mod object_detection;
 pub mod pipelines;
+pub mod quantized_gptq;
 pub mod quantized_nn;
 pub mod quantized_var_builder;
 pub mod utils;

--- a/candle-transformers/src/models/gptq_qwen2.rs
+++ b/candle-transformers/src/models/gptq_qwen2.rs
@@ -1,0 +1,403 @@
+//! Qwen2 with GPTQ-quantized linear layers, loaded directly from an AutoGPTQ/GPTQModel
+//! checkpoint (e.g. `Qwen/Qwen2-0.5B-Instruct-GPTQ-Int4` on the Hugging Face Hub).
+//!
+//! This mirrors [`crate::models::qwen2`] but routes every attention/MLP projection through
+//! [`crate::quantized_gptq::gptq_linear`], which reads the checkpoint's packed
+//! `qweight`/`qzeros`/`scales`/(optional `g_idx`) tensors and dequantizes them once at load time.
+//! `embed_tokens`, the RMSNorm layers, and (when present) `lm_head` stay dense, matching how
+//! GPTQ checkpoints are actually exported. Real checkpoints store a `bias` tensor on every
+//! quantized projection (unlike the dense Qwen2 model, which omits bias on `o_proj` and the MLP
+//! projections), so all projections here are built with `bias: true`.
+
+use crate::models::with_tracing::{linear_no_bias, Linear as TracingLinear, RmsNorm};
+use crate::quantized_gptq::{gptq_linear, GptqConfig};
+use candle::{DType, Device, Module, Result, Tensor, D};
+use candle_nn::{Activation, Linear, VarBuilder};
+use std::sync::Arc;
+
+pub use crate::models::qwen2::Config;
+
+#[derive(Debug, Clone)]
+struct RotaryEmbedding {
+    sin: Tensor,
+    cos: Tensor,
+}
+
+impl RotaryEmbedding {
+    fn new(dtype: DType, cfg: &Config, dev: &Device) -> Result<Self> {
+        let dim = cfg.hidden_size / cfg.num_attention_heads;
+        let max_seq_len = cfg.max_position_embeddings;
+        let inv_freq: Vec<_> = (0..dim)
+            .step_by(2)
+            .map(|i| 1f32 / cfg.rope_theta.powf(i as f64 / dim as f64) as f32)
+            .collect();
+        let inv_freq_len = inv_freq.len();
+        let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?.to_dtype(dtype)?;
+        let t = Tensor::arange(0u32, max_seq_len as u32, dev)?
+            .to_dtype(dtype)?
+            .reshape((max_seq_len, 1))?;
+        let freqs = t.matmul(&inv_freq)?;
+        Ok(Self {
+            sin: freqs.sin()?,
+            cos: freqs.cos()?,
+        })
+    }
+
+    fn apply_rotary_emb_qkv(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        seqlen_offset: usize,
+    ) -> Result<(Tensor, Tensor)> {
+        let (_b_sz, _h, seq_len, _n_embd) = q.dims4()?;
+        let cos = self.cos.narrow(0, seqlen_offset, seq_len)?;
+        let sin = self.sin.narrow(0, seqlen_offset, seq_len)?;
+        let q_embed = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
+        let k_embed = candle_nn::rotary_emb::rope(&k.contiguous()?, &cos, &sin)?;
+        Ok((q_embed, k_embed))
+    }
+}
+
+#[derive(Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
+struct MLP {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+    act_fn: Activation,
+}
+
+impl MLP {
+    fn new(cfg: &Config, gptq_cfg: GptqConfig, vb: VarBuilder) -> Result<Self> {
+        let hidden_sz = cfg.hidden_size;
+        let intermediate_sz = cfg.intermediate_size;
+        let gate_proj = gptq_linear(
+            hidden_sz,
+            intermediate_sz,
+            gptq_cfg,
+            true,
+            vb.pp("gate_proj"),
+        )?;
+        let up_proj = gptq_linear(hidden_sz, intermediate_sz, gptq_cfg, true, vb.pp("up_proj"))?;
+        let down_proj = gptq_linear(
+            intermediate_sz,
+            hidden_sz,
+            gptq_cfg,
+            true,
+            vb.pp("down_proj"),
+        )?;
+        Ok(Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+            act_fn: cfg.hidden_act,
+        })
+    }
+}
+
+impl Module for MLP {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let lhs = xs.apply(&self.gate_proj)?.apply(&self.act_fn)?;
+        let rhs = xs.apply(&self.up_proj)?;
+        (lhs * rhs)?.apply(&self.down_proj)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Attention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    o_proj: Linear,
+    num_heads: usize,
+    num_kv_heads: usize,
+    num_kv_groups: usize,
+    head_dim: usize,
+    hidden_size: usize,
+    rotary_emb: Arc<RotaryEmbedding>,
+    kv_cache: Option<(Tensor, Tensor)>,
+}
+
+impl Attention {
+    fn new(
+        rotary_emb: Arc<RotaryEmbedding>,
+        cfg: &Config,
+        gptq_cfg: GptqConfig,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let hidden_sz = cfg.hidden_size;
+        let num_heads = cfg.num_attention_heads;
+        let num_kv_heads = cfg.num_key_value_heads;
+        let num_kv_groups = num_heads / num_kv_heads;
+        let head_dim = hidden_sz / num_heads;
+        let q_proj = gptq_linear(
+            hidden_sz,
+            num_heads * head_dim,
+            gptq_cfg,
+            true,
+            vb.pp("q_proj"),
+        )?;
+        let k_proj = gptq_linear(
+            hidden_sz,
+            num_kv_heads * head_dim,
+            gptq_cfg,
+            true,
+            vb.pp("k_proj"),
+        )?;
+        let v_proj = gptq_linear(
+            hidden_sz,
+            num_kv_heads * head_dim,
+            gptq_cfg,
+            true,
+            vb.pp("v_proj"),
+        )?;
+        let o_proj = gptq_linear(
+            num_heads * head_dim,
+            hidden_sz,
+            gptq_cfg,
+            true,
+            vb.pp("o_proj"),
+        )?;
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            num_heads,
+            num_kv_heads,
+            num_kv_groups,
+            head_dim,
+            hidden_size: hidden_sz,
+            rotary_emb,
+            kv_cache: None,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        xs: &Tensor,
+        attention_mask: Option<&Tensor>,
+        seqlen_offset: usize,
+    ) -> Result<Tensor> {
+        let (b_sz, q_len, _) = xs.dims3()?;
+
+        let query_states = self.q_proj.forward(xs)?;
+        let key_states = self.k_proj.forward(xs)?;
+        let value_states = self.v_proj.forward(xs)?;
+
+        let query_states = query_states
+            .reshape((b_sz, q_len, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let key_states = key_states
+            .reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let value_states = value_states
+            .reshape((b_sz, q_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        let (query_states, key_states) =
+            self.rotary_emb
+                .apply_rotary_emb_qkv(&query_states, &key_states, seqlen_offset)?;
+
+        let (key_states, value_states) = match &self.kv_cache {
+            None => (key_states, value_states),
+            Some((prev_k, prev_v)) => {
+                let key_states = Tensor::cat(&[prev_k, &key_states], 2)?;
+                let value_states = Tensor::cat(&[prev_v, &value_states], 2)?;
+                (key_states, value_states)
+            }
+        };
+        self.kv_cache = Some((key_states.clone(), value_states.clone()));
+
+        let key_states = crate::utils::repeat_kv(key_states, self.num_kv_groups)?.contiguous()?;
+        let value_states =
+            crate::utils::repeat_kv(value_states, self.num_kv_groups)?.contiguous()?;
+
+        let attn_output = {
+            let scale = 1f64 / f64::sqrt(self.head_dim as f64);
+            let attn_weights = (query_states.matmul(&key_states.transpose(2, 3)?)? * scale)?;
+
+            let attn_weights = match attention_mask {
+                None => attn_weights,
+                Some(mask) => attn_weights.broadcast_add(mask)?,
+            };
+            let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
+            attn_weights.matmul(&value_states)?
+        };
+        attn_output
+            .transpose(1, 2)?
+            .reshape((b_sz, q_len, self.hidden_size))?
+            .apply(&self.o_proj)
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.kv_cache = None
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DecoderLayer {
+    self_attn: Attention,
+    mlp: MLP,
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+}
+
+impl DecoderLayer {
+    fn new(
+        rotary_emb: Arc<RotaryEmbedding>,
+        cfg: &Config,
+        gptq_cfg: GptqConfig,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let self_attn = Attention::new(rotary_emb, cfg, gptq_cfg, vb.pp("self_attn"))?;
+        let mlp = MLP::new(cfg, gptq_cfg, vb.pp("mlp"))?;
+        let input_layernorm =
+            RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
+        let post_attention_layernorm = RmsNorm::new(
+            cfg.hidden_size,
+            cfg.rms_norm_eps,
+            vb.pp("post_attention_layernorm"),
+        )?;
+        Ok(Self {
+            self_attn,
+            mlp,
+            input_layernorm,
+            post_attention_layernorm,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        xs: &Tensor,
+        attention_mask: Option<&Tensor>,
+        seqlen_offset: usize,
+    ) -> Result<Tensor> {
+        let residual = xs;
+        let xs = self.input_layernorm.forward(xs)?;
+        let xs = self.self_attn.forward(&xs, attention_mask, seqlen_offset)?;
+        let xs = (xs + residual)?;
+        let residual = &xs;
+        let xs = xs.apply(&self.post_attention_layernorm)?.apply(&self.mlp)?;
+        residual + xs
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.self_attn.clear_kv_cache()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Model {
+    embed_tokens: candle_nn::Embedding,
+    layers: Vec<DecoderLayer>,
+    norm: RmsNorm,
+    sliding_window: usize,
+    device: Device,
+    dtype: DType,
+}
+
+impl Model {
+    pub fn new(cfg: &Config, gptq_cfg: GptqConfig, vb: VarBuilder) -> Result<Self> {
+        let vb_m = vb.pp("model");
+        let embed_tokens =
+            candle_nn::embedding(cfg.vocab_size, cfg.hidden_size, vb_m.pp("embed_tokens"))?;
+        let rotary_emb = Arc::new(RotaryEmbedding::new(vb.dtype(), cfg, vb_m.device())?);
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        let vb_l = vb_m.pp("layers");
+        for layer_idx in 0..cfg.num_hidden_layers {
+            let layer = DecoderLayer::new(rotary_emb.clone(), cfg, gptq_cfg, vb_l.pp(layer_idx))?;
+            layers.push(layer)
+        }
+        let norm = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb_m.pp("norm"))?;
+        Ok(Self {
+            embed_tokens,
+            layers,
+            norm,
+            sliding_window: cfg.sliding_window,
+            device: vb.device().clone(),
+            dtype: vb.dtype(),
+        })
+    }
+
+    fn prepare_causal_attention_mask(
+        &self,
+        b_size: usize,
+        tgt_len: usize,
+        seqlen_offset: usize,
+    ) -> Result<Tensor> {
+        let mask: Vec<_> = (0..tgt_len)
+            .flat_map(|i| {
+                (0..tgt_len).map(move |j| {
+                    if i < j || j + self.sliding_window < i {
+                        f32::NEG_INFINITY
+                    } else {
+                        0.
+                    }
+                })
+            })
+            .collect();
+        let mask = Tensor::from_slice(&mask, (tgt_len, tgt_len), &self.device)?;
+        let mask = if seqlen_offset > 0 {
+            let mask0 = Tensor::zeros((tgt_len, seqlen_offset), self.dtype, &self.device)?;
+            Tensor::cat(&[&mask0, &mask], D::Minus1)?
+        } else {
+            mask
+        };
+        mask.expand((b_size, 1, tgt_len, tgt_len + seqlen_offset))?
+            .to_dtype(self.dtype)
+    }
+
+    pub fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
+        let (b_size, seq_len) = input_ids.dims2()?;
+        let attention_mask = if seq_len <= 1 {
+            None
+        } else {
+            Some(self.prepare_causal_attention_mask(b_size, seq_len, seqlen_offset)?)
+        };
+        let mut xs = self.embed_tokens.forward(input_ids)?;
+        for layer in self.layers.iter_mut() {
+            xs = layer.forward(&xs, attention_mask.as_ref(), seqlen_offset)?
+        }
+        xs.apply(&self.norm)
+    }
+
+    pub fn clear_kv_cache(&mut self) {
+        for layer in self.layers.iter_mut() {
+            layer.clear_kv_cache()
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ModelForCausalLM {
+    base_model: Model,
+    lm_head: TracingLinear,
+}
+
+impl ModelForCausalLM {
+    pub fn new(cfg: &Config, gptq_cfg: GptqConfig, vb: VarBuilder) -> Result<Self> {
+        let base_model = Model::new(cfg, gptq_cfg, vb.clone())?;
+        let lm_head = if vb.contains_tensor("lm_head.weight") {
+            linear_no_bias(cfg.hidden_size, cfg.vocab_size, vb.pp("lm_head"))?
+        } else {
+            TracingLinear::from_weights(base_model.embed_tokens.embeddings().clone(), None)
+        };
+        Ok(Self {
+            base_model,
+            lm_head,
+        })
+    }
+
+    pub fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
+        let (_b_size, seq_len) = input_ids.dims2()?;
+        self.base_model
+            .forward(input_ids, seqlen_offset)?
+            .narrow(1, seq_len - 1, 1)?
+            .apply(&self.lm_head)
+    }
+
+    pub fn clear_kv_cache(&mut self) {
+        self.base_model.clear_kv_cache()
+    }
+}

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -48,6 +48,7 @@ pub mod gemma3;
 pub mod gemma4;
 pub mod glm4;
 pub mod glm4_new;
+pub mod gptq_qwen2;
 pub mod granite;
 pub mod granitemoehybrid;
 pub mod helium;

--- a/candle-transformers/src/quantized_gptq.rs
+++ b/candle-transformers/src/quantized_gptq.rs
@@ -1,0 +1,455 @@
+//! Loading and dequantizing GPTQ checkpoints (AutoGPTQ / GPTQModel layout) from safetensors.
+//!
+//! GPTQ packs `bits`-wide integers into `i32` words and stores per-group scales and zero
+//! points. This module unpacks those checkpoints into a plain dense `f32` weight matrix on
+//! load so that the rest of the model can use the regular (unquantized) matmul path. There is
+//! With the `gptq-cuda` feature enabled, [`cuda::GptqLinearCuda`] instead keeps the checkpoint
+//! packed and runs a fused dequantize+GEMM CUDA kernel (`candle-gptq-kernels`) on every forward
+//! pass; there is no CPU fallback for that path.
+
+use candle::{DType, Result, Tensor};
+use candle_nn::{Linear, VarBuilder};
+
+/// GPTQ quantization parameters, as found in the checkpoint's `quantize_config.json`.
+#[derive(Debug, Clone, Copy)]
+pub struct GptqConfig {
+    pub bits: usize,
+    pub group_size: usize,
+}
+
+/// Unpack a GPTQ-quantized weight into a dense `[in_dim, out_dim]` `f32` tensor.
+///
+/// `qweight` has shape `[in_dim / pack_factor, out_dim]`, `qzeros` has shape
+/// `[n_groups, out_dim / pack_factor]`, and `scales` has shape `[n_groups, out_dim]`, where
+/// `pack_factor = 32 / bits` and `n_groups = ceil(in_dim / group_size)`. `g_idx`, when present,
+/// maps each input row to its group index (used by "desc_act" checkpoints); otherwise rows are
+/// assigned to groups sequentially based on `group_size`.
+pub fn dequantize_gptq(
+    qweight: &Tensor,
+    qzeros: &Tensor,
+    scales: &Tensor,
+    g_idx: Option<&Tensor>,
+    bits: usize,
+    group_size: usize,
+) -> Result<Tensor> {
+    if 32 % bits != 0 {
+        candle::bail!(
+            "gptq: unsupported bits {bits}, only values dividing 32 (2/4/8) are supported"
+        )
+    }
+    let pack_factor = 32 / bits;
+    let mask = (1i32 << bits) - 1;
+
+    let (packed_in, out_dim) = qweight.dims2()?;
+    let in_dim = packed_in * pack_factor;
+    let qweight = qweight.to_dtype(DType::I32)?.to_vec2::<i32>()?;
+    let qzeros = qzeros.to_dtype(DType::I32)?.to_vec2::<i32>()?;
+    let scales = scales.to_dtype(DType::F32)?.to_vec2::<f32>()?;
+    let n_groups = scales.len();
+    let g_idx: Vec<i32> = match g_idx {
+        Some(g_idx) => g_idx.to_dtype(DType::I32)?.to_vec1::<i32>()?,
+        None => (0..in_dim as i32).map(|i| i / group_size as i32).collect(),
+    };
+
+    // Unpack the per-(group, out-column) zero points.
+    let mut zeros = vec![0i32; n_groups * out_dim];
+    for (g, qzeros_row) in qzeros.iter().enumerate() {
+        for col in 0..out_dim {
+            let packed = qzeros_row[col / pack_factor];
+            let shift = (col % pack_factor) * bits;
+            zeros[g * out_dim + col] = ((packed >> shift) & mask) + 1;
+        }
+    }
+
+    let mut weight = vec![0f32; in_dim * out_dim];
+    for (row_packed, qweight_row) in qweight.iter().enumerate() {
+        for col in 0..out_dim {
+            let packed = qweight_row[col];
+            for sub in 0..pack_factor {
+                let row = row_packed * pack_factor + sub;
+                if row >= in_dim {
+                    break;
+                }
+                let shift = sub * bits;
+                let q = (packed >> shift) & mask;
+                let g = g_idx[row] as usize;
+                let z = zeros[g * out_dim + col];
+                let s = scales[g][col];
+                weight[row * out_dim + col] = (q - z) as f32 * s;
+            }
+        }
+    }
+    // `to_vec2`/`to_vec1` above moved the data off whichever device the checkpoint tensors live
+    // on, so the dequantized result is built on the CPU and the caller moves it back if needed.
+    Tensor::from_vec(weight, (in_dim, out_dim), &candle::Device::Cpu)
+}
+
+/// Build a [`candle_nn::Linear`] layer from a GPTQ-quantized checkpoint, reading
+/// `qweight`/`qzeros`/`scales`/(optional `g_idx`)/(optional `bias`) tensors at the current
+/// `VarBuilder` path.
+pub fn gptq_linear(
+    in_dim: usize,
+    out_dim: usize,
+    cfg: GptqConfig,
+    bias: bool,
+    vb: VarBuilder,
+) -> Result<Linear> {
+    let pack_factor = 32 / cfg.bits;
+    let n_groups = in_dim.div_ceil(cfg.group_size);
+
+    let qweight = vb.get_with_hints_dtype(
+        (in_dim / pack_factor, out_dim),
+        "qweight",
+        Default::default(),
+        DType::I32,
+    )?;
+    let qzeros = vb.get_with_hints_dtype(
+        (n_groups, out_dim / pack_factor),
+        "qzeros",
+        Default::default(),
+        DType::I32,
+    )?;
+    let scales = vb.get_with_hints_dtype(
+        (n_groups, out_dim),
+        "scales",
+        Default::default(),
+        DType::F32,
+    )?;
+    let g_idx = if vb.contains_tensor("g_idx") {
+        Some(vb.get_with_hints_dtype(in_dim, "g_idx", Default::default(), DType::I32)?)
+    } else {
+        None
+    };
+
+    let weight = dequantize_gptq(
+        &qweight,
+        &qzeros,
+        &scales,
+        g_idx.as_ref(),
+        cfg.bits,
+        cfg.group_size,
+    )?;
+    let weight = weight.t()?.contiguous()?.to_device(vb.device())?;
+    let bias = if bias {
+        Some(vb.get(out_dim, "bias")?)
+    } else {
+        None
+    };
+    Ok(Linear::new(weight, bias))
+}
+
+/// Fused dequantize+GEMM CUDA path: keeps the GPTQ checkpoint packed and runs the kernel from
+/// `candle-gptq-kernels` on every forward pass instead of dequantizing once at load time.
+#[cfg(feature = "gptq-cuda")]
+pub mod cuda {
+    use super::GptqConfig;
+    use candle::{DType, Module, Result, Tensor};
+    use candle_nn::VarBuilder;
+
+    #[derive(Debug, Clone)]
+    pub struct GptqLinearCuda {
+        qweight: Tensor,
+        qzeros: Tensor,
+        scales: Tensor,
+        g_idx: Tensor,
+        bias: Option<Tensor>,
+        bits: usize,
+        group_size: usize,
+        /// Pre-repacked `(B, s)` Marlin weights, set at construction when the checkpoint is
+        /// Marlin-eligible (4-bit symmetric, group size 128/-1, aligned shapes). When present, the
+        /// forward pass routes through the vendored Marlin tensor-core kernel.
+        marlin: Option<(Tensor, Tensor)>,
+    }
+
+    impl GptqLinearCuda {
+        pub fn new(
+            in_dim: usize,
+            out_dim: usize,
+            cfg: GptqConfig,
+            bias: bool,
+            vb: VarBuilder,
+        ) -> Result<Self> {
+            let pack_factor = 32 / cfg.bits;
+            let n_groups = in_dim.div_ceil(cfg.group_size);
+            let qweight = vb.get_with_hints_dtype(
+                (in_dim / pack_factor, out_dim),
+                "qweight",
+                Default::default(),
+                DType::I32,
+            )?;
+            let qzeros = vb.get_with_hints_dtype(
+                (n_groups, out_dim / pack_factor),
+                "qzeros",
+                Default::default(),
+                DType::I32,
+            )?;
+            let scales = vb.get_with_hints_dtype(
+                (n_groups, out_dim),
+                "scales",
+                Default::default(),
+                DType::F32,
+            )?;
+            let g_idx = if vb.contains_tensor("g_idx") {
+                vb.get_with_hints_dtype(in_dim, "g_idx", Default::default(), DType::I32)?
+            } else {
+                let g_idx: Vec<i32> = (0..in_dim as i32)
+                    .map(|i| i / cfg.group_size as i32)
+                    .collect();
+                Tensor::from_vec(g_idx, in_dim, vb.device())?
+            };
+            let bias = if bias {
+                Some(vb.get(out_dim, "bias")?)
+            } else {
+                None
+            };
+
+            // Try the real Marlin tensor-core kernel for the common 4-bit symmetric case. Marlin
+            // has no act-order support, so only attempt the repack when `g_idx` is sequential
+            // (`g_idx[i] == i / group_size`); `marlin_repack_gptq` checks the remaining
+            // eligibility constraints (symmetry, group size, shape alignment) and returns `None`
+            // otherwise, in which case we keep the generic kernels.
+            let marlin = if cfg.bits == 4 && Self::g_idx_is_sequential(&g_idx, cfg.group_size)? {
+                candle_gptq_kernels::marlin_repack_gptq(
+                    &qweight,
+                    &qzeros,
+                    &scales,
+                    cfg.bits,
+                    cfg.group_size,
+                )?
+            } else {
+                None
+            };
+
+            Ok(Self {
+                qweight,
+                qzeros,
+                scales,
+                g_idx,
+                bias,
+                bits: cfg.bits,
+                group_size: cfg.group_size,
+                marlin,
+            })
+        }
+
+        fn g_idx_is_sequential(g_idx: &Tensor, group_size: usize) -> Result<bool> {
+            let g_idx = g_idx.to_dtype(DType::I32)?.to_vec1::<i32>()?;
+            Ok(g_idx
+                .iter()
+                .enumerate()
+                .all(|(i, &g)| g == (i / group_size) as i32))
+        }
+    }
+
+    impl Module for GptqLinearCuda {
+        fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+            let in_dims = xs.dims();
+            let in_dim = *in_dims.last().unwrap();
+            let m: usize = in_dims[..in_dims.len() - 1].iter().product();
+            // When the checkpoint is Marlin-eligible, drive the vendored Marlin tensor-core kernel
+            // (fp16 in/out). Otherwise fall back to the fused fp32 kernels: the WMMA tensor-core
+            // one for the 4-bit case, the scalar one for other bit widths. Either way the result
+            // is normalized to f32, matching the existing forward contract.
+            let ys = if let Some((b, s)) = &self.marlin {
+                let xs2 = xs
+                    .reshape((m, in_dim))?
+                    .to_dtype(DType::F16)?
+                    .contiguous()?;
+                candle_gptq_kernels::marlin_gemm(&xs2, b, s)?.to_dtype(DType::F32)?
+            } else {
+                let xs2 = xs
+                    .reshape((m, in_dim))?
+                    .to_dtype(DType::F32)?
+                    .contiguous()?;
+                if self.bits == 4 {
+                    candle_gptq_kernels::gptq_gemm_tensor_core(
+                        &xs2,
+                        &self.qweight,
+                        &self.qzeros,
+                        &self.scales,
+                        &self.g_idx,
+                        self.bits,
+                    )?
+                } else {
+                    candle_gptq_kernels::gptq_gemm(
+                        &xs2,
+                        &self.qweight,
+                        &self.qzeros,
+                        &self.scales,
+                        &self.g_idx,
+                        self.bits,
+                        self.group_size,
+                    )?
+                }
+            };
+            let out_dim = ys.dim(1)?;
+            let mut out_dims = in_dims[..in_dims.len() - 1].to_vec();
+            out_dims.push(out_dim);
+            let ys = ys.reshape(out_dims)?;
+            match &self.bias {
+                None => Ok(ys),
+                Some(bias) => ys.broadcast_add(bias),
+            }
+        }
+    }
+}
+
+/// Fused dequantize+GEMM Metal path: keeps the GPTQ checkpoint packed and runs the Metal kernel
+/// from `candle-gptq-kernels` on every forward pass. Apple Silicon has no tensor-core / Marlin
+/// equivalent here, so this always uses the scalar tiled kernel (any `bits` dividing 32).
+#[cfg(feature = "gptq-metal")]
+pub mod metal {
+    use super::GptqConfig;
+    use candle::{DType, Module, Result, Tensor};
+    use candle_nn::VarBuilder;
+
+    #[derive(Debug, Clone)]
+    pub struct GptqLinearMetal {
+        qweight: Tensor,
+        qzeros: Tensor,
+        scales: Tensor,
+        g_idx: Tensor,
+        bias: Option<Tensor>,
+        bits: usize,
+        group_size: usize,
+    }
+
+    impl GptqLinearMetal {
+        pub fn new(
+            in_dim: usize,
+            out_dim: usize,
+            cfg: GptqConfig,
+            bias: bool,
+            vb: VarBuilder,
+        ) -> Result<Self> {
+            let pack_factor = 32 / cfg.bits;
+            let n_groups = in_dim.div_ceil(cfg.group_size);
+            let qweight = vb.get_with_hints_dtype(
+                (in_dim / pack_factor, out_dim),
+                "qweight",
+                Default::default(),
+                DType::I32,
+            )?;
+            let qzeros = vb.get_with_hints_dtype(
+                (n_groups, out_dim / pack_factor),
+                "qzeros",
+                Default::default(),
+                DType::I32,
+            )?;
+            let scales = vb.get_with_hints_dtype(
+                (n_groups, out_dim),
+                "scales",
+                Default::default(),
+                DType::F32,
+            )?;
+            let g_idx = if vb.contains_tensor("g_idx") {
+                vb.get_with_hints_dtype(in_dim, "g_idx", Default::default(), DType::I32)?
+            } else {
+                let g_idx: Vec<i32> = (0..in_dim as i32)
+                    .map(|i| i / cfg.group_size as i32)
+                    .collect();
+                Tensor::from_vec(g_idx, in_dim, vb.device())?
+            };
+            let bias = if bias {
+                Some(vb.get(out_dim, "bias")?)
+            } else {
+                None
+            };
+
+            Ok(Self {
+                qweight,
+                qzeros,
+                scales,
+                g_idx,
+                bias,
+                bits: cfg.bits,
+                group_size: cfg.group_size,
+            })
+        }
+    }
+
+    impl Module for GptqLinearMetal {
+        fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+            let in_dims = xs.dims();
+            let in_dim = *in_dims.last().unwrap();
+            let m: usize = in_dims[..in_dims.len() - 1].iter().product();
+            let xs2 = xs
+                .reshape((m, in_dim))?
+                .to_dtype(DType::F32)?
+                .contiguous()?;
+            let ys = candle_gptq_kernels::gptq_gemm(
+                &xs2,
+                &self.qweight,
+                &self.qzeros,
+                &self.scales,
+                &self.g_idx,
+                self.bits,
+                self.group_size,
+            )?;
+            let out_dim = ys.dim(1)?;
+            let mut out_dims = in_dims[..in_dims.len() - 1].to_vec();
+            out_dims.push(out_dim);
+            let ys = ys.reshape(out_dims)?;
+            match &self.bias {
+                None => Ok(ys),
+                Some(bias) => ys.broadcast_add(bias),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::Device;
+
+    // Build a 4-bit GPTQ tensor set for a single [in_dim=8, out_dim=8] weight with one group
+    // and check that dequantization recovers the values used to construct it. `out_dim` must be
+    // a multiple of `pack_factor` (8 for 4-bit) for `qzeros` packing to be well-defined.
+    #[test]
+    fn dequantize_gptq_4bit_roundtrip() -> Result<()> {
+        let bits = 4;
+        let group_size = 8;
+        let in_dim = 8;
+        let out_dim = 8;
+        let pack_factor = 32 / bits;
+
+        // Raw quantized levels (0..15) per [row, col], chosen arbitrarily.
+        let q: [[i32; 8]; 8] =
+            std::array::from_fn(|row| std::array::from_fn(|col| ((row * 3 + col * 5) % 16) as i32));
+        let zero_point: [i32; 8] = std::array::from_fn(|col| 1 + (col % 4) as i32);
+        let scale: [f32; 8] = std::array::from_fn(|col| 0.25 * (1 + col as i32) as f32);
+
+        // Pack qweight: [in_dim / pack_factor, out_dim].
+        let mut qweight_data = vec![0i32; (in_dim / pack_factor) * out_dim];
+        for col in 0..out_dim {
+            let mut packed = 0i32;
+            for (row, q_row) in q.iter().enumerate() {
+                packed |= q_row[col] << (row * bits);
+            }
+            qweight_data[col] = packed;
+        }
+        let qweight =
+            Tensor::from_vec(qweight_data, (in_dim / pack_factor, out_dim), &Device::Cpu)?;
+
+        // Pack qzeros: [n_groups=1, out_dim / pack_factor]. Stored value is `zero_point - 1`.
+        let mut qzeros_data = vec![0i32; out_dim / pack_factor];
+        for col in 0..out_dim {
+            qzeros_data[col / pack_factor] |= (zero_point[col] - 1) << ((col % pack_factor) * bits);
+        }
+        let qzeros = Tensor::from_vec(qzeros_data, (1, out_dim / pack_factor), &Device::Cpu)?;
+
+        let scales = Tensor::from_vec(scale.to_vec(), (1, out_dim), &Device::Cpu)?;
+
+        let weight = dequantize_gptq(&qweight, &qzeros, &scales, None, bits, group_size)?;
+        let weight = weight.to_vec2::<f32>()?;
+
+        for row in 0..in_dim {
+            for col in 0..out_dim {
+                let expected = (q[row][col] - zero_point[col]) as f32 * scale[col];
+                assert!((weight[row][col] - expected).abs() < 1e-6);
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for loading GPTQ-quantized checkpoints, as requested in #3650.

- `candle-gptq-kernels`: a new crate with fused dequantize+GEMM CUDA and
  Metal kernels for GPTQ 4-bit linear layers (CUDA kernel includes a
  tensor-core path adapted from the Marlin project — see
  `candle-gptq-kernels/kernels/marlin/ATTRIBUTION.md` for license/provenance).
  Kept as its own crate rather than folded into `candle-kernels` so it's only
  built for checkpoints that actually use GPTQ; see the crate's README for the
  full rationale.
- `candle_transformers::quantized_gptq`: portable CPU dequantize-at-load path
  (`gptq_linear`/`GptqConfig`) that works on any backend without requiring the
  `gptq-cuda`/`gptq-metal` feature.
- `candle_transformers::models::gptq_qwen2`: a Qwen2 model that routes every
  attention/MLP projection through the GPTQ path above.
- `examples/quantized-gptq-qwen2`: end-to-end example that downloads a GPTQ
  checkpoint from the Hub (default
  [`Qwen/Qwen2-0.5B-Instruct-GPTQ-Int4`](https://huggingface.co/Qwen/Qwen2-0.5B-Instruct-GPTQ-Int4))
  and runs text generation through it.

## Why split into multiple PRs

This is the first of three PRs addressing #3650 (GPTQ, then AWQ, then
block-wise FP8). The original branch implemented all three formats together,
but several commits ended up mixing CUDA/Metal/CI work across formats, which
made the diff hard to review and hard for CI to validate per-format. This PR
is the GPTQ-only slice, reconstructed to be independently buildable and
testable so reviewers/CI can validate GPTQ in isolation before the AWQ and
FP8 PRs land on top of it. The two follow-up PRs:

- AWQ support + a `QuantizedLinear`/`QuantMethod` abstraction unifying
  GPTQ/AWQ behind one `Module` impl, generalizing this PR's example into a
  single `quantized-qwen2` example that auto-detects the format from
  `config.json`.
- Block-wise FP8 (DeepSeek-V3-style) support, extending the same
  `QuantizedLinear` enum with an `Fp8` variant.

## Test plan

- [x] `cargo test -p candle-transformers --lib quantized_gptq` — dequantize
      roundtrip unit test
- [x] `cargo test --manifest-path candle-gptq-kernels/Cargo.toml
      --no-default-features` — kernel crate builds/tests standalone (CPU)
- [x] `cargo clippy -p candle-transformers -p candle-examples --example
      quantized-gptq-qwen2 --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manually ran `cargo run --example quantized-gptq-qwen2 --release` against
      `Qwen/Qwen2-0.5B-Instruct-GPTQ-Int4`
- [x] CI: `cargo test -p candle-transformers --features cuda,gptq-cuda` and
      `cargo test --manifest-path candle-gptq-kernels/Cargo.toml` (tensor-core
      kernel correctness) on CUDA; `--features metal` GPTQ kernel test on
      Metal — added as new steps in `ci_cuda.yaml`/`ci_metal.yaml`.

Closes #3650 (GPTQ portion; AWQ and FP8 to follow in separate PRs).