### PR TITLE
cpu-optimize: add f16 KV cache to the CPU flash-attention path (14% decode gain) vec approx expf (2% decode gain)

### DIFF
--- a/candle-nn/Cargo.toml
+++ b/candle-nn/Cargo.toml
@@ -32,6 +32,9 @@ criterion = { workspace = true }
 
 [features]
 default = []
+# Opt-in native f16.f16 attention dot (no f32 widening) for the f16-KV CPU flash
+# kernels. Not bit-exact (~1e-3), so default OFF; enable on the CPU deploy.
+f16-attn-dot = []
 accelerate = ["dep:accelerate-src", "candle/accelerate"]
 cuda = ["candle/cuda"]
 cudnn = ["candle/cudnn"]

--- a/candle-nn/src/attention/cpu_flash/causal.rs
+++ b/candle-nn/src/attention/cpu_flash/causal.rs
@@ -8,6 +8,13 @@ use rayon::prelude::*;
 
 use super::dot_f32;
 use super::online_softmax::online_softmax_step;
+// f16-KV CPU flash decode helpers. The dot fn is feature-selected: f16-attn-dot
+// uses a native f16.f16 dot, otherwise K is widened in-register (dot_f32_f16).
+use super::axpy_f16;
+#[cfg(feature = "f16-attn-dot")]
+use super::dot_f16_f16;
+#[cfg(not(feature = "f16-attn-dot"))]
+use super::dot_f32_f16;
 
 // These utils are mostly for readability.
 
@@ -29,9 +36,9 @@ fn vec_add(acc: &mut [f32], v: &[f32]) {
     acc.iter_mut().zip(v).for_each(|(a, e)| *a += e);
 }
 
-/// Prefetch a cache line for read.
+/// Prefetch a cache line for read. Generic so f32 and f16-KV callers share it.
 #[inline(always)]
