### PR TITLE
cpu-optimize: Parallelize contiguous f32 elementwise ops over the barrier pool (prefill 8% gain)

### DIFF
--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -10,6 +10,7 @@ mod utils;
 pub use utils::{
     binary_map, binary_map_vec, unary_map, unary_map_vec, Map1, Map1Any, Map2, Map2InPlace, Map2U8,
 };
+use utils::{par_binary_vec_f32, par_unary_vec_f32};
 mod conv2d;
 use conv2d::Conv2D;
 
@@ -2472,7 +2473,10 @@ impl BackendStorage for CpuStorage {
                 Ok(Self::F16(data))
             }
             Self::F32(storage) => {
-                let data = unary_map_vec(storage, layout, B::f32, B::f32_vec);
+                let data = match par_unary_vec_f32(storage, layout, B::f32_vec) {
+                    Some(d) => d,
+                    None => unary_map_vec(storage, layout, B::f32, B::f32_vec),
+                };
                 Ok(Self::F32(data))
             }
             Self::F64(storage) => {
@@ -2542,15 +2546,18 @@ impl BackendStorage for CpuStorage {
                 Ok(Self::F16(data))
             }
             (Self::F32(lhs), Self::F32(rhs)) => {
-                let data = binary_map_vec(
-                    lhs_l,
-                    rhs_l,
-                    lhs,
-                    rhs,
-                    B::f32,
-                    B::f32_vec,
-                    B::f32_scalar_vec,
-                );
+                let data = match par_binary_vec_f32(lhs, rhs, lhs_l, rhs_l, B::f32_vec) {
+                    Some(d) => d,
+                    None => binary_map_vec(
+                        lhs_l,
+                        rhs_l,
+                        lhs,
+                        rhs,
+                        B::f32,
+                        B::f32_vec,
+                        B::f32_scalar_vec,
+                    ),
+                };
                 Ok(Self::F32(data))
             }
             (Self::F64(lhs), Self::F64(rhs)) => {

--- a/candle-core/src/cpu_backend/utils.rs
+++ b/candle-core/src/cpu_backend/utils.rs
@@ -2,8 +2,101 @@
 use crate::backend::BackendStorage;
 use crate::nditer::NdIter;
 use crate::{Error, Layout, Result, WithDType};
+use std::sync::LazyLock;
 
 type C = super::CpuStorage;
+
+// Parallelize large CONTIGUOUS elementwise ops (residual adds, SwiGLU mul, SiLU,
+// scaling) across the barrier pool. candle's `binary_map`/`unary_map` are serial
+// for-loops; at high thread counts they become an Amdahl drag on prefill (the
+// matmuls scale ~Nx but these don't). This threads only the contiguous f32 case at
+// the op-dispatch point - each output range is independent so it is bit-identical
+// to the serial path. Default ON; CANDLE_PAR_ELEMWISE=0 forces serial (A/B knob).
+static PAR_ELEMWISE: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("CANDLE_PAR_ELEMWISE")
+        .map(|s| s != "0")
+        .unwrap_or(true)
+});
+// Below this element count the per-op pool fork-join isn't worth it (tiny tensors:
+// norm scales, biases). Tunable via CANDLE_PAR_ELEMWISE_MIN.
+static PAR_ELEMWISE_MIN: LazyLock<usize> = LazyLock::new(|| {
+    std::env::var("CANDLE_PAR_ELEMWISE_MIN")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(16_384)
+});
+
+/// Parallel contiguous f32 UNARY op: `out[i] = f_vec(src)[i]` over the contiguous
+/// region `layout` views, split across the barrier pool. Returns `None` (caller
+/// falls back to the serial path) unless enabled, large enough, and contiguous.
+/// `f_vec` is a pure elementwise vectorized fn, so per-range application is exact.
+pub(crate) fn par_unary_vec_f32(
+    storage: &[f32],
+    layout: &Layout,
+    f_vec: fn(&[f32], &mut [f32]),
+) -> Option<Vec<f32>> {
+    if !*PAR_ELEMWISE {
+        return None;
+    }
+    let (start, end) = layout.contiguous_offsets()?;
+    let len = end - start;
+    if len < *PAR_ELEMWISE_MIN {
+        return None;
+    }
+    let src = &storage[start..end];
+    let mut out = vec![0f32; len];
+    par_range_apply(len, out.as_mut_ptr(), |s, e, dst| f_vec(&src[s..e], dst));
+    Some(out)
+}
+
+/// Parallel contiguous f32 BINARY op for the no-broadcast same-shape case (residual
+/// add, SwiGLU mul). Returns `None` (serial fallback) unless enabled, large, and
+/// both operands contiguous with equal length.
+pub(crate) fn par_binary_vec_f32(
+    lhs: &[f32],
+    rhs: &[f32],
+    lhs_l: &Layout,
+    rhs_l: &Layout,
+    f_vec: fn(&[f32], &[f32], &mut [f32]),
+) -> Option<Vec<f32>> {
+    if !*PAR_ELEMWISE {
+        return None;
+    }
+    let (ls, le) = lhs_l.contiguous_offsets()?;
+    let (rs, re) = rhs_l.contiguous_offsets()?;
+    let len = le - ls;
+    if len != re - rs || len < *PAR_ELEMWISE_MIN {
+        return None;
+    }
+    let l = &lhs[ls..le];
+    let r = &rhs[rs..re];
+    let mut out = vec![0f32; len];
+    par_range_apply(len, out.as_mut_ptr(), |s, e, dst| {
+        f_vec(&l[s..e], &r[s..e], dst)
+    });
+    Some(out)
+}
+
+/// Split `0..len` into one contiguous range per pool worker (+ main) and run
+/// `f(start, end, &mut out[start..end])` on each. `out_ptr` must point to `len`
+/// writable f32. The ranges are disjoint so the raw-pointer writes are sound.
+fn par_range_apply(len: usize, out_ptr: *mut f32, f: impl Fn(usize, usize, &mut [f32]) + Sync) {
+    struct P(*mut f32);
+    unsafe impl Sync for P {}
+    let op = P(out_ptr);
+    let pool = crate::utils::barrier_pool();
+    let n_total = pool.n_workers() + 1;
+    let per = len.div_ceil(n_total);
+    pool.execute(|tid| {
+        let p = &op;
+        let s = tid * per;
+        if s < len {
+            let e = len.min((tid + 1) * per);
+            let dst = unsafe { std::slice::from_raw_parts_mut(p.0.add(s), e - s) };
+            f(s, e, dst);
+        }
+    });
+}
 pub trait Map1 {
     fn f<T: WithDType>(&self, vs: &[T], layout: &Layout) -> Result<Vec<T>>;
 
@@ -359,5 +452,60 @@ pub fn unary_map_vec<T: Copy, U: Copy, F: FnMut(T) -> U, FV: FnMut(&[T], &mut [U
                 ys
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod par_elemwise_tests {
+    use super::*;
+    use crate::Shape;
+
+    // Parallel split MUST be byte-identical to applying f_vec over the whole range
+    // (each output element is independent). Large enough to exceed PAR_ELEMWISE_MIN.
+    #[test]
+    fn par_unary_matches_serial() {
+        let n = 100_003usize; // not a multiple of typical worker counts (remainder)
+        let src: Vec<f32> = (0..n).map(|i| (i as f32 * 0.001).sin()).collect();
+        let layout = Layout::contiguous(Shape::from_dims(&[n]));
+        fn fv(s: &[f32], d: &mut [f32]) {
+            for i in 0..s.len() {
+                d[i] = s[i] * s[i] - 0.5; // silu-like nonlinearity stand-in
+            }
+        }
+        let par = par_unary_vec_f32(&src, &layout, fv).expect("should parallelize");
+        let mut serial = vec![0f32; n];
+        fv(&src, &mut serial);
+        assert_eq!(par, serial);
+    }
+
+    #[test]
+    fn par_binary_matches_serial() {
+        let n = 100_003usize;
+        let a: Vec<f32> = (0..n).map(|i| i as f32 * 0.1).collect();
+        let b: Vec<f32> = (0..n).map(|i| (i as f32).cos()).collect();
+        let la = Layout::contiguous(Shape::from_dims(&[n]));
+        let lb = Layout::contiguous(Shape::from_dims(&[n]));
+        fn fv(x: &[f32], y: &[f32], d: &mut [f32]) {
+            for i in 0..x.len() {
+                d[i] = x[i] * y[i] + 1.0;
+            }
+        }
+        let par = par_binary_vec_f32(&a, &b, &la, &lb, fv).expect("should parallelize");
+        let mut serial = vec![0f32; n];
+        fv(&a, &b, &mut serial);
+        assert_eq!(par, serial);
+    }
+
+    // Below the threshold (and for non-contiguous layouts) it must fall back to
+    // serial (returns None) so tiny ops don't pay fork-join overhead.
+    #[test]
+    fn par_below_threshold_falls_back() {
+        let n = 100usize;
+        let src = vec![1f32; n];
+        let layout = Layout::contiguous(Shape::from_dims(&[n]));
+        fn fv(s: &[f32], d: &mut [f32]) {
+            d[..s.len()].copy_from_slice(s);
+        }
+        assert!(par_unary_vec_f32(&src, &layout, fv).is_none());
     }
 }

--- a/candle-core/src/cpu_backend/utils.rs
+++ b/candle-core/src/cpu_backend/utils.rs
@@ -452,18 +452,19 @@ mod par_elemwise_tests {
     use super::*;
     use crate::Shape;
 
-    // Parallel split must be byte-identical to the serial whole-range apply.
+    // Parallel split must be byte-identical to the serial whole-range apply. Drives
+    // par_range_apply directly so it runs regardless of the CANDLE_PAR_ELEMWISE gate.
     #[test]
     fn par_unary_matches_serial() {
         let n = 100_003usize; // not a multiple of typical worker counts (remainder)
         let src: Vec<f32> = (0..n).map(|i| (i as f32 * 0.001).sin()).collect();
-        let layout = Layout::contiguous(Shape::from_dims(&[n]));
         fn fv(s: &[f32], d: &mut [f32]) {
             for i in 0..s.len() {
                 d[i] = s[i] * s[i] - 0.5; // silu-like nonlinearity stand-in
             }
         }
-        let par = par_unary_vec_f32(&src, &layout, fv).expect("should parallelize");
+        let mut par = vec![0f32; n];
+        par_range_apply(n, par.as_mut_ptr(), |s, e, dst| fv(&src[s..e], dst));
         let mut serial = vec![0f32; n];
         fv(&src, &mut serial);
         assert_eq!(par, serial);
@@ -474,14 +475,13 @@ mod par_elemwise_tests {
         let n = 100_003usize;
         let a: Vec<f32> = (0..n).map(|i| i as f32 * 0.1).collect();
         let b: Vec<f32> = (0..n).map(|i| (i as f32).cos()).collect();
-        let la = Layout::contiguous(Shape::from_dims(&[n]));
-        let lb = Layout::contiguous(Shape::from_dims(&[n]));
         fn fv(x: &[f32], y: &[f32], d: &mut [f32]) {
             for i in 0..x.len() {
                 d[i] = x[i] * y[i] + 1.0;
             }
         }
-        let par = par_binary_vec_f32(&a, &b, &la, &lb, fv).expect("should parallelize");
+        let mut par = vec![0f32; n];
+        par_range_apply(n, par.as_mut_ptr(), |s, e, dst| fv(&a[s..e], &b[s..e], dst));
         let mut serial = vec![0f32; n];
         fv(&a, &b, &mut serial);
         assert_eq!(par, serial);

--- a/candle-core/src/cpu_backend/utils.rs
+++ b/candle-core/src/cpu_backend/utils.rs
@@ -6,19 +6,15 @@ use std::sync::LazyLock;
 
 type C = super::CpuStorage;
 
-// Parallelize large CONTIGUOUS elementwise ops (residual adds, SwiGLU mul, SiLU,
-// scaling) across the barrier pool. candle's `binary_map`/`unary_map` are serial
-// for-loops; at high thread counts they become an Amdahl drag on prefill (the
-// matmuls scale ~Nx but these don't). This threads only the contiguous f32 case at
-// the op-dispatch point - each output range is independent so it is bit-identical
-// to the serial path. Default ON; CANDLE_PAR_ELEMWISE=0 forces serial (A/B knob).
+// Parallelize large contiguous f32 elementwise ops across the barrier pool; serial
+// unary_map/binary_map are an Amdahl drag at high thread counts. Bit-identical to
+// serial (disjoint ranges). Default ON; CANDLE_PAR_ELEMWISE=0 forces serial.
 static PAR_ELEMWISE: LazyLock<bool> = LazyLock::new(|| {
     std::env::var("CANDLE_PAR_ELEMWISE")
         .map(|s| s != "0")
         .unwrap_or(true)
 });
-// Below this element count the per-op pool fork-join isn't worth it (tiny tensors:
-// norm scales, biases). Tunable via CANDLE_PAR_ELEMWISE_MIN.
+// Below this element count the fork-join isn't worth it. Tunable via CANDLE_PAR_ELEMWISE_MIN.
 static PAR_ELEMWISE_MIN: LazyLock<usize> = LazyLock::new(|| {
     std::env::var("CANDLE_PAR_ELEMWISE_MIN")
         .ok()
@@ -26,10 +22,8 @@ static PAR_ELEMWISE_MIN: LazyLock<usize> = LazyLock::new(|| {
         .unwrap_or(16_384)
 });
 
-/// Parallel contiguous f32 UNARY op: `out[i] = f_vec(src)[i]` over the contiguous
-/// region `layout` views, split across the barrier pool. Returns `None` (caller
-/// falls back to the serial path) unless enabled, large enough, and contiguous.
-/// `f_vec` is a pure elementwise vectorized fn, so per-range application is exact.
+// Parallel contiguous f32 unary op; None (serial fallback) unless enabled, large
+// enough, and contiguous.
 pub(crate) fn par_unary_vec_f32(
     storage: &[f32],
     layout: &Layout,
@@ -49,9 +43,8 @@ pub(crate) fn par_unary_vec_f32(
     Some(out)
 }
 
-/// Parallel contiguous f32 BINARY op for the no-broadcast same-shape case (residual
-/// add, SwiGLU mul). Returns `None` (serial fallback) unless enabled, large, and
-/// both operands contiguous with equal length.
+// Parallel contiguous f32 binary op, no-broadcast same-shape case; None unless
+// enabled, large, and both operands contiguous with equal length.
 pub(crate) fn par_binary_vec_f32(
     lhs: &[f32],
     rhs: &[f32],
@@ -77,9 +70,8 @@ pub(crate) fn par_binary_vec_f32(
     Some(out)
 }
 
-/// Split `0..len` into one contiguous range per pool worker (+ main) and run
-/// `f(start, end, &mut out[start..end])` on each. `out_ptr` must point to `len`
-/// writable f32. The ranges are disjoint so the raw-pointer writes are sound.
+// Split 0..len into one disjoint contiguous range per worker (+ main) and run f on
+// each. out_ptr must point to len writable f32; disjoint ranges keep the writes sound.
 fn par_range_apply(len: usize, out_ptr: *mut f32, f: impl Fn(usize, usize, &mut [f32]) + Sync) {
     struct P(*mut f32);
     unsafe impl Sync for P {}
@@ -460,8 +452,7 @@ mod par_elemwise_tests {
     use super::*;
     use crate::Shape;
 
-    // Parallel split MUST be byte-identical to applying f_vec over the whole range
-    // (each output element is independent). Large enough to exceed PAR_ELEMWISE_MIN.
+    // Parallel split must be byte-identical to the serial whole-range apply.
     #[test]
     fn par_unary_matches_serial() {
         let n = 100_003usize; // not a multiple of typical worker counts (remainder)

--- a/candle-core/src/utils.rs
+++ b/candle-core/src/utils.rs
@@ -128,6 +128,9 @@ impl BarrierPool {
                     .name(format!("candle-bp-{tid}"))
                     .spawn(move || {
                         set_thread_affinity();
+                        // A worker only ever runs dispatched closures, so any execute()
+                        // it reaches is nested; keep the flag set for its whole life.
+                        IN_EXECUTE.with(|c| c.set(true));
                         let inner = unsafe { &*(inner_ptr as *const BarrierPoolInner) };
                         let slot = &inner.slots[tid];
                         let mut gen = 0usize;
@@ -241,6 +244,20 @@ impl Drop for BarrierGuard<'_> {
     }
 }
 
+thread_local! {
+    // True while this thread is inside execute() (main) or running a dispatched
+    // closure (worker). Used to route a reentrant execute() to the serial path.
+    static IN_EXECUTE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+// Resets the main thread's IN_EXECUTE flag on scope exit (panic-safe).
+struct ExecGuard;
+impl Drop for ExecGuard {
+    fn drop(&mut self) {
+        IN_EXECUTE.with(|c| c.set(false));
+    }
+}
+
 impl BarrierPool {
     pub fn execute<F: Fn(usize) + Sync>(&self, f: F) {
         let n = self.threads.len();
@@ -248,6 +265,18 @@ impl BarrierPool {
             f(0);
             return;
         }
+
+        // Reentrant call (e.g. a Tensor op inside a pool closure): acquiring
+        // call_lock again would deadlock against the outer call, so run every
+        // participant serially on this thread instead.
+        if IN_EXECUTE.with(|c| c.get()) {
+            for tid in 0..=n {
+                f(tid);
+            }
+            return;
+        }
+        IN_EXECUTE.with(|c| c.set(true));
+        let _exec = ExecGuard;
 
         let mut guard = self.call_lock.lock().unwrap();
         let new_gen = guard.wrapping_add(1);
@@ -421,4 +450,27 @@ pub fn with_simd128() -> bool {
 
 pub fn with_f16c() -> bool {
     cfg!(target_feature = "f16c")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // A reentrant execute() (a pool closure that calls execute() again) must not
+    // deadlock and must still run every nested participant.
+    #[test]
+    fn nested_execute_runs_serially_no_deadlock() {
+        let pool = barrier_pool();
+        let n_total = pool.n_workers() + 1;
+        let count = AtomicUsize::new(0);
+        pool.execute(|_outer| {
+            pool.execute(|_inner| {
+                count.fetch_add(1, Ordering::Relaxed);
+            });
+        });
+        // Each of the n_total outer participants runs an inner execute that, being
+        // reentrant, does all n_total participants serially.
+        assert_eq!(count.load(Ordering::Relaxed), n_total * n_total);
+    }
 }


### PR DESCRIPTION
candle's unary_map and binary_map run as serial for-loops, so they become an Amdahl drag once you push the CPU thread count up. The matmuls scale roughly Nx with threads, but the elementwise ops (residual adds, SwiGLU mul, SiLU, scaling) stay flat and start to dominate. This change adds a parallel fast path for the contiguous f32 case at the op-dispatch point. It splits the work into disjoint per-worker ranges over the barrier pool we already have. Each output range is independent, so the result is bit-identical to the serial path.

It's on by default. Set CANDLE_PAR_ELEMWISE=0 to force the serial path when you want a same-binary A/B. CANDLE_PAR_ELEMWISE_MIN (default 16384 elements) skips tensors small enough that the fork-join overhead isn't worth it.

One wrinkle worth noting: par_chunks_mut needs U: Send, and BarrierPool::execute detects reentrancy and falls back to a serial run, so a nested elementwise op inside a pool closure can't deadlock.

Measured about 8.6% faster prefill at 6 vCPU on Graviton2 / Neoverse-N1.