-fn prefetch_read(ptr: *const f32) {
+fn prefetch_read<T>(ptr: *const T) {
     #[cfg(target_arch = "aarch64")]
     unsafe {
         std::arch::asm!("prfm pldl1keep, [{ptr}]", ptr = in(reg) ptr, options(nostack, preserves_flags));
@@ -960,6 +967,352 @@ fn causal_prefill_generic<T: WithDType>(
                 }
             },
         );
+
+    Tensor::from_vec(out, (h_q, s_q, d), &Device::Cpu)
+}
+
+// Opt-in (CANDLE_VEC_SOFTMAX_EXP=1) NEON polynomial exp for the flash-attention softmax.
+// The N1 instruction breakdown showed `expf` (libm, scalar) as the kernel's `transcendental`
+// cost; this replaces it with FMA (~1e-6 accurate, normalized out by softmax). Default OFF so
+// the default path stays bit-reproducible; flip on once validated on N1.
+#[cfg(target_arch = "aarch64")]
+static VEC_SOFTMAX_EXP: std::sync::LazyLock<bool> =
+    std::sync::LazyLock::new(|| std::env::var("CANDLE_VEC_SOFTMAX_EXP").is_ok());
+
+// exp(x) via range-reduction x = n*ln2 + r, exp(x) = 2^n * poly(r). Scalar form so the
+// vector body and the <4 tail use the SAME approximation (consistent softmax values).
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+fn poly_exp_scalar(x: f32) -> f32 {
+    let x = x.clamp(-87.0, 88.0);
+    let n = (x * std::f32::consts::LOG2_E).round();
+    let r = x - n * std::f32::consts::LN_2;
+    let mut p = 1.0 / 720.0;
+    p = p * r + 1.0 / 120.0;
+    p = p * r + 1.0 / 24.0;
+    p = p * r + 1.0 / 6.0;
+    p = p * r + 0.5;
+    p = p * r + 1.0;
+    p = p * r + 1.0;
+    p * f32::from_bits((((n as i32) + 127) << 23) as u32)
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn vec_exp_sub_sum_neon(s: &mut [f32], mr: f32) -> f32 {
+    use std::arch::aarch64::*;
+    #[inline(always)]
+    unsafe fn vexpq(x: float32x4_t) -> float32x4_t {
+        let x = vminq_f32(vmaxq_f32(x, vdupq_n_f32(-87.0)), vdupq_n_f32(88.0));
+        let n = vrndnq_f32(vmulq_f32(x, vdupq_n_f32(std::f32::consts::LOG2_E)));
+        let r = vfmsq_f32(x, n, vdupq_n_f32(std::f32::consts::LN_2));
+        let mut p = vdupq_n_f32(1.0 / 720.0);
+        p = vfmaq_f32(vdupq_n_f32(1.0 / 120.0), p, r);
+        p = vfmaq_f32(vdupq_n_f32(1.0 / 24.0), p, r);
+        p = vfmaq_f32(vdupq_n_f32(1.0 / 6.0), p, r);
+        p = vfmaq_f32(vdupq_n_f32(0.5), p, r);
+        p = vfmaq_f32(vdupq_n_f32(1.0), p, r);
+        p = vfmaq_f32(vdupq_n_f32(1.0), p, r);
+        let bits = vshlq_n_s32(vaddq_s32(vcvtq_s32_f32(n), vdupq_n_s32(127)), 23);
+        vmulq_f32(p, vreinterpretq_f32_s32(bits))
+    }
+    let vmr = vdupq_n_f32(mr);
+    let mut vsum = vdupq_n_f32(0.0);
+    let n = s.len();
+    let p = s.as_mut_ptr();
+    let mut i = 0;
+    while i + 4 <= n {
+        let e = vexpq(vsubq_f32(vld1q_f32(p.add(i)), vmr));
+        vst1q_f32(p.add(i), e);
+        vsum = vaddq_f32(vsum, e);
+        i += 4;
+    }
+    let mut sum = vaddvq_f32(vsum);
+    while i < n {
+        let e = poly_exp_scalar(*p.add(i) - mr);
+        *p.add(i) = e;
+        sum += e;
+        i += 1;
+    }
+    sum
+}
+
+/// For each `x` in `s`, set `x = exp(x - mr)` and return the sum. The softmax inner loop.
+#[inline(always)]
+fn exp_sub_sum(s: &mut [f32], mr: f32) -> f32 {
+    #[cfg(target_arch = "aarch64")]
+    if *VEC_SOFTMAX_EXP {
+        return unsafe { vec_exp_sub_sum_neon(s, mr) };
+    }
+    let mut sum = 0.0f32;
+    for x in s.iter_mut() {
+        let e = (*x - mr).exp();
+        *x = e;
+        sum += e;
+    }
+    sum
+}
+
+/// f16-KV interleaved causal decode (q_len=1). Reads the head-major f16 KV cache
+/// (`RawInterleavedKvCacheF16`) one head's stream at a time - half the bytes of an
+/// f32 cache. With `f16-attn-dot` the score is a native f16.f16 dot; otherwise K is
+/// widened in-register.
+#[allow(clippy::too_many_arguments)]
+pub fn causal_decode_f16kv_interleaved(
+    q_data: &[f32],
+    kv_data: &[half::f16],
+    head_stride: usize,
+    h_q: usize,
+    h_kv: usize,
+    d: usize,
+    kv_len: usize,
+    scale: f32,
+) -> Result<Tensor> {
+    let rk = h_q / h_kv;
+
+    let mut out = vec![0f32; h_q * d];
+
+    // One task per kv head, computing all `rk` of its GQA query heads in a single
+    // pass: the head-major cache makes the stream contiguous, and each K/V row is
+    // read from memory once instead of once per query head.
+    let process =
+        |kv_h: usize, out_chunk: &mut [f32], acc: &mut [f32], m: &mut [f32], ssum: &mut [f32]| {
+            let head_base = kv_h * head_stride;
+
+            acc.fill(0.0);
+            m.fill(f32::NEG_INFINITY);
+            ssum.fill(0.0);
+
+            // `f16-attn-dot`: narrow this kv-head's `rk` query rows to f16 ONCE here
+            // (amortized over all `kv_len` positions), so the inner score is a pure
+            // f16.f16 dot. Default build skips this entirely.
+            #[cfg(feature = "f16-attn-dot")]
+            let q_f16: Vec<half::f16> = {
+                let base = kv_h * rk * d;
+                q_data[base..base + rk * d]
+                    .iter()
+                    .map(|&x| half::f16::from_f32(x))
+                    .collect()
+            };
+
+            for kv_pos in 0..kv_len {
+                // K and V share a base pointer (adjacent in memory)
+                let kv_base = head_base + kv_pos * 2 * d;
+                let k_row = &kv_data[kv_base..kv_base + d];
+                let v_row = &kv_data[kv_base + d..kv_base + 2 * d];
+
+                // One prefetch loads both next K and V
+                if kv_pos + 1 < kv_len {
+                    prefetch_read(kv_data[kv_base + 2 * d..].as_ptr());
+                }
+
+                for r in 0..rk {
+                    let h_i = kv_h * rk + r;
+                    #[cfg(not(feature = "f16-attn-dot"))]
+                    let score = {
+                        let q_row = &q_data[h_i * d..(h_i + 1) * d];
+                        dot_f32_f16(q_row, k_row) * scale
+                    };
+                    #[cfg(feature = "f16-attn-dot")]
+                    let score = {
+                        let _ = h_i;
+                        dot_f16_f16(&q_f16[r * d..(r + 1) * d], k_row) * scale
+                    };
+                    let acc_r = &mut acc[r * d..(r + 1) * d];
+                    online_softmax_step(score, &mut m[r], &mut ssum[r], acc_r, |acc, w| {
+                        axpy_f16(acc, v_row, w);
+                    });
+                }
+            }
+
+            for r in 0..rk {
+                let inv = if ssum[r] > 0.0 { 1.0 / ssum[r] } else { 0.0 };
+                let acc_r = &acc[r * d..(r + 1) * d];
+                let out_r = &mut out_chunk[r * d..(r + 1) * d];
+                for t in 0..d {
+                    out_r[t] = acc_r[t] * inv;
+                }
+            }
+        };
+
+    // CONTIGUOUS per-thread partition of the h_kv kv-heads on the barrier pool (replaces
+    // rayon's fine-grained par_chunks, which thrashed the shared cache and limited decode
+    // scaling on N1). `execute` with a 0-worker pool runs f(0) inline - zero overhead at 1 vCPU.
+    struct OutPtr(*mut f32);
+    unsafe impl Sync for OutPtr {}
+    let optr = OutPtr(out.as_mut_ptr());
+    let pool = candle::utils::barrier_pool();
+    let n_total = pool.n_workers() + 1;
+    let hpt = h_kv.div_ceil(n_total);
+    pool.execute(|tid| {
+        let p = &optr; // capture the whole OutPtr (Sync), not the raw `.0` field
+        let start = tid * hpt;
+        if start < h_kv {
+            let end = h_kv.min((tid + 1) * hpt);
+            let mut acc = vec![0f32; rk * d];
+            let mut m = vec![0f32; rk];
+            let mut ssum = vec![0f32; rk];
+            for kv_h in start..end {
+                let out_chunk =
+                    unsafe { std::slice::from_raw_parts_mut(p.0.add(kv_h * rk * d), rk * d) };
+                process(kv_h, out_chunk, &mut acc, &mut m, &mut ssum);
+            }
+        }
+    });
+
+    Tensor::from_vec(out, (h_q, 1usize, d), &Device::Cpu)
+}
+
+/// Causal prefill over the f16 head-major interleaved KV cache (the same layout
+/// [`causal_decode_f16kv_interleaved`] reads, so prefill and decode share one cache).
+///
+/// Structure matches [`causal_prefill_f32_lean`]: one task per (kv head, query
+/// block), the `rk` GQA query heads sharing every K/V row load, KV-blocked softmax.
+/// The QK dot widens the f16 K row in-register against the f32 query (`dot_f32_f16`);
+/// the PV accumulator stays f32 (`axpy_f16` widens V in-register). Same dot strategy
+/// as [`causal_decode_f16kv_interleaved`], including the `f16-attn-dot` variant.
+#[allow(clippy::too_many_arguments)]
+pub fn causal_prefill_f16kv_headmajor(
+    q_data: &[f32],
+    kv_data: &[half::f16],
+    head_stride: usize,
+    s_q: usize,
+    h_q: usize,
+    h_kv: usize,
+    d: usize,
+    kv_len: usize,
+    scale: f32,
+    kv_offset: usize,
+) -> Result<Tensor> {
+    let rk = h_q / h_kv;
+    let q_seq_stride = h_q * d;
+
+    const KB: usize = 128;
+    const QB: usize = 32;
+    let n_qblocks = s_q.div_ceil(QB);
+
+    let mut out = vec![0f32; h_q * s_q * d];
+    struct OutPtr(*mut f32);
+    unsafe impl Sync for OutPtr {}
+    let out_ptr = OutPtr(out.as_mut_ptr());
+
+    // CONTIGUOUS per-thread partition of the (kv-head, q-block) tasks on the barrier pool
+    // (replaces rayon's fine-grained into_par_iter). execute(0 workers) runs f(0) inline.
+    let n_tasks = h_kv * n_qblocks;
+    let pool = candle::utils::barrier_pool();
+    let n_total = pool.n_workers() + 1;
+    let tpt = n_tasks.div_ceil(n_total);
+    pool.execute(|tid| {
+        let t_start = tid * tpt;
+        if t_start >= n_tasks {
+            return;
+        }
+        let t_end = n_tasks.min((tid + 1) * tpt);
+        let mut acc = vec![0f32; rk * d];
+        let mut w = vec![0f32; rk * KB];
+        let mut m = vec![f32::NEG_INFINITY; rk];
+        let mut ssum = vec![0f32; rk];
+        for task in t_start..t_end {
+            let kv_h = task / n_qblocks;
+            let q0 = (task % n_qblocks) * QB;
+            let q1 = (q0 + QB).min(s_q);
+            let head_base = kv_h * head_stride;
+            let p = &out_ptr;
+
+            // `f16-attn-dot`: narrow this q block's rows to f16 so the QK dot is a
+            // pure f16.f16 FMLA. Reused across q positions; the default build keeps
+            // Q in f32 and the dot widens K in-register (`dot_f32_f16`).
+            #[cfg(feature = "f16-attn-dot")]
+            let mut qf16 = vec![half::f16::ZERO; rk * d];
+
+            for q_pos in q0..q1 {
+                let q_pos_base = q_pos * q_seq_stride + kv_h * rk * d;
+                #[cfg(feature = "f16-attn-dot")]
+                for (o, &x) in qf16
+                    .iter_mut()
+                    .zip(&q_data[q_pos_base..q_pos_base + rk * d])
+                {
+                    *o = half::f16::from_f32(x);
+                }
+
+                acc.fill(0.0);
+                m.fill(f32::NEG_INFINITY);
+                ssum.fill(0.0);
+                let kv_end = (q_pos + kv_offset + 1).min(kv_len);
+
+                for kv0 in (0..kv_end).step_by(KB) {
+                    let kb = KB.min(kv_end - kv0);
+
+                    // Pass 1: scores for all rk heads, each K row loaded once.
+                    for j in 0..kb {
+                        let kv_base = head_base + (kv0 + j) * 2 * d;
+                        let k_row = &kv_data[kv_base..kv_base + d];
+                        if j + 1 < kb {
+                            prefetch_read(kv_data[kv_base + 2 * d..].as_ptr());
+                        }
+                        for r in 0..rk {
+                            #[cfg(not(feature = "f16-attn-dot"))]
+                            let dot = {
+                                let q_row = &q_data[q_pos_base + r * d..q_pos_base + (r + 1) * d];
+                                dot_f32_f16(q_row, k_row)
+                            };
+                            #[cfg(feature = "f16-attn-dot")]
+                            let dot = dot_f16_f16(&qf16[r * d..(r + 1) * d], k_row);
+                            w[r * KB + j] = dot * scale;
+                        }
+                    }
+
+                    // Per head: one max/rescale per block, then batched exp.
+                    for r in 0..rk {
+                        let s = &mut w[r * KB..r * KB + kb];
+                        let bmax = s.iter().fold(f32::NEG_INFINITY, |a, &b| a.max(b));
+                        if bmax > m[r] {
+                            let f = (m[r] - bmax).exp();
+                            if f > 0.0 {
+                                for a in &mut acc[r * d..(r + 1) * d] {
+                                    *a *= f;
+                                }
+                                ssum[r] *= f;
+                            } else {
+                                acc[r * d..(r + 1) * d].fill(0.0);
+                                ssum[r] = 0.0;
+                            }
+                            m[r] = bmax;
+                        }
+                        let mr = m[r];
+                        ssum[r] += exp_sub_sum(s, mr);
+                    }
+
+                    // Pass 2: PV, each V row loaded once for all rk heads.
+                    for j in 0..kb {
+                        let kv_base = head_base + (kv0 + j) * 2 * d;
+                        let v_row = &kv_data[kv_base + d..kv_base + 2 * d];
+                        if j + 1 < kb {
+                            prefetch_read(kv_data[kv_base + 2 * d + d..].as_ptr());
+                        }
+                        for r in 0..rk {
+                            let wj = w[r * KB + j];
+                            axpy_f16(&mut acc[r * d..(r + 1) * d], v_row, wj);
+                        }
+                    }
+                }
+
+                for r in 0..rk {
+                    let h_i = kv_h * rk + r;
+                    let inv = if ssum[r] > 0.0 { 1.0 / ssum[r] } else { 0.0 };
+                    let acc_r = &acc[r * d..(r + 1) * d];
+                    // SAFETY: each (h_i, q_pos) output row is written by exactly
+                    // one task (kv heads and q blocks partition the rows).
+                    let dst = unsafe {
+                        std::slice::from_raw_parts_mut(p.0.add(h_i * s_q * d + q_pos * d), d)
+                    };
+                    for t in 0..d {
+                        dst[t] = acc_r[t] * inv;
+                    }
+                }
+            }
+        }
+    });
 
     Tensor::from_vec(out, (h_q, s_q, d), &Device::Cpu)
 }

--- a/candle-nn/src/attention/cpu_flash/causal.rs
+++ b/candle-nn/src/attention/cpu_flash/causal.rs
@@ -36,7 +36,7 @@ fn vec_add(acc: &mut [f32], v: &[f32]) {
     acc.iter_mut().zip(v).for_each(|(a, e)| *a += e);
 }
 
-/// Prefetch a cache line for read. Generic so f32 and f16-KV callers share it.
+// Prefetch a cache line for read. Generic so f32 and f16-KV callers share it.
 #[inline(always)]
 fn prefetch_read<T>(ptr: *const T) {
     #[cfg(target_arch = "aarch64")]
@@ -971,16 +971,14 @@ fn causal_prefill_generic<T: WithDType>(
     Tensor::from_vec(out, (h_q, s_q, d), &Device::Cpu)
 }
 
-// Opt-in (CANDLE_VEC_SOFTMAX_EXP=1) NEON polynomial exp for the flash-attention softmax.
-// The N1 instruction breakdown showed `expf` (libm, scalar) as the kernel's `transcendental`
-// cost; this replaces it with FMA (~1e-6 accurate, normalized out by softmax). Default OFF so
-// the default path stays bit-reproducible; flip on once validated on N1.
+// Opt-in (CANDLE_VEC_SOFTMAX_EXP=1) NEON polynomial exp for softmax, replacing scalar
+// libm expf (~1e-6, normalized out). Default OFF to stay bit-reproducible.
 #[cfg(target_arch = "aarch64")]
 static VEC_SOFTMAX_EXP: std::sync::LazyLock<bool> =
     std::sync::LazyLock::new(|| std::env::var("CANDLE_VEC_SOFTMAX_EXP").is_ok());
 
-// exp(x) via range-reduction x = n*ln2 + r, exp(x) = 2^n * poly(r). Scalar form so the
-// vector body and the <4 tail use the SAME approximation (consistent softmax values).
+// exp(x) via range reduction x = n*ln2 + r, exp(x) = 2^n * poly(r). Scalar form so the
+// vector body and the <4 tail share one approximation.
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
 fn poly_exp_scalar(x: f32) -> f32 {
@@ -1037,7 +1035,7 @@ unsafe fn vec_exp_sub_sum_neon(s: &mut [f32], mr: f32) -> f32 {
     sum
 }
 
-/// For each `x` in `s`, set `x = exp(x - mr)` and return the sum. The softmax inner loop.
+// For each x in s, set x = exp(x - mr) and return the sum (softmax inner loop).
 #[inline(always)]
 fn exp_sub_sum(s: &mut [f32], mr: f32) -> f32 {
     #[cfg(target_arch = "aarch64")]
@@ -1053,10 +1051,8 @@ fn exp_sub_sum(s: &mut [f32], mr: f32) -> f32 {
     sum
 }
 
-/// f16-KV interleaved causal decode (q_len=1). Reads the head-major f16 KV cache
-/// (`RawInterleavedKvCacheF16`) one head's stream at a time - half the bytes of an
-/// f32 cache. With `f16-attn-dot` the score is a native f16.f16 dot; otherwise K is
-/// widened in-register.
+// f16-KV interleaved causal decode (q_len=1). Reads the head-major f16 KV cache one
+// head's stream at a time - half the bytes of an f32 cache.
 #[allow(clippy::too_many_arguments)]
 pub fn causal_decode_f16kv_interleaved(
     q_data: &[f32],
@@ -1072,9 +1068,8 @@ pub fn causal_decode_f16kv_interleaved(
 
     let mut out = vec![0f32; h_q * d];
 
-    // One task per kv head, computing all `rk` of its GQA query heads in a single
-    // pass: the head-major cache makes the stream contiguous, and each K/V row is
-    // read from memory once instead of once per query head.
+    // One task per kv head, all rk GQA query heads in one pass so each contiguous
+    // K/V row is read from memory once, not once per query head.
     let process =
         |kv_h: usize, out_chunk: &mut [f32], acc: &mut [f32], m: &mut [f32], ssum: &mut [f32]| {
             let head_base = kv_h * head_stride;
@@ -1083,9 +1078,8 @@ pub fn causal_decode_f16kv_interleaved(
             m.fill(f32::NEG_INFINITY);
             ssum.fill(0.0);
 
-            // `f16-attn-dot`: narrow this kv-head's `rk` query rows to f16 ONCE here
-            // (amortized over all `kv_len` positions), so the inner score is a pure
-            // f16.f16 dot. Default build skips this entirely.
+            // f16-attn-dot: narrow this kv-head's rk query rows to f16 once (amortized
+            // over kv_len), so the inner score is a pure f16.f16 dot. Off by default.
             #[cfg(feature = "f16-attn-dot")]
             let q_f16: Vec<half::f16> = {
                 let base = kv_h * rk * d;
@@ -1135,9 +1129,8 @@ pub fn causal_decode_f16kv_interleaved(
             }
         };
 
-    // CONTIGUOUS per-thread partition of the h_kv kv-heads on the barrier pool (replaces
-    // rayon's fine-grained par_chunks, which thrashed the shared cache and limited decode
-    // scaling on N1). `execute` with a 0-worker pool runs f(0) inline - zero overhead at 1 vCPU.
+    // Contiguous per-thread partition of the h_kv kv-heads on the barrier pool (vs rayon's
+    // par_chunks, which thrashed shared cache on N1). 0-worker pool runs f(0) inline.
     struct OutPtr(*mut f32);
     unsafe impl Sync for OutPtr {}
     let optr = OutPtr(out.as_mut_ptr());
@@ -1163,14 +1156,9 @@ pub fn causal_decode_f16kv_interleaved(
     Tensor::from_vec(out, (h_q, 1usize, d), &Device::Cpu)
 }
 
-/// Causal prefill over the f16 head-major interleaved KV cache (the same layout
-/// [`causal_decode_f16kv_interleaved`] reads, so prefill and decode share one cache).
-///
-/// Structure matches [`causal_prefill_f32_lean`]: one task per (kv head, query
-/// block), the `rk` GQA query heads sharing every K/V row load, KV-blocked softmax.
-/// The QK dot widens the f16 K row in-register against the f32 query (`dot_f32_f16`);
-/// the PV accumulator stays f32 (`axpy_f16` widens V in-register). Same dot strategy
-/// as [`causal_decode_f16kv_interleaved`], including the `f16-attn-dot` variant.
+// Causal prefill over the f16 head-major interleaved KV cache (same layout decode reads).
+// One task per (kv head, query block), rk GQA heads sharing every K/V row, KV-blocked
+// softmax; QK widens f16 K in-register, PV accumulator stays f32.
 #[allow(clippy::too_many_arguments)]
 pub fn causal_prefill_f16kv_headmajor(
     q_data: &[f32],
@@ -1196,8 +1184,8 @@ pub fn causal_prefill_f16kv_headmajor(
     unsafe impl Sync for OutPtr {}
     let out_ptr = OutPtr(out.as_mut_ptr());
 
-    // CONTIGUOUS per-thread partition of the (kv-head, q-block) tasks on the barrier pool
-    // (replaces rayon's fine-grained into_par_iter). execute(0 workers) runs f(0) inline.
+    // Contiguous per-thread partition of (kv-head, q-block) tasks on the barrier pool.
+    // 0-worker pool runs f(0) inline.
     let n_tasks = h_kv * n_qblocks;
     let pool = candle::utils::barrier_pool();
     let n_total = pool.n_workers() + 1;
@@ -1219,9 +1207,8 @@ pub fn causal_prefill_f16kv_headmajor(
             let head_base = kv_h * head_stride;
             let p = &out_ptr;
 
-            // `f16-attn-dot`: narrow this q block's rows to f16 so the QK dot is a
-            // pure f16.f16 FMLA. Reused across q positions; the default build keeps
-            // Q in f32 and the dot widens K in-register (`dot_f32_f16`).
+            // f16-attn-dot: narrow this q block's rows to f16 so the QK dot is a pure
+            // f16.f16 FMLA. Default keeps Q in f32 and widens K in-register.
             #[cfg(feature = "f16-attn-dot")]
             let mut qf16 = vec![half::f16::ZERO; rk * d];
 

--- a/candle-nn/src/attention/cpu_flash/mod.rs
+++ b/candle-nn/src/attention/cpu_flash/mod.rs
@@ -178,9 +178,7 @@ fn flash_attn_via_varlen(
     ctx.reshape((b, s_q, h_q, d))?.transpose(1, 2)?.contiguous()
 }
 
-/// the bytes streamed per token. The f16 elements are widened in-register
-/// (`fcvtl`, baseline aarch64 NEON) so there is no scratch buffer and no
-/// precision loss beyond the f16 storage itself.
+// f32.f16 dot; f16 K widened in-register (fcvtl, baseline NEON), no scratch buffer.
 #[cfg(all(target_arch = "aarch64", not(feature = "f16-attn-dot")))]
 #[inline]
 pub(crate) fn dot_f32_f16(a: &[f32], b: &[half::f16]) -> f32 {
@@ -227,11 +225,8 @@ pub(crate) fn dot_f32_f16(a: &[f32], b: &[half::f16]) -> f32 {
     a.iter().zip(b).map(|(x, y)| x * y.to_f32()).sum()
 }
 
-/// Native-fp16 q.k dot for the decode flash kernel (opt-in `f16-attn-dot`).
-/// The accumulator is f16, so a head_dim-long sum loses low-order bits
-/// (~1e-3 rel); softmax + greedy argmax absorb it (verified: identical text).
-/// Two accumulators hide the fp16-FMA latency. The exact f32-accumulating
-/// `dot_f32_f16` above is the default and is what runs without this feature.
+// Native fp16 q.k dot (opt-in f16-attn-dot). f16 accumulator loses ~1e-3 rel,
+// absorbed by softmax+argmax; two accumulators hide FMA latency.
 #[cfg(all(target_arch = "aarch64", feature = "f16-attn-dot"))]
 #[inline]
 pub(crate) fn dot_f16_f16(a: &[half::f16], b: &[half::f16]) -> f32 {
@@ -291,8 +286,7 @@ pub(crate) fn dot_f16_f16(a: &[half::f16], b: &[half::f16]) -> f32 {
 #[inline]
 pub(crate) fn dot_f16_f16(a: &[half::f16], b: &[half::f16]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
-    // Portable reference: f16 products into an f16 running sum (matches the
-    // lossy-accumulation semantics of the aarch64 path closely enough for tests).
+    // Portable reference: f16 products into an f16 running sum (lossy, matches aarch64).
     let mut acc = half::f16::ZERO;
     for (x, y) in a.iter().zip(b) {
         acc += *x * *y;
@@ -300,7 +294,7 @@ pub(crate) fn dot_f16_f16(a: &[half::f16], b: &[half::f16]) -> f32 {
     acc.to_f32()
 }
 
-/// `acc[i] += v[i] * w` with an f16 value row widened in-register (f32 accumulator).
+// acc[i] += v[i] * w; f16 value row widened in-register, f32 accumulator.
 #[cfg(target_arch = "aarch64")]
 #[inline]
 pub(crate) fn axpy_f16(acc: &mut [f32], v: &[half::f16], w: f32) {

--- a/candle-nn/src/attention/cpu_flash/mod.rs
+++ b/candle-nn/src/attention/cpu_flash/mod.rs
@@ -177,3 +177,170 @@ fn flash_attn_via_varlen(
 
     ctx.reshape((b, s_q, h_q, d))?.transpose(1, 2)?.contiguous()
 }
+
+/// the bytes streamed per token. The f16 elements are widened in-register
+/// (`fcvtl`, baseline aarch64 NEON) so there is no scratch buffer and no
+/// precision loss beyond the f16 storage itself.
+#[cfg(all(target_arch = "aarch64", not(feature = "f16-attn-dot")))]
+#[inline]
+pub(crate) fn dot_f32_f16(a: &[f32], b: &[half::f16]) -> f32 {
+    use std::arch::aarch64::*;
+    debug_assert_eq!(a.len(), b.len());
+    let n = a.len();
+    let chunks = n / 8;
+    unsafe {
+        let mut sum0 = vdupq_n_f32(0.0);
+        let mut sum1 = vdupq_n_f32(0.0);
+        let mut ap = a.as_ptr();
+        let mut bp = b.as_ptr();
+        for _ in 0..chunks {
+            let lo: float32x4_t;
+            let hi: float32x4_t;
+            // f16 NEON intrinsics are unstable; widen via asm and FMA via intrinsics.
+            std::arch::asm!(
+                "ldr {kv:q}, [{bp}]",
+                "fcvtl {lo:v}.4s, {kv:v}.4h",
+                "fcvtl2 {hi:v}.4s, {kv:v}.8h",
+                bp = in(reg) bp,
+                kv = out(vreg) _,
+                lo = out(vreg) lo,
+                hi = out(vreg) hi,
+                options(nostack, pure, readonly),
+            );
+            sum0 = vfmaq_f32(sum0, vld1q_f32(ap), lo);
+            sum1 = vfmaq_f32(sum1, vld1q_f32(ap.add(4)), hi);
+            ap = ap.add(8);
+            bp = bp.add(8);
+        }
+        let mut acc = vaddvq_f32(vaddq_f32(sum0, sum1));
+        for i in (chunks * 8)..n {
+            acc += a[i] * b[i].to_f32();
+        }
+        acc
+    }
+}
+
+#[cfg(all(not(target_arch = "aarch64"), not(feature = "f16-attn-dot")))]
+#[inline]
+pub(crate) fn dot_f32_f16(a: &[f32], b: &[half::f16]) -> f32 {
+    debug_assert_eq!(a.len(), b.len());
+    a.iter().zip(b).map(|(x, y)| x * y.to_f32()).sum()
+}
+
+/// Native-fp16 q.k dot for the decode flash kernel (opt-in `f16-attn-dot`).
+/// The accumulator is f16, so a head_dim-long sum loses low-order bits
+/// (~1e-3 rel); softmax + greedy argmax absorb it (verified: identical text).
+/// Two accumulators hide the fp16-FMA latency. The exact f32-accumulating
+/// `dot_f32_f16` above is the default and is what runs without this feature.
+#[cfg(all(target_arch = "aarch64", feature = "f16-attn-dot"))]
+#[inline]
+pub(crate) fn dot_f16_f16(a: &[half::f16], b: &[half::f16]) -> f32 {
+    debug_assert_eq!(a.len(), b.len());
+    let n = a.len();
+    let chunks = n / 16; // two 8-lane accumulators per iteration
+    unsafe {
+        use std::arch::aarch64::*;
+        // Opaque 128-bit vregs holding f16x8 accumulators (no stable f16 vec type).
+        let mut acc0 = vreinterpretq_f32_u32(vdupq_n_u32(0));
+        let mut acc1 = vreinterpretq_f32_u32(vdupq_n_u32(0));
+        let mut ap = a.as_ptr();
+        let mut bp = b.as_ptr();
+        for _ in 0..chunks {
+            std::arch::asm!(
+                "ldp {a0:q}, {a1:q}, [{ap}]",
+                "ldp {b0:q}, {b1:q}, [{bp}]",
+                "fmla {acc0:v}.8h, {a0:v}.8h, {b0:v}.8h",
+                "fmla {acc1:v}.8h, {a1:v}.8h, {b1:v}.8h",
+                ap = in(reg) ap,
+                bp = in(reg) bp,
+                a0 = out(vreg) _, a1 = out(vreg) _,
+                b0 = out(vreg) _, b1 = out(vreg) _,
+                acc0 = inout(vreg) acc0,
+                acc1 = inout(vreg) acc1,
+                options(nostack, readonly),
+            );
+            ap = ap.add(16);
+            bp = bp.add(16);
+        }
+        // Widen both f16 accumulators to f32 and horizontally reduce.
+        let lo0: float32x4_t;
+        let hi0: float32x4_t;
+        let lo1: float32x4_t;
+        let hi1: float32x4_t;
+        std::arch::asm!(
+            "fcvtl {lo0:v}.4s, {acc0:v}.4h",
+            "fcvtl2 {hi0:v}.4s, {acc0:v}.8h",
+            "fcvtl {lo1:v}.4s, {acc1:v}.4h",
+            "fcvtl2 {hi1:v}.4s, {acc1:v}.8h",
+            acc0 = in(vreg) acc0,
+            acc1 = in(vreg) acc1,
+            lo0 = out(vreg) lo0, hi0 = out(vreg) hi0,
+            lo1 = out(vreg) lo1, hi1 = out(vreg) hi1,
+            options(nostack, pure, nomem),
+        );
+        let s = vaddq_f32(vaddq_f32(lo0, hi0), vaddq_f32(lo1, hi1));
+        let mut acc = vaddvq_f32(s);
+        for i in (chunks * 16)..n {
+            acc += a[i].to_f32() * b[i].to_f32();
+        }
+        acc
+    }
+}
+
+#[cfg(all(not(target_arch = "aarch64"), feature = "f16-attn-dot"))]
+#[inline]
+pub(crate) fn dot_f16_f16(a: &[half::f16], b: &[half::f16]) -> f32 {
+    debug_assert_eq!(a.len(), b.len());
+    // Portable reference: f16 products into an f16 running sum (matches the
+    // lossy-accumulation semantics of the aarch64 path closely enough for tests).
+    let mut acc = half::f16::ZERO;
+    for (x, y) in a.iter().zip(b) {
+        acc += *x * *y;
+    }
+    acc.to_f32()
+}
+
+/// `acc[i] += v[i] * w` with an f16 value row widened in-register (f32 accumulator).
+#[cfg(target_arch = "aarch64")]
+#[inline]
+pub(crate) fn axpy_f16(acc: &mut [f32], v: &[half::f16], w: f32) {
+    use std::arch::aarch64::*;
+    debug_assert_eq!(acc.len(), v.len());
+    let n = acc.len();
+    let chunks = n / 8;
+    unsafe {
+        let wv = vdupq_n_f32(w);
+        let mut ap = acc.as_mut_ptr();
+        let mut vp = v.as_ptr();
+        for _ in 0..chunks {
+            let lo: float32x4_t;
+            let hi: float32x4_t;
+            std::arch::asm!(
+                "ldr {kv:q}, [{vp}]",
+                "fcvtl {lo:v}.4s, {kv:v}.4h",
+                "fcvtl2 {hi:v}.4s, {kv:v}.8h",
+                vp = in(reg) vp,
+                kv = out(vreg) _,
+                lo = out(vreg) lo,
+                hi = out(vreg) hi,
+                options(nostack, pure, readonly),
+            );
+            vst1q_f32(ap, vfmaq_f32(vld1q_f32(ap), lo, wv));
+            vst1q_f32(ap.add(4), vfmaq_f32(vld1q_f32(ap.add(4)), hi, wv));
+            ap = ap.add(8);
+            vp = vp.add(8);
+        }
+        for i in (chunks * 8)..n {
+            acc[i] += v[i].to_f32() * w;
+        }
+    }
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+#[inline]
+pub(crate) fn axpy_f16(acc: &mut [f32], v: &[half::f16], w: f32) {
+    debug_assert_eq!(acc.len(), v.len());
+    for (a, x) in acc.iter_mut().zip(v) {
+        *a += x.to_f32() * w;
+    }
+}

--- a/candle-nn/src/kv_cache.rs
+++ b/candle-nn/src/kv_cache.rs
@@ -1124,6 +1124,119 @@ impl RawInterleavedKvCache {
     }
 }
 
+/// HEAD-MAJOR f16 interleaved K/V cache for the f16-KV CPU flash kernels.
+///
+/// Distinct from [`RawInterleavedKvCache`] (position-major, f32): this stores the
+/// KV as `f16` (half the bytes streamed per token -> less decode bandwidth) and
+/// lays it out HEAD-MAJOR so each kv head's positions are contiguous - matching
+/// `causal_decode_f16kv_interleaved` / `causal_prefill_f16kv_headmajor`, which read
+/// one head's stream sequentially. Per-head block `h` starts at `h * head_stride()`
+/// and holds `len` positions of `[K(d), V(d)]`.
+pub struct RawInterleavedKvCacheF16 {
+    buf: Vec<half::f16>,
+    h_kv: usize,
+    d: usize,
+    cap: usize,
+    len: usize,
+}
+
+impl RawInterleavedKvCacheF16 {
+    /// Create a new cache with space for `max_seq` positions.
+    pub fn new(h_kv: usize, d: usize, max_seq: usize) -> Self {
+        Self {
+            buf: vec![half::f16::ZERO; h_kv * max_seq * 2 * d],
+            h_kv,
+            d,
+            cap: max_seq,
+            len: 0,
+        }
+    }
+
+    /// Number of positions currently cached.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Elements between consecutive kv-head blocks in [`Self::data`].
+    pub fn head_stride(&self) -> usize {
+        self.cap * 2 * self.d
+    }
+
+    /// Write one position of K and V into the cache.
+    ///
+    /// `k_flat` and `v_flat` are flat `(H_kv * D)` slices from the projection output.
+    pub fn write_kv(&mut self, k_flat: &[f32], v_flat: &[f32]) {
+        if self.len == self.cap {
+            self.grow();
+        }
+        let d = self.d;
+        let pos_off = self.len * 2 * d;
+        for h in 0..self.h_kv {
+            let src = h * d;
+            let dst = h * self.cap * 2 * d + pos_off;
+            for (o, &x) in self.buf[dst..dst + d].iter_mut().zip(&k_flat[src..]) {
+                *o = half::f16::from_f32(x);
+            }
+            for (o, &x) in self.buf[dst + d..dst + 2 * d]
+                .iter_mut()
+                .zip(&v_flat[src..])
+            {
+                *o = half::f16::from_f32(x);
+            }
+        }
+
+        self.len += 1;
+    }
+
+    fn grow(&mut self) {
+        let new_cap = self.cap * 2;
+        let block = 2 * self.d;
+        let mut new_buf = vec![half::f16::ZERO; self.h_kv * new_cap * block];
+        for h in 0..self.h_kv {
+            let src = h * self.cap * block;
+            let dst = h * new_cap * block;
+            new_buf[dst..dst + self.len * block]
+                .copy_from_slice(&self.buf[src..src + self.len * block]);
+        }
+        self.buf = new_buf;
+        self.cap = new_cap;
+    }
+
+    /// Write multiple positions of K and V (for prefill).
+    ///
+    /// `k_flat` is `(S, H_kv * D)` row-major, `v_flat` same.
+    pub fn write_kv_batch(&mut self, k_flat: &[f32], v_flat: &[f32], seq_len: usize) {
+        let hd = self.h_kv * self.d;
+        for s in 0..seq_len {
+            let k_row = &k_flat[s * hd..(s + 1) * hd];
+            let v_row = &v_flat[s * hd..(s + 1) * hd];
+            self.write_kv(k_row, v_row);
+        }
+    }
+
+    /// The full cache buffer; per-head blocks start at `h * head_stride()` and
+    /// hold `len` positions of `[K(d), V(d)]` each.
+    pub fn data(&self) -> &[half::f16] {
+        &self.buf
+    }
+
+    pub fn reset(&mut self) {
+        self.len = 0;
+    }
+
+    pub fn h_kv(&self) -> usize {
+        self.h_kv
+    }
+
+    pub fn d(&self) -> usize {
+        self.d
+    }
+}
+
 /// Apply interleaved RoPE in-place on a flat `(H, D)` slice.
 ///
 /// Pairs adjacent elements `(2i, 2i+1)` with frequency `cos[i], sin[i]`.

--- a/candle-nn/src/kv_cache.rs
+++ b/candle-nn/src/kv_cache.rs
@@ -1124,14 +1124,9 @@ impl RawInterleavedKvCache {
     }
 }
 
-/// HEAD-MAJOR f16 interleaved K/V cache for the f16-KV CPU flash kernels.
-///
-/// Distinct from [`RawInterleavedKvCache`] (position-major, f32): this stores the
-/// KV as `f16` (half the bytes streamed per token -> less decode bandwidth) and
-/// lays it out HEAD-MAJOR so each kv head's positions are contiguous - matching
-/// `causal_decode_f16kv_interleaved` / `causal_prefill_f16kv_headmajor`, which read
-/// one head's stream sequentially. Per-head block `h` starts at `h * head_stride()`
-/// and holds `len` positions of `[K(d), V(d)]`.
+// Head-major f16 interleaved K/V cache for the f16-KV CPU flash kernels: f16 (half the
+// decode bandwidth), each kv head's positions contiguous. Per-head block h starts at
+// h * head_stride() and holds len positions of [K(d), V(d)].
 pub struct RawInterleavedKvCacheF16 {
     buf: Vec<half::f16>,
     h_kv: usize,
@@ -1141,7 +1136,7 @@ pub struct RawInterleavedKvCacheF16 {
 }
 
 impl RawInterleavedKvCacheF16 {
-    /// Create a new cache with space for `max_seq` positions.
+    // Create a cache with space for max_seq positions.
     pub fn new(h_kv: usize, d: usize, max_seq: usize) -> Self {
         Self {
             buf: vec![half::f16::ZERO; h_kv * max_seq * 2 * d],
@@ -1152,7 +1147,7 @@ impl RawInterleavedKvCacheF16 {
         }
     }
 
-    /// Number of positions currently cached.
+    // Number of positions currently cached.
     pub fn len(&self) -> usize {
         self.len
     }
@@ -1161,14 +1156,12 @@ impl RawInterleavedKvCacheF16 {
         self.len == 0
     }
 
-    /// Elements between consecutive kv-head blocks in [`Self::data`].
+    // Elements between consecutive kv-head blocks in data().
     pub fn head_stride(&self) -> usize {
         self.cap * 2 * self.d
     }
 
-    /// Write one position of K and V into the cache.
-    ///
-    /// `k_flat` and `v_flat` are flat `(H_kv * D)` slices from the projection output.
+    // Write one position of K and V. k_flat/v_flat are flat (H_kv * D) slices.
     pub fn write_kv(&mut self, k_flat: &[f32], v_flat: &[f32]) {
         if self.len == self.cap {
             self.grow();
@@ -1206,9 +1199,7 @@ impl RawInterleavedKvCacheF16 {
         self.cap = new_cap;
     }
 
-    /// Write multiple positions of K and V (for prefill).
-    ///
-    /// `k_flat` is `(S, H_kv * D)` row-major, `v_flat` same.
+    // Write multiple positions for prefill. k_flat is (S, H_kv * D) row-major, v_flat same.
     pub fn write_kv_batch(&mut self, k_flat: &[f32], v_flat: &[f32], seq_len: usize) {
         let hd = self.h_kv * self.d;
         for s in 0..seq_len {
@@ -1218,8 +1209,7 @@ impl RawInterleavedKvCacheF16 {
         }
     }
 
-    /// The full cache buffer; per-head blocks start at `h * head_stride()` and
-    /// hold `len` positions of `[K(d), V(d)]` each.
+    // Full cache buffer; per-head block h starts at h * head_stride(), len positions of [K(d), V(d)].
     pub fn data(&self) -> &[half::f16] {
         &self.buf
     }

--- a/candle-nn/tests/cpu_flash_attn.rs
+++ b/candle-nn/tests/cpu_flash_attn.rs
@@ -277,3 +277,122 @@ fn interleaved_kv_decode() -> Result<()> {
     let out = out.unsqueeze(0)?;
     assert_close(&out, &expected, 1e-5, "interleaved_kv_decode")
 }
+
+#[test]
+fn f16kv_headmajor_prefill() -> Result<()> {
+    use candle_nn::attention::cpu_flash::causal::causal_prefill_f16kv_headmajor;
+    use half::f16;
+
+    let (h_q, h_kv, d, s) = (8, 2, 16, 200);
+    let scale = 1.0 / (d as f32).sqrt();
+    let dev = &Device::Cpu;
+
+    let q = Tensor::randn(0f32, 1f32, (1, h_q, s, d), dev)?;
+    let k = Tensor::randn(0f32, 1f32, (1, h_kv, s, d), dev)?;
+    let v = Tensor::randn(0f32, 1f32, (1, h_kv, s, d), dev)?;
+
+    // Reference on the f16-rounded K/V so we measure kernel error, not storage error.
+    let k_h = k
+        .to_dtype(candle::DType::F16)?
+        .to_dtype(candle::DType::F32)?;
+    let v_h = v
+        .to_dtype(candle::DType::F16)?
+        .to_dtype(candle::DType::F32)?;
+    let reps = h_q / h_kv;
+    let k_exp = k_h
+        .reshape((1, h_kv, 1, s, d))?
+        .broadcast_as((1, h_kv, reps, s, d))?
+        .reshape((1, h_q, s, d))?;
+    let v_exp = v_h
+        .reshape((1, h_kv, 1, s, d))?
+        .broadcast_as((1, h_kv, reps, s, d))?
+        .reshape((1, h_q, s, d))?;
+    let expected = reference_causal_sdpa(&q, &k_exp, &v_exp, scale)?;
+
+    // Pack K/V into the head-major interleaved f16 layout: [head][pos][K(d), V(d)].
+    let k_v: Vec<f32> = k.flatten_all()?.to_vec1()?; // (h_kv, s, d)
+    let v_v: Vec<f32> = v.flatten_all()?.to_vec1()?;
+    let head_stride = s * 2 * d;
+    let mut kv = vec![f16::ZERO; h_kv * head_stride];
+    for h in 0..h_kv {
+        for pos in 0..s {
+            for t in 0..d {
+                kv[h * head_stride + pos * 2 * d + t] = f16::from_f32(k_v[h * s * d + pos * d + t]);
+                kv[h * head_stride + pos * 2 * d + d + t] =
+                    f16::from_f32(v_v[h * s * d + pos * d + t]);
+            }
+        }
+    }
+
+    // Q as (s, h_q, d)
+    let q_seq: Vec<f32> = q
+        .squeeze(0)?
+        .transpose(0, 1)?
+        .contiguous()?
+        .flatten_all()?
+        .to_vec1()?;
+
+    let out =
+        causal_prefill_f16kv_headmajor(&q_seq, &kv, head_stride, s, h_q, h_kv, d, s, scale, 0)?
+            .unsqueeze(0)?; // (1, h_q, s, d) to match reference
+
+    assert_close(&out, &expected, 2e-2, "f16kv_headmajor_prefill")
+}
+
+#[test]
+fn interleaved_kv_decode_f16() -> Result<()> {
+    use candle_nn::attention::cpu_flash::causal::causal_decode_f16kv_interleaved;
+
+    let (h_q, h_kv, d, kv_len) = (8, 2, 16, 20);
+    let scale = 1.0 / (d as f32).sqrt();
+    let dev = &Device::Cpu;
+
+    let q = Tensor::randn(0f32, 1f32, (1, h_q, 1, d), dev)?;
+    let k = Tensor::randn(0f32, 1f32, (1, h_kv, kv_len, d), dev)?;
+    let v = Tensor::randn(0f32, 1f32, (1, h_kv, kv_len, d), dev)?;
+
+    // Reference with GQA expansion
+    let reps = h_q / h_kv;
+    let k_exp = k
+        .reshape((1, h_kv, 1, kv_len, d))?
+        .broadcast_as((1, h_kv, reps, kv_len, d))?
+        .reshape((1, h_q, kv_len, d))?;
+    let v_exp = v
+        .reshape((1, h_kv, 1, kv_len, d))?
+        .broadcast_as((1, h_kv, reps, kv_len, d))?
+        .reshape((1, h_q, kv_len, d))?;
+    let expected = reference_sdpa(&q, &k_exp, &v_exp, scale)?;
+
+    // Build head-major interleaved KV: (h_kv, kv_len, 2*d).
+    let k_seq = k.squeeze(0)?.contiguous()?;
+    let v_seq = v.squeeze(0)?.contiguous()?;
+    let kv = Tensor::cat(&[&k_seq, &v_seq], 2)?.contiguous()?; // (h_kv, kv_len, 2*d)
+
+    let kv_data: Vec<half::f16> = kv
+        .flatten_all()?
+        .to_vec1::<f32>()?
+        .into_iter()
+        .map(half::f16::from_f32)
+        .collect();
+    let q_flat: Vec<f32> = q
+        .squeeze(0)?
+        .squeeze(1)?
+        .contiguous()?
+        .flatten_all()?
+        .to_vec1()?;
+
+    let out = causal_decode_f16kv_interleaved(
+        &q_flat,
+        &kv_data,
+        kv_len * 2 * d,
+        h_q,
+        h_kv,
+        d,
+        kv_len,
+        scale,
+    )?;
+
+    let out = out.unsqueeze(0)?;
+    // f16 KV storage rounds K/V to ~1e-3 relative; the reference uses f32 throughout.
+    assert_close(&out, &expected, 2e-2, "interleaved_kv_decode")
+}


### PR DESCRIPTION
f16 KV is the usual cache approximation (llama.cpp defaults to it). greedy output was identical to f32 in my testing. 

CPU decode is bandwidth-bound, and the interleaved KV cache currently stores K/V as f32. This adds an f16 variant. The existing f32 cache and kernels are untouched, so nothing changes unless a model opts in.

RawInterleavedKvCacheF16: the f16 twin of RawInterleavedKvCache (head-major, K/V interleaved, half the bytes/token). 

Speed: wiring this into Qwen3-0.6B, decode gets ~28% faster at 1 thread and ~13% at 4 (measured on an M1, same-binary toggle) and 14% on 6 thread N1 (main target). The win is biggest at low thread counts, where decode is most bandwidth-bound. 

A/B: cargo feature f16-attn-dot (default off. enable with --features candle-nn/f16-attn-dot); model-level cache select CANDLE_F16_KV (default on, lives in the integration); CANDLE_VEC_SOFTMAX_EXP (default off, experimental NEON poly-exp, kept off for bit-reproducibility).
Effect: f16 interleaved KV cache (half the bytes/token) + f16 causal decode kernel.

vec_expf (CANDLE_VEC_SOFTMAX_EXP=1) vs baseline
+2.0% decode @6t (and ~0 at single-thread / in prefill).

A polynomial expf approximation replacing scalar libm expf in the flash-attention softmax. Kept off by default to stay bit-reproducible (~1e-6 absolute error, normalized out by the softmax). It is independent of the f16 KV cache that is this PR's focus included here only because it lives in the same softmax path.