### PR TITLE
cpu-optimization: wire f16kv changes to Qwen3 (and remove feature toggles for PR 3664-3667 27% gain in prefill, 14% gain decode)

### DIFF
--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -10,6 +10,7 @@ mod utils;
 pub use utils::{
     binary_map, binary_map_vec, unary_map, unary_map_vec, Map1, Map1Any, Map2, Map2InPlace, Map2U8,
 };
+use utils::{par_binary_vec_f32, par_unary_vec_f32};
 mod conv2d;
 use conv2d::Conv2D;
 
@@ -2472,7 +2473,10 @@ impl BackendStorage for CpuStorage {
                 Ok(Self::F16(data))
             }
             Self::F32(storage) => {
-                let data = unary_map_vec(storage, layout, B::f32, B::f32_vec);
+                let data = match par_unary_vec_f32(storage, layout, B::f32_vec) {
+                    Some(d) => d,
+                    None => unary_map_vec(storage, layout, B::f32, B::f32_vec),
+                };
                 Ok(Self::F32(data))
             }
             Self::F64(storage) => {
@@ -2542,15 +2546,18 @@ impl BackendStorage for CpuStorage {
                 Ok(Self::F16(data))
             }
             (Self::F32(lhs), Self::F32(rhs)) => {
-                let data = binary_map_vec(
-                    lhs_l,
-                    rhs_l,
-                    lhs,
-                    rhs,
-                    B::f32,
-                    B::f32_vec,
-                    B::f32_scalar_vec,
-                );
+                let data = match par_binary_vec_f32(lhs, rhs, lhs_l, rhs_l, B::f32_vec) {
+                    Some(d) => d,
+                    None => binary_map_vec(
+                        lhs_l,
+                        rhs_l,
+                        lhs,
+                        rhs,
+                        B::f32,
+                        B::f32_vec,
+                        B::f32_scalar_vec,
+                    ),
+                };
                 Ok(Self::F32(data))
             }
             (Self::F64(lhs), Self::F64(rhs)) => {

--- a/candle-core/src/cpu_backend/utils.rs
+++ b/candle-core/src/cpu_backend/utils.rs
@@ -8,12 +8,7 @@ type C = super::CpuStorage;
 
 // Parallelize large contiguous f32 elementwise ops across the barrier pool; serial
 // unary_map/binary_map are an Amdahl drag at high thread counts. Bit-identical to
-// serial (disjoint ranges). Default ON; CANDLE_PAR_ELEMWISE=0 forces serial.
-static PAR_ELEMWISE: LazyLock<bool> = LazyLock::new(|| {
-    std::env::var("CANDLE_PAR_ELEMWISE")
-        .map(|s| s != "0")
-        .unwrap_or(true)
-});
+// serial (disjoint ranges).
 // Below this element count the fork-join isn't worth it. Tunable via CANDLE_PAR_ELEMWISE_MIN.
 static PAR_ELEMWISE_MIN: LazyLock<usize> = LazyLock::new(|| {
     std::env::var("CANDLE_PAR_ELEMWISE_MIN")
@@ -29,9 +24,6 @@ pub(crate) fn par_unary_vec_f32(
     layout: &Layout,
     f_vec: fn(&[f32], &mut [f32]),
 ) -> Option<Vec<f32>> {
-    if !*PAR_ELEMWISE {
-        return None;
-    }
     let (start, end) = layout.contiguous_offsets()?;
     let len = end - start;
     if len < *PAR_ELEMWISE_MIN {
@@ -52,9 +44,6 @@ pub(crate) fn par_binary_vec_f32(
     rhs_l: &Layout,
     f_vec: fn(&[f32], &[f32], &mut [f32]),
 ) -> Option<Vec<f32>> {
-    if !*PAR_ELEMWISE {
-        return None;
-    }
     let (ls, le) = lhs_l.contiguous_offsets()?;
     let (rs, re) = rhs_l.contiguous_offsets()?;
     let len = le - ls;
@@ -453,7 +442,7 @@ mod par_elemwise_tests {
     use crate::Shape;
 
     // Parallel split must be byte-identical to the serial whole-range apply. Drives
-    // par_range_apply directly so it runs regardless of the CANDLE_PAR_ELEMWISE gate.
+    // par_range_apply directly.
     #[test]
     fn par_unary_matches_serial() {
         let n = 100_003usize; // not a multiple of typical worker counts (remainder)

--- a/candle-core/src/cpu_backend/utils.rs
+++ b/candle-core/src/cpu_backend/utils.rs
@@ -2,8 +2,101 @@
 use crate::backend::BackendStorage;
 use crate::nditer::NdIter;
 use crate::{Error, Layout, Result, WithDType};
+use std::sync::LazyLock;
 
 type C = super::CpuStorage;
+
+// Parallelize large CONTIGUOUS elementwise ops (residual adds, SwiGLU mul, SiLU,
+// scaling) across the barrier pool. candle's `binary_map`/`unary_map` are serial
+// for-loops; at high thread counts they become an Amdahl drag on prefill (the
+// matmuls scale ~Nx but these don't). This threads only the contiguous f32 case at
+// the op-dispatch point - each output range is independent so it is bit-identical
+// to the serial path. Default ON; CANDLE_PAR_ELEMWISE=0 forces serial (A/B knob).
+static PAR_ELEMWISE: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("CANDLE_PAR_ELEMWISE")
+        .map(|s| s != "0")
+        .unwrap_or(true)
+});
+// Below this element count the per-op pool fork-join isn't worth it (tiny tensors:
+// norm scales, biases). Tunable via CANDLE_PAR_ELEMWISE_MIN.
+static PAR_ELEMWISE_MIN: LazyLock<usize> = LazyLock::new(|| {
+    std::env::var("CANDLE_PAR_ELEMWISE_MIN")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(16_384)
+});
+
+/// Parallel contiguous f32 UNARY op: `out[i] = f_vec(src)[i]` over the contiguous
+/// region `layout` views, split across the barrier pool. Returns `None` (caller
+/// falls back to the serial path) unless enabled, large enough, and contiguous.
+/// `f_vec` is a pure elementwise vectorized fn, so per-range application is exact.
+pub(crate) fn par_unary_vec_f32(
+    storage: &[f32],
+    layout: &Layout,
+    f_vec: fn(&[f32], &mut [f32]),
+) -> Option<Vec<f32>> {
+    if !*PAR_ELEMWISE {
+        return None;
+    }
+    let (start, end) = layout.contiguous_offsets()?;
+    let len = end - start;
+    if len < *PAR_ELEMWISE_MIN {
+        return None;
+    }
+    let src = &storage[start..end];
+    let mut out = vec![0f32; len];
+    par_range_apply(len, out.as_mut_ptr(), |s, e, dst| f_vec(&src[s..e], dst));
+    Some(out)
+}
+
+/// Parallel contiguous f32 BINARY op for the no-broadcast same-shape case (residual
+/// add, SwiGLU mul). Returns `None` (serial fallback) unless enabled, large, and
+/// both operands contiguous with equal length.
+pub(crate) fn par_binary_vec_f32(
+    lhs: &[f32],
+    rhs: &[f32],
+    lhs_l: &Layout,
+    rhs_l: &Layout,
+    f_vec: fn(&[f32], &[f32], &mut [f32]),
+) -> Option<Vec<f32>> {
+    if !*PAR_ELEMWISE {
+        return None;
+    }
+    let (ls, le) = lhs_l.contiguous_offsets()?;
+    let (rs, re) = rhs_l.contiguous_offsets()?;
+    let len = le - ls;
+    if len != re - rs || len < *PAR_ELEMWISE_MIN {
+        return None;
+    }
+    let l = &lhs[ls..le];
+    let r = &rhs[rs..re];
+    let mut out = vec![0f32; len];
+    par_range_apply(len, out.as_mut_ptr(), |s, e, dst| {
+        f_vec(&l[s..e], &r[s..e], dst)
+    });
+    Some(out)
+}
+
+/// Split `0..len` into one contiguous range per pool worker (+ main) and run
+/// `f(start, end, &mut out[start..end])` on each. `out_ptr` must point to `len`
+/// writable f32. The ranges are disjoint so the raw-pointer writes are sound.
+fn par_range_apply(len: usize, out_ptr: *mut f32, f: impl Fn(usize, usize, &mut [f32]) + Sync) {
+    struct P(*mut f32);
+    unsafe impl Sync for P {}
+    let op = P(out_ptr);
+    let pool = crate::utils::barrier_pool();
+    let n_total = pool.n_workers() + 1;
+    let per = len.div_ceil(n_total);
+    pool.execute(|tid| {
+        let p = &op;
+        let s = tid * per;
+        if s < len {
+            let e = len.min((tid + 1) * per);
+            let dst = unsafe { std::slice::from_raw_parts_mut(p.0.add(s), e - s) };
+            f(s, e, dst);
+        }
+    });
+}
 pub trait Map1 {
     fn f<T: WithDType>(&self, vs: &[T], layout: &Layout) -> Result<Vec<T>>;
 
@@ -359,5 +452,60 @@ pub fn unary_map_vec<T: Copy, U: Copy, F: FnMut(T) -> U, FV: FnMut(&[T], &mut [U
                 ys
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod par_elemwise_tests {
+    use super::*;
+    use crate::Shape;
+
+    // Parallel split MUST be byte-identical to applying f_vec over the whole range
+    // (each output element is independent). Large enough to exceed PAR_ELEMWISE_MIN.
+    #[test]
+    fn par_unary_matches_serial() {
+        let n = 100_003usize; // not a multiple of typical worker counts (remainder)
+        let src: Vec<f32> = (0..n).map(|i| (i as f32 * 0.001).sin()).collect();
+        let layout = Layout::contiguous(Shape::from_dims(&[n]));
+        fn fv(s: &[f32], d: &mut [f32]) {
+            for i in 0..s.len() {
+                d[i] = s[i] * s[i] - 0.5; // silu-like nonlinearity stand-in
+            }
+        }
+        let par = par_unary_vec_f32(&src, &layout, fv).expect("should parallelize");
+        let mut serial = vec![0f32; n];
+        fv(&src, &mut serial);
+        assert_eq!(par, serial);
+    }
+
+    #[test]
+    fn par_binary_matches_serial() {
+        let n = 100_003usize;
+        let a: Vec<f32> = (0..n).map(|i| i as f32 * 0.1).collect();
+        let b: Vec<f32> = (0..n).map(|i| (i as f32).cos()).collect();
+        let la = Layout::contiguous(Shape::from_dims(&[n]));
+        let lb = Layout::contiguous(Shape::from_dims(&[n]));
+        fn fv(x: &[f32], y: &[f32], d: &mut [f32]) {
+            for i in 0..x.len() {
+                d[i] = x[i] * y[i] + 1.0;
+            }
+        }
+        let par = par_binary_vec_f32(&a, &b, &la, &lb, fv).expect("should parallelize");
+        let mut serial = vec![0f32; n];
+        fv(&a, &b, &mut serial);
+        assert_eq!(par, serial);
+    }
+
+    // Below the threshold (and for non-contiguous layouts) it must fall back to
+    // serial (returns None) so tiny ops don't pay fork-join overhead.
+    #[test]
+    fn par_below_threshold_falls_back() {
+        let n = 100usize;
+        let src = vec![1f32; n];
+        let layout = Layout::contiguous(Shape::from_dims(&[n]));
+        fn fv(s: &[f32], d: &mut [f32]) {
+            d[..s.len()].copy_from_slice(s);
+        }
+        assert!(par_unary_vec_f32(&src, &layout, fv).is_none());
     }
 }

--- a/candle-core/src/cpu_backend/utils.rs
+++ b/candle-core/src/cpu_backend/utils.rs
@@ -452,18 +452,19 @@ mod par_elemwise_tests {
     use super::*;
     use crate::Shape;
 
-    // Parallel split must be byte-identical to the serial whole-range apply.
+    // Parallel split must be byte-identical to the serial whole-range apply. Drives
+    // par_range_apply directly so it runs regardless of the CANDLE_PAR_ELEMWISE gate.
     #[test]
     fn par_unary_matches_serial() {
         let n = 100_003usize; // not a multiple of typical worker counts (remainder)
         let src: Vec<f32> = (0..n).map(|i| (i as f32 * 0.001).sin()).collect();
-        let layout = Layout::contiguous(Shape::from_dims(&[n]));
         fn fv(s: &[f32], d: &mut [f32]) {
             for i in 0..s.len() {
                 d[i] = s[i] * s[i] - 0.5; // silu-like nonlinearity stand-in
             }
         }
-        let par = par_unary_vec_f32(&src, &layout, fv).expect("should parallelize");
+        let mut par = vec![0f32; n];
+        par_range_apply(n, par.as_mut_ptr(), |s, e, dst| fv(&src[s..e], dst));
         let mut serial = vec![0f32; n];
         fv(&src, &mut serial);
         assert_eq!(par, serial);
@@ -474,14 +475,13 @@ mod par_elemwise_tests {
         let n = 100_003usize;
         let a: Vec<f32> = (0..n).map(|i| i as f32 * 0.1).collect();
         let b: Vec<f32> = (0..n).map(|i| (i as f32).cos()).collect();
-        let la = Layout::contiguous(Shape::from_dims(&[n]));
-        let lb = Layout::contiguous(Shape::from_dims(&[n]));
         fn fv(x: &[f32], y: &[f32], d: &mut [f32]) {
             for i in 0..x.len() {
                 d[i] = x[i] * y[i] + 1.0;
             }
         }
-        let par = par_binary_vec_f32(&a, &b, &la, &lb, fv).expect("should parallelize");
+        let mut par = vec![0f32; n];
+        par_range_apply(n, par.as_mut_ptr(), |s, e, dst| fv(&a[s..e], &b[s..e], dst));
         let mut serial = vec![0f32; n];
         fv(&a, &b, &mut serial);
         assert_eq!(par, serial);

--- a/candle-core/src/cpu_backend/utils.rs
+++ b/candle-core/src/cpu_backend/utils.rs
@@ -6,19 +6,15 @@ use std::sync::LazyLock;
 
 type C = super::CpuStorage;
 
-// Parallelize large CONTIGUOUS elementwise ops (residual adds, SwiGLU mul, SiLU,
-// scaling) across the barrier pool. candle's `binary_map`/`unary_map` are serial
-// for-loops; at high thread counts they become an Amdahl drag on prefill (the
-// matmuls scale ~Nx but these don't). This threads only the contiguous f32 case at
-// the op-dispatch point - each output range is independent so it is bit-identical
-// to the serial path. Default ON; CANDLE_PAR_ELEMWISE=0 forces serial (A/B knob).
+// Parallelize large contiguous f32 elementwise ops across the barrier pool; serial
+// unary_map/binary_map are an Amdahl drag at high thread counts. Bit-identical to
+// serial (disjoint ranges). Default ON; CANDLE_PAR_ELEMWISE=0 forces serial.
 static PAR_ELEMWISE: LazyLock<bool> = LazyLock::new(|| {
     std::env::var("CANDLE_PAR_ELEMWISE")
         .map(|s| s != "0")
         .unwrap_or(true)
 });
-// Below this element count the per-op pool fork-join isn't worth it (tiny tensors:
-// norm scales, biases). Tunable via CANDLE_PAR_ELEMWISE_MIN.
+// Below this element count the fork-join isn't worth it. Tunable via CANDLE_PAR_ELEMWISE_MIN.
 static PAR_ELEMWISE_MIN: LazyLock<usize> = LazyLock::new(|| {
     std::env::var("CANDLE_PAR_ELEMWISE_MIN")
         .ok()
@@ -26,10 +22,8 @@ static PAR_ELEMWISE_MIN: LazyLock<usize> = LazyLock::new(|| {
         .unwrap_or(16_384)
 });
 
-/// Parallel contiguous f32 UNARY op: `out[i] = f_vec(src)[i]` over the contiguous
-/// region `layout` views, split across the barrier pool. Returns `None` (caller
-/// falls back to the serial path) unless enabled, large enough, and contiguous.
-/// `f_vec` is a pure elementwise vectorized fn, so per-range application is exact.
+// Parallel contiguous f32 unary op; None (serial fallback) unless enabled, large
+// enough, and contiguous.
 pub(crate) fn par_unary_vec_f32(
     storage: &[f32],
     layout: &Layout,
@@ -49,9 +43,8 @@ pub(crate) fn par_unary_vec_f32(
     Some(out)
 }
 
-/// Parallel contiguous f32 BINARY op for the no-broadcast same-shape case (residual
-/// add, SwiGLU mul). Returns `None` (serial fallback) unless enabled, large, and
-/// both operands contiguous with equal length.
+// Parallel contiguous f32 binary op, no-broadcast same-shape case; None unless
+// enabled, large, and both operands contiguous with equal length.
 pub(crate) fn par_binary_vec_f32(
     lhs: &[f32],
     rhs: &[f32],
@@ -77,9 +70,8 @@ pub(crate) fn par_binary_vec_f32(
     Some(out)
 }
 
-/// Split `0..len` into one contiguous range per pool worker (+ main) and run
-/// `f(start, end, &mut out[start..end])` on each. `out_ptr` must point to `len`
-/// writable f32. The ranges are disjoint so the raw-pointer writes are sound.
+// Split 0..len into one disjoint contiguous range per worker (+ main) and run f on
+// each. out_ptr must point to len writable f32; disjoint ranges keep the writes sound.
 fn par_range_apply(len: usize, out_ptr: *mut f32, f: impl Fn(usize, usize, &mut [f32]) + Sync) {
     struct P(*mut f32);
     unsafe impl Sync for P {}
@@ -460,8 +452,7 @@ mod par_elemwise_tests {
     use super::*;
     use crate::Shape;
 
-    // Parallel split MUST be byte-identical to applying f_vec over the whole range
-    // (each output element is independent). Large enough to exceed PAR_ELEMWISE_MIN.
+    // Parallel split must be byte-identical to the serial whole-range apply.
     #[test]
     fn par_unary_matches_serial() {
         let n = 100_003usize; // not a multiple of typical worker counts (remainder)

--- a/candle-core/src/quantized/cuda.rs
+++ b/candle-core/src/quantized/cuda.rs
@@ -691,6 +691,8 @@ impl QCudaStorage {
             GgmlDType::Q5K => deq::<crate::quantized::BlockQ5K>(&buffer, block_len, &mut out),
             GgmlDType::Q6K => deq::<crate::quantized::BlockQ6K>(&buffer, block_len, &mut out),
             GgmlDType::Q8K => deq::<crate::quantized::BlockQ8K>(&buffer, block_len, &mut out),
+            // CPU-only; never loaded onto CUDA (from_data bails first).
+            GgmlDType::Q6Kx8 => crate::bail!("Q6Kx8 is CPU-only"),
         }
 
         self.device

--- a/candle-core/src/quantized/ggml_file.rs
+++ b/candle-core/src/quantized/ggml_file.rs
@@ -193,6 +193,21 @@ pub fn qtensor_from_ggml(
                 Some(n) => *n,
                 None => crate::bail!("Q6Kx8 tensor has no dims"),
             };
+            // Q6Kx8 packs 8 output rows per block, so n must be whole 8-row groups
+            // and the bytes must be exactly (n/8)*(k/QK_K) blocks - else from_bytes
+            // panics or the matmul runs with groups == 0 and emits zeros.
+            if n == 0 || n % 8 != 0 {
+                crate::bail!("Q6Kx8 tensor {dims:?}: n must be a positive multiple of 8");
+            }
+            let k = tensor_elems / n;
+            let block_bytes = std::mem::size_of::<super::repack::BlockQ6Kx8>();
+            if k % k_quants::QK_K != 0
+                || size_in_bytes != (n / 8) * (k / k_quants::QK_K) * block_bytes
+            {
+                crate::bail!(
+                    "Q6Kx8 tensor {dims:?}: byte count must equal (n/8)*(k/QK_K) packed blocks"
+                );
+            }
             let packed = super::repack::PackedQ6Kx8::from_bytes(&raw_data[..size_in_bytes], n);
             let storage = QStorage::Cpu(Box::new(packed));
             super::QTensor::new(storage, dims)
@@ -275,5 +290,25 @@ impl Content {
             None => crate::bail!("cannot find tensor with name '{name}'"),
             Some(tensor) => Ok(tensor),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Q6Kx8 dims that aren't whole 8-row groups must bail, not panic or zero-load.
+    #[test]
+    fn q6kx8_rejects_misaligned_rows() {
+        let dev = Device::Cpu;
+        let raw = vec![0u8; 1 << 16];
+        // n=4 previously panicked in from_bytes; n=1 loaded then ran with groups==0.
+        for dims in [vec![4usize, 256], vec![1, 2048]] {
+            assert!(qtensor_from_ggml(GgmlDType::Q6Kx8, &raw, dims, &dev).is_err());
+        }
+        // A whole 8-row group with one super-block loads.
+        let bs = std::mem::size_of::<crate::quantized::repack::BlockQ6Kx8>();
+        let ok = vec![0u8; bs];
+        assert!(qtensor_from_ggml(GgmlDType::Q6Kx8, &ok, vec![8, 256], &dev).is_ok());
     }
 }

--- a/candle-core/src/quantized/ggml_file.rs
+++ b/candle-core/src/quantized/ggml_file.rs
@@ -185,8 +185,7 @@ pub fn qtensor_from_ggml(
             from_raw_data::<k_quants::BlockQ6K>(raw_data, size_in_bytes, dims, device)
         }
         GgmlDType::Q6Kx8 => {
-            // Pre-packed interleaved Q6_K: owned copy from the raw bytes. n = dims[0]
-            // (output channels); k = dims[1]. CPU only.
+            // Pre-packed Q6_K, owned copy from raw bytes (n = dims[0]); CPU only.
             if !matches!(device, Device::Cpu) {
                 crate::bail!("Q6Kx8 is CPU-only");
             }

--- a/candle-core/src/quantized/ggml_file.rs
+++ b/candle-core/src/quantized/ggml_file.rs
@@ -184,6 +184,20 @@ pub fn qtensor_from_ggml(
         GgmlDType::Q6K => {
             from_raw_data::<k_quants::BlockQ6K>(raw_data, size_in_bytes, dims, device)
         }
+        GgmlDType::Q6Kx8 => {
+            // Pre-packed interleaved Q6_K: owned copy from the raw bytes. n = dims[0]
+            // (output channels); k = dims[1]. CPU only.
+            if !matches!(device, Device::Cpu) {
+                crate::bail!("Q6Kx8 is CPU-only");
+            }
+            let n = match dims.first() {
+                Some(n) => *n,
+                None => crate::bail!("Q6Kx8 tensor has no dims"),
+            };
+            let packed = super::repack::PackedQ6Kx8::from_bytes(&raw_data[..size_in_bytes], n);
+            let storage = QStorage::Cpu(Box::new(packed));
+            super::QTensor::new(storage, dims)
+        }
         _ => crate::bail!("quantized type {ggml_dtype:?} is not supported yet"),
     }
 }

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -115,6 +115,9 @@ impl QMetalStorage {
                 let vec: Vec<crate::quantized::BlockQ8K> = read_to_vec(&buffer, block_len);
                 crate::quantized::BlockQ8K::to_float(&vec, &mut out);
             }
+            // Q6Kx8 is a CPU-only baked dtype; it can never be loaded onto Metal
+            // (`QStorage::from_data` bails first), so this arm is unreachable.
+            GgmlDType::Q6Kx8 => crate::bail!("Q6Kx8 is CPU-only"),
         }
 
         let buffer = self
@@ -497,6 +500,9 @@ impl From<GgmlDType> for candle_metal_kernels::GgmlDType {
             GgmlDType::F16 => candle_metal_kernels::GgmlDType::F16,
             GgmlDType::F32 => candle_metal_kernels::GgmlDType::F32,
             GgmlDType::BF16 => candle_metal_kernels::GgmlDType::BF16,
+            // CPU-only baked dtype; there is no Metal-kernel equivalent and it can
+            // never reach a Metal storage, so the conversion is unreachable.
+            GgmlDType::Q6Kx8 => unreachable!("Q6Kx8 is CPU-only"),
         }
     }
 }

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -115,8 +115,7 @@ impl QMetalStorage {
                 let vec: Vec<crate::quantized::BlockQ8K> = read_to_vec(&buffer, block_len);
                 crate::quantized::BlockQ8K::to_float(&vec, &mut out);
             }
-            // Q6Kx8 is a CPU-only baked dtype; it can never be loaded onto Metal
-            // (`QStorage::from_data` bails first), so this arm is unreachable.
+            // CPU-only; never loaded onto Metal (from_data bails first).
             GgmlDType::Q6Kx8 => crate::bail!("Q6Kx8 is CPU-only"),
         }
 
@@ -500,8 +499,7 @@ impl From<GgmlDType> for candle_metal_kernels::GgmlDType {
             GgmlDType::F16 => candle_metal_kernels::GgmlDType::F16,
             GgmlDType::F32 => candle_metal_kernels::GgmlDType::F32,
             GgmlDType::BF16 => candle_metal_kernels::GgmlDType::BF16,
-            // CPU-only baked dtype; there is no Metal-kernel equivalent and it can
-            // never reach a Metal storage, so the conversion is unreachable.
+            // CPU-only; no Metal-kernel equivalent and never reaches Metal storage.
             GgmlDType::Q6Kx8 => unreachable!("Q6Kx8 is CPU-only"),
         }
     }

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -962,6 +962,29 @@ impl crate::CustomOp1 for QTensor {
 
                     let total_blocks =
                         self_storage.storage_size_in_bytes() / std::mem::size_of::<BlockQ4K>();
+
+                    // Prefill (m >= 4): route to the lane=row 8x4 SDOT GEMM (llama's
+                    // N1 prefill kernel), which beats the per-column SDOT path on
+                    // wide prompts. Decode (m < 4) returns false and falls through
+                    // to the upstream BlockQ4Kx8 repacked path below.
+                    {
+                        let m = dst_shape.elem_count() / n;
+                        let blocks = unsafe {
+                            std::slice::from_raw_parts(
+                                self_storage.as_ptr() as *const BlockQ4K,
+                                total_blocks,
+                            )
+                        };
+                        if repack::try_matmul_q4k_lanerow_prefill(
+                            (m, k, n),
+                            slice,
+                            blocks,
+                            &mut dst_storage,
+                        ) {
+                            return Ok((crate::CpuStorage::F32(dst_storage), dst_shape));
+                        }
+                    }
+
                     let repacked = self.repacked_qs.get_or_init(|| {
                         let blocks = unsafe {
                             std::slice::from_raw_parts(

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -64,6 +64,11 @@ pub struct QTensor {
     /// Not always used.
     #[allow(dead_code)]
     repacked_qs: OnceLock<Option<Vec<u8>>>,
+    /// Lazily initialized lane=row (interleave-4) Q4_K repack for the aarch64
+    /// prefill GEMM (`repack::BlockQ4Kx8L`), raw bytes. Tied to this tensor's
+    /// lifetime so a dropped/reallocated weight can't return a stale pack. CPU-only.
+    #[allow(dead_code)]
+    repacked_laneq: OnceLock<Option<Vec<u8>>>,
 }
 
 impl Device {
@@ -558,6 +563,7 @@ impl QTensor {
             storage,
             shape,
             repacked_qs: OnceLock::new(),
+            repacked_laneq: OnceLock::new(),
         })
     }
 
@@ -579,6 +585,7 @@ impl QTensor {
             storage,
             shape: shape.clone(),
             repacked_qs: OnceLock::new(),
+            repacked_laneq: OnceLock::new(),
         })
     }
 
@@ -615,6 +622,7 @@ impl QTensor {
             storage,
             shape: shape.clone(),
             repacked_qs: OnceLock::new(),
+            repacked_laneq: OnceLock::new(),
         })
     }
 
@@ -659,6 +667,7 @@ impl QTensor {
             storage,
             shape: shape.clone(),
             repacked_qs: OnceLock::new(),
+            repacked_laneq: OnceLock::new(),
         })
     }
 
@@ -688,6 +697,7 @@ impl QTensor {
             storage,
             shape: shape.clone(),
             repacked_qs: OnceLock::new(),
+            repacked_laneq: OnceLock::new(),
         })
     }
 
@@ -965,22 +975,40 @@ impl crate::CustomOp1 for QTensor {
 
                     // Prefill (m >= 4): route to the lane=row 8x4 SDOT GEMM (llama's
                     // N1 prefill kernel), which beats the per-column SDOT path on
-                    // wide prompts. Decode (m < 4) returns false and falls through
-                    // to the upstream BlockQ4Kx8 repacked path below.
-                    {
+                    // wide prompts. The interleave-4 pack is cached on THIS tensor
+                    // (`repacked_laneq`, like `repacked_qs`) so it shares the weight's
+                    // lifetime - no stale reuse if the tensor is dropped/reallocated.
+                    // Decode (m < 4) or a disabled toggle falls through to the
+                    // upstream BlockQ4Kx8 path below.
+                    if dst_shape.elem_count() / n >= 4 && repack::prefill_lanerow_enabled() {
                         let m = dst_shape.elem_count() / n;
-                        let blocks = unsafe {
-                            std::slice::from_raw_parts(
-                                self_storage.as_ptr() as *const BlockQ4K,
-                                total_blocks,
-                            )
-                        };
-                        if repack::try_matmul_q4k_lanerow_prefill(
-                            (m, k, n),
-                            slice,
-                            blocks,
-                            &mut dst_storage,
-                        ) {
+                        let laneq = self.repacked_laneq.get_or_init(|| {
+                            let blocks = unsafe {
+                                std::slice::from_raw_parts(
+                                    self_storage.as_ptr() as *const BlockQ4K,
+                                    total_blocks,
+                                )
+                            };
+                            let packed =
+                                repack::repack_q4k_weight_laneq4(blocks, n, total_blocks / n);
+                            Some(packed.as_bytes().to_vec())
+                        });
+                        if let Some(laneq_bytes) = laneq {
+                            let laneq_blocks: &[repack::BlockQ4Kx8L] =
+                                <[repack::BlockQ4Kx8L]>::ref_from_bytes(laneq_bytes).map_err(
+                                    |_| {
+                                        crate::Error::Msg(
+                                            "repacked_laneq alignment invariant violated"
+                                                .to_string(),
+                                        )
+                                    },
+                                )?;
+                            repack::matmul_q4kx8l_lanerow(
+                                (m, k, n),
+                                slice,
+                                laneq_blocks,
+                                &mut dst_storage,
+                            );
                             return Ok((crate::CpuStorage::F32(dst_storage), dst_shape));
                         }
                     }

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -14,6 +14,7 @@ pub mod imatrix_file;
 pub mod k_quants;
 #[cfg(feature = "metal")]
 pub mod metal;
+pub mod repack;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod tokenizer;
 #[cfg(not(feature = "metal"))]
@@ -111,6 +112,7 @@ impl QStorage {
                 GgmlDType::Q6K => metal::load_quantized(d, as_t_slice::<BlockQ6K>(data)),
                 GgmlDType::Q8K => metal::load_quantized(d, as_t_slice::<BlockQ8K>(data)),
                 GgmlDType::BF16 => metal::load_quantized(d, as_t_slice::<bf16>(data)),
+                GgmlDType::Q6Kx8 => crate::bail!("Q6Kx8 is CPU-only"),
             },
             Device::Cuda(d) => match dtype {
                 GgmlDType::F32 => cuda::load_quantized(d, as_t_slice::<f32>(data)),
@@ -128,6 +130,7 @@ impl QStorage {
                 GgmlDType::Q6K => cuda::load_quantized(d, as_t_slice::<BlockQ6K>(data)),
                 GgmlDType::Q8K => cuda::load_quantized(d, as_t_slice::<BlockQ8K>(data)),
                 GgmlDType::BF16 => cuda::load_quantized(d, as_t_slice::<bf16>(data)),
+                GgmlDType::Q6Kx8 => crate::bail!("Q6Kx8 is CPU-only"),
             },
         }
     }
@@ -294,6 +297,11 @@ pub enum GgmlDType {
     Q5K,
     Q6K,
     Q8K,
+    /// 8-row-interleaved Q6_K for the fast aarch64 SDOT GEMM (`repack::BlockQ6Kx8`).
+    /// Baked offline (via gguf-requant `--pack`); llama.cpp will not read it. The
+    /// Q6_K analogue of the upstream runtime-repacked Q4_K x8 path, for the residual
+    /// Q6_K tensors (attn_v / ffn_down). CPU-only.
+    Q6Kx8,
 }
 
 impl GgmlDType {
@@ -315,6 +323,7 @@ impl GgmlDType {
             15 => Self::Q8K,
             // https://github.com/ggerganov/ggml/blob/29d87fc6676e7ed0cdfdec0804b06001d9c2bb44/include/ggml.h#L389
             30 => Self::BF16,
+            1001 => Self::Q6Kx8,
             _ => crate::bail!("unknown dtype for tensor {u}"),
         };
         Ok(dtype)
@@ -338,6 +347,7 @@ impl GgmlDType {
             Self::Q8K => 15,
             // https://github.com/ggerganov/ggml/blob/29d87fc6676e7ed0cdfdec0804b06001d9c2bb44/include/ggml.h#L389
             Self::BF16 => 30,
+            Self::Q6Kx8 => 1001,
         }
     }
 
@@ -359,6 +369,7 @@ impl GgmlDType {
             Self::Q6K => Box::new(vec![BlockQ6K::zeros(); elem_count / BlockQ6K::BLCK_SIZE]),
             Self::Q8K => Box::new(vec![BlockQ8K::zeros(); elem_count / BlockQ8K::BLCK_SIZE]),
             Self::BF16 => Box::new(vec![bf16::zeros(); elem_count]),
+            Self::Q6Kx8 => unreachable!("Q6Kx8 loaded via qtensor_from_ggml/mmap"),
         }
     }
 
@@ -380,6 +391,8 @@ impl GgmlDType {
             Self::Q6K => Box::new(as_t_slice::<BlockQ6K>(data).to_vec()),
             Self::Q8K => Box::new(as_t_slice::<BlockQ8K>(data).to_vec()),
             Self::BF16 => Box::new(as_t_slice::<bf16>(data).to_vec()),
+            // n is not available here; Q6Kx8 is built in qtensor_from_ggml/mmap.
+            Self::Q6Kx8 => unreachable!("Q6Kx8 loaded via qtensor_from_ggml/mmap"),
         }
     }
 
@@ -402,6 +415,13 @@ impl GgmlDType {
             Self::Q5K => std::mem::size_of::<BlockQ5K>(),
             Self::Q6K => std::mem::size_of::<BlockQ6K>(),
             Self::Q8K => std::mem::size_of::<BlockQ8K>(),
+            // 8-row interleaved: type_size is the per-row block stride, so
+            // (n/8)*(k/256)*sizeof = exactly the BlockQ6Kx8 byte count.
+            Self::Q6Kx8 => {
+                let sz = std::mem::size_of::<repack::BlockQ6Kx8>();
+                debug_assert_eq!(sz % repack::Q4KX8_ROWS, 0, "BlockQ6Kx8 size {sz} not /8");
+                sz / repack::Q4KX8_ROWS
+            }
         }
     }
 
@@ -417,6 +437,7 @@ impl GgmlDType {
             Self::Q8_0 => k_quants::QK8_0,
             Self::Q8_1 => k_quants::QK8_1,
             Self::Q2K | Self::Q3K | Self::Q4K | Self::Q5K | Self::Q6K | Self::Q8K => k_quants::QK_K,
+            Self::Q6Kx8 => k_quants::QK_K,
         }
     }
 }

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -64,9 +64,8 @@ pub struct QTensor {
     /// Not always used.
     #[allow(dead_code)]
     repacked_qs: OnceLock<Option<Vec<u8>>>,
-    /// Lazily initialized lane=row (interleave-4) Q4_K repack for the aarch64
-    /// prefill GEMM (`repack::BlockQ4Kx8L`), raw bytes. Tied to this tensor's
-    /// lifetime so a dropped/reallocated weight can't return a stale pack. CPU-only.
+    /// Lazily repacked lane=row Q4_K weight (`repack::BlockQ4Kx8L` bytes) for the
+    /// aarch64 prefill GEMM; tied to this tensor's lifetime so it can't go stale.
     #[allow(dead_code)]
     repacked_laneq: OnceLock<Option<Vec<u8>>>,
 }
@@ -302,10 +301,8 @@ pub enum GgmlDType {
     Q5K,
     Q6K,
     Q8K,
-    /// 8-row-interleaved Q6_K for the fast aarch64 SDOT GEMM (`repack::BlockQ6Kx8`).
-    /// Baked offline (via gguf-requant `--pack`); llama.cpp will not read it. The
-    /// Q6_K analogue of the upstream runtime-repacked Q4_K x8 path, for the residual
-    /// Q6_K tensors (attn_v / ffn_down). CPU-only.
+    /// 8-row-interleaved Q6_K (`repack::BlockQ6Kx8`), baked offline via gguf-requant
+    /// `--pack`. CPU-only; the Q6_K analogue of the upstream Q4_K x8 path.
     Q6Kx8,
 }
 
@@ -420,8 +417,7 @@ impl GgmlDType {
             Self::Q5K => std::mem::size_of::<BlockQ5K>(),
             Self::Q6K => std::mem::size_of::<BlockQ6K>(),
             Self::Q8K => std::mem::size_of::<BlockQ8K>(),
-            // 8-row interleaved: type_size is the per-row block stride, so
-            // (n/8)*(k/256)*sizeof = exactly the BlockQ6Kx8 byte count.
+            // 8-row interleaved: per-row block stride = BlockQ6Kx8 size / 8.
             Self::Q6Kx8 => {
                 let sz = std::mem::size_of::<repack::BlockQ6Kx8>();
                 debug_assert_eq!(sz % repack::Q4KX8_ROWS, 0, "BlockQ6Kx8 size {sz} not /8");
@@ -973,13 +969,9 @@ impl crate::CustomOp1 for QTensor {
                     let total_blocks =
                         self_storage.storage_size_in_bytes() / std::mem::size_of::<BlockQ4K>();
 
-                    // Prefill (m >= 4): route to the lane=row 8x4 SDOT GEMM (llama's
-                    // N1 prefill kernel), which beats the per-column SDOT path on
-                    // wide prompts. The interleave-4 pack is cached on THIS tensor
-                    // (`repacked_laneq`, like `repacked_qs`) so it shares the weight's
-                    // lifetime - no stale reuse if the tensor is dropped/reallocated.
-                    // Decode (m < 4) or a disabled toggle falls through to the
-                    // upstream BlockQ4Kx8 path below.
+                    // Prefill (m >= 4) routes to the lane=row 8x4 GEMM; the pack is
+                    // cached on this tensor (`repacked_laneq`). Decode (m < 4) or a
+                    // disabled toggle falls through to the #3643 path below.
                     if dst_shape.elem_count() / n >= 4 && repack::prefill_lanerow_enabled() {
                         let m = dst_shape.elem_count() / n;
                         let laneq = self.repacked_laneq.get_or_init(|| {

--- a/candle-core/src/quantized/neon.rs
+++ b/candle-core/src/quantized/neon.rs
@@ -4,6 +4,8 @@ use super::k_quants::{
     BlockQ2K, BlockQ3K, BlockQ4K, BlockQ4_0, BlockQ5K, BlockQ6K, BlockQ8K, BlockQ8_0, QK8_0, QK_K,
 };
 use super::repack::BlockQ6Kx8;
+#[cfg(target_feature = "dotprod")]
+use super::repack::{BlockQ4Kx8L, BlockQ8Kx4};
 use byteorder::{ByteOrder, LittleEndian};
 
 #[allow(unused_imports)]
@@ -1444,6 +1446,218 @@ pub(crate) fn gemm_q6kx8_q8k<const MR: usize>(
             for a in 0..MR {
                 dst[c * MR + a] = sumf[c][a];
             }
+        }
+    }
+}
+
+/// Unpack one sub-block-pair's 6-bit scales/mins from the laneq 12-byte group into
+/// 8 i8 scales + an int16x8 of mins. Port of llama's `decode_q_Kx8_6bit_scales`.
+#[cfg(target_feature = "dotprod")]
+#[inline(always)]
+unsafe fn decode_q_kx8_6bit_scales(
+    scales_in: &[u8],
+    out_mins: &mut int16x8_t,
+    out_scales: &mut [i8; 8],
+) {
+    const KMASK1: u32 = 0x3f3f_3f3f;
+    const KMASK2: u32 = 0x0f0f_0f0f;
+    const KMASK3: u32 = 0x0303_0303;
+    let sm = [
+        u32::from_le_bytes([scales_in[0], scales_in[1], scales_in[2], scales_in[3]]),
+        u32::from_le_bytes([scales_in[4], scales_in[5], scales_in[6], scales_in[7]]),
+        u32::from_le_bytes([scales_in[8], scales_in[9], scales_in[10], scales_in[11]]),
+    ];
+    let mins_0_3 = sm[1] & KMASK1;
+    let mins_4_7 = ((sm[2] >> 4) & KMASK2) | (((sm[1] >> 6) & KMASK3) << 4);
+    let mins_u32 = [mins_0_3, mins_4_7];
+    let mins_u8 = vreinterpret_u8_u32(vld1_u32(mins_u32.as_ptr()));
+    *out_mins = vreinterpretq_s16_u16(vmovl_u8(mins_u8));
+    let s0 = (sm[0] & KMASK1).to_le_bytes();
+    let s1 = ((sm[2] & KMASK2) | (((sm[0] >> 6) & KMASK3) << 4)).to_le_bytes();
+    for l in 0..4 {
+        out_scales[l] = s0[l] as i8;
+        out_scales[4 + l] = s1[l] as i8;
+    }
+}
+
+/// Lane-indexed SDOT: `acc += dot4(a[i], b[LANE])` per output lane i, where b's
+/// 4-byte group `LANE` is broadcast as the multiplier. Emits `SDOT (by element)`
+/// directly (the std `vdotq_laneq_s32` intrinsic is unstable). Safe on stable:
+/// `dotprod` is a target feature. Used by the lane=row GEMM where LANE selects the
+/// activation ROW, so one weight load feeds all 4 rows of the tile.
+#[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
+#[inline(always)]
+unsafe fn vdot_laneq<const LANE: i32>(mut acc: int32x4_t, a: int8x16_t, b: int8x16_t) -> int32x4_t {
+    core::arch::asm!(
+        "sdot {acc:v}.4s, {a:v}.16b, {b:v}.4b[{lane}]",
+        acc = inout(vreg) acc,
+        a = in(vreg) a,
+        b = in(vreg) b,
+        lane = const LANE,
+        options(pure, nomem, nostack, preserves_flags),
+    );
+    acc
+}
+
+/// Packed Q4_K prefill GEMM, lane=row SDOT: 8 output channels x 4 activation rows,
+/// writing a row-major 4x8 tile `dst[row*8 + col]` (same as `gemm_q4kx8_q8k_i8mm`,
+/// so it shares that driver/scatter). This is llama's ACTUAL N1 prefill kernel
+/// (`ggml_gemm_q4_K_8x4_q8_K`, DOTPROD branch) - NOT i8mm, runs on any dotprod core
+/// incl. N1. The win vs candle's `gemm_q4kx_q8k`: the activation is the row-
+/// interleaved `BlockQ8Kx4` (4x4 pack) so the SDOT LANE selects the row - one
+/// weight load (`q4_0123_lo`) feeds all 4 rows via 4 lane dots - AND the 6-bit
+/// scale is folded to f32 PER SUB-BLOCK, so only ~16 live int accumulators are
+/// needed for the 8-col x 4-row tile (candle's kernel holds 32 scaled-int accs
+/// across all chunks, which spills the 32 NEON regs at this tile width). Consumes
+/// the `BlockQ4Kx8L` weight (interleave 8) + `BlockQ8Kx4` from `quantize_mat_q8_k_4x4`.
+/// Bit-exact (mod f32 reassociation) to the scalar Q4_K dot.
+#[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
+#[allow(clippy::needless_range_loop)]
+pub(crate) fn gemm_q4kx8_q8k_lanerow(q4: &[BlockQ4Kx8L], q8: &[BlockQ8Kx4], dst: &mut [f32]) {
+    let nb = q4.len();
+    debug_assert!(q8.len() == nb && dst.len() == 32);
+    unsafe {
+        let m4b = vdupq_n_u8(0x0f);
+        // f32 output accumulators: acc_f32[2*row + cg], cg 0 = cols 0123, 1 = 4567.
+        let mut acc_f32 = [vdupq_n_f32(0.0); 8];
+        for b in 0..nb {
+            let q4b = &q4[b];
+            let q8b = &q8[b];
+            let q4d0 = {
+                let a: [f32; 4] = core::array::from_fn(|l| q4b.d[l].to_f32());
+                vld1q_f32(a.as_ptr())
+            };
+            let q4d1 = {
+                let a: [f32; 4] = core::array::from_fn(|l| q4b.d[4 + l].to_f32());
+                vld1q_f32(a.as_ptr())
+            };
+            let q4m0 = {
+                let a: [f32; 4] = core::array::from_fn(|l| q4b.dmin[l].to_f32());
+                vld1q_f32(a.as_ptr())
+            };
+            let q4m1 = {
+                let a: [f32; 4] = core::array::from_fn(|l| q4b.dmin[4 + l].to_f32());
+                vld1q_f32(a.as_ptr())
+            };
+            let q8d = vld1q_f32(q8b.d.as_ptr());
+            // Per-row super-block scale/min (q4_d * q8_d[row]).
+            let sbd_s0 = [
+                vmulq_laneq_f32(q4d0, q8d, 0),
+                vmulq_laneq_f32(q4d0, q8d, 1),
+                vmulq_laneq_f32(q4d0, q8d, 2),
+                vmulq_laneq_f32(q4d0, q8d, 3),
+            ];
+            let sbd_s1 = [
+                vmulq_laneq_f32(q4d1, q8d, 0),
+                vmulq_laneq_f32(q4d1, q8d, 1),
+                vmulq_laneq_f32(q4d1, q8d, 2),
+                vmulq_laneq_f32(q4d1, q8d, 3),
+            ];
+            let sbd_m0 = [
+                vmulq_laneq_f32(q4m0, q8d, 0),
+                vmulq_laneq_f32(q4m0, q8d, 1),
+                vmulq_laneq_f32(q4m0, q8d, 2),
+                vmulq_laneq_f32(q4m0, q8d, 3),
+            ];
+            let sbd_m1 = [
+                vmulq_laneq_f32(q4m1, q8d, 0),
+                vmulq_laneq_f32(q4m1, q8d, 1),
+                vmulq_laneq_f32(q4m1, q8d, 2),
+                vmulq_laneq_f32(q4m1, q8d, 3),
+            ];
+            let mut bsums_arr = [[0i16; 8]; 4];
+            for r in 0..4 {
+                let p = q8b.bsums.as_ptr().add(16 * r);
+                let v = vpaddq_s16(vld1q_s16(p), vld1q_s16(p.add(8)));
+                vst1q_s16(bsums_arr[r].as_mut_ptr(), v);
+            }
+            let mut bias_acc = [vdupq_n_s32(0); 8];
+            for sb in 0..QK_K / 64 {
+                let mut acc_lo = [vdupq_n_s32(0); 8]; // [row]=cols0123, [row+4]=4567
+                let mut acc_hi = [vdupq_n_s32(0); 8];
+                let mut q4sb_scales = [vdupq_n_s16(0); 2];
+                let mut q4sb_mins = [vdupq_n_s16(0); 2];
+                for i in 0..2 {
+                    let mut aux = [0i8; 8];
+                    decode_q_kx8_6bit_scales(
+                        &q4b.scales[sb * 24 + i * 12..],
+                        &mut q4sb_mins[i],
+                        &mut aux,
+                    );
+                    q4sb_scales[i] = vmovl_s8(vld1_s8(aux.as_ptr()));
+                }
+                for k in 0..8 {
+                    let q8_blk0 = vld1q_s8(q8b.qs.as_ptr().add(sb * 256 + 16 * k));
+                    let q8_blk1 = vld1q_s8(q8b.qs.as_ptr().add(sb * 256 + 16 * k + 128));
+                    let q4_0123 = vld1q_u8(q4b.qs.as_ptr().add(sb * QK_K + 32 * k));
+                    let q4_4567 = vld1q_u8(q4b.qs.as_ptr().add(sb * QK_K + 32 * k + 16));
+                    let lo0 = vreinterpretq_s8_u8(vandq_u8(q4_0123, m4b));
+                    let hi0 = vreinterpretq_s8_u8(vshrq_n_u8(q4_0123, 4));
+                    let lo1 = vreinterpretq_s8_u8(vandq_u8(q4_4567, m4b));
+                    let hi1 = vreinterpretq_s8_u8(vshrq_n_u8(q4_4567, 4));
+                    // One weight load feeds all 4 rows; LANE = row.
+                    acc_lo[0] = vdot_laneq::<0>(acc_lo[0], lo0, q8_blk0);
+                    acc_lo[1] = vdot_laneq::<1>(acc_lo[1], lo0, q8_blk0);
+                    acc_lo[2] = vdot_laneq::<2>(acc_lo[2], lo0, q8_blk0);
+                    acc_lo[3] = vdot_laneq::<3>(acc_lo[3], lo0, q8_blk0);
+                    acc_hi[0] = vdot_laneq::<0>(acc_hi[0], hi0, q8_blk1);
+                    acc_hi[1] = vdot_laneq::<1>(acc_hi[1], hi0, q8_blk1);
+                    acc_hi[2] = vdot_laneq::<2>(acc_hi[2], hi0, q8_blk1);
+                    acc_hi[3] = vdot_laneq::<3>(acc_hi[3], hi0, q8_blk1);
+                    acc_lo[4] = vdot_laneq::<0>(acc_lo[4], lo1, q8_blk0);
+                    acc_lo[5] = vdot_laneq::<1>(acc_lo[5], lo1, q8_blk0);
+                    acc_lo[6] = vdot_laneq::<2>(acc_lo[6], lo1, q8_blk0);
+                    acc_lo[7] = vdot_laneq::<3>(acc_lo[7], lo1, q8_blk0);
+                    acc_hi[4] = vdot_laneq::<0>(acc_hi[4], hi1, q8_blk1);
+                    acc_hi[5] = vdot_laneq::<1>(acc_hi[5], hi1, q8_blk1);
+                    acc_hi[6] = vdot_laneq::<2>(acc_hi[6], hi1, q8_blk1);
+                    acc_hi[7] = vdot_laneq::<3>(acc_hi[7], hi1, q8_blk1);
+                }
+                // Fold the 6-bit scale to f32 for THIS sub-block (keeps live int
+                // accumulators at 16, so the 8x4 tile fits in registers).
+                let sc0_lo = vmovl_s16(vget_low_s16(q4sb_scales[0]));
+                let sc1_lo = vmovl_s16(vget_high_s16(q4sb_scales[0]));
+                let sc0_hi = vmovl_s16(vget_low_s16(q4sb_scales[1]));
+                let sc1_hi = vmovl_s16(vget_high_s16(q4sb_scales[1]));
+                for row in 0..4 {
+                    let sumf0 = vcvtq_f32_s32(vaddq_s32(
+                        vmulq_s32(sc0_lo, acc_lo[row]),
+                        vmulq_s32(sc0_hi, acc_hi[row]),
+                    ));
+                    acc_f32[2 * row] = vfmaq_f32(acc_f32[2 * row], sbd_s0[row], sumf0);
+                    let sumf1 = vcvtq_f32_s32(vaddq_s32(
+                        vmulq_s32(sc1_lo, acc_lo[row + 4]),
+                        vmulq_s32(sc1_hi, acc_hi[row + 4]),
+                    ));
+                    acc_f32[2 * row + 1] = vfmaq_f32(acc_f32[2 * row + 1], sbd_s1[row], sumf1);
+                    let blo = vdup_n_s16(bsums_arr[sb][row * 2]);
+                    let bhi = vdup_n_s16(bsums_arr[sb][row * 2 + 1]);
+                    bias_acc[2 * row] =
+                        vmlal_s16(bias_acc[2 * row], blo, vget_low_s16(q4sb_mins[0]));
+                    bias_acc[2 * row] =
+                        vmlal_s16(bias_acc[2 * row], bhi, vget_low_s16(q4sb_mins[1]));
+                    bias_acc[2 * row + 1] =
+                        vmlal_s16(bias_acc[2 * row + 1], blo, vget_high_s16(q4sb_mins[0]));
+                    bias_acc[2 * row + 1] =
+                        vmlal_s16(bias_acc[2 * row + 1], bhi, vget_high_s16(q4sb_mins[1]));
+                }
+            }
+            for row in 0..4 {
+                acc_f32[2 * row] = vmlsq_f32(
+                    acc_f32[2 * row],
+                    vcvtq_f32_s32(bias_acc[2 * row]),
+                    sbd_m0[row],
+                );
+                acc_f32[2 * row + 1] = vmlsq_f32(
+                    acc_f32[2 * row + 1],
+                    vcvtq_f32_s32(bias_acc[2 * row + 1]),
+                    sbd_m1[row],
+                );
+            }
+        }
+        for row in 0..4 {
+            vst1q_f32(dst.as_mut_ptr().add(row * 8), acc_f32[2 * row]);
+            vst1q_f32(dst.as_mut_ptr().add(row * 8 + 4), acc_f32[2 * row + 1]);
         }
     }
 }

--- a/candle-core/src/quantized/neon.rs
+++ b/candle-core/src/quantized/neon.rs
@@ -3,6 +3,7 @@ use super::k_quants::BlockQ4Kx8;
 use super::k_quants::{
     BlockQ2K, BlockQ3K, BlockQ4K, BlockQ4_0, BlockQ5K, BlockQ6K, BlockQ8K, BlockQ8_0, QK8_0, QK_K,
 };
+use super::repack::BlockQ6Kx8;
 use byteorder::{ByteOrder, LittleEndian};
 
 #[allow(unused_imports)]
@@ -1324,4 +1325,125 @@ pub(crate) fn vec_dot_8_q4k_q8k(n: usize, xs: &[BlockQ4Kx8], ys: &[BlockQ8K]) ->
         vst1q_f32(out.as_mut_ptr().add(4), vacc_1);
     }
     out
+}
+
+#[allow(clippy::needless_range_loop)]
+pub(crate) fn gemm_q6kx8_q8k<const MR: usize>(
+    packed: &[BlockQ6Kx8],
+    rows: &[&[BlockQ8K]; MR],
+    dst: &mut [f32],
+) {
+    const NC: usize = 8;
+    const QLC: usize = QK_K / 4; // 64 ql bytes / chunk
+    const QHC: usize = QK_K / 8; // 32 qh bytes / chunk
+    const NSC: usize = QK_K / 16; // 16 scales / super-block
+    debug_assert!(dst.len() == NC * MR);
+    let nb = packed.len();
+    let mut sumf = [[0f32; MR]; NC];
+    unsafe {
+        let m4b = vdupq_n_u8(0xF);
+        let mone = vdupq_n_u8(3);
+        for i in 0..nb {
+            let blk = &packed[i];
+            // Hoist base pointers once per block (same address-arithmetic win as the Q4 kernel):
+            // inner addresses become `base + const` instead of re-walking `blk.*.as_ptr().add(..)`
+            // and re-indexing `rows[a][i]` every chunk.
+            let qh_ptr = blk.qh.as_ptr();
+            let ql_ptr = blk.ql.as_ptr();
+            let sc_ptr = blk.scales.as_ptr();
+            let mut rq = [core::ptr::null::<i8>(); MR];
+            let mut rd = [0f32; MR];
+            for a in 0..MR {
+                rq[a] = rows[a][i].qs.as_ptr();
+                rd[a] = rows[a][i].d;
+            }
+            // Bias: isum_mins[c][a] = sum_s scales[c][s] * bsums[a][s] (16 sub-blocks).
+            let mut bsums = [(vdupq_n_s16(0), vdupq_n_s16(0)); MR];
+            for a in 0..MR {
+                let b = rows[a][i].bsums.as_ptr();
+                bsums[a] = (vld1q_s16(b), vld1q_s16(b.add(8)));
+            }
+            let mut isum_mins = [[0i32; MR]; NC];
+            for c in 0..NC {
+                let sc8 = vld1q_s8(sc_ptr.add(c * NSC));
+                let s_lo = vmovl_s8(vget_low_s8(sc8));
+                let s_hi = vmovl_s8(vget_high_s8(sc8));
+                for a in 0..MR {
+                    let prod = vaddq_s32(
+                        vaddq_s32(
+                            vmull_s16(vget_low_s16(bsums[a].0), vget_low_s16(s_lo)),
+                            vmull_s16(vget_high_s16(bsums[a].0), vget_high_s16(s_lo)),
+                        ),
+                        vaddq_s32(
+                            vmull_s16(vget_low_s16(bsums[a].1), vget_low_s16(s_hi)),
+                            vmull_s16(vget_high_s16(bsums[a].1), vget_high_s16(s_hi)),
+                        ),
+                    );
+                    isum_mins[c][a] = vaddvq_s32(prod);
+                }
+            }
+            // Main: isum[c][a].
+            let mut isum = [[0i32; MR]; NC];
+            for j in 0..QK_K / 128 {
+                let ql_base = j * (NC * QLC);
+                let qh_base = j * (NC * QHC);
+                for c in 0..NC {
+                    let qhbits = vld1q_u8_x2(qh_ptr.add(qh_base + c * QHC));
+                    let q6bits = vld1q_u8_x4(ql_ptr.add(ql_base + c * QLC));
+                    let sc = sc_ptr.add(c * NSC + j * 8);
+                    // First half: low nibbles + low two-bit highs.
+                    let q6h_0 = vshlq_n_u8(vandq_u8(mone, qhbits.0), 4);
+                    let q6h_1 = vshlq_n_u8(vandq_u8(mone, qhbits.1), 4);
+                    let q6h_2 = vshlq_n_u8(vandq_u8(mone, vshrq_n_u8(qhbits.0, 2)), 4);
+                    let q6h_3 = vshlq_n_u8(vandq_u8(mone, vshrq_n_u8(qhbits.1, 2)), 4);
+                    let b0 = vreinterpretq_s8_u8(vorrq_u8(vandq_u8(q6bits.0, m4b), q6h_0));
+                    let b1 = vreinterpretq_s8_u8(vorrq_u8(vandq_u8(q6bits.1, m4b), q6h_1));
+                    let b2 = vreinterpretq_s8_u8(vorrq_u8(vandq_u8(q6bits.2, m4b), q6h_2));
+                    let b3 = vreinterpretq_s8_u8(vorrq_u8(vandq_u8(q6bits.3, m4b), q6h_3));
+                    for a in 0..MR {
+                        let q8 = vld1q_s8_x4(rq[a].add(j * 128));
+                        let p0 = vdotq_s32(b0, q8.0);
+                        let p1 = vdotq_s32(b1, q8.1);
+                        isum[c][a] +=
+                            vaddvq_s32(p0) * (*sc as i32) + vaddvq_s32(p1) * (*sc.add(1) as i32);
+                        let p2 = vdotq_s32(b2, q8.2);
+                        let p3 = vdotq_s32(b3, q8.3);
+                        isum[c][a] += vaddvq_s32(p2) * (*sc.add(2) as i32)
+                            + vaddvq_s32(p3) * (*sc.add(3) as i32);
+                    }
+                    // Second half: high nibbles + high two-bit highs.
+                    let q6h_0 = vshlq_n_u8(vandq_u8(mone, vshrq_n_u8(qhbits.0, 4)), 4);
+                    let q6h_1 = vshlq_n_u8(vandq_u8(mone, vshrq_n_u8(qhbits.1, 4)), 4);
+                    let q6h_2 = vshlq_n_u8(vandq_u8(mone, vshrq_n_u8(qhbits.0, 6)), 4);
+                    let q6h_3 = vshlq_n_u8(vandq_u8(mone, vshrq_n_u8(qhbits.1, 6)), 4);
+                    let b0 = vreinterpretq_s8_u8(vorrq_u8(vshrq_n_u8(q6bits.0, 4), q6h_0));
+                    let b1 = vreinterpretq_s8_u8(vorrq_u8(vshrq_n_u8(q6bits.1, 4), q6h_1));
+                    let b2 = vreinterpretq_s8_u8(vorrq_u8(vshrq_n_u8(q6bits.2, 4), q6h_2));
+                    let b3 = vreinterpretq_s8_u8(vorrq_u8(vshrq_n_u8(q6bits.3, 4), q6h_3));
+                    for a in 0..MR {
+                        let q8 = vld1q_s8_x4(rq[a].add(j * 128 + 64));
+                        let p0 = vdotq_s32(b0, q8.0);
+                        let p1 = vdotq_s32(b1, q8.1);
+                        isum[c][a] += vaddvq_s32(p0) * (*sc.add(4) as i32)
+                            + vaddvq_s32(p1) * (*sc.add(5) as i32);
+                        let p2 = vdotq_s32(b2, q8.2);
+                        let p3 = vdotq_s32(b3, q8.3);
+                        isum[c][a] += vaddvq_s32(p2) * (*sc.add(6) as i32)
+                            + vaddvq_s32(p3) * (*sc.add(7) as i32);
+                    }
+                }
+            }
+            for c in 0..NC {
+                let dc = blk.d[c].to_f32();
+                for a in 0..MR {
+                    sumf[c][a] += dc * rd[a] * ((isum[c][a] - 32 * isum_mins[c][a]) as f32);
+                }
+            }
+        }
+        for c in 0..NC {
+            for a in 0..MR {
+                dst[c * MR + a] = sumf[c][a];
+            }
+        }
+    }
 }

--- a/candle-core/src/quantized/neon.rs
+++ b/candle-core/src/quantized/neon.rs
@@ -1450,8 +1450,7 @@ pub(crate) fn gemm_q6kx8_q8k<const MR: usize>(
     }
 }
 
-/// Unpack one sub-block-pair's 6-bit scales/mins from the laneq 12-byte group into
-/// 8 i8 scales + an int16x8 of mins. Port of llama's `decode_q_Kx8_6bit_scales`.
+// Unpack a 12-byte laneq scale group into 8 i8 scales + an int16x8 of mins.
 #[cfg(target_feature = "dotprod")]
 #[inline(always)]
 unsafe fn decode_q_kx8_6bit_scales(
@@ -1480,11 +1479,8 @@ unsafe fn decode_q_kx8_6bit_scales(
     }
 }
 
-/// Lane-indexed SDOT: `acc += dot4(a[i], b[LANE])` per output lane i, where b's
-/// 4-byte group `LANE` is broadcast as the multiplier. Emits `SDOT (by element)`
-/// directly (the std `vdotq_laneq_s32` intrinsic is unstable). Safe on stable:
-/// `dotprod` is a target feature. Used by the lane=row GEMM where LANE selects the
-/// activation ROW, so one weight load feeds all 4 rows of the tile.
+// Lane-indexed SDOT (emits `sdot ... .4b[LANE]`; the std vdotq_laneq_s32 is unstable).
+// LANE selects the activation row, so one weight load feeds all 4 rows of the tile.
 #[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
 #[inline(always)]
 unsafe fn vdot_laneq<const LANE: i32>(mut acc: int32x4_t, a: int8x16_t, b: int8x16_t) -> int32x4_t {
@@ -1499,18 +1495,10 @@ unsafe fn vdot_laneq<const LANE: i32>(mut acc: int32x4_t, a: int8x16_t, b: int8x
     acc
 }
 
-/// Packed Q4_K prefill GEMM, lane=row SDOT: 8 output channels x 4 activation rows,
-/// writing a row-major 4x8 tile `dst[row*8 + col]` (same as `gemm_q4kx8_q8k_i8mm`,
-/// so it shares that driver/scatter). This is llama's ACTUAL N1 prefill kernel
-/// (`ggml_gemm_q4_K_8x4_q8_K`, DOTPROD branch) - NOT i8mm, runs on any dotprod core
-/// incl. N1. The win vs candle's `gemm_q4kx_q8k`: the activation is the row-
-/// interleaved `BlockQ8Kx4` (4x4 pack) so the SDOT LANE selects the row - one
-/// weight load (`q4_0123_lo`) feeds all 4 rows via 4 lane dots - AND the 6-bit
-/// scale is folded to f32 PER SUB-BLOCK, so only ~16 live int accumulators are
-/// needed for the 8-col x 4-row tile (candle's kernel holds 32 scaled-int accs
-/// across all chunks, which spills the 32 NEON regs at this tile width). Consumes
-/// the `BlockQ4Kx8L` weight (interleave 8) + `BlockQ8Kx4` from `quantize_mat_q8_k_4x4`.
-/// Bit-exact (mod f32 reassociation) to the scalar Q4_K dot.
+// llama's DOTPROD N1 prefill kernel (ggml_gemm_q4_K_8x4_q8_K): 8 channels x 4 rows,
+// row-major 4x8 tile. The SDOT lane selects the row (one weight load feeds 4 rows)
+// and the 6-bit scale folds to f32 per sub-block, keeping ~16 live int accs so the
+// tile fits the 32 NEON regs. Equivalent to the scalar Q4_K dot mod f32 reassociation.
 #[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
 #[allow(clippy::needless_range_loop)]
 pub(crate) fn gemm_q4kx8_q8k_lanerow(q4: &[BlockQ4Kx8L], q8: &[BlockQ8Kx4], dst: &mut [f32]) {

--- a/candle-core/src/quantized/repack.rs
+++ b/candle-core/src/quantized/repack.rs
@@ -1,0 +1,535 @@
+//! Candle-native interleaved repacking of Q6_K weights for fast aarch64 GEMM/GEMV.
+//!
+//! Mirrors the Q4_K x8 idea (8-row-interleaved layout consumed by a dedicated SDOT
+//! kernel) for the Q6_K residual tensors (attn_v / ffn_down that Q4_K_M keeps as
+//! Q6_K). The packed `BlockQ6Kx8` is loaded from a baked GGUF (GgmlDType::Q6Kx8) and
+//! driven by `gemm_q6kx8_q8k`; no runtime repack.
+#![allow(clippy::needless_range_loop)]
+
+use super::k_quants::{BlockQ6K, BlockQ8K, GgmlType, QK_K};
+use half::f16;
+use std::sync::{Arc, LazyLock};
+
+// ---- shared interleave constants ----
+pub(crate) const Q4KX8_ROWS: usize = 8;
+
+// ---- prefill tile selection (shared with the Q4 path upstream) ----
+#[derive(Clone, Copy, PartialEq)]
+enum PrefillTile {
+    Nc8mr4,
+    Nc4mr4,
+    Nc8mr2,
+}
+static PACKED_PREFILL_TILE: LazyLock<PrefillTile> = LazyLock::new(|| {
+    match std::env::var("CANDLE_PACKED_PREFILL")
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "nc8mr4" => PrefillTile::Nc8mr4,
+        "nc8mr2" => PrefillTile::Nc8mr2,
+        _ => PrefillTile::Nc4mr4,
+    }
+});
+
+// ---- packed Q6_K weight block + repack ----
+pub struct BlockQ6Kx8 {
+    pub(crate) d: [f16; Q4KX8_ROWS],
+    pub(crate) scales: [i8; Q4KX8_ROWS * (QK_K / 16)], // 128
+    pub(crate) ql: [u8; Q4KX8_ROWS * (QK_K / 2)],      // 1024: [chunk(2)][row(8)][64]
+    pub(crate) qh: [u8; Q4KX8_ROWS * (QK_K / 4)],      // 512:  [chunk(2)][row(8)][32]
+}
+
+impl BlockQ6Kx8 {
+    fn zeroed() -> Self {
+        Self {
+            d: [f16::ZERO; Q4KX8_ROWS],
+            scales: [0; Q4KX8_ROWS * (QK_K / 16)],
+            ql: [0; Q4KX8_ROWS * (QK_K / 2)],
+            qh: [0; Q4KX8_ROWS * (QK_K / 4)],
+        }
+    }
+}
+
+/// Repack `Q4KX8_ROWS` Q6_K weight rows (each `nb` super-blocks) into `nb`
+/// interleaved `BlockQ6Kx8`. Scalar (load-time, not perf-critical); the i8 scales
+/// copy directly and the 128B `ql`/64B `qh` split into two 64B/32B chunks.
+pub(crate) fn repack_q6k_x8(rows: &[&[BlockQ6K]; Q4KX8_ROWS]) -> Vec<BlockQ6Kx8> {
+    let nb = rows[0].len();
+    debug_assert!(
+        rows.iter().all(|r| r.len() == nb),
+        "ragged rows in repack_q6k_x8"
+    );
+    const QLC: usize = QK_K / 4; // 64 ql bytes / 128-value chunk
+    const QHC: usize = QK_K / 8; // 32 qh bytes / chunk
+    let mut out = Vec::with_capacity(nb);
+    for i in 0..nb {
+        let mut blk = BlockQ6Kx8::zeroed();
+        for r in 0..Q4KX8_ROWS {
+            let src = &rows[r][i];
+            blk.d[r] = src.d;
+            for s in 0..(QK_K / 16) {
+                blk.scales[r * (QK_K / 16) + s] = src.scales[s];
+            }
+            for j in 0..2 {
+                let qld = j * (Q4KX8_ROWS * QLC) + r * QLC;
+                blk.ql[qld..qld + QLC].copy_from_slice(&src.ql[j * QLC..j * QLC + QLC]);
+                let qhd = j * (Q4KX8_ROWS * QHC) + r * QHC;
+                blk.qh[qhd..qhd + QHC].copy_from_slice(&src.qh[j * QHC..j * QHC + QHC]);
+            }
+        }
+        out.push(blk);
+    }
+    out
+}
+
+/// Repack a full row-major Q6_K weight matrix into the interleaved `BlockQ6Kx8`
+/// layout for all `n/8` channel groups. Mirror of `repack_q4k_weight`.
+pub fn repack_q6k_weight(rows: &[BlockQ6K], n: usize, nb: usize) -> Vec<BlockQ6Kx8> {
+    debug_assert_eq!(n % Q4KX8_ROWS, 0, "repack_q6k_weight: n {n} not /8");
+    debug_assert_eq!(rows.len(), n * nb, "repack_q6k_weight: rows len mismatch");
+    let mut packed = Vec::with_capacity((n / 8) * nb);
+    for g in 0..n / 8 {
+        let grp: [&[BlockQ6K]; Q4KX8_ROWS] =
+            std::array::from_fn(|r| &rows[(g * 8 + r) * nb..(g * 8 + r + 1) * nb]);
+        packed.extend(repack_q6k_x8(&grp));
+    }
+    packed
+}
+
+// ---- prepacked GEMM driver ----
+pub(crate) fn matmul_q6kx8_prepacked(
+    (m, k, n): (usize, usize, usize),
+    lhs: &[f32],
+    packed: &[BlockQ6Kx8],
+    dst: &mut [f32],
+) {
+    use super::neon::gemm_q6kx8_q8k;
+    let nb = k / QK_K;
+    let groups = n / Q4KX8_ROWS;
+    // Q6 has only the 8-channel kernel; widen the prefill tile to MR=4 (the nc8mr4
+    // default) for the same channel+row reuse win, else MR=2.
+    let mr4 = *PACKED_PREFILL_TILE == PrefillTile::Nc8mr4;
+
+    thread_local! {
+        static LHS_Q: std::cell::RefCell<Vec<BlockQ8K>> =
+            const { std::cell::RefCell::new(Vec::new()) };
+    }
+    LHS_Q.with(|cell| {
+        let mut scratch = cell.borrow_mut();
+        if scratch.len() < m * nb {
+            scratch.resize(m * nb, BlockQ8K::zeros());
+        }
+        for a in 0..m {
+            BlockQ8K::from_float(&lhs[a * k..(a + 1) * k], &mut scratch[a * nb..(a + 1) * nb]);
+        }
+        let lhs_q: &[BlockQ8K] = &scratch;
+
+        struct DstPtr(*mut f32);
+        unsafe impl Sync for DstPtr {}
+        let dptr = DstPtr(dst.as_mut_ptr());
+        let process = |g: usize| {
+            let w = &packed[g * nb..(g + 1) * nb];
+            let p = &dptr;
+            let row = |r: usize| -> &[BlockQ8K] { &lhs_q[r * nb..(r + 1) * nb] };
+            let mut r = 0;
+            if mr4 {
+                while r + 4 <= m {
+                    let rows: [&[BlockQ8K]; 4] = std::array::from_fn(|a| row(r + a));
+                    let mut t = [0f32; Q4KX8_ROWS * 4];
+                    gemm_q6kx8_q8k::<4>(w, &rows, &mut t);
+                    for c in 0..Q4KX8_ROWS {
+                        for a in 0..4 {
+                            unsafe { *p.0.add((r + a) * n + g * 8 + c) = t[c * 4 + a] };
+                        }
+                    }
+                    r += 4;
+                }
+            }
+            while r + 2 <= m {
+                let rows: [&[BlockQ8K]; 2] = std::array::from_fn(|a| row(r + a));
+                let mut t = [0f32; Q4KX8_ROWS * 2];
+                gemm_q6kx8_q8k::<2>(w, &rows, &mut t);
+                for c in 0..Q4KX8_ROWS {
+                    for a in 0..2 {
+                        unsafe { *p.0.add((r + a) * n + g * 8 + c) = t[c * 2 + a] };
+                    }
+                }
+                r += 2;
+            }
+            while r < m {
+                let rows: [&[BlockQ8K]; 1] = [row(r)];
+                let mut t = [0f32; Q4KX8_ROWS];
+                gemm_q6kx8_q8k::<1>(w, &rows, &mut t);
+                for c in 0..Q4KX8_ROWS {
+                    unsafe { *p.0.add(r * n + g * 8 + c) = t[c] };
+                }
+                r += 1;
+            }
+        };
+
+        let pool = crate::utils::barrier_pool();
+        let n_total = pool.n_workers() + 1;
+        let gpt = groups.div_ceil(n_total);
+        pool.execute(|tid| {
+            let start = tid * gpt;
+            if start < groups {
+                let end = groups.min((tid + 1) * gpt);
+                for g in start..end {
+                    process(g);
+                }
+            }
+        });
+    });
+}
+
+// ===========================================================================
+// Pre-packed Q6_Kx8 as a first-class quantized storage type (GgmlDType::Q6Kx8).
+//
+// The interleaved BlockQ6Kx8 layout is baked into a GGUF offline (see the
+// gguf-requant `--pack` flag) and loaded as a SINGLE copy with no runtime
+// repack. Owned or mmap-backed; the mmap path is zero-copy (GGUF tensors are
+// 32-aligned, which covers BlockQ6Kx8's f16/u8 alignment of 2).
+// ===========================================================================
+
+// ---- packed storage type (GGUF-loaded) ----
+// Backing store for a `PackedQ6Kx8`: either an owned `Vec` (built from raw bytes)
+// or a view into a memory-mapped GGUF region (zero-copy, read-only).
+enum PackedStoreQ6 {
+    Owned(Vec<BlockQ6Kx8>),
+    Mmap {
+        mmap: Arc<memmap2::Mmap>,
+        offset: usize,
+        count: usize,
+    },
+}
+
+// SAFETY: identical to PackedStore - the Mmap variant references an immutable,
+// file-backed region kept alive by the Arc; BlockQ6Kx8 is a #[repr(C)] POD.
+unsafe impl Send for PackedStoreQ6 {}
+unsafe impl Sync for PackedStoreQ6 {}
+
+/// A pre-packed Q6_K weight: `n` output channels (`n % 8 == 0`) stored as the
+/// interleaved `BlockQ6Kx8` groups, ready for the SDOT GEMM with no repack.
+pub struct PackedQ6Kx8 {
+    store: PackedStoreQ6,
+    n: usize,
+}
+
+impl PackedQ6Kx8 {
+    #[inline]
+    fn as_slice(&self) -> &[BlockQ6Kx8] {
+        match &self.store {
+            PackedStoreQ6::Owned(v) => v.as_slice(),
+            PackedStoreQ6::Mmap {
+                mmap,
+                offset,
+                count,
+            } => {
+                // SAFETY: offset/count/alignment checked in `from_mmap`; Arc keeps
+                // the mapping alive for the lifetime of the returned slice.
+                unsafe {
+                    std::slice::from_raw_parts(
+                        mmap.as_ptr().add(*offset) as *const BlockQ6Kx8,
+                        *count,
+                    )
+                }
+            }
+        }
+    }
+
+    /// Build an owned `PackedQ6Kx8` by copying raw interleaved bytes. `raw` length
+    /// must be a whole number of blocks.
+    pub fn from_bytes(raw: &[u8], n: usize) -> Self {
+        let bs = std::mem::size_of::<BlockQ6Kx8>();
+        assert_eq!(
+            raw.len() % bs,
+            0,
+            "PackedQ6Kx8::from_bytes: {} bytes not a multiple of block size {bs}",
+            raw.len()
+        );
+        let count = raw.len() / bs;
+        let mut v: Vec<BlockQ6Kx8> = Vec::with_capacity(count);
+        unsafe {
+            std::ptr::copy_nonoverlapping(raw.as_ptr(), v.as_mut_ptr() as *mut u8, raw.len());
+            v.set_len(count);
+        }
+        Self {
+            store: PackedStoreQ6::Owned(v),
+            n,
+        }
+    }
+
+    /// Build a zero-copy `PackedQ6Kx8` viewing `byte_len` bytes at `offset` in an
+    /// mmap'd GGUF. Validates bounds and alignment.
+    pub fn from_mmap(
+        mmap: Arc<memmap2::Mmap>,
+        offset: usize,
+        byte_len: usize,
+        n: usize,
+    ) -> crate::Result<Self> {
+        let bs = std::mem::size_of::<BlockQ6Kx8>();
+        if offset + byte_len > mmap.len() {
+            crate::bail!(
+                "Q6Kx8 mmap region end {} exceeds map len {}",
+                offset + byte_len,
+                mmap.len()
+            );
+        }
+        if !byte_len.is_multiple_of(bs) {
+            crate::bail!("Q6Kx8 mmap byte_len {byte_len} not a multiple of block size {bs}");
+        }
+        let base = mmap.as_ptr() as usize + offset;
+        if !base.is_multiple_of(std::mem::align_of::<BlockQ6Kx8>()) {
+            crate::bail!(
+                "Q6Kx8 mmap tensor at offset {offset} not aligned to {}",
+                std::mem::align_of::<BlockQ6Kx8>()
+            );
+        }
+        Ok(Self {
+            store: PackedStoreQ6::Mmap {
+                mmap,
+                offset,
+                count: byte_len / bs,
+            },
+            n,
+        })
+    }
+
+    /// Dequantize the packed weight back to f32 of shape `[n, k]` (row-major).
+    /// Mirrors `BlockQ6K::to_float` per channel: the i8 sub-block scales and the
+    /// `ql`/`qh` quants come from the chunk-major, row-interleaved layout produced
+    /// by `repack_q6k_x8`. Correctness-only (not perf).
+    fn dequantize_to(&self, elem_count: usize, ys: &mut [f32]) {
+        const QLC: usize = QK_K / 4; // 64 ql bytes / 128-value chunk
+        const QHC: usize = QK_K / 8; // 32 qh bytes / chunk
+        const NSC: usize = QK_K / 16; // 16 i8 scales / row
+        let n = self.n;
+        let k = elem_count / n;
+        let nb = k / QK_K;
+        let blocks = self.as_slice();
+        debug_assert_eq!(blocks.len(), (n / Q4KX8_ROWS) * nb);
+        for g in 0..n / Q4KX8_ROWS {
+            for r in 0..Q4KX8_ROWS {
+                let out_row = g * Q4KX8_ROWS + r;
+                for i in 0..nb {
+                    let blk = &blocks[g * nb + i];
+                    let d = blk.d[r].to_f32();
+                    let base = out_row * k + i * QK_K;
+                    // Two 128-value chunks, exactly as BlockQ6K::to_float steps by 128.
+                    for idx in 0..2 {
+                        let sc = &blk.scales[r * NSC + 8 * idx..];
+                        let ql = &blk.ql[idx * (Q4KX8_ROWS * QLC) + r * QLC..];
+                        let qh = &blk.qh[idx * (Q4KX8_ROWS * QHC) + r * QHC..];
+                        let cbase = base + idx * 128;
+                        for l in 0..32 {
+                            let is = l / 16;
+                            let q1 = ((ql[l] & 0xF) | ((qh[l] & 3) << 4)) as i8 - 32;
+                            let q2 = ((ql[l + 32] & 0xF) | (((qh[l] >> 2) & 3) << 4)) as i8 - 32;
+                            let q3 = ((ql[l] >> 4) | (((qh[l] >> 4) & 3) << 4)) as i8 - 32;
+                            let q4 = ((ql[l + 32] >> 4) | (((qh[l] >> 6) & 3) << 4)) as i8 - 32;
+                            ys[cbase + l] = d * sc[is] as f32 * q1 as f32;
+                            ys[cbase + l + 32] = d * sc[is + 2] as f32 * q2 as f32;
+                            ys[cbase + l + 64] = d * sc[is + 4] as f32 * q3 as f32;
+                            ys[cbase + l + 96] = d * sc[is + 6] as f32 * q4 as f32;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl super::QuantizedType for PackedQ6Kx8 {
+    #[cfg(target_feature = "neon")]
+    fn matmul_t(
+        &self,
+        mkn: (usize, usize, usize),
+        lhs: &[f32],
+        dst: &mut [f32],
+    ) -> crate::Result<()> {
+        matmul_q6kx8_prepacked(mkn, lhs, self.as_slice(), dst);
+        Ok(())
+    }
+
+    #[cfg(not(target_feature = "neon"))]
+    fn matmul_t(
+        &self,
+        _mkn: (usize, usize, usize),
+        _lhs: &[f32],
+        _dst: &mut [f32],
+    ) -> crate::Result<()> {
+        crate::bail!("Q6Kx8 packed matmul requires the neon target feature")
+    }
+
+    fn matmul_t_f16(
+        &self,
+        mkn: (usize, usize, usize),
+        lhs: &[f16],
+        dst: &mut [f16],
+    ) -> crate::Result<()> {
+        let lhs_f: Vec<f32> = lhs.iter().map(|x| x.to_f32()).collect();
+        let mut dst_f = vec![0f32; dst.len()];
+        self.matmul_t(mkn, &lhs_f, &mut dst_f)?;
+        for (o, v) in dst.iter_mut().zip(dst_f.iter()) {
+            *o = f16::from_f32(*v);
+        }
+        Ok(())
+    }
+
+    fn dequantize(&self, elem_count: usize) -> crate::Result<super::CpuStorage> {
+        let mut ys = vec![0f32; elem_count];
+        self.dequantize_to(elem_count, &mut ys);
+        Ok(super::CpuStorage::F32(ys))
+    }
+
+    fn embedding(
+        &self,
+        _ids: &[u32],
+        _rows: usize,
+        _hidden: usize,
+    ) -> crate::Result<super::CpuStorage> {
+        // Q6Kx8 is 8-row interleaved, so individual rows can't be gathered. The
+        // `--pack` tool never packs gather-used weights (token_embd stays Q6_K), so
+        // this is only a defensive bail.
+        crate::bail!("Q6Kx8 is matmul-only (8-row interleaved); embedding gather is unsupported")
+    }
+
+    fn storage_size_in_bytes(&self) -> usize {
+        std::mem::size_of_val(self.as_slice())
+    }
+
+    fn size(&self) -> usize {
+        self.storage_size_in_bytes()
+    }
+
+    fn as_ptr(&self) -> *const u8 {
+        self.as_slice().as_ptr() as *const u8
+    }
+
+    fn block_size(&self) -> usize {
+        QK_K
+    }
+
+    fn dtype(&self) -> super::GgmlDType {
+        super::GgmlDType::Q6Kx8
+    }
+
+    fn from_float(&mut self, _xs: &[f32]) {
+        unreachable!("Q6Kx8 is bake-only; quantize-to is not supported")
+    }
+
+    fn from_float_imatrix(&mut self, _xs: &[f32], _imatrix_weights: &[f32], _n_per_row: usize) {
+        unreachable!("Q6Kx8 is bake-only; quantize-to is not supported")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quantized::k_quants::GgmlType;
+
+    fn lcg(s: &mut u64) -> f32 {
+        *s = s
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        2.0 * ((*s >> 33) as f32 / (1u64 << 31) as f32) - 1.0
+    }
+
+    // gemm_q6kx8_q8k (packed Q6_K GEMV) must be BIT-IDENTICAL to the scalar
+    // vec_dot_q6k_q8k applied per row - it mirrors the same integer ops/order.
+    #[cfg(target_feature = "neon")]
+    #[test]
+    fn gemm_q6kx8_matches_vec_dot() {
+        use crate::quantized::k_quants::{BlockQ6K, BlockQ8K};
+        use crate::quantized::neon::{gemm_q6kx8_q8k, vec_dot_q6k_q8k};
+
+        let nb = 4usize;
+        let k = nb * QK_K;
+        let mut st = 0x1357_9bdf_2468_ace0u64;
+        let mut rows_q: Vec<Vec<BlockQ6K>> = Vec::new();
+        for _ in 0..Q4KX8_ROWS {
+            let f: Vec<f32> = (0..k).map(|_| lcg(&mut st)).collect();
+            let mut q = vec![BlockQ6K::zeros(); nb];
+            BlockQ6K::from_float(&f, &mut q);
+            rows_q.push(q);
+        }
+        let af: Vec<f32> = (0..k).map(|_| lcg(&mut st)).collect();
+        let mut q8 = vec![BlockQ8K::zeros(); nb];
+        BlockQ8K::from_float(&af, &mut q8);
+
+        let reference: [f32; 8] = std::array::from_fn(|r| vec_dot_q6k_q8k(k, &rows_q[r], &q8));
+        let refs: [&[BlockQ6K]; Q4KX8_ROWS] = std::array::from_fn(|r| rows_q[r].as_slice());
+        let packed = repack_q6k_x8(&refs);
+        let mut dst = [0f32; 8];
+        gemm_q6kx8_q8k::<1>(&packed, &[q8.as_slice()], &mut dst);
+        for c in 0..8 {
+            assert_eq!(
+                dst[c].to_bits(),
+                reference[c].to_bits(),
+                "channel {c}: packed {} vs ref {}",
+                dst[c],
+                reference[c]
+            );
+        }
+    }
+
+    // End-to-end bake check: row-major Q6_K -> repack -> raw bytes -> PackedQ6Kx8
+    // must match the scalar Q6_K matmul bit-for-bit, and dequantize() must
+    // reproduce the original Q6_K dequant.
+    #[test]
+    fn packed_q6kx8_from_bytes_matches_baseline() {
+        use crate::quantized::k_quants::{matmul, BlockQ6K};
+        use crate::quantized::QuantizedType;
+
+        let k = 512usize; // 2 super-blocks
+        let n = 24usize; // 3 groups of 8
+        let nb = k / QK_K;
+        let mut st = 0x51c6_ba9d_2244_8821u64;
+
+        // Row-major Q6_K weight: channel r at r*nb.
+        let mut rhs_t = vec![BlockQ6K::zeros(); n * nb];
+        for r in 0..n {
+            let f: Vec<f32> = (0..k).map(|_| lcg(&mut st)).collect();
+            BlockQ6K::from_float(&f, &mut rhs_t[r * nb..(r + 1) * nb]);
+        }
+
+        // Offline bake: repack -> raw bytes -> PackedQ6Kx8 (owned, from bytes).
+        let packed = repack_q6k_weight(&rhs_t, n, nb);
+        let raw: &[u8] = unsafe {
+            std::slice::from_raw_parts(
+                packed.as_ptr() as *const u8,
+                std::mem::size_of_val(packed.as_slice()),
+            )
+        };
+        let pq = PackedQ6Kx8::from_bytes(raw, n);
+
+        for &m in &[1usize, 4usize] {
+            let lhs: Vec<f32> = (0..m * k).map(|_| lcg(&mut st)).collect();
+            let mut dst_base = vec![0f32; m * n];
+            let mut dst_pack = vec![0f32; m * n];
+            matmul::<BlockQ6K>((m, k, n), &lhs, &rhs_t, &mut dst_base).unwrap();
+            pq.matmul_t((m, k, n), &lhs, &mut dst_pack).unwrap();
+            for i in 0..m * n {
+                assert_eq!(
+                    dst_base[i].to_bits(),
+                    dst_pack[i].to_bits(),
+                    "m={m} idx {i}: base {} packed {}",
+                    dst_base[i],
+                    dst_pack[i]
+                );
+            }
+        }
+
+        // dequantize() must reproduce the original Q6_K dequant (same formula).
+        let mut want = vec![0f32; n * k];
+        BlockQ6K::to_float(&rhs_t, &mut want);
+        let got = match pq.dequantize(n * k).unwrap() {
+            crate::CpuStorage::F32(v) => v,
+            _ => panic!("expected f32"),
+        };
+        for i in 0..n * k {
+            assert_eq!(want[i].to_bits(), got[i].to_bits(), "dequant idx {i}");
+        }
+    }
+}

--- a/candle-core/src/quantized/repack.rs
+++ b/candle-core/src/quantized/repack.rs
@@ -23,23 +23,14 @@ pub(crate) const Q4KX8_ROWS: usize = 8;
 // ---- prefill tile selection (NEON Q6 driver only) ----
 #[cfg(target_feature = "neon")]
 #[derive(Clone, Copy, PartialEq)]
+#[allow(dead_code)]
 enum PrefillTile {
     Nc8mr4,
     Nc4mr4,
     Nc8mr2,
 }
 #[cfg(target_feature = "neon")]
-static PACKED_PREFILL_TILE: LazyLock<PrefillTile> = LazyLock::new(|| {
-    match std::env::var("CANDLE_PACKED_PREFILL")
-        .unwrap_or_default()
-        .to_ascii_lowercase()
-        .as_str()
-    {
-        "nc8mr4" => PrefillTile::Nc8mr4,
-        "nc8mr2" => PrefillTile::Nc8mr2,
-        _ => PrefillTile::Nc4mr4,
-    }
-});
+static PACKED_PREFILL_TILE: LazyLock<PrefillTile> = LazyLock::new(|| PrefillTile::Nc4mr4);
 
 // On-disk Q6Kx8 GGUF block (from_bytes memcpy / from_mmap cast); repr(C) pins the
 // field order so baked models can't mis-decode across rustc versions.
@@ -120,8 +111,7 @@ pub(crate) fn matmul_q6kx8_prepacked(
     let groups = n / Q4KX8_ROWS;
     // Q6 has only the 8-channel kernel. MR=2 (16 accumulators) is the default and
     // the N1-safe tile; MR=4 (32 acc) tends to spill the 32 NEON regs - the same
-    // regression seen on Q4's nc8mr4 tile. CANDLE_PACKED_PREFILL=nc8mr4 opts into
-    // MR=4 for wide cores where it does not spill.
+    // regression seen on Q4's nc8mr4 tile.
     let mr4 = *PACKED_PREFILL_TILE == PrefillTile::Nc8mr4;
 
     thread_local! {
@@ -812,23 +802,6 @@ pub(crate) fn quantize_mat_q8_k_4x4(rows: &[&[f32]; 4], nb: usize) -> Vec<BlockQ
     out
 }
 
-// Default ON; CANDLE_PREFILL_LANEROW=0 forces the upstream #3643 path (same-binary A/B).
-#[cfg(target_feature = "dotprod")]
-static PREFILL_LANEROW: LazyLock<bool> = LazyLock::new(|| {
-    std::env::var("CANDLE_PREFILL_LANEROW")
-        .map(|s| s != "0")
-        .unwrap_or(true)
-});
-
-// Default ON: parallelize the prefill activation quant over the pool (bit-identical
-// to serial). CANDLE_PREFILL_PARQUANT=0 forces serial for A/B.
-#[cfg(target_feature = "dotprod")]
-static PREFILL_PARQUANT: LazyLock<bool> = LazyLock::new(|| {
-    std::env::var("CANDLE_PREFILL_PARQUANT")
-        .map(|s| s != "0")
-        .unwrap_or(true)
-});
-
 // Repack a full Q4_K weight into interleave-4 laneq groups for all n/8 channels.
 #[cfg(target_feature = "dotprod")]
 pub(crate) fn repack_q4k_weight_laneq4(rows: &[BlockQ4K], n: usize, nb: usize) -> Vec<BlockQ4Kx8L> {
@@ -850,7 +823,7 @@ pub(crate) fn repack_q4k_weight_laneq4(rows: &[BlockQ4K], n: usize, nb: usize) -
 // Whether the lane=row Q4_K prefill path is enabled; the pack is cached per-QTensor.
 #[cfg(target_feature = "dotprod")]
 pub(crate) fn prefill_lanerow_enabled() -> bool {
-    *PREFILL_LANEROW
+    true
 }
 
 // Lane=row prefill GEMM: dst(m,n) = lhs(m,k) x W^T over interleave-4 laneq weights,
@@ -870,7 +843,7 @@ pub(crate) fn matmul_q4kx8l_lanerow(
     // Quantize all m activation rows to Q8 (4x4 interleave) into 4-row tiles, the
     // last zero-padded. Parallelized over row-tiles on the barrier pool (each tile
     // is independent), so it does not serialize multi-thread prefill; identical
-    // bytes to the serial path. CANDLE_PREFILL_PARQUANT=0 forces serial for A/B.
+    // bytes to the serial path.
     let zeros = vec![0f32; k];
     let mut q8: Vec<BlockQ8Kx4> = vec![BlockQ8Kx4::zeroed(); row_tiles * nb];
     let tile_rows = |rt: usize| -> [&[f32]; 4] {
@@ -883,15 +856,9 @@ pub(crate) fn matmul_q4kx8l_lanerow(
             }
         })
     };
-    if *PREFILL_PARQUANT {
-        crate::utils::par_chunks_mut(&mut q8, nb, |rt, chunk| {
-            quantize_mat_q8_k_4x4_into(&tile_rows(rt), chunk);
-        });
-    } else {
-        for rt in 0..row_tiles {
-            quantize_mat_q8_k_4x4_into(&tile_rows(rt), &mut q8[rt * nb..(rt + 1) * nb]);
-        }
-    }
+    crate::utils::par_chunks_mut(&mut q8, nb, |rt, chunk| {
+        quantize_mat_q8_k_4x4_into(&tile_rows(rt), chunk);
+    });
 
     struct DstPtr(*mut f32);
     unsafe impl Sync for DstPtr {}

--- a/candle-core/src/quantized/repack.rs
+++ b/candle-core/src/quantized/repack.rs
@@ -6,8 +6,14 @@
 //! driven by `gemm_q6kx8_q8k`; no runtime repack.
 #![allow(clippy::needless_range_loop)]
 
+#[cfg(target_feature = "dotprod")]
+use super::k_quants::BlockQ4K;
 use super::k_quants::{BlockQ6K, BlockQ8K, GgmlType, QK_K};
 use half::f16;
+#[cfg(target_feature = "dotprod")]
+use std::collections::HashMap;
+#[cfg(target_feature = "dotprod")]
+use std::sync::Mutex;
 use std::sync::{Arc, LazyLock};
 
 // ---- shared interleave constants ----
@@ -532,4 +538,434 @@ mod tests {
             assert_eq!(want[i].to_bits(), got[i].to_bits(), "dequant idx {i}");
         }
     }
+
+    // The lane=row 8x4 SDOT kernel (laneq-4 weights + q8_Kx4 4x4 activations) vs
+    // the f32 ground truth: validates the laneq weight layout, the q8_Kx4 (4x4)
+    // activation pack, the 6-bit scale unpack, and the lane-row tiling/fold. Runs on
+    // any dotprod host (incl. M1), so this is a real check of the N1 kernel.
+    #[cfg(all(target_feature = "neon", target_feature = "dotprod"))]
+    #[test]
+    fn gemm_q4kx8_lanerow_matches_reference() {
+        use crate::quantized::k_quants::BlockQ4K;
+        use crate::quantized::neon::gemm_q4kx8_q8k_lanerow;
+
+        let nb = 3usize;
+        let k = nb * QK_K;
+        let mut st = 0x9e37_79b9_7f4a_7c15u64;
+
+        let mut wq: Vec<Vec<BlockQ4K>> = Vec::new();
+        let mut wf: Vec<Vec<f32>> = Vec::new();
+        for _ in 0..8 {
+            let f: Vec<f32> = (0..k).map(|_| lcg(&mut st)).collect();
+            let mut q = vec![BlockQ4K::zeros(); nb];
+            BlockQ4K::from_float(&f, &mut q);
+            let mut deq = vec![0f32; k];
+            BlockQ4K::to_float(&q, &mut deq);
+            wq.push(q);
+            wf.push(deq);
+        }
+        let cols: [&[BlockQ4K]; 8] = std::array::from_fn(|c| wq[c].as_slice());
+        let packed = repack_q4kx8_laneq4(&cols);
+
+        let af: Vec<Vec<f32>> = (0..4)
+            .map(|_| (0..k).map(|_| lcg(&mut st)).collect())
+            .collect();
+        let arows: [&[f32]; 4] = std::array::from_fn(|r| af[r].as_slice());
+        let q8 = quantize_mat_q8_k_4x4(&arows, nb);
+
+        let mut dst = [0f32; 32];
+        gemm_q4kx8_q8k_lanerow(&packed, &q8, &mut dst);
+
+        // Reconstruct each row's q8 from the 4x4 interleave: element e of row r
+        // lives at qs[j], j = (e/4)*16 + r*4 + (e%4).
+        for r in 0..4 {
+            for col in 0..8 {
+                let mut sum = 0f64;
+                for blk in 0..nb {
+                    let qb = &q8[blk];
+                    for e in 0..QK_K {
+                        let j = (e / 4) * 16 + r * 4 + (e % 4);
+                        let actd = qb.d[r] as f64 * qb.qs[j] as f64;
+                        sum += wf[col][blk * QK_K + e] as f64 * actd;
+                    }
+                }
+                let got = dst[r * 8 + col] as f64;
+                let rel = (got - sum).abs() / sum.abs().max(1e-6);
+                assert!(rel < 1e-2, "r{r} col{col}: got {got} ref {sum} rel {rel}");
+            }
+        }
+    }
+
+    // The lane=row prefill driver must match the baseline matmul end-to-end (full
+    // dst, multiple 8-channel groups), for m a multiple of 4 and not (zero-padded
+    // remainder). Validates tiling, scatter, and the parallel group partition.
+    #[cfg(all(target_feature = "neon", target_feature = "dotprod"))]
+    #[test]
+    fn matmul_q4kx8l_lanerow_matches_baseline() {
+        use crate::quantized::k_quants::{matmul, BlockQ4K};
+
+        let k = 512usize; // 2 super-blocks
+        let n = 24usize; // 3 groups of 8
+        let nb = k / QK_K;
+        let mut st = 0xc0ff_ee00_1234_abcdu64;
+
+        let mut rhs_t = vec![BlockQ4K::zeros(); n * nb];
+        for r in 0..n {
+            let f: Vec<f32> = (0..k).map(|_| lcg(&mut st)).collect();
+            BlockQ4K::from_float(&f, &mut rhs_t[r * nb..(r + 1) * nb]);
+        }
+        let laneq = repack_q4k_weight_laneq4(&rhs_t, n, nb);
+
+        for &m in &[4usize, 7usize, 16usize] {
+            let lhs: Vec<f32> = (0..m * k).map(|_| lcg(&mut st)).collect();
+            let mut dst_base = vec![0f32; m * n];
+            let mut dst_lr = vec![0f32; m * n];
+            matmul::<BlockQ4K>((m, k, n), &lhs, &rhs_t, &mut dst_base).unwrap();
+            matmul_q4kx8l_lanerow((m, k, n), &lhs, &laneq, &mut dst_lr);
+            let mut err = 0f64;
+            let mut sig = 0f64;
+            for i in 0..m * n {
+                let d = dst_lr[i] as f64 - dst_base[i] as f64;
+                err += d * d;
+                sig += (dst_base[i] as f64) * (dst_base[i] as f64);
+            }
+            let rel = (err / sig.max(1e-12)).sqrt();
+            assert!(rel < 2e-2, "m={m}: relative L2 error {rel} too high");
+        }
+    }
+}
+
+#[cfg(target_feature = "dotprod")]
+#[repr(C)]
+#[derive(Clone)]
+pub struct BlockQ4Kx8L {
+    pub(crate) d: [f16; 8],
+    pub(crate) dmin: [f16; 8],
+    pub(crate) scales: [u8; 96], // 6-bit scales+mins, repacked (8 cols)
+    pub(crate) qs: [u8; 1024],   // 4-bit quants, 8-byte round-robin interleave
+}
+
+#[cfg(target_feature = "dotprod")]
+impl BlockQ4Kx8L {
+    fn zeroed() -> Self {
+        Self {
+            d: [f16::ZERO; 8],
+            dmin: [f16::ZERO; 8],
+            scales: [0; 96],
+            qs: [0; 1024],
+        }
+    }
+}
+
+/// Port of llama's `make_block_q4_Kx8` for one super-block of 8 columns. `bsi` is
+/// the `blck_size_interleave` (4 for the lane=row `8x4` kernel) - only the qs
+/// interleave stride depends on it; scales/mins are identical. Pure data
+/// rearrangement; deterministic.
+#[cfg(target_feature = "dotprod")]
+fn make_q4kx8_laneq_bsi(cols: &[&[BlockQ4K]; 8], i: usize, bsi: usize) -> BlockQ4Kx8L {
+    let mut out = BlockQ4Kx8L::zeroed();
+    for c in 0..8 {
+        out.d[c] = cols[c][i].d;
+        out.dmin[c] = cols[c][i].dmin;
+    }
+    // qs: take `bsi` bytes at a time, round-robin across the 8 columns.
+    // end = QK_K * 4 / bsi; src col = t%8, src off = (t/8)*bsi, dst = t*bsi.
+    let end = QK_K * 4 / bsi;
+    for t in 0..end {
+        let src_id = t % 8;
+        let src_off = (t / 8) * bsi;
+        let dst_off = t * bsi;
+        out.qs[dst_off..dst_off + bsi].copy_from_slice(&cols[src_id][i].qs[src_off..src_off + bsi]);
+    }
+    // scales: repack the 6-bit packed scales/mins of all 8 columns into 96 bytes.
+    let mut s = [0u8; 8];
+    let mut m = [0u8; 8];
+    for ii in 0..4 {
+        for j in 0..8 {
+            s[j] = cols[j][i].scales[ii] & 63;
+            m[j] = cols[j][i].scales[ii + 4] & 63;
+        }
+        let b = ii * 12;
+        out.scales[b] = (s[0] & 63) + ((s[4] & 48) << 2);
+        out.scales[b + 1] = (s[1] & 63) + ((s[5] & 48) << 2);
+        out.scales[b + 2] = (s[2] & 63) + ((s[6] & 48) << 2);
+        out.scales[b + 3] = (s[3] & 63) + ((s[7] & 48) << 2);
+        out.scales[b + 4] = (m[0] & 63) + ((m[4] & 48) << 2);
+        out.scales[b + 5] = (m[1] & 63) + ((m[5] & 48) << 2);
+        out.scales[b + 6] = (m[2] & 63) + ((m[6] & 48) << 2);
+        out.scales[b + 7] = (m[3] & 63) + ((m[7] & 48) << 2);
+        out.scales[b + 8] = (s[4] & 15) + ((m[4] & 15) << 4);
+        out.scales[b + 9] = (s[5] & 15) + ((m[5] & 15) << 4);
+        out.scales[b + 10] = (s[6] & 15) + ((m[6] & 15) << 4);
+        out.scales[b + 11] = (s[7] & 15) + ((m[7] & 15) << 4);
+    }
+    for ii in 0..4 {
+        for j in 0..8 {
+            s[j] = ((cols[j][i].scales[ii] & 192) >> 2) | (cols[j][i].scales[ii + 8] & 15);
+            m[j] =
+                ((cols[j][i].scales[ii + 4] & 192) >> 2) | ((cols[j][i].scales[ii + 8] & 240) >> 4);
+        }
+        let b = ii * 12 + 48;
+        out.scales[b] = (s[0] & 63) + ((s[4] & 48) << 2);
+        out.scales[b + 1] = (s[1] & 63) + ((s[5] & 48) << 2);
+        out.scales[b + 2] = (s[2] & 63) + ((s[6] & 48) << 2);
+        out.scales[b + 3] = (s[3] & 63) + ((s[7] & 48) << 2);
+        out.scales[b + 4] = (m[0] & 63) + ((m[4] & 48) << 2);
+        out.scales[b + 5] = (m[1] & 63) + ((m[5] & 48) << 2);
+        out.scales[b + 6] = (m[2] & 63) + ((m[6] & 48) << 2);
+        out.scales[b + 7] = (m[3] & 63) + ((m[7] & 48) << 2);
+        out.scales[b + 8] = (s[4] & 15) + ((m[4] & 15) << 4);
+        out.scales[b + 9] = (s[5] & 15) + ((m[5] & 15) << 4);
+        out.scales[b + 10] = (s[6] & 15) + ((m[6] & 15) << 4);
+        out.scales[b + 11] = (s[7] & 15) + ((m[7] & 15) << 4);
+    }
+    out
+}
+
+/// Repack 8 weight columns into `nb` laneq blocks, interleave 4 (the weight layout
+/// the lane=row `8x4` DOTPROD kernel consumes - 4 bytes/column per 16-byte read).
+#[cfg(target_feature = "dotprod")]
+pub(crate) fn repack_q4kx8_laneq4(cols: &[&[BlockQ4K]; 8]) -> Vec<BlockQ4Kx8L> {
+    let nb = cols[0].len();
+    (0..nb).map(|i| make_q4kx8_laneq_bsi(cols, i, 4)).collect()
+}
+
+// ===========================================================================
+
+/// Four Q8_K activation rows interleaved for the lane=row GEMM. Mirrors llama's
+/// `block_q8_Kx4` field layout (`d[4]`, interleaved `qs`, grouped `bsums`).
+#[cfg(target_feature = "dotprod")]
+#[repr(C)]
+#[derive(Clone)]
+pub(crate) struct BlockQ8Kx4 {
+    pub(crate) d: [f32; 4],
+    pub(crate) qs: [i8; QK_K * 4],
+    pub(crate) bsums: [i16; QK_K / 4],
+}
+
+#[cfg(target_feature = "dotprod")]
+impl BlockQ8Kx4 {
+    fn zeroed() -> Self {
+        Self {
+            d: [0.0; 4],
+            qs: [0; QK_K * 4],
+            bsums: [0; QK_K / 4],
+        }
+    }
+}
+
+/// Quantize and interleave 4 activation rows into the `nb` `BlockQ8Kx4` of `out`
+/// (`out.len() == nb`) with `blck_size_interleave = 4` - the layout llama's DOTPROD
+/// `ggml_gemm_q4_K_8x4` consumes, where the SDOT lane index selects the ROW (4
+/// bytes/row per 16-byte group). Distinct from `quantize_mat_q8_k_4x8_into`
+/// (interleave 8, for the i8mm/SMMLA kernel) only in the interleave stride and the
+/// bsums index. Each super-block is independent (safe on disjoint `out` slices from
+/// different threads). Port of llama's `ggml_quantize_mat_q8_K_4x4_generic`.
+#[cfg(target_feature = "dotprod")]
+pub(crate) fn quantize_mat_q8_k_4x4_into(rows: &[&[f32]; 4], out: &mut [BlockQ8Kx4]) {
+    const BSI: usize = 4; // blck_size_interleave
+    for (i, blk) in out.iter_mut().enumerate() {
+        *blk = BlockQ8Kx4::zeroed();
+        let mut srcv = [[0f32; QK_K]; 4];
+        let mut iscale = [0f32; 4];
+        for (row, &r) in rows.iter().enumerate() {
+            let mut amax = 0f32;
+            let mut max = 0f32;
+            for j in 0..QK_K {
+                let v = r[i * QK_K + j];
+                srcv[row][j] = v;
+                if amax < v.abs() {
+                    amax = v.abs();
+                    max = v;
+                }
+            }
+            iscale[row] = if amax != 0.0 { -127.0 / max } else { 0.0 };
+            blk.d[row] = if amax != 0.0 { 1.0 / iscale[row] } else { 0.0 };
+        }
+        // Quants interleaved in 4-byte runs across the 4 rows; bsums grouped
+        // 4-at-a-time per source super-block (the kernel's bias term).
+        for j in 0..QK_K * 4 {
+            let mut src_offset = (j / (4 * BSI)) * BSI;
+            let src_id = (j % (4 * BSI)) / BSI;
+            src_offset += j % BSI;
+            let index = (((j & 15) >> 2) << 2) + ((j >> 8) << 4) + ((j >> 6) & 3);
+            let x0 = srcv[src_id][src_offset] * iscale[src_id];
+            let q = x0.round() as i8;
+            blk.qs[j] = q;
+            blk.bsums[index] += q as i16;
+        }
+    }
+}
+
+/// Vec-returning convenience wrapper over `quantize_mat_q8_k_4x4_into` (test only).
+#[cfg(all(test, target_feature = "dotprod"))]
+pub(crate) fn quantize_mat_q8_k_4x4(rows: &[&[f32]; 4], nb: usize) -> Vec<BlockQ8Kx4> {
+    let mut out = vec![BlockQ8Kx4::zeroed(); nb];
+    quantize_mat_q8_k_4x4_into(rows, &mut out);
+    out
+}
+
+// A/B switch for the lane=row prefill path (default ON for dotprod builds). Set
+// CANDLE_PREFILL_LANEROW=0 to force the upstream #3643 SDOT path for same-binary
+// benchmarking on N1.
+#[cfg(target_feature = "dotprod")]
+static PREFILL_LANEROW: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("CANDLE_PREFILL_LANEROW")
+        .map(|s| s != "0")
+        .unwrap_or(true)
+});
+
+// A/B switch for parallelizing the prefill activation quantization across the
+// barrier pool (default ON). The lane=row driver quantizes all m rows to Q8 before
+// the parallel GEMM; doing it serially is an Amdahl ceiling on multi-thread prefill
+// scaling. Set CANDLE_PREFILL_PARQUANT=0 to force the serial quant for same-binary
+// A/B on N1. Result is bit-identical either way (per-tile independent).
+#[cfg(target_feature = "dotprod")]
+static PREFILL_PARQUANT: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("CANDLE_PREFILL_PARQUANT")
+        .map(|s| s != "0")
+        .unwrap_or(true)
+});
+
+/// Repack a Q4_K weight into the interleave-4 laneq `BlockQ4Kx8L` groups the
+/// lane=row `8x4` kernel consumes (`repack_q4kx8_laneq4` per 8-channel group).
+#[cfg(target_feature = "dotprod")]
+pub(crate) fn repack_q4k_weight_laneq4(rows: &[BlockQ4K], n: usize, nb: usize) -> Vec<BlockQ4Kx8L> {
+    debug_assert_eq!(n % Q4KX8_ROWS, 0, "repack_q4k_weight_laneq4: n {n} not /8");
+    debug_assert_eq!(
+        rows.len(),
+        n * nb,
+        "repack_q4k_weight_laneq4: rows len mismatch"
+    );
+    let mut packed = Vec::with_capacity((n / 8) * nb);
+    for g in 0..n / 8 {
+        let grp: [&[BlockQ4K]; Q4KX8_ROWS] =
+            std::array::from_fn(|r| &rows[(g * 8 + r) * nb..(g * 8 + r + 1) * nb]);
+        packed.extend(repack_q4kx8_laneq4(&grp));
+    }
+    packed
+}
+
+/// Interleave-4 laneq repack cache, keyed on the source Q4_K pointer. Populated on
+/// first lane=row prefill of each weight; model weights live for the whole run.
+#[cfg(target_feature = "dotprod")]
+static LANEQ4_CACHE: LazyLock<Mutex<HashMap<usize, Arc<Vec<BlockQ4Kx8L>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[cfg(target_feature = "dotprod")]
+fn packed_laneq4_cache_get(rhs: &[BlockQ4K], n: usize, nb: usize) -> Arc<Vec<BlockQ4Kx8L>> {
+    let key = rhs.as_ptr() as usize;
+    {
+        if let Some(p) = LANEQ4_CACHE.lock().unwrap().get(&key) {
+            return p.clone();
+        }
+    }
+    let mut map = LANEQ4_CACHE.lock().unwrap();
+    if let Some(p) = map.get(&key) {
+        return p.clone();
+    }
+    let arc = Arc::new(repack_q4k_weight_laneq4(rhs, n, nb));
+    map.insert(key, arc.clone());
+    arc
+}
+
+/// Lane=row prefill GEMM driver: `dst(m,n) = lhs(m,k) x W^T` over interleave-4
+/// laneq weights. Mirrors `matmul_q4kx8l_prepacked_i8mm` exactly (4-row activation
+/// tiles via `quantize_mat_q8_k_4x4`, last tile zero-padded, barrier-pool over
+/// channel groups, same 4x8 sub-tile scatter), but calls the lane=row SDOT kernel
+/// instead of SMMLA - so it runs on any dotprod core (Graviton2/N1).
+#[cfg(all(target_feature = "neon", target_feature = "dotprod"))]
+pub(crate) fn matmul_q4kx8l_lanerow(
+    (m, k, n): (usize, usize, usize),
+    lhs: &[f32],
+    packed: &[BlockQ4Kx8L],
+    dst: &mut [f32],
+) {
+    use super::neon::gemm_q4kx8_q8k_lanerow;
+    let nb = k / QK_K;
+    let groups = n / Q4KX8_ROWS;
+    let row_tiles = m.div_ceil(4);
+
+    // Quantize all m activation rows to Q8 (4x4 interleave) into 4-row tiles, the
+    // last zero-padded. Parallelized over row-tiles on the barrier pool (each tile
+    // is independent), so it does not serialize multi-thread prefill; identical
+    // bytes to the serial path. CANDLE_PREFILL_PARQUANT=0 forces serial for A/B.
+    let zeros = vec![0f32; k];
+    let mut q8: Vec<BlockQ8Kx4> = vec![BlockQ8Kx4::zeroed(); row_tiles * nb];
+    let tile_rows = |rt: usize| -> [&[f32]; 4] {
+        std::array::from_fn(|a| {
+            let r = rt * 4 + a;
+            if r < m {
+                &lhs[r * k..(r + 1) * k]
+            } else {
+                zeros.as_slice()
+            }
+        })
+    };
+    if *PREFILL_PARQUANT {
+        crate::utils::par_chunks_mut(&mut q8, nb, |rt, chunk| {
+            quantize_mat_q8_k_4x4_into(&tile_rows(rt), chunk);
+        });
+    } else {
+        for rt in 0..row_tiles {
+            quantize_mat_q8_k_4x4_into(&tile_rows(rt), &mut q8[rt * nb..(rt + 1) * nb]);
+        }
+    }
+
+    struct DstPtr(*mut f32);
+    unsafe impl Sync for DstPtr {}
+    let dptr = DstPtr(dst.as_mut_ptr());
+
+    let process = |g: usize| {
+        let w = &packed[g * nb..(g + 1) * nb];
+        let p = &dptr;
+        for rt in 0..row_tiles {
+            let q8t = &q8[rt * nb..(rt + 1) * nb];
+            let mut t = [0f32; 32];
+            gemm_q4kx8_q8k_lanerow(w, q8t, &mut t);
+            for a in 0..4 {
+                let r = rt * 4 + a;
+                if r >= m {
+                    break;
+                }
+                for c in 0..Q4KX8_ROWS {
+                    unsafe { *p.0.add(r * n + g * 8 + c) = t[a * 8 + c] };
+                }
+            }
+        }
+    };
+
+    let pool = crate::utils::barrier_pool();
+    let n_total = pool.n_workers() + 1;
+    let gpt = groups.div_ceil(n_total);
+    pool.execute(|tid| {
+        let start = tid * gpt;
+        if start < groups {
+            let end = groups.min((tid + 1) * gpt);
+            for g in start..end {
+                process(g);
+            }
+        }
+    });
+}
+
+/// Prefill entry point layered on the upstream (#3643) Q4_K matmul: if this is a
+/// wide GEMM (`m >= 4`) and the lane=row path is enabled, repack the weight to the
+/// interleave-4 laneq layout (cached) and run the `8x4` SDOT GEMM, returning `true`.
+/// Returns `false` for decode (`m < 4`) or when disabled, so the caller falls
+/// through to the upstream `BlockQ4Kx8` path (which owns decode). CPU-only.
+#[cfg(target_feature = "dotprod")]
+pub(crate) fn try_matmul_q4k_lanerow_prefill(
+    (m, k, n): (usize, usize, usize),
+    lhs: &[f32],
+    rhs_q4k: &[BlockQ4K],
+    dst: &mut [f32],
+) -> bool {
+    if m < 4 || !*PREFILL_LANEROW {
+        return false;
+    }
+    let nb = k / QK_K;
+    let packed = packed_laneq4_cache_get(rhs_q4k, n, nb);
+    matmul_q4kx8l_lanerow((m, k, n), lhs, &packed, dst);
+    true
 }

--- a/candle-core/src/quantized/repack.rs
+++ b/candle-core/src/quantized/repack.rs
@@ -41,11 +41,8 @@ static PACKED_PREFILL_TILE: LazyLock<PrefillTile> = LazyLock::new(|| {
     }
 });
 
-// ---- packed Q6_K weight block + repack ----
-// `#[repr(C)]` is load-bearing: this block is the on-disk Q6Kx8 GGUF format
-// (`PackedQ6Kx8::from_bytes` memcpy's raw file bytes in, `from_mmap` casts the
-// mapping). A default-repr struct may reorder fields across compiler versions,
-// which would silently mis-decode baked models. Mirrors `k_quants::BlockQ4Kx8`.
+// On-disk Q6Kx8 GGUF block (from_bytes memcpy / from_mmap cast); repr(C) pins the
+// field order so baked models can't mis-decode across rustc versions.
 #[repr(C)]
 pub struct BlockQ6Kx8 {
     pub(crate) d: [f16; Q4KX8_ROWS],
@@ -53,8 +50,6 @@ pub struct BlockQ6Kx8 {
     pub(crate) ql: [u8; Q4KX8_ROWS * (QK_K / 2)],      // 1024: [chunk(2)][row(8)][64]
     pub(crate) qh: [u8; Q4KX8_ROWS * (QK_K / 4)],      // 512:  [chunk(2)][row(8)][32]
 }
-// d (16) + scales (128) + ql (1024) + qh (512); all fields are <=2-byte aligned, so
-// the packed layout has no interior padding. Pins the persisted block size.
 const _: () = assert!(std::mem::size_of::<BlockQ6Kx8>() == 1680);
 
 impl BlockQ6Kx8 {
@@ -68,9 +63,7 @@ impl BlockQ6Kx8 {
     }
 }
 
-/// Repack `Q4KX8_ROWS` Q6_K weight rows (each `nb` super-blocks) into `nb`
-/// interleaved `BlockQ6Kx8`. Scalar (load-time, not perf-critical); the i8 scales
-/// copy directly and the 128B `ql`/64B `qh` split into two 64B/32B chunks.
+// Repack 8 Q6_K weight rows into interleaved `BlockQ6Kx8` (load-time, scalar).
 pub(crate) fn repack_q6k_x8(rows: &[&[BlockQ6K]; Q4KX8_ROWS]) -> Vec<BlockQ6Kx8> {
     let nb = rows[0].len();
     debug_assert!(
@@ -100,8 +93,7 @@ pub(crate) fn repack_q6k_x8(rows: &[&[BlockQ6K]; Q4KX8_ROWS]) -> Vec<BlockQ6Kx8>
     out
 }
 
-/// Repack a full row-major Q6_K weight matrix into the interleaved `BlockQ6Kx8`
-/// layout for all `n/8` channel groups. Mirror of `repack_q4k_weight`.
+// Repack a full row-major Q6_K weight into `BlockQ6Kx8` for all n/8 channel groups.
 pub fn repack_q6k_weight(rows: &[BlockQ6K], n: usize, nb: usize) -> Vec<BlockQ6Kx8> {
     debug_assert_eq!(n % Q4KX8_ROWS, 0, "repack_q6k_weight: n {n} not /8");
     debug_assert_eq!(rows.len(), n * nb, "repack_q6k_weight: rows len mismatch");
@@ -115,9 +107,7 @@ pub fn repack_q6k_weight(rows: &[BlockQ6K], n: usize, nb: usize) -> Vec<BlockQ6K
 }
 
 // ---- prepacked GEMM driver ----
-// NEON-only: `gemm_q6kx8_q8k` lives in the `neon` module, which is not compiled on
-// non-NEON targets. The `matmul_t` caller has a `not(neon)` arm that bails, so this
-// must carry the same gate or the `super::neon` import fails to resolve on x86_64.
+// NEON-only (uses `neon::gemm_q6kx8_q8k`); `matmul_t` bails on the not(neon) arm.
 #[cfg(target_feature = "neon")]
 pub(crate) fn matmul_q6kx8_prepacked(
     (m, k, n): (usize, usize, usize),
@@ -230,8 +220,7 @@ enum PackedStoreQ6 {
 unsafe impl Send for PackedStoreQ6 {}
 unsafe impl Sync for PackedStoreQ6 {}
 
-/// A pre-packed Q6_K weight: `n` output channels (`n % 8 == 0`) stored as the
-/// interleaved `BlockQ6Kx8` groups, ready for the SDOT GEMM with no repack.
+// Pre-packed Q6_K weight: n output channels (n % 8 == 0) as `BlockQ6Kx8` groups.
 pub struct PackedQ6Kx8 {
     store: PackedStoreQ6,
     n: usize,
@@ -259,8 +248,7 @@ impl PackedQ6Kx8 {
         }
     }
 
-    /// Build an owned `PackedQ6Kx8` by copying raw interleaved bytes. `raw` length
-    /// must be a whole number of blocks.
+    // Owned copy from raw interleaved bytes (whole number of blocks).
     pub fn from_bytes(raw: &[u8], n: usize) -> Self {
         let bs = std::mem::size_of::<BlockQ6Kx8>();
         assert_eq!(
@@ -281,8 +269,7 @@ impl PackedQ6Kx8 {
         }
     }
 
-    /// Build a zero-copy `PackedQ6Kx8` viewing `byte_len` bytes at `offset` in an
-    /// mmap'd GGUF. Validates bounds and alignment.
+    // Zero-copy view of `byte_len` bytes at `offset` in an mmap'd GGUF.
     pub fn from_mmap(
         mmap: Arc<memmap2::Mmap>,
         offset: usize,
@@ -317,10 +304,7 @@ impl PackedQ6Kx8 {
         })
     }
 
-    /// Dequantize the packed weight back to f32 of shape `[n, k]` (row-major).
-    /// Mirrors `BlockQ6K::to_float` per channel: the i8 sub-block scales and the
-    /// `ql`/`qh` quants come from the chunk-major, row-interleaved layout produced
-    /// by `repack_q6k_x8`. Correctness-only (not perf).
+    // Dequantize back to row-major f32 [n, k]; mirrors `BlockQ6K::to_float`.
     fn dequantize_to(&self, elem_count: usize, ys: &mut [f32]) {
         const QLC: usize = QK_K / 4; // 64 ql bytes / 128-value chunk
         const QHC: usize = QK_K / 8; // 32 qh bytes / chunk
@@ -500,22 +484,21 @@ mod tests {
     // reproduce the original Q6_K dequant.
     #[test]
     fn packed_q6kx8_from_bytes_matches_baseline() {
-        use crate::quantized::k_quants::{matmul, BlockQ6K};
+        use crate::quantized::k_quants::BlockQ6K;
         use crate::quantized::QuantizedType;
 
-        let k = 512usize; // 2 super-blocks
-        let n = 24usize; // 3 groups of 8
+        let k = 512usize;
+        let n = 24usize;
         let nb = k / QK_K;
         let mut st = 0x51c6_ba9d_2244_8821u64;
 
-        // Row-major Q6_K weight: channel r at r*nb.
         let mut rhs_t = vec![BlockQ6K::zeros(); n * nb];
         for r in 0..n {
             let f: Vec<f32> = (0..k).map(|_| lcg(&mut st)).collect();
             BlockQ6K::from_float(&f, &mut rhs_t[r * nb..(r + 1) * nb]);
         }
 
-        // Offline bake: repack -> raw bytes -> PackedQ6Kx8 (owned, from bytes).
+        // bake: repack -> raw bytes -> owned PackedQ6Kx8
         let packed = repack_q6k_weight(&rhs_t, n, nb);
         let raw: &[u8] = unsafe {
             std::slice::from_raw_parts(
@@ -525,24 +508,28 @@ mod tests {
         };
         let pq = PackedQ6Kx8::from_bytes(raw, n);
 
-        for &m in &[1usize, 4usize] {
-            let lhs: Vec<f32> = (0..m * k).map(|_| lcg(&mut st)).collect();
-            let mut dst_base = vec![0f32; m * n];
-            let mut dst_pack = vec![0f32; m * n];
-            matmul::<BlockQ6K>((m, k, n), &lhs, &rhs_t, &mut dst_base).unwrap();
-            pq.matmul_t((m, k, n), &lhs, &mut dst_pack).unwrap();
-            for i in 0..m * n {
-                assert_eq!(
-                    dst_base[i].to_bits(),
-                    dst_pack[i].to_bits(),
-                    "m={m} idx {i}: base {} packed {}",
-                    dst_base[i],
-                    dst_pack[i]
-                );
+        // matmul_t requires NEON; off-NEON it bails, so only assert it there.
+        #[cfg(target_feature = "neon")]
+        {
+            use crate::quantized::k_quants::matmul;
+            for &m in &[1usize, 4usize] {
+                let lhs: Vec<f32> = (0..m * k).map(|_| lcg(&mut st)).collect();
+                let mut dst_base = vec![0f32; m * n];
+                let mut dst_pack = vec![0f32; m * n];
+                matmul::<BlockQ6K>((m, k, n), &lhs, &rhs_t, &mut dst_base).unwrap();
+                pq.matmul_t((m, k, n), &lhs, &mut dst_pack).unwrap();
+                for i in 0..m * n {
+                    assert_eq!(
+                        dst_base[i].to_bits(),
+                        dst_pack[i].to_bits(),
+                        "m={m} idx {i}: base {} packed {}",
+                        dst_base[i],
+                        dst_pack[i]
+                    );
+                }
             }
         }
 
-        // dequantize() must reproduce the original Q6_K dequant (same formula).
         let mut want = vec![0f32; n * k];
         BlockQ6K::to_float(&rhs_t, &mut want);
         let got = match pq.dequantize(n * k).unwrap() {
@@ -650,9 +637,8 @@ mod tests {
     }
 }
 
-// Same fields/size (1152 B) as `k_quants::BlockQ4Kx8`; only the `qs` interleave
-// differs (bsi=4 lane=row vs #3643's bsi=8). zerocopy derives let the per-QTensor
-// `repacked_laneq` cache round-trip it through raw bytes, mirroring #3643.
+// Same 1152-byte layout as k_quants::BlockQ4Kx8 (only the qs interleave differs:
+// bsi=4 vs 8); zerocopy derives let the per-QTensor `repacked_laneq` cache it as bytes.
 #[cfg(target_feature = "dotprod")]
 #[derive(
     Clone,
@@ -684,10 +670,8 @@ impl BlockQ4Kx8L {
     }
 }
 
-/// Port of llama's `make_block_q4_Kx8` for one super-block of 8 columns. `bsi` is
-/// the `blck_size_interleave` (4 for the lane=row `8x4` kernel) - only the qs
-/// interleave stride depends on it; scales/mins are identical. Pure data
-/// rearrangement; deterministic.
+// Port of llama's make_block_q4_Kx8 for one 8-column super-block; `bsi` is the qs
+// interleave stride (4 for the lane=row kernel). Scales/mins are bsi-independent.
 #[cfg(target_feature = "dotprod")]
 fn make_q4kx8_laneq_bsi(cols: &[&[BlockQ4K]; 8], i: usize, bsi: usize) -> BlockQ4Kx8L {
     let mut out = BlockQ4Kx8L::zeroed();
@@ -749,18 +733,14 @@ fn make_q4kx8_laneq_bsi(cols: &[&[BlockQ4K]; 8], i: usize, bsi: usize) -> BlockQ
     out
 }
 
-/// Repack 8 weight columns into `nb` laneq blocks, interleave 4 (the weight layout
-/// the lane=row `8x4` DOTPROD kernel consumes - 4 bytes/column per 16-byte read).
+// Repack 8 weight columns into `nb` interleave-4 laneq blocks (lane=row layout).
 #[cfg(target_feature = "dotprod")]
 pub(crate) fn repack_q4kx8_laneq4(cols: &[&[BlockQ4K]; 8]) -> Vec<BlockQ4Kx8L> {
     let nb = cols[0].len();
     (0..nb).map(|i| make_q4kx8_laneq_bsi(cols, i, 4)).collect()
 }
 
-// ===========================================================================
-
-/// Four Q8_K activation rows interleaved for the lane=row GEMM. Mirrors llama's
-/// `block_q8_Kx4` field layout (`d[4]`, interleaved `qs`, grouped `bsums`).
+// Four Q8_K activation rows interleaved for the lane=row GEMM (llama block_q8_Kx4).
 #[cfg(target_feature = "dotprod")]
 #[repr(C)]
 #[derive(Clone)]
@@ -781,13 +761,9 @@ impl BlockQ8Kx4 {
     }
 }
 
-/// Quantize and interleave 4 activation rows into the `nb` `BlockQ8Kx4` of `out`
-/// (`out.len() == nb`) with `blck_size_interleave = 4` - the layout llama's DOTPROD
-/// `ggml_gemm_q4_K_8x4` consumes, where the SDOT lane index selects the ROW (4
-/// bytes/row per 16-byte group). Distinct from `quantize_mat_q8_k_4x8_into`
-/// (interleave 8, for the i8mm/SMMLA kernel) only in the interleave stride and the
-/// bsums index. Each super-block is independent (safe on disjoint `out` slices from
-/// different threads). Port of llama's `ggml_quantize_mat_q8_K_4x4_generic`.
+// Quantize+interleave 4 activation rows into `out` (len nb), interleave-4 so the
+// SDOT lane selects the row. Per-super-block independent. Port of llama's
+// ggml_quantize_mat_q8_K_4x4_generic.
 #[cfg(target_feature = "dotprod")]
 pub(crate) fn quantize_mat_q8_k_4x4_into(rows: &[&[f32]; 4], out: &mut [BlockQ8Kx4]) {
     const BSI: usize = 4; // blck_size_interleave
@@ -824,7 +800,7 @@ pub(crate) fn quantize_mat_q8_k_4x4_into(rows: &[&[f32]; 4], out: &mut [BlockQ8K
     }
 }
 
-/// Vec-returning convenience wrapper over `quantize_mat_q8_k_4x4_into` (test only).
+// Vec-returning wrapper over `quantize_mat_q8_k_4x4_into` (test only).
 #[cfg(all(test, target_feature = "dotprod"))]
 pub(crate) fn quantize_mat_q8_k_4x4(rows: &[&[f32]; 4], nb: usize) -> Vec<BlockQ8Kx4> {
     let mut out = vec![BlockQ8Kx4::zeroed(); nb];
@@ -832,9 +808,7 @@ pub(crate) fn quantize_mat_q8_k_4x4(rows: &[&[f32]; 4], nb: usize) -> Vec<BlockQ
     out
 }
 
-// A/B switch for the lane=row prefill path (default ON for dotprod builds). Set
-// CANDLE_PREFILL_LANEROW=0 to force the upstream #3643 SDOT path for same-binary
-// benchmarking on N1.
+// Default ON; CANDLE_PREFILL_LANEROW=0 forces the upstream #3643 path (same-binary A/B).
 #[cfg(target_feature = "dotprod")]
 static PREFILL_LANEROW: LazyLock<bool> = LazyLock::new(|| {
     std::env::var("CANDLE_PREFILL_LANEROW")
@@ -842,11 +816,8 @@ static PREFILL_LANEROW: LazyLock<bool> = LazyLock::new(|| {
         .unwrap_or(true)
 });
 
-// A/B switch for parallelizing the prefill activation quantization across the
-// barrier pool (default ON). The lane=row driver quantizes all m rows to Q8 before
-// the parallel GEMM; doing it serially is an Amdahl ceiling on multi-thread prefill
-// scaling. Set CANDLE_PREFILL_PARQUANT=0 to force the serial quant for same-binary
-// A/B on N1. Result is bit-identical either way (per-tile independent).
+// Default ON: parallelize the prefill activation quant over the pool (bit-identical
+// to serial). CANDLE_PREFILL_PARQUANT=0 forces serial for A/B.
 #[cfg(target_feature = "dotprod")]
 static PREFILL_PARQUANT: LazyLock<bool> = LazyLock::new(|| {
     std::env::var("CANDLE_PREFILL_PARQUANT")
@@ -854,8 +825,7 @@ static PREFILL_PARQUANT: LazyLock<bool> = LazyLock::new(|| {
         .unwrap_or(true)
 });
 
-/// Repack a Q4_K weight into the interleave-4 laneq `BlockQ4Kx8L` groups the
-/// lane=row `8x4` kernel consumes (`repack_q4kx8_laneq4` per 8-channel group).
+// Repack a full Q4_K weight into interleave-4 laneq groups for all n/8 channels.
 #[cfg(target_feature = "dotprod")]
 pub(crate) fn repack_q4k_weight_laneq4(rows: &[BlockQ4K], n: usize, nb: usize) -> Vec<BlockQ4Kx8L> {
     debug_assert_eq!(n % Q4KX8_ROWS, 0, "repack_q4k_weight_laneq4: n {n} not /8");
@@ -873,19 +843,14 @@ pub(crate) fn repack_q4k_weight_laneq4(rows: &[BlockQ4K], n: usize, nb: usize) -
     packed
 }
 
-/// Whether the lane=row Q4_K prefill path is enabled (default on for dotprod
-/// builds; `CANDLE_PREFILL_LANEROW=0` forces the upstream #3643 path). The repacked
-/// weight is cached per-QTensor (`QTensor::repacked_laneq`), not globally.
+// Whether the lane=row Q4_K prefill path is enabled; the pack is cached per-QTensor.
 #[cfg(target_feature = "dotprod")]
 pub(crate) fn prefill_lanerow_enabled() -> bool {
     *PREFILL_LANEROW
 }
 
-/// Lane=row prefill GEMM driver: `dst(m,n) = lhs(m,k) x W^T` over interleave-4
-/// laneq weights. Mirrors `matmul_q4kx8l_prepacked_i8mm` exactly (4-row activation
-/// tiles via `quantize_mat_q8_k_4x4`, last tile zero-padded, barrier-pool over
-/// channel groups, same 4x8 sub-tile scatter), but calls the lane=row SDOT kernel
-/// instead of SMMLA - so it runs on any dotprod core (Graviton2/N1).
+// Lane=row prefill GEMM: dst(m,n) = lhs(m,k) x W^T over interleave-4 laneq weights,
+// 4-row tiles (last zero-padded), parallelized over channel groups on the pool.
 #[cfg(all(target_feature = "neon", target_feature = "dotprod"))]
 pub(crate) fn matmul_q4kx8l_lanerow(
     (m, k, n): (usize, usize, usize),

--- a/candle-core/src/quantized/repack.rs
+++ b/candle-core/src/quantized/repack.rs
@@ -13,13 +13,9 @@ use super::k_quants::{BlockQ6K, QK_K};
 #[cfg(target_feature = "neon")]
 use super::k_quants::{BlockQ8K, GgmlType};
 use half::f16;
-#[cfg(target_feature = "dotprod")]
-use std::collections::HashMap;
 use std::sync::Arc;
 #[cfg(target_feature = "neon")]
 use std::sync::LazyLock;
-#[cfg(target_feature = "dotprod")]
-use std::sync::Mutex;
 
 // ---- shared interleave constants ----
 pub(crate) const Q4KX8_ROWS: usize = 8;
@@ -654,15 +650,27 @@ mod tests {
     }
 }
 
+// Same fields/size (1152 B) as `k_quants::BlockQ4Kx8`; only the `qs` interleave
+// differs (bsi=4 lane=row vs #3643's bsi=8). zerocopy derives let the per-QTensor
+// `repacked_laneq` cache round-trip it through raw bytes, mirroring #3643.
 #[cfg(target_feature = "dotprod")]
+#[derive(
+    Clone,
+    Copy,
+    zerocopy::FromBytes,
+    zerocopy::IntoBytes,
+    zerocopy::KnownLayout,
+    zerocopy::Immutable,
+)]
 #[repr(C)]
-#[derive(Clone)]
 pub struct BlockQ4Kx8L {
     pub(crate) d: [f16; 8],
     pub(crate) dmin: [f16; 8],
     pub(crate) scales: [u8; 96], // 6-bit scales+mins, repacked (8 cols)
-    pub(crate) qs: [u8; 1024],   // 4-bit quants, 8-byte round-robin interleave
+    pub(crate) qs: [u8; 1024],   // 4-bit quants, 4-byte round-robin interleave
 }
+#[cfg(target_feature = "dotprod")]
+const _: () = assert!(std::mem::size_of::<BlockQ4Kx8L>() == 1152);
 
 #[cfg(target_feature = "dotprod")]
 impl BlockQ4Kx8L {
@@ -865,27 +873,12 @@ pub(crate) fn repack_q4k_weight_laneq4(rows: &[BlockQ4K], n: usize, nb: usize) -
     packed
 }
 
-/// Interleave-4 laneq repack cache, keyed on the source Q4_K pointer. Populated on
-/// first lane=row prefill of each weight; model weights live for the whole run.
+/// Whether the lane=row Q4_K prefill path is enabled (default on for dotprod
+/// builds; `CANDLE_PREFILL_LANEROW=0` forces the upstream #3643 path). The repacked
+/// weight is cached per-QTensor (`QTensor::repacked_laneq`), not globally.
 #[cfg(target_feature = "dotprod")]
-static LANEQ4_CACHE: LazyLock<Mutex<HashMap<usize, Arc<Vec<BlockQ4Kx8L>>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-#[cfg(target_feature = "dotprod")]
-fn packed_laneq4_cache_get(rhs: &[BlockQ4K], n: usize, nb: usize) -> Arc<Vec<BlockQ4Kx8L>> {
-    let key = rhs.as_ptr() as usize;
-    {
-        if let Some(p) = LANEQ4_CACHE.lock().unwrap().get(&key) {
-            return p.clone();
-        }
-    }
-    let mut map = LANEQ4_CACHE.lock().unwrap();
-    if let Some(p) = map.get(&key) {
-        return p.clone();
-    }
-    let arc = Arc::new(repack_q4k_weight_laneq4(rhs, n, nb));
-    map.insert(key, arc.clone());
-    arc
+pub(crate) fn prefill_lanerow_enabled() -> bool {
+    *PREFILL_LANEROW
 }
 
 /// Lane=row prefill GEMM driver: `dst(m,n) = lhs(m,k) x W^T` over interleave-4
@@ -966,25 +959,4 @@ pub(crate) fn matmul_q4kx8l_lanerow(
             }
         }
     });
-}
-
-/// Prefill entry point layered on the upstream (#3643) Q4_K matmul: if this is a
-/// wide GEMM (`m >= 4`) and the lane=row path is enabled, repack the weight to the
-/// interleave-4 laneq layout (cached) and run the `8x4` SDOT GEMM, returning `true`.
-/// Returns `false` for decode (`m < 4`) or when disabled, so the caller falls
-/// through to the upstream `BlockQ4Kx8` path (which owns decode). CPU-only.
-#[cfg(target_feature = "dotprod")]
-pub(crate) fn try_matmul_q4k_lanerow_prefill(
-    (m, k, n): (usize, usize, usize),
-    lhs: &[f32],
-    rhs_q4k: &[BlockQ4K],
-    dst: &mut [f32],
-) -> bool {
-    if m < 4 || !*PREFILL_LANEROW {
-        return false;
-    }
-    let nb = k / QK_K;
-    let packed = packed_laneq4_cache_get(rhs_q4k, n, nb);
-    matmul_q4kx8l_lanerow((m, k, n), lhs, &packed, dst);
-    true
 }

--- a/candle-core/src/quantized/repack.rs
+++ b/candle-core/src/quantized/repack.rs
@@ -8,24 +8,31 @@
 
 #[cfg(target_feature = "dotprod")]
 use super::k_quants::BlockQ4K;
-use super::k_quants::{BlockQ6K, BlockQ8K, GgmlType, QK_K};
+use super::k_quants::{BlockQ6K, QK_K};
+// Used only by the NEON-gated Q6 packed GEMM driver.
+#[cfg(target_feature = "neon")]
+use super::k_quants::{BlockQ8K, GgmlType};
 use half::f16;
 #[cfg(target_feature = "dotprod")]
 use std::collections::HashMap;
+use std::sync::Arc;
+#[cfg(target_feature = "neon")]
+use std::sync::LazyLock;
 #[cfg(target_feature = "dotprod")]
 use std::sync::Mutex;
-use std::sync::{Arc, LazyLock};
 
 // ---- shared interleave constants ----
 pub(crate) const Q4KX8_ROWS: usize = 8;
 
-// ---- prefill tile selection (shared with the Q4 path upstream) ----
+// ---- prefill tile selection (NEON Q6 driver only) ----
+#[cfg(target_feature = "neon")]
 #[derive(Clone, Copy, PartialEq)]
 enum PrefillTile {
     Nc8mr4,
     Nc4mr4,
     Nc8mr2,
 }
+#[cfg(target_feature = "neon")]
 static PACKED_PREFILL_TILE: LazyLock<PrefillTile> = LazyLock::new(|| {
     match std::env::var("CANDLE_PACKED_PREFILL")
         .unwrap_or_default()
@@ -39,12 +46,20 @@ static PACKED_PREFILL_TILE: LazyLock<PrefillTile> = LazyLock::new(|| {
 });
 
 // ---- packed Q6_K weight block + repack ----
+// `#[repr(C)]` is load-bearing: this block is the on-disk Q6Kx8 GGUF format
+// (`PackedQ6Kx8::from_bytes` memcpy's raw file bytes in, `from_mmap` casts the
+// mapping). A default-repr struct may reorder fields across compiler versions,
+// which would silently mis-decode baked models. Mirrors `k_quants::BlockQ4Kx8`.
+#[repr(C)]
 pub struct BlockQ6Kx8 {
     pub(crate) d: [f16; Q4KX8_ROWS],
     pub(crate) scales: [i8; Q4KX8_ROWS * (QK_K / 16)], // 128
     pub(crate) ql: [u8; Q4KX8_ROWS * (QK_K / 2)],      // 1024: [chunk(2)][row(8)][64]
     pub(crate) qh: [u8; Q4KX8_ROWS * (QK_K / 4)],      // 512:  [chunk(2)][row(8)][32]
 }
+// d (16) + scales (128) + ql (1024) + qh (512); all fields are <=2-byte aligned, so
+// the packed layout has no interior padding. Pins the persisted block size.
+const _: () = assert!(std::mem::size_of::<BlockQ6Kx8>() == 1680);
 
 impl BlockQ6Kx8 {
     fn zeroed() -> Self {
@@ -104,6 +119,10 @@ pub fn repack_q6k_weight(rows: &[BlockQ6K], n: usize, nb: usize) -> Vec<BlockQ6K
 }
 
 // ---- prepacked GEMM driver ----
+// NEON-only: `gemm_q6kx8_q8k` lives in the `neon` module, which is not compiled on
+// non-NEON targets. The `matmul_t` caller has a `not(neon)` arm that bails, so this
+// must carry the same gate or the `super::neon` import fails to resolve on x86_64.
+#[cfg(target_feature = "neon")]
 pub(crate) fn matmul_q6kx8_prepacked(
     (m, k, n): (usize, usize, usize),
     lhs: &[f32],

--- a/candle-core/src/quantized/repack.rs
+++ b/candle-core/src/quantized/repack.rs
@@ -118,8 +118,10 @@ pub(crate) fn matmul_q6kx8_prepacked(
     use super::neon::gemm_q6kx8_q8k;
     let nb = k / QK_K;
     let groups = n / Q4KX8_ROWS;
-    // Q6 has only the 8-channel kernel; widen the prefill tile to MR=4 (the nc8mr4
-    // default) for the same channel+row reuse win, else MR=2.
+    // Q6 has only the 8-channel kernel. MR=2 (16 accumulators) is the default and
+    // the N1-safe tile; MR=4 (32 acc) tends to spill the 32 NEON regs - the same
+    // regression seen on Q4's nc8mr4 tile. CANDLE_PACKED_PREFILL=nc8mr4 opts into
+    // MR=4 for wide cores where it does not spill.
     let mr4 = *PACKED_PREFILL_TILE == PrefillTile::Nc8mr4;
 
     thread_local! {
@@ -277,12 +279,14 @@ impl PackedQ6Kx8 {
         n: usize,
     ) -> crate::Result<Self> {
         let bs = std::mem::size_of::<BlockQ6Kx8>();
-        if offset + byte_len > mmap.len() {
-            crate::bail!(
-                "Q6Kx8 mmap region end {} exceeds map len {}",
-                offset + byte_len,
+        // checked_add: a malformed offset near usize::MAX would otherwise wrap and
+        // pass the bounds check, yielding a pointer outside the mapping.
+        match offset.checked_add(byte_len) {
+            Some(end) if end <= mmap.len() => {}
+            _ => crate::bail!(
+                "Q6Kx8 mmap region at offset {offset} (+{byte_len}) out of bounds for map len {}",
                 mmap.len()
-            );
+            ),
         }
         if !byte_len.is_multiple_of(bs) {
             crate::bail!("Q6Kx8 mmap byte_len {byte_len} not a multiple of block size {bs}");

--- a/candle-core/src/utils.rs
+++ b/candle-core/src/utils.rs
@@ -128,6 +128,9 @@ impl BarrierPool {
                     .name(format!("candle-bp-{tid}"))
                     .spawn(move || {
                         set_thread_affinity();
+                        // A worker only ever runs dispatched closures, so any execute()
+                        // it reaches is nested; keep the flag set for its whole life.
+                        IN_EXECUTE.with(|c| c.set(true));
                         let inner = unsafe { &*(inner_ptr as *const BarrierPoolInner) };
                         let slot = &inner.slots[tid];
                         let mut gen = 0usize;
@@ -241,6 +244,20 @@ impl Drop for BarrierGuard<'_> {
     }
 }
 
+thread_local! {
+    // True while this thread is inside execute() (main) or running a dispatched
+    // closure (worker). Used to route a reentrant execute() to the serial path.
+    static IN_EXECUTE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+// Resets the main thread's IN_EXECUTE flag on scope exit (panic-safe).
+struct ExecGuard;
+impl Drop for ExecGuard {
+    fn drop(&mut self) {
+        IN_EXECUTE.with(|c| c.set(false));
+    }
+}
+
 impl BarrierPool {
     pub fn execute<F: Fn(usize) + Sync>(&self, f: F) {
         let n = self.threads.len();
@@ -248,6 +265,18 @@ impl BarrierPool {
             f(0);
             return;
         }
+
+        // Reentrant call (e.g. a Tensor op inside a pool closure): acquiring
+        // call_lock again would deadlock against the outer call, so run every
+        // participant serially on this thread instead.
+        if IN_EXECUTE.with(|c| c.get()) {
+            for tid in 0..=n {
+                f(tid);
+            }
+            return;
+        }
+        IN_EXECUTE.with(|c| c.set(true));
+        let _exec = ExecGuard;
 
         let mut guard = self.call_lock.lock().unwrap();
         let new_gen = guard.wrapping_add(1);
@@ -421,4 +450,27 @@ pub fn with_simd128() -> bool {
 
 pub fn with_f16c() -> bool {
     cfg!(target_feature = "f16c")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // A reentrant execute() (a pool closure that calls execute() again) must not
+    // deadlock and must still run every nested participant.
+    #[test]
+    fn nested_execute_runs_serially_no_deadlock() {
+        let pool = barrier_pool();
+        let n_total = pool.n_workers() + 1;
+        let count = AtomicUsize::new(0);
+        pool.execute(|_outer| {
+            pool.execute(|_inner| {
+                count.fetch_add(1, Ordering::Relaxed);
+            });
+        });
+        // Each of the n_total outer participants runs an inner execute that, being
+        // reentrant, does all n_total participants serially.
+        assert_eq!(count.load(Ordering::Relaxed), n_total * n_total);
+    }
 }

--- a/candle-core/src/utils.rs
+++ b/candle-core/src/utils.rs
@@ -306,11 +306,9 @@ pub fn barrier_pool() -> &'static BarrierPool {
     BARRIER_POOL.get_or_init(|| BarrierPool::new(candle_num_threads().saturating_sub(1)))
 }
 
-/// Apply `f` to each `chunk`-sized slice of `dst` in parallel across the barrier
-/// pool. `dst.len()` must be a multiple of `chunk`; `f(chunk_index, &mut chunk)`
-/// gets disjoint sub-slices, so it must not touch any state outside its own chunk.
-/// Used to parallelize the prefill activation quantization (each tile independent).
-pub fn par_chunks_mut<U>(dst: &mut [U], chunk: usize, f: impl Fn(usize, &mut [U]) + Sync) {
+// Apply `f` to each `chunk`-sized disjoint sub-slice of `dst` in parallel across the
+// barrier pool. `dst.len()` must be a multiple of `chunk`.
+pub fn par_chunks_mut<U: Send>(dst: &mut [U], chunk: usize, f: impl Fn(usize, &mut [U]) + Sync) {
     let n = dst.len() / chunk;
     struct DstP<U>(*mut U);
     unsafe impl<U> Sync for DstP<U> {}

--- a/candle-core/src/utils.rs
+++ b/candle-core/src/utils.rs
@@ -306,6 +306,31 @@ pub fn barrier_pool() -> &'static BarrierPool {
     BARRIER_POOL.get_or_init(|| BarrierPool::new(candle_num_threads().saturating_sub(1)))
 }
 
+/// Apply `f` to each `chunk`-sized slice of `dst` in parallel across the barrier
+/// pool. `dst.len()` must be a multiple of `chunk`; `f(chunk_index, &mut chunk)`
+/// gets disjoint sub-slices, so it must not touch any state outside its own chunk.
+/// Used to parallelize the prefill activation quantization (each tile independent).
+pub fn par_chunks_mut<U>(dst: &mut [U], chunk: usize, f: impl Fn(usize, &mut [U]) + Sync) {
+    let n = dst.len() / chunk;
+    struct DstP<U>(*mut U);
+    unsafe impl<U> Sync for DstP<U> {}
+    let dp = DstP(dst.as_mut_ptr());
+    let pool = barrier_pool();
+    let n_total = pool.n_workers() + 1;
+    let cpt = n.div_ceil(n_total);
+    pool.execute(|tid| {
+        let p = &dp;
+        let start = tid * cpt;
+        if start < n {
+            let end = n.min((tid + 1) * cpt);
+            for ci in start..end {
+                let d = unsafe { std::slice::from_raw_parts_mut(p.0.add(ci * chunk), chunk) };
+                f(ci, d);
+            }
+        }
+    });
+}
+
 pub fn with_threadpool<F: FnOnce() -> R + Send, R: Send>(f: F) -> R {
     candle_pool().install(f)
 }

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -1329,6 +1329,19 @@ quantized_matmul!(
     GgmlDType::Q8K
 );
 
+// Exercises the aarch64 lane=row Q4_K prefill kernel end-to-end through QMatMul:
+// m >= 4 + n % 8 == 0 routes the matmul through the `try_matmul_q4k_lanerow_prefill`
+// dispatch (quantized/mod.rs) instead of the upstream BlockQ4Kx8 decode path. On
+// non-dotprod hosts the dispatch falls through, so this just re-checks Q4_K matmul.
+// Catches a wiring regression that the m=3 `quantized_matmul_q4k` test cannot.
+#[test]
+fn quantized_matmul_q4k_lanerow_prefill_cpu() -> Result<()> {
+    let cpu = &Device::Cpu;
+    test_matmul(cpu, (1, 8, 16, 256), GgmlDType::Q4K)?;
+    test_matmul(cpu, (1, 6, 24, 512), GgmlDType::Q4K)?; // 6 rows = one full + zero-padded tile
+    Ok(())
+}
+
 #[test]
 fn quantized_matmul_q2k() -> Result<()> {
     use k_quants::BlockQ2K;

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -1117,6 +1117,8 @@ fn ggml_reference_matmul_error(dtype: GgmlDType) -> Result<f32> {
 
         // Not from the ggml repo.
         GgmlDType::Q8K => 0.00065,
+        // Baked CPU-only repack of Q6_K; same numerical error as Q6_K.
+        GgmlDType::Q6Kx8 => 0.000952,
     };
     Ok(err)
 }

--- a/candle-examples/examples/gguf-requant/main.rs
+++ b/candle-examples/examples/gguf-requant/main.rs
@@ -1,0 +1,180 @@
+//! Offline requantizer for the deploy artifact: rewrite a GGUF, optionally
+//! requantizing selected tensors to a lower-bit dtype (e.g. tied lm_head Q6_K ->
+//! Q4_K) and/or baking Q6_K matmul weights into the pre-packed Q6_Kx8 interleaved
+//! layout (no load-time repack). Q4_K weights are left as-is - the runtime path
+//! repacks/lane-rows them (#3643 + lanerow), so only Q6_K residuals are baked here.
+//!
+//!   gguf-requant --input m.gguf --output m-q6packed.gguf --pack
+//!   gguf-requant --input m.gguf --output m-q4out.gguf --tensors token_embd,output --dtype q4k
+use anyhow::Result;
+use candle::quantized::{
+    ggml_file, gguf_file, k_quants::BlockQ6K, repack, GgmlDType, GgmlType, QTensor,
+};
+use candle::Device;
+use clap::Parser;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(long)]
+    input: String,
+    #[arg(long)]
+    output: String,
+    /// Comma-separated substrings; any tensor whose name contains one is requantized.
+    #[arg(long, default_value = "token_embd,output")]
+    tensors: String,
+    /// Requant target dtype: q4k | q5k | q3k | q4_0.
+    #[arg(long, default_value = "q4k")]
+    dtype: String,
+    /// Bake the pre-packed Q6_Kx8 layout for Q6_K matmul weights (attn_v/ffn_down).
+    #[arg(long, default_value_t = false)]
+    pack: bool,
+}
+
+fn parse_dtype(s: &str) -> Result<GgmlDType> {
+    Ok(match s {
+        "q4k" | "q4_k" => GgmlDType::Q4K,
+        "q5k" | "q5_k" => GgmlDType::Q5K,
+        "q3k" | "q3_k" => GgmlDType::Q3K,
+        "q4_0" => GgmlDType::Q4_0,
+        other => anyhow::bail!("unsupported dtype {other}"),
+    })
+}
+
+// Matmul weight name suffixes eligible for packing.
+const PACK_MATMUL: &[&str] = &[
+    "attn_q",
+    "attn_k",
+    "attn_v",
+    "attn_output",
+    "ffn_gate",
+    "ffn_up",
+    "ffn_down",
+];
+
+fn is_packable_matmul(name: &str) -> bool {
+    !name.contains("norm")
+        && name.ends_with(".weight")
+        && PACK_MATMUL.iter().any(|p| name.contains(p))
+}
+
+// Repack a Q6_K weight QTensor [n, k] into a pre-packed Q6_Kx8 QTensor (the residual
+// attn_v/ffn_down weights Q4_K_M leaves at Q6_K). Q4_K is left for the runtime path.
+fn pack_q6k_to_q6kx8(qt: &QTensor) -> Result<QTensor> {
+    let (n, k) = qt.shape().dims2()?;
+    anyhow::ensure!(qt.dtype() == GgmlDType::Q6K, "pack expects Q6_K input");
+    anyhow::ensure!(n % 8 == 0 && k % 256 == 0, "pack needs n%8==0 && k%256==0");
+    let nb = k / 256;
+    let data = qt.data()?;
+    let bs = std::mem::size_of::<BlockQ6K>();
+    anyhow::ensure!(
+        data.len() == n * nb * bs,
+        "unexpected Q6_K byte count {} vs {}",
+        data.len(),
+        n * nb * bs
+    );
+    let mut rows = vec![BlockQ6K::zeros(); n * nb];
+    // SAFETY: bytes came straight from a Q6_K QTensor (POD #[repr(C)] BlockQ6K) and the
+    // length is an exact multiple of the block size; copy into an aligned Vec first.
+    unsafe {
+        std::ptr::copy_nonoverlapping(data.as_ptr(), rows.as_mut_ptr() as *mut u8, data.len());
+    }
+    let packed = repack::repack_q6k_weight(&rows, n, nb);
+    let raw: &[u8] = unsafe {
+        std::slice::from_raw_parts(
+            packed.as_ptr() as *const u8,
+            std::mem::size_of_val(packed.as_slice()),
+        )
+    };
+    let tensor = ggml_file::qtensor_from_ggml(GgmlDType::Q6Kx8, raw, vec![n, k], &Device::Cpu)?;
+    Ok(tensor)
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let device = Device::Cpu;
+    let target = parse_dtype(&args.dtype)?;
+    let pats: Vec<&str> = args.tensors.split(',').filter(|s| !s.is_empty()).collect();
+
+    let mut f = std::fs::File::open(&args.input)?;
+    let content = gguf_file::Content::read(&mut f).map_err(|e| e.with_path(&args.input))?;
+
+    let names: Vec<String> = content.tensor_infos.keys().cloned().collect();
+    let mut owned: Vec<(String, QTensor)> = Vec::with_capacity(names.len() + 1);
+    let (mut before, mut after) = (0usize, 0usize);
+    let mut has_output = false;
+
+    for name in &names {
+        if name == "output.weight" {
+            has_output = true;
+        }
+        let qt = content.tensor(&mut f, name, &device)?;
+        before += qt.storage_size_in_bytes();
+        // Never requant norm weights (tiny F32, precision-critical).
+        let is_norm = name.contains("norm");
+        let qt = if !is_norm && pats.iter().any(|p| name.contains(p)) && qt.dtype() != target {
+            let de = qt.dequantize(&device)?;
+            let rq = QTensor::quantize(&de, target)?;
+            println!("  requant {name}: {:?} -> {:?}", qt.dtype(), target);
+            rq
+        } else {
+            qt
+        };
+
+        // Pack only Q6_K matmul weights -> Q6Kx8; Q4_K stays plain.
+        let packable = args.pack
+            && is_packable_matmul(name)
+            && qt.dtype() == GgmlDType::Q6K
+            && qt
+                .shape()
+                .dims2()
+                .map(|(n, k)| n % 8 == 0 && k % 256 == 0)
+                .unwrap_or(false);
+        let qt = if packable {
+            let packed = pack_q6k_to_q6kx8(&qt)?;
+            println!("  pack    {name}: Q6K -> Q6Kx8");
+            packed
+        } else {
+            qt
+        };
+
+        after += qt.storage_size_in_bytes();
+        owned.push((name.clone(), qt));
+    }
+
+    // Tied embedding (no output.weight): emit a packed Q6Kx8 output.weight from a Q6_K
+    // token_embd for the lm_head matmul. token_embd itself stays Q6_K (gather lookup).
+    if args.pack && !has_output {
+        if let Some((_, te)) = owned.iter().find(|(n, _)| n == "token_embd.weight") {
+            if te.dtype() == GgmlDType::Q6K
+                && te.shape().dims2().map(|(n, _)| n % 8 == 0).unwrap_or(false)
+            {
+                match pack_q6k_to_q6kx8(te) {
+                    Ok(packed) => {
+                        println!("  emit    output.weight (tied): Q6K -> Q6Kx8");
+                        after += packed.storage_size_in_bytes();
+                        owned.push(("output.weight".to_string(), packed));
+                    }
+                    Err(e) => println!("  skip tied output.weight pack: {e}"),
+                }
+            }
+        }
+    }
+
+    let metadata: Vec<(&str, &gguf_file::Value)> = content
+        .metadata
+        .iter()
+        .map(|(k, v)| (k.as_str(), v))
+        .collect();
+    let tensors: Vec<(&str, &QTensor)> = owned.iter().map(|(n, t)| (n.as_str(), t)).collect();
+
+    let mut w = std::fs::File::create(&args.output)?;
+    gguf_file::write(&mut w, &metadata, &tensors)?;
+    println!(
+        "wrote {} ({} tensors): weights {:.1}MB -> {:.1}MB",
+        args.output,
+        tensors.len(),
+        before as f64 / 1e6,
+        after as f64 / 1e6,
+    );
+    Ok(())
+}

--- a/candle-examples/examples/gguf-requant/main.rs
+++ b/candle-examples/examples/gguf-requant/main.rs
@@ -19,8 +19,11 @@ struct Args {
     input: String,
     #[arg(long)]
     output: String,
-    /// Comma-separated substrings; any tensor whose name contains one is requantized.
-    #[arg(long, default_value = "token_embd,output")]
+    /// Comma-separated substrings; any tensor whose name contains one is requantized
+    /// to --dtype. Empty (default) = no requant: --pack alone only bakes Q6Kx8 and
+    /// leaves embeddings/lm_head untouched. Pass e.g. --tensors token_embd,output to
+    /// opt into requant (q6->q4 lm_head).
+    #[arg(long, default_value = "")]
     tensors: String,
     /// Requant target dtype: q4k | q5k | q3k | q4_0.
     #[arg(long, default_value = "q4k")]

--- a/candle-examples/examples/quantized-qwen3-bench/main.rs
+++ b/candle-examples/examples/quantized-qwen3-bench/main.rs
@@ -1,0 +1,136 @@
+//! Throughput benchmark for the quantized Qwen3 model, matched to `llama-bench`
+//! methodology so candle and llama.cpp numbers are comparable:
+//!   - prefill (pp): one forward over a dummy prompt of `--pp` tokens.
+//!   - decode  (tg): `--tg` greedy single-token forwards.
+//!
+//! No tokenizer, no sampling, no repeat penalty - raw model throughput only.
+//! Reports median tokens/s over `--reps` measured runs (after `--warmup`).
+//!
+//! Pair with thread pinning to simulate a Lambda tier, e.g.:
+//!   CANDLE_QMATMUL_DECODE_THREADS=2 CANDLE_QMATMUL_PREFILL_THREADS=2 \
+//!     taskset -c 0-1 cargo run --release --example quantized-qwen3-bench -- \
+//!     --model model.gguf --json
+
+use anyhow::Result;
+use candle::quantized::gguf_file;
+use candle::{Device, Tensor, D};
+use candle_transformers::models::quantized_qwen3::ModelWeights as Qwen3;
+use clap::Parser;
+use std::time::Instant;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// GGUF file to load.
+    #[arg(long)]
+    model: String,
+
+    /// Prompt length in tokens for the prefill (pp) measurement.
+    #[arg(long, default_value_t = 512)]
+    pp: usize,
+
+    /// Number of tokens to generate for the decode (tg) measurement.
+    #[arg(long, default_value_t = 128)]
+    tg: usize,
+
+    /// Measured repetitions (median is reported).
+    #[arg(long, default_value_t = 5)]
+    reps: usize,
+
+    /// Warmup repetitions discarded before measuring.
+    #[arg(long, default_value_t = 1)]
+    warmup: usize,
+
+    /// Dummy token id used to fill the synthetic prompt (must be < vocab size).
+    #[arg(long, default_value_t = 100)]
+    token_id: u32,
+
+    /// Emit a single JSON line on stdout instead of a human table.
+    #[arg(long)]
+    json: bool,
+}
+
+/// Greedy next token from a 1-D logits tensor, computed on-device so the host
+/// copy stays out of the decode loop.
+fn argmax(logits: &Tensor) -> Result<u32> {
+    Ok(logits.argmax(D::Minus1)?.to_scalar::<u32>()?)
+}
+
+/// (median, min, max) of a sample. Returns zeros for an empty slice.
+fn stats(xs: &[f64]) -> (f64, f64, f64) {
+    let mut s = xs.to_vec();
+    s.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = s.len();
+    if n == 0 {
+        return (0.0, 0.0, 0.0);
+    }
+    let median = if n % 2 == 1 {
+        s[n / 2]
+    } else {
+        (s[n / 2 - 1] + s[n / 2]) / 2.0
+    };
+    (median, s[0], s[n - 1])
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let device = Device::Cpu;
+
+    let mut file = std::fs::File::open(&args.model)?;
+    let content = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(&args.model))?;
+    let mut model = Qwen3::from_gguf(content, &mut file, &device)?;
+
+    let prompt: Vec<u32> = vec![args.token_id; args.pp];
+
+    let mut pp_rates = Vec::new();
+    let mut tg_rates = Vec::new();
+
+    let total = args.warmup + args.reps;
+    for rep in 0..total {
+        model.clear_kv_cache();
+
+        // Prefill: one forward over the whole synthetic prompt.
+        let input = Tensor::new(prompt.as_slice(), &device)?.unsqueeze(0)?;
+        let t = Instant::now();
+        let logits = model.forward(&input, 0)?.squeeze(0)?;
+        let pp_dt = t.elapsed().as_secs_f64();
+        let mut next = argmax(&logits)?;
+
+        // Decode: tg greedy single-token forwards.
+        let t = Instant::now();
+        for i in 0..args.tg {
+            let input = Tensor::new(&[next], &device)?.unsqueeze(0)?;
+            let logits = model.forward(&input, args.pp + i)?.squeeze(0)?;
+            next = argmax(&logits)?;
+        }
+        let tg_dt = t.elapsed().as_secs_f64();
+
+        let pp_rate = args.pp as f64 / pp_dt;
+        let tg_rate = args.tg as f64 / tg_dt;
+        if rep >= args.warmup {
+            pp_rates.push(pp_rate);
+            tg_rates.push(tg_rate);
+        }
+        if !args.json {
+            let tag = if rep < args.warmup { "warmup" } else { "run" };
+            eprintln!("{tag} {rep}: pp {pp_rate:.2} t/s   tg {tg_rate:.2} t/s");
+        }
+    }
+
+    let (pp_med, pp_min, pp_max) = stats(&pp_rates);
+    let (tg_med, tg_min, tg_max) = stats(&tg_rates);
+
+    if args.json {
+        println!(
+            "{{\"engine\":\"candle\",\"pp\":{},\"tg\":{},\"reps\":{},\
+\"pp_tok_s_median\":{:.3},\"pp_tok_s_min\":{:.3},\"pp_tok_s_max\":{:.3},\
+\"tg_tok_s_median\":{:.3},\"tg_tok_s_min\":{:.3},\"tg_tok_s_max\":{:.3}}}",
+            args.pp, args.tg, args.reps, pp_med, pp_min, pp_max, tg_med, tg_min, tg_max
+        );
+    } else {
+        println!("\ncandle  pp{}  tg{}  reps={}", args.pp, args.tg, args.reps);
+        println!("  prefill (pp): {pp_med:.2} t/s  [{pp_min:.2}..{pp_max:.2}]");
+        println!("  decode  (tg): {tg_med:.2} t/s  [{tg_min:.2}..{tg_max:.2}]");
+    }
+    Ok(())
+}

--- a/candle-nn/Cargo.toml
+++ b/candle-nn/Cargo.toml
@@ -32,6 +32,9 @@ criterion = { workspace = true }
 
 [features]
 default = []
+# Opt-in native f16.f16 attention dot (no f32 widening) for the f16-KV CPU flash
+# kernels. Not bit-exact (~1e-3), so default OFF; enable on the CPU deploy.
+f16-attn-dot = []
 accelerate = ["dep:accelerate-src", "candle/accelerate"]
 cuda = ["candle/cuda"]
 cudnn = ["candle/cudnn"]

--- a/candle-nn/src/attention/cpu_flash/causal.rs
+++ b/candle-nn/src/attention/cpu_flash/causal.rs
@@ -8,6 +8,13 @@ use rayon::prelude::*;
 
 use super::dot_f32;
 use super::online_softmax::online_softmax_step;
+// f16-KV CPU flash decode helpers. The dot fn is feature-selected: f16-attn-dot
+// uses a native f16.f16 dot, otherwise K is widened in-register (dot_f32_f16).
+use super::axpy_f16;
+#[cfg(feature = "f16-attn-dot")]
+use super::dot_f16_f16;
+#[cfg(not(feature = "f16-attn-dot"))]
+use super::dot_f32_f16;
 
 // These utils are mostly for readability.
 
@@ -29,9 +36,9 @@ fn vec_add(acc: &mut [f32], v: &[f32]) {
     acc.iter_mut().zip(v).for_each(|(a, e)| *a += e);
 }
 
-/// Prefetch a cache line for read.
+/// Prefetch a cache line for read. Generic so f32 and f16-KV callers share it.
 #[inline(always)]
-fn prefetch_read(ptr: *const f32) {
+fn prefetch_read<T>(ptr: *const T) {
     #[cfg(target_arch = "aarch64")]
     unsafe {
         std::arch::asm!("prfm pldl1keep, [{ptr}]", ptr = in(reg) ptr, options(nostack, preserves_flags));
@@ -960,6 +967,352 @@ fn causal_prefill_generic<T: WithDType>(
                 }
             },
         );
+
+    Tensor::from_vec(out, (h_q, s_q, d), &Device::Cpu)
+}
+
+// Opt-in (CANDLE_VEC_SOFTMAX_EXP=1) NEON polynomial exp for the flash-attention softmax.
+// The N1 instruction breakdown showed `expf` (libm, scalar) as the kernel's `transcendental`
+// cost; this replaces it with FMA (~1e-6 accurate, normalized out by softmax). Default OFF so
+// the default path stays bit-reproducible; flip on once validated on N1.
+#[cfg(target_arch = "aarch64")]
+static VEC_SOFTMAX_EXP: std::sync::LazyLock<bool> =
+    std::sync::LazyLock::new(|| std::env::var("CANDLE_VEC_SOFTMAX_EXP").is_ok());
+
+// exp(x) via range-reduction x = n*ln2 + r, exp(x) = 2^n * poly(r). Scalar form so the
+// vector body and the <4 tail use the SAME approximation (consistent softmax values).
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+fn poly_exp_scalar(x: f32) -> f32 {
+    let x = x.clamp(-87.0, 88.0);
+    let n = (x * std::f32::consts::LOG2_E).round();
+    let r = x - n * std::f32::consts::LN_2;
+    let mut p = 1.0 / 720.0;
+    p = p * r + 1.0 / 120.0;
+    p = p * r + 1.0 / 24.0;
+    p = p * r + 1.0 / 6.0;
+    p = p * r + 0.5;
+    p = p * r + 1.0;
+    p = p * r + 1.0;
+    p * f32::from_bits((((n as i32) + 127) << 23) as u32)
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn vec_exp_sub_sum_neon(s: &mut [f32], mr: f32) -> f32 {
+    use std::arch::aarch64::*;
+    #[inline(always)]
+    unsafe fn vexpq(x: float32x4_t) -> float32x4_t {
+        let x = vminq_f32(vmaxq_f32(x, vdupq_n_f32(-87.0)), vdupq_n_f32(88.0));
+        let n = vrndnq_f32(vmulq_f32(x, vdupq_n_f32(std::f32::consts::LOG2_E)));
+        let r = vfmsq_f32(x, n, vdupq_n_f32(std::f32::consts::LN_2));
+        let mut p = vdupq_n_f32(1.0 / 720.0);
+        p = vfmaq_f32(vdupq_n_f32(1.0 / 120.0), p, r);
+        p = vfmaq_f32(vdupq_n_f32(1.0 / 24.0), p, r);
+        p = vfmaq_f32(vdupq_n_f32(1.0 / 6.0), p, r);
+        p = vfmaq_f32(vdupq_n_f32(0.5), p, r);
+        p = vfmaq_f32(vdupq_n_f32(1.0), p, r);
+        p = vfmaq_f32(vdupq_n_f32(1.0), p, r);
+        let bits = vshlq_n_s32(vaddq_s32(vcvtq_s32_f32(n), vdupq_n_s32(127)), 23);
+        vmulq_f32(p, vreinterpretq_f32_s32(bits))
+    }
+    let vmr = vdupq_n_f32(mr);
+    let mut vsum = vdupq_n_f32(0.0);
+    let n = s.len();
+    let p = s.as_mut_ptr();
+    let mut i = 0;
+    while i + 4 <= n {
+        let e = vexpq(vsubq_f32(vld1q_f32(p.add(i)), vmr));
+        vst1q_f32(p.add(i), e);
+        vsum = vaddq_f32(vsum, e);
+        i += 4;
+    }
+    let mut sum = vaddvq_f32(vsum);
+    while i < n {
+        let e = poly_exp_scalar(*p.add(i) - mr);
+        *p.add(i) = e;
+        sum += e;
+        i += 1;
+    }
+    sum
+}
+
+/// For each `x` in `s`, set `x = exp(x - mr)` and return the sum. The softmax inner loop.
+#[inline(always)]
+fn exp_sub_sum(s: &mut [f32], mr: f32) -> f32 {
+    #[cfg(target_arch = "aarch64")]
+    if *VEC_SOFTMAX_EXP {
+        return unsafe { vec_exp_sub_sum_neon(s, mr) };
+    }
+    let mut sum = 0.0f32;
+    for x in s.iter_mut() {
+        let e = (*x - mr).exp();
+        *x = e;
+        sum += e;
+    }
+    sum
+}
+
+/// f16-KV interleaved causal decode (q_len=1). Reads the head-major f16 KV cache
+/// (`RawInterleavedKvCacheF16`) one head's stream at a time - half the bytes of an
+/// f32 cache. With `f16-attn-dot` the score is a native f16.f16 dot; otherwise K is
+/// widened in-register.
+#[allow(clippy::too_many_arguments)]
+pub fn causal_decode_f16kv_interleaved(
+    q_data: &[f32],
+    kv_data: &[half::f16],
+    head_stride: usize,
+    h_q: usize,
+    h_kv: usize,
+    d: usize,
+    kv_len: usize,
+    scale: f32,
+) -> Result<Tensor> {
+    let rk = h_q / h_kv;
+
+    let mut out = vec![0f32; h_q * d];
+
+    // One task per kv head, computing all `rk` of its GQA query heads in a single
+    // pass: the head-major cache makes the stream contiguous, and each K/V row is
+    // read from memory once instead of once per query head.
+    let process =
+        |kv_h: usize, out_chunk: &mut [f32], acc: &mut [f32], m: &mut [f32], ssum: &mut [f32]| {
+            let head_base = kv_h * head_stride;
+
+            acc.fill(0.0);
+            m.fill(f32::NEG_INFINITY);
+            ssum.fill(0.0);
+
+            // `f16-attn-dot`: narrow this kv-head's `rk` query rows to f16 ONCE here
+            // (amortized over all `kv_len` positions), so the inner score is a pure
+            // f16.f16 dot. Default build skips this entirely.
+            #[cfg(feature = "f16-attn-dot")]
+            let q_f16: Vec<half::f16> = {
+                let base = kv_h * rk * d;
+                q_data[base..base + rk * d]
+                    .iter()
+                    .map(|&x| half::f16::from_f32(x))
+                    .collect()
+            };
+
+            for kv_pos in 0..kv_len {
+                // K and V share a base pointer (adjacent in memory)
+                let kv_base = head_base + kv_pos * 2 * d;
+                let k_row = &kv_data[kv_base..kv_base + d];
+                let v_row = &kv_data[kv_base + d..kv_base + 2 * d];
+
+                // One prefetch loads both next K and V
+                if kv_pos + 1 < kv_len {
+                    prefetch_read(kv_data[kv_base + 2 * d..].as_ptr());
+                }
+
+                for r in 0..rk {
+                    let h_i = kv_h * rk + r;
+                    #[cfg(not(feature = "f16-attn-dot"))]
+                    let score = {
+                        let q_row = &q_data[h_i * d..(h_i + 1) * d];
+                        dot_f32_f16(q_row, k_row) * scale
+                    };
+                    #[cfg(feature = "f16-attn-dot")]
+                    let score = {
+                        let _ = h_i;
+                        dot_f16_f16(&q_f16[r * d..(r + 1) * d], k_row) * scale
+                    };
+                    let acc_r = &mut acc[r * d..(r + 1) * d];
+                    online_softmax_step(score, &mut m[r], &mut ssum[r], acc_r, |acc, w| {
+                        axpy_f16(acc, v_row, w);
+                    });
+                }
+            }
+
+            for r in 0..rk {
+                let inv = if ssum[r] > 0.0 { 1.0 / ssum[r] } else { 0.0 };
+                let acc_r = &acc[r * d..(r + 1) * d];
+                let out_r = &mut out_chunk[r * d..(r + 1) * d];
+                for t in 0..d {
+                    out_r[t] = acc_r[t] * inv;
+                }
+            }
+        };
+
+    // CONTIGUOUS per-thread partition of the h_kv kv-heads on the barrier pool (replaces
+    // rayon's fine-grained par_chunks, which thrashed the shared cache and limited decode
+    // scaling on N1). `execute` with a 0-worker pool runs f(0) inline - zero overhead at 1 vCPU.
+    struct OutPtr(*mut f32);
+    unsafe impl Sync for OutPtr {}
+    let optr = OutPtr(out.as_mut_ptr());
+    let pool = candle::utils::barrier_pool();
+    let n_total = pool.n_workers() + 1;
+    let hpt = h_kv.div_ceil(n_total);
+    pool.execute(|tid| {
+        let p = &optr; // capture the whole OutPtr (Sync), not the raw `.0` field
+        let start = tid * hpt;
+        if start < h_kv {
+            let end = h_kv.min((tid + 1) * hpt);
+            let mut acc = vec![0f32; rk * d];
+            let mut m = vec![0f32; rk];
+            let mut ssum = vec![0f32; rk];
+            for kv_h in start..end {
+                let out_chunk =
+                    unsafe { std::slice::from_raw_parts_mut(p.0.add(kv_h * rk * d), rk * d) };
+                process(kv_h, out_chunk, &mut acc, &mut m, &mut ssum);
+            }
+        }
+    });
+
+    Tensor::from_vec(out, (h_q, 1usize, d), &Device::Cpu)
+}
+
+/// Causal prefill over the f16 head-major interleaved KV cache (the same layout
+/// [`causal_decode_f16kv_interleaved`] reads, so prefill and decode share one cache).
+///
+/// Structure matches [`causal_prefill_f32_lean`]: one task per (kv head, query
+/// block), the `rk` GQA query heads sharing every K/V row load, KV-blocked softmax.
+/// The QK dot widens the f16 K row in-register against the f32 query (`dot_f32_f16`);
+/// the PV accumulator stays f32 (`axpy_f16` widens V in-register). Same dot strategy
+/// as [`causal_decode_f16kv_interleaved`], including the `f16-attn-dot` variant.
+#[allow(clippy::too_many_arguments)]
+pub fn causal_prefill_f16kv_headmajor(
+    q_data: &[f32],
+    kv_data: &[half::f16],
+    head_stride: usize,
+    s_q: usize,
+    h_q: usize,
+    h_kv: usize,
+    d: usize,
+    kv_len: usize,
+    scale: f32,
+    kv_offset: usize,
+) -> Result<Tensor> {
+    let rk = h_q / h_kv;
+    let q_seq_stride = h_q * d;
+
+    const KB: usize = 128;
+    const QB: usize = 32;
+    let n_qblocks = s_q.div_ceil(QB);
+
+    let mut out = vec![0f32; h_q * s_q * d];
+    struct OutPtr(*mut f32);
+    unsafe impl Sync for OutPtr {}
+    let out_ptr = OutPtr(out.as_mut_ptr());
+
+    // CONTIGUOUS per-thread partition of the (kv-head, q-block) tasks on the barrier pool
+    // (replaces rayon's fine-grained into_par_iter). execute(0 workers) runs f(0) inline.
+    let n_tasks = h_kv * n_qblocks;
+    let pool = candle::utils::barrier_pool();
+    let n_total = pool.n_workers() + 1;
+    let tpt = n_tasks.div_ceil(n_total);
+    pool.execute(|tid| {
+        let t_start = tid * tpt;
+        if t_start >= n_tasks {
+            return;
+        }
+        let t_end = n_tasks.min((tid + 1) * tpt);
+        let mut acc = vec![0f32; rk * d];
+        let mut w = vec![0f32; rk * KB];
+        let mut m = vec![f32::NEG_INFINITY; rk];
+        let mut ssum = vec![0f32; rk];
+        for task in t_start..t_end {
+            let kv_h = task / n_qblocks;
+            let q0 = (task % n_qblocks) * QB;
+            let q1 = (q0 + QB).min(s_q);
+            let head_base = kv_h * head_stride;
+            let p = &out_ptr;
+
+            // `f16-attn-dot`: narrow this q block's rows to f16 so the QK dot is a
+            // pure f16.f16 FMLA. Reused across q positions; the default build keeps
+            // Q in f32 and the dot widens K in-register (`dot_f32_f16`).
+            #[cfg(feature = "f16-attn-dot")]
+            let mut qf16 = vec![half::f16::ZERO; rk * d];
+
+            for q_pos in q0..q1 {
+                let q_pos_base = q_pos * q_seq_stride + kv_h * rk * d;
+                #[cfg(feature = "f16-attn-dot")]
+                for (o, &x) in qf16
+                    .iter_mut()
+                    .zip(&q_data[q_pos_base..q_pos_base + rk * d])
+                {
+                    *o = half::f16::from_f32(x);
+                }
+
+                acc.fill(0.0);
+                m.fill(f32::NEG_INFINITY);
+                ssum.fill(0.0);
+                let kv_end = (q_pos + kv_offset + 1).min(kv_len);
+
+                for kv0 in (0..kv_end).step_by(KB) {
+                    let kb = KB.min(kv_end - kv0);
+
+                    // Pass 1: scores for all rk heads, each K row loaded once.
+                    for j in 0..kb {
+                        let kv_base = head_base + (kv0 + j) * 2 * d;
+                        let k_row = &kv_data[kv_base..kv_base + d];
+                        if j + 1 < kb {
+                            prefetch_read(kv_data[kv_base + 2 * d..].as_ptr());
+                        }
+                        for r in 0..rk {
+                            #[cfg(not(feature = "f16-attn-dot"))]
+                            let dot = {
+                                let q_row = &q_data[q_pos_base + r * d..q_pos_base + (r + 1) * d];
+                                dot_f32_f16(q_row, k_row)
+                            };
+                            #[cfg(feature = "f16-attn-dot")]
+                            let dot = dot_f16_f16(&qf16[r * d..(r + 1) * d], k_row);
+                            w[r * KB + j] = dot * scale;
+                        }
+                    }
+
+                    // Per head: one max/rescale per block, then batched exp.
+                    for r in 0..rk {
+                        let s = &mut w[r * KB..r * KB + kb];
+                        let bmax = s.iter().fold(f32::NEG_INFINITY, |a, &b| a.max(b));
+                        if bmax > m[r] {
+                            let f = (m[r] - bmax).exp();
+                            if f > 0.0 {
+                                for a in &mut acc[r * d..(r + 1) * d] {
+                                    *a *= f;
+                                }
+                                ssum[r] *= f;
+                            } else {
+                                acc[r * d..(r + 1) * d].fill(0.0);
+                                ssum[r] = 0.0;
+                            }
+                            m[r] = bmax;
+                        }
+                        let mr = m[r];
+                        ssum[r] += exp_sub_sum(s, mr);
+                    }
+
+                    // Pass 2: PV, each V row loaded once for all rk heads.
+                    for j in 0..kb {
+                        let kv_base = head_base + (kv0 + j) * 2 * d;
+                        let v_row = &kv_data[kv_base + d..kv_base + 2 * d];
+                        if j + 1 < kb {
+                            prefetch_read(kv_data[kv_base + 2 * d + d..].as_ptr());
+                        }
+                        for r in 0..rk {
+                            let wj = w[r * KB + j];
+                            axpy_f16(&mut acc[r * d..(r + 1) * d], v_row, wj);
+                        }
+                    }
+                }
+
+                for r in 0..rk {
+                    let h_i = kv_h * rk + r;
+                    let inv = if ssum[r] > 0.0 { 1.0 / ssum[r] } else { 0.0 };
+                    let acc_r = &acc[r * d..(r + 1) * d];
+                    // SAFETY: each (h_i, q_pos) output row is written by exactly
+                    // one task (kv heads and q blocks partition the rows).
+                    let dst = unsafe {
+                        std::slice::from_raw_parts_mut(p.0.add(h_i * s_q * d + q_pos * d), d)
+                    };
+                    for t in 0..d {
+                        dst[t] = acc_r[t] * inv;
+                    }
+                }
+            }
+        }
+    });
 
     Tensor::from_vec(out, (h_q, s_q, d), &Device::Cpu)
 }

--- a/candle-nn/src/attention/cpu_flash/causal.rs
+++ b/candle-nn/src/attention/cpu_flash/causal.rs
@@ -36,7 +36,7 @@ fn vec_add(acc: &mut [f32], v: &[f32]) {
     acc.iter_mut().zip(v).for_each(|(a, e)| *a += e);
 }
 
-/// Prefetch a cache line for read. Generic so f32 and f16-KV callers share it.
+// Prefetch a cache line for read. Generic so f32 and f16-KV callers share it.
 #[inline(always)]
 fn prefetch_read<T>(ptr: *const T) {
     #[cfg(target_arch = "aarch64")]
@@ -971,16 +971,14 @@ fn causal_prefill_generic<T: WithDType>(
     Tensor::from_vec(out, (h_q, s_q, d), &Device::Cpu)
 }
 
-// Opt-in (CANDLE_VEC_SOFTMAX_EXP=1) NEON polynomial exp for the flash-attention softmax.
-// The N1 instruction breakdown showed `expf` (libm, scalar) as the kernel's `transcendental`
-// cost; this replaces it with FMA (~1e-6 accurate, normalized out by softmax). Default OFF so
-// the default path stays bit-reproducible; flip on once validated on N1.
+// Opt-in (CANDLE_VEC_SOFTMAX_EXP=1) NEON polynomial exp for softmax, replacing scalar
+// libm expf (~1e-6, normalized out). Default OFF to stay bit-reproducible.
 #[cfg(target_arch = "aarch64")]
 static VEC_SOFTMAX_EXP: std::sync::LazyLock<bool> =
     std::sync::LazyLock::new(|| std::env::var("CANDLE_VEC_SOFTMAX_EXP").is_ok());
 
-// exp(x) via range-reduction x = n*ln2 + r, exp(x) = 2^n * poly(r). Scalar form so the
-// vector body and the <4 tail use the SAME approximation (consistent softmax values).
+// exp(x) via range reduction x = n*ln2 + r, exp(x) = 2^n * poly(r). Scalar form so the
+// vector body and the <4 tail share one approximation.
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
 fn poly_exp_scalar(x: f32) -> f32 {
@@ -1037,7 +1035,7 @@ unsafe fn vec_exp_sub_sum_neon(s: &mut [f32], mr: f32) -> f32 {
     sum
 }
 
-/// For each `x` in `s`, set `x = exp(x - mr)` and return the sum. The softmax inner loop.
+// For each x in s, set x = exp(x - mr) and return the sum (softmax inner loop).
 #[inline(always)]
 fn exp_sub_sum(s: &mut [f32], mr: f32) -> f32 {
     #[cfg(target_arch = "aarch64")]
@@ -1053,10 +1051,8 @@ fn exp_sub_sum(s: &mut [f32], mr: f32) -> f32 {
     sum
 }
 
-/// f16-KV interleaved causal decode (q_len=1). Reads the head-major f16 KV cache
-/// (`RawInterleavedKvCacheF16`) one head's stream at a time - half the bytes of an
-/// f32 cache. With `f16-attn-dot` the score is a native f16.f16 dot; otherwise K is
-/// widened in-register.
+// f16-KV interleaved causal decode (q_len=1). Reads the head-major f16 KV cache one
+// head's stream at a time - half the bytes of an f32 cache.
 #[allow(clippy::too_many_arguments)]
 pub fn causal_decode_f16kv_interleaved(
     q_data: &[f32],
@@ -1072,9 +1068,8 @@ pub fn causal_decode_f16kv_interleaved(
 
     let mut out = vec![0f32; h_q * d];
 
-    // One task per kv head, computing all `rk` of its GQA query heads in a single
-    // pass: the head-major cache makes the stream contiguous, and each K/V row is
-    // read from memory once instead of once per query head.
+    // One task per kv head, all rk GQA query heads in one pass so each contiguous
+    // K/V row is read from memory once, not once per query head.
     let process =
         |kv_h: usize, out_chunk: &mut [f32], acc: &mut [f32], m: &mut [f32], ssum: &mut [f32]| {
             let head_base = kv_h * head_stride;
@@ -1083,9 +1078,8 @@ pub fn causal_decode_f16kv_interleaved(
             m.fill(f32::NEG_INFINITY);
             ssum.fill(0.0);
 
-            // `f16-attn-dot`: narrow this kv-head's `rk` query rows to f16 ONCE here
-            // (amortized over all `kv_len` positions), so the inner score is a pure
-            // f16.f16 dot. Default build skips this entirely.
+            // f16-attn-dot: narrow this kv-head's rk query rows to f16 once (amortized
+            // over kv_len), so the inner score is a pure f16.f16 dot. Off by default.
             #[cfg(feature = "f16-attn-dot")]
             let q_f16: Vec<half::f16> = {
                 let base = kv_h * rk * d;
@@ -1135,9 +1129,8 @@ pub fn causal_decode_f16kv_interleaved(
             }
         };
 
-    // CONTIGUOUS per-thread partition of the h_kv kv-heads on the barrier pool (replaces
-    // rayon's fine-grained par_chunks, which thrashed the shared cache and limited decode
-    // scaling on N1). `execute` with a 0-worker pool runs f(0) inline - zero overhead at 1 vCPU.
+    // Contiguous per-thread partition of the h_kv kv-heads on the barrier pool (vs rayon's
+    // par_chunks, which thrashed shared cache on N1). 0-worker pool runs f(0) inline.
     struct OutPtr(*mut f32);
     unsafe impl Sync for OutPtr {}
     let optr = OutPtr(out.as_mut_ptr());
@@ -1163,14 +1156,9 @@ pub fn causal_decode_f16kv_interleaved(
     Tensor::from_vec(out, (h_q, 1usize, d), &Device::Cpu)
 }
 
-/// Causal prefill over the f16 head-major interleaved KV cache (the same layout
-/// [`causal_decode_f16kv_interleaved`] reads, so prefill and decode share one cache).
-///
-/// Structure matches [`causal_prefill_f32_lean`]: one task per (kv head, query
-/// block), the `rk` GQA query heads sharing every K/V row load, KV-blocked softmax.
-/// The QK dot widens the f16 K row in-register against the f32 query (`dot_f32_f16`);
-/// the PV accumulator stays f32 (`axpy_f16` widens V in-register). Same dot strategy
-/// as [`causal_decode_f16kv_interleaved`], including the `f16-attn-dot` variant.
+// Causal prefill over the f16 head-major interleaved KV cache (same layout decode reads).
+// One task per (kv head, query block), rk GQA heads sharing every K/V row, KV-blocked
+// softmax; QK widens f16 K in-register, PV accumulator stays f32.
 #[allow(clippy::too_many_arguments)]
 pub fn causal_prefill_f16kv_headmajor(
     q_data: &[f32],
@@ -1196,8 +1184,8 @@ pub fn causal_prefill_f16kv_headmajor(
     unsafe impl Sync for OutPtr {}
     let out_ptr = OutPtr(out.as_mut_ptr());
 
-    // CONTIGUOUS per-thread partition of the (kv-head, q-block) tasks on the barrier pool
-    // (replaces rayon's fine-grained into_par_iter). execute(0 workers) runs f(0) inline.
+    // Contiguous per-thread partition of (kv-head, q-block) tasks on the barrier pool.
+    // 0-worker pool runs f(0) inline.
     let n_tasks = h_kv * n_qblocks;
     let pool = candle::utils::barrier_pool();
     let n_total = pool.n_workers() + 1;
@@ -1219,9 +1207,8 @@ pub fn causal_prefill_f16kv_headmajor(
             let head_base = kv_h * head_stride;
             let p = &out_ptr;
 
-            // `f16-attn-dot`: narrow this q block's rows to f16 so the QK dot is a
-            // pure f16.f16 FMLA. Reused across q positions; the default build keeps
-            // Q in f32 and the dot widens K in-register (`dot_f32_f16`).
+            // f16-attn-dot: narrow this q block's rows to f16 so the QK dot is a pure
+            // f16.f16 FMLA. Default keeps Q in f32 and widens K in-register.
             #[cfg(feature = "f16-attn-dot")]
             let mut qf16 = vec![half::f16::ZERO; rk * d];
 

--- a/candle-nn/src/attention/cpu_flash/mod.rs
+++ b/candle-nn/src/attention/cpu_flash/mod.rs
@@ -178,9 +178,7 @@ fn flash_attn_via_varlen(
     ctx.reshape((b, s_q, h_q, d))?.transpose(1, 2)?.contiguous()
 }
 
-/// the bytes streamed per token. The f16 elements are widened in-register
-/// (`fcvtl`, baseline aarch64 NEON) so there is no scratch buffer and no
-/// precision loss beyond the f16 storage itself.
+// f32.f16 dot; f16 K widened in-register (fcvtl, baseline NEON), no scratch buffer.
 #[cfg(all(target_arch = "aarch64", not(feature = "f16-attn-dot")))]
 #[inline]
 pub(crate) fn dot_f32_f16(a: &[f32], b: &[half::f16]) -> f32 {
@@ -227,11 +225,8 @@ pub(crate) fn dot_f32_f16(a: &[f32], b: &[half::f16]) -> f32 {
     a.iter().zip(b).map(|(x, y)| x * y.to_f32()).sum()
 }
 
-/// Native-fp16 q.k dot for the decode flash kernel (opt-in `f16-attn-dot`).
-/// The accumulator is f16, so a head_dim-long sum loses low-order bits
-/// (~1e-3 rel); softmax + greedy argmax absorb it (verified: identical text).
-/// Two accumulators hide the fp16-FMA latency. The exact f32-accumulating
-/// `dot_f32_f16` above is the default and is what runs without this feature.
+// Native fp16 q.k dot (opt-in f16-attn-dot). f16 accumulator loses ~1e-3 rel,
+// absorbed by softmax+argmax; two accumulators hide FMA latency.
 #[cfg(all(target_arch = "aarch64", feature = "f16-attn-dot"))]
 #[inline]
 pub(crate) fn dot_f16_f16(a: &[half::f16], b: &[half::f16]) -> f32 {
@@ -291,8 +286,7 @@ pub(crate) fn dot_f16_f16(a: &[half::f16], b: &[half::f16]) -> f32 {
 #[inline]
 pub(crate) fn dot_f16_f16(a: &[half::f16], b: &[half::f16]) -> f32 {
     debug_assert_eq!(a.len(), b.len());
-    // Portable reference: f16 products into an f16 running sum (matches the
-    // lossy-accumulation semantics of the aarch64 path closely enough for tests).
+    // Portable reference: f16 products into an f16 running sum (lossy, matches aarch64).
     let mut acc = half::f16::ZERO;
     for (x, y) in a.iter().zip(b) {
         acc += *x * *y;
@@ -300,7 +294,7 @@ pub(crate) fn dot_f16_f16(a: &[half::f16], b: &[half::f16]) -> f32 {
     acc.to_f32()
 }
 
-/// `acc[i] += v[i] * w` with an f16 value row widened in-register (f32 accumulator).
+// acc[i] += v[i] * w; f16 value row widened in-register, f32 accumulator.
 #[cfg(target_arch = "aarch64")]
 #[inline]
 pub(crate) fn axpy_f16(acc: &mut [f32], v: &[half::f16], w: f32) {

--- a/candle-nn/src/attention/cpu_flash/mod.rs
+++ b/candle-nn/src/attention/cpu_flash/mod.rs
@@ -177,3 +177,170 @@ fn flash_attn_via_varlen(
 
     ctx.reshape((b, s_q, h_q, d))?.transpose(1, 2)?.contiguous()
 }
+
+/// the bytes streamed per token. The f16 elements are widened in-register
+/// (`fcvtl`, baseline aarch64 NEON) so there is no scratch buffer and no
+/// precision loss beyond the f16 storage itself.
+#[cfg(all(target_arch = "aarch64", not(feature = "f16-attn-dot")))]
+#[inline]
+pub(crate) fn dot_f32_f16(a: &[f32], b: &[half::f16]) -> f32 {
+    use std::arch::aarch64::*;
+    debug_assert_eq!(a.len(), b.len());
+    let n = a.len();
+    let chunks = n / 8;
+    unsafe {
+        let mut sum0 = vdupq_n_f32(0.0);
+        let mut sum1 = vdupq_n_f32(0.0);
+        let mut ap = a.as_ptr();
+        let mut bp = b.as_ptr();
+        for _ in 0..chunks {
+            let lo: float32x4_t;
+            let hi: float32x4_t;
+            // f16 NEON intrinsics are unstable; widen via asm and FMA via intrinsics.
+            std::arch::asm!(
+                "ldr {kv:q}, [{bp}]",
+                "fcvtl {lo:v}.4s, {kv:v}.4h",
+                "fcvtl2 {hi:v}.4s, {kv:v}.8h",
+                bp = in(reg) bp,
+                kv = out(vreg) _,
+                lo = out(vreg) lo,
+                hi = out(vreg) hi,
+                options(nostack, pure, readonly),
+            );
+            sum0 = vfmaq_f32(sum0, vld1q_f32(ap), lo);
+            sum1 = vfmaq_f32(sum1, vld1q_f32(ap.add(4)), hi);
+            ap = ap.add(8);
+            bp = bp.add(8);
+        }
+        let mut acc = vaddvq_f32(vaddq_f32(sum0, sum1));
+        for i in (chunks * 8)..n {
+            acc += a[i] * b[i].to_f32();
+        }
+        acc
+    }
+}
+
+#[cfg(all(not(target_arch = "aarch64"), not(feature = "f16-attn-dot")))]
+#[inline]
+pub(crate) fn dot_f32_f16(a: &[f32], b: &[half::f16]) -> f32 {
+    debug_assert_eq!(a.len(), b.len());
+    a.iter().zip(b).map(|(x, y)| x * y.to_f32()).sum()
+}
+
+/// Native-fp16 q.k dot for the decode flash kernel (opt-in `f16-attn-dot`).
+/// The accumulator is f16, so a head_dim-long sum loses low-order bits
+/// (~1e-3 rel); softmax + greedy argmax absorb it (verified: identical text).
+/// Two accumulators hide the fp16-FMA latency. The exact f32-accumulating
+/// `dot_f32_f16` above is the default and is what runs without this feature.
+#[cfg(all(target_arch = "aarch64", feature = "f16-attn-dot"))]
+#[inline]
+pub(crate) fn dot_f16_f16(a: &[half::f16], b: &[half::f16]) -> f32 {
+    debug_assert_eq!(a.len(), b.len());
+    let n = a.len();
+    let chunks = n / 16; // two 8-lane accumulators per iteration
+    unsafe {
+        use std::arch::aarch64::*;
+        // Opaque 128-bit vregs holding f16x8 accumulators (no stable f16 vec type).
+        let mut acc0 = vreinterpretq_f32_u32(vdupq_n_u32(0));
+        let mut acc1 = vreinterpretq_f32_u32(vdupq_n_u32(0));
+        let mut ap = a.as_ptr();
+        let mut bp = b.as_ptr();
+        for _ in 0..chunks {
+            std::arch::asm!(
+                "ldp {a0:q}, {a1:q}, [{ap}]",
+                "ldp {b0:q}, {b1:q}, [{bp}]",
+                "fmla {acc0:v}.8h, {a0:v}.8h, {b0:v}.8h",
+                "fmla {acc1:v}.8h, {a1:v}.8h, {b1:v}.8h",
+                ap = in(reg) ap,
+                bp = in(reg) bp,
+                a0 = out(vreg) _, a1 = out(vreg) _,
+                b0 = out(vreg) _, b1 = out(vreg) _,
+                acc0 = inout(vreg) acc0,
+                acc1 = inout(vreg) acc1,
+                options(nostack, readonly),
+            );
+            ap = ap.add(16);
+            bp = bp.add(16);
+        }
+        // Widen both f16 accumulators to f32 and horizontally reduce.
+        let lo0: float32x4_t;
+        let hi0: float32x4_t;
+        let lo1: float32x4_t;
+        let hi1: float32x4_t;
+        std::arch::asm!(
+            "fcvtl {lo0:v}.4s, {acc0:v}.4h",
+            "fcvtl2 {hi0:v}.4s, {acc0:v}.8h",
+            "fcvtl {lo1:v}.4s, {acc1:v}.4h",
+            "fcvtl2 {hi1:v}.4s, {acc1:v}.8h",
+            acc0 = in(vreg) acc0,
+            acc1 = in(vreg) acc1,
+            lo0 = out(vreg) lo0, hi0 = out(vreg) hi0,
+            lo1 = out(vreg) lo1, hi1 = out(vreg) hi1,
+            options(nostack, pure, nomem),
+        );
+        let s = vaddq_f32(vaddq_f32(lo0, hi0), vaddq_f32(lo1, hi1));
+        let mut acc = vaddvq_f32(s);
+        for i in (chunks * 16)..n {
+            acc += a[i].to_f32() * b[i].to_f32();
+        }
+        acc
+    }
+}
+
+#[cfg(all(not(target_arch = "aarch64"), feature = "f16-attn-dot"))]
+#[inline]
+pub(crate) fn dot_f16_f16(a: &[half::f16], b: &[half::f16]) -> f32 {
+    debug_assert_eq!(a.len(), b.len());
+    // Portable reference: f16 products into an f16 running sum (matches the
+    // lossy-accumulation semantics of the aarch64 path closely enough for tests).
+    let mut acc = half::f16::ZERO;
+    for (x, y) in a.iter().zip(b) {
+        acc += *x * *y;
+    }
+    acc.to_f32()
+}
+
+/// `acc[i] += v[i] * w` with an f16 value row widened in-register (f32 accumulator).
+#[cfg(target_arch = "aarch64")]
+#[inline]
+pub(crate) fn axpy_f16(acc: &mut [f32], v: &[half::f16], w: f32) {
+    use std::arch::aarch64::*;
+    debug_assert_eq!(acc.len(), v.len());
+    let n = acc.len();
+    let chunks = n / 8;
+    unsafe {
+        let wv = vdupq_n_f32(w);
+        let mut ap = acc.as_mut_ptr();
+        let mut vp = v.as_ptr();
+        for _ in 0..chunks {
+            let lo: float32x4_t;
+            let hi: float32x4_t;
+            std::arch::asm!(
+                "ldr {kv:q}, [{vp}]",
+                "fcvtl {lo:v}.4s, {kv:v}.4h",
+                "fcvtl2 {hi:v}.4s, {kv:v}.8h",
+                vp = in(reg) vp,
+                kv = out(vreg) _,
+                lo = out(vreg) lo,
+                hi = out(vreg) hi,
+                options(nostack, pure, readonly),
+            );
+            vst1q_f32(ap, vfmaq_f32(vld1q_f32(ap), lo, wv));
+            vst1q_f32(ap.add(4), vfmaq_f32(vld1q_f32(ap.add(4)), hi, wv));
+            ap = ap.add(8);
+            vp = vp.add(8);
+        }
+        for i in (chunks * 8)..n {
+            acc[i] += v[i].to_f32() * w;
+        }
+    }
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+#[inline]
+pub(crate) fn axpy_f16(acc: &mut [f32], v: &[half::f16], w: f32) {
+    debug_assert_eq!(acc.len(), v.len());
+    for (a, x) in acc.iter_mut().zip(v) {
+        *a += x.to_f32() * w;
+    }
+}

--- a/candle-nn/src/kv_cache.rs
+++ b/candle-nn/src/kv_cache.rs
@@ -1124,6 +1124,119 @@ impl RawInterleavedKvCache {
     }
 }
 
+/// HEAD-MAJOR f16 interleaved K/V cache for the f16-KV CPU flash kernels.
+///
+/// Distinct from [`RawInterleavedKvCache`] (position-major, f32): this stores the
+/// KV as `f16` (half the bytes streamed per token -> less decode bandwidth) and
+/// lays it out HEAD-MAJOR so each kv head's positions are contiguous - matching
+/// `causal_decode_f16kv_interleaved` / `causal_prefill_f16kv_headmajor`, which read
+/// one head's stream sequentially. Per-head block `h` starts at `h * head_stride()`
+/// and holds `len` positions of `[K(d), V(d)]`.
+pub struct RawInterleavedKvCacheF16 {
+    buf: Vec<half::f16>,
+    h_kv: usize,
+    d: usize,
+    cap: usize,
+    len: usize,
+}
+
+impl RawInterleavedKvCacheF16 {
+    /// Create a new cache with space for `max_seq` positions.
+    pub fn new(h_kv: usize, d: usize, max_seq: usize) -> Self {
+        Self {
+            buf: vec![half::f16::ZERO; h_kv * max_seq * 2 * d],
+            h_kv,
+            d,
+            cap: max_seq,
+            len: 0,
+        }
+    }
+
+    /// Number of positions currently cached.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Elements between consecutive kv-head blocks in [`Self::data`].
+    pub fn head_stride(&self) -> usize {
+        self.cap * 2 * self.d
+    }
+
+    /// Write one position of K and V into the cache.
+    ///
+    /// `k_flat` and `v_flat` are flat `(H_kv * D)` slices from the projection output.
+    pub fn write_kv(&mut self, k_flat: &[f32], v_flat: &[f32]) {
+        if self.len == self.cap {
+            self.grow();
+        }
+        let d = self.d;
+        let pos_off = self.len * 2 * d;
+        for h in 0..self.h_kv {
+            let src = h * d;
+            let dst = h * self.cap * 2 * d + pos_off;
+            for (o, &x) in self.buf[dst..dst + d].iter_mut().zip(&k_flat[src..]) {
+                *o = half::f16::from_f32(x);
+            }
+            for (o, &x) in self.buf[dst + d..dst + 2 * d]
+                .iter_mut()
+                .zip(&v_flat[src..])
+            {
+                *o = half::f16::from_f32(x);
+            }
+        }
+
+        self.len += 1;
+    }
+
+    fn grow(&mut self) {
+        let new_cap = self.cap * 2;
+        let block = 2 * self.d;
+        let mut new_buf = vec![half::f16::ZERO; self.h_kv * new_cap * block];
+        for h in 0..self.h_kv {
+            let src = h * self.cap * block;
+            let dst = h * new_cap * block;
+            new_buf[dst..dst + self.len * block]
+                .copy_from_slice(&self.buf[src..src + self.len * block]);
+        }
+        self.buf = new_buf;
+        self.cap = new_cap;
+    }
+
+    /// Write multiple positions of K and V (for prefill).
+    ///
+    /// `k_flat` is `(S, H_kv * D)` row-major, `v_flat` same.
+    pub fn write_kv_batch(&mut self, k_flat: &[f32], v_flat: &[f32], seq_len: usize) {
+        let hd = self.h_kv * self.d;
+        for s in 0..seq_len {
+            let k_row = &k_flat[s * hd..(s + 1) * hd];
+            let v_row = &v_flat[s * hd..(s + 1) * hd];
+            self.write_kv(k_row, v_row);
+        }
+    }
+
+    /// The full cache buffer; per-head blocks start at `h * head_stride()` and
+    /// hold `len` positions of `[K(d), V(d)]` each.
+    pub fn data(&self) -> &[half::f16] {
+        &self.buf
+    }
+
+    pub fn reset(&mut self) {
+        self.len = 0;
+    }
+
+    pub fn h_kv(&self) -> usize {
+        self.h_kv
+    }
+
+    pub fn d(&self) -> usize {
+        self.d
+    }
+}
+
 /// Apply interleaved RoPE in-place on a flat `(H, D)` slice.
 ///
 /// Pairs adjacent elements `(2i, 2i+1)` with frequency `cos[i], sin[i]`.

--- a/candle-nn/src/kv_cache.rs
+++ b/candle-nn/src/kv_cache.rs
@@ -1127,6 +1127,7 @@ impl RawInterleavedKvCache {
 // Head-major f16 interleaved K/V cache for the f16-KV CPU flash kernels: f16 (half the
 // decode bandwidth), each kv head's positions contiguous. Per-head block h starts at
 // h * head_stride() and holds len positions of [K(d), V(d)].
+#[derive(Debug, Clone)]
 pub struct RawInterleavedKvCacheF16 {
     buf: Vec<half::f16>,
     h_kv: usize,

--- a/candle-nn/src/kv_cache.rs
+++ b/candle-nn/src/kv_cache.rs
@@ -1124,14 +1124,9 @@ impl RawInterleavedKvCache {
     }
 }
 
-/// HEAD-MAJOR f16 interleaved K/V cache for the f16-KV CPU flash kernels.
-///
-/// Distinct from [`RawInterleavedKvCache`] (position-major, f32): this stores the
-/// KV as `f16` (half the bytes streamed per token -> less decode bandwidth) and
-/// lays it out HEAD-MAJOR so each kv head's positions are contiguous - matching
-/// `causal_decode_f16kv_interleaved` / `causal_prefill_f16kv_headmajor`, which read
-/// one head's stream sequentially. Per-head block `h` starts at `h * head_stride()`
-/// and holds `len` positions of `[K(d), V(d)]`.
+// Head-major f16 interleaved K/V cache for the f16-KV CPU flash kernels: f16 (half the
+// decode bandwidth), each kv head's positions contiguous. Per-head block h starts at
+// h * head_stride() and holds len positions of [K(d), V(d)].
 pub struct RawInterleavedKvCacheF16 {
     buf: Vec<half::f16>,
     h_kv: usize,
@@ -1141,7 +1136,7 @@ pub struct RawInterleavedKvCacheF16 {
 }
 
 impl RawInterleavedKvCacheF16 {
-    /// Create a new cache with space for `max_seq` positions.
+    // Create a cache with space for max_seq positions.
     pub fn new(h_kv: usize, d: usize, max_seq: usize) -> Self {
         Self {
             buf: vec![half::f16::ZERO; h_kv * max_seq * 2 * d],
@@ -1152,7 +1147,7 @@ impl RawInterleavedKvCacheF16 {
         }
     }
 
-    /// Number of positions currently cached.
+    // Number of positions currently cached.
     pub fn len(&self) -> usize {
         self.len
     }
@@ -1161,14 +1156,12 @@ impl RawInterleavedKvCacheF16 {
         self.len == 0
     }
 
-    /// Elements between consecutive kv-head blocks in [`Self::data`].
+    // Elements between consecutive kv-head blocks in data().
     pub fn head_stride(&self) -> usize {
         self.cap * 2 * self.d
     }
 
-    /// Write one position of K and V into the cache.
-    ///
-    /// `k_flat` and `v_flat` are flat `(H_kv * D)` slices from the projection output.
+    // Write one position of K and V. k_flat/v_flat are flat (H_kv * D) slices.
     pub fn write_kv(&mut self, k_flat: &[f32], v_flat: &[f32]) {
         if self.len == self.cap {
             self.grow();
@@ -1206,9 +1199,7 @@ impl RawInterleavedKvCacheF16 {
         self.cap = new_cap;
     }
 
-    /// Write multiple positions of K and V (for prefill).
-    ///
-    /// `k_flat` is `(S, H_kv * D)` row-major, `v_flat` same.
+    // Write multiple positions for prefill. k_flat is (S, H_kv * D) row-major, v_flat same.
     pub fn write_kv_batch(&mut self, k_flat: &[f32], v_flat: &[f32], seq_len: usize) {
         let hd = self.h_kv * self.d;
         for s in 0..seq_len {
@@ -1218,8 +1209,7 @@ impl RawInterleavedKvCacheF16 {
         }
     }
 
-    /// The full cache buffer; per-head blocks start at `h * head_stride()` and
-    /// hold `len` positions of `[K(d), V(d)]` each.
+    // Full cache buffer; per-head block h starts at h * head_stride(), len positions of [K(d), V(d)].
     pub fn data(&self) -> &[half::f16] {
         &self.buf
     }

--- a/candle-nn/tests/cpu_flash_attn.rs
+++ b/candle-nn/tests/cpu_flash_attn.rs
@@ -277,3 +277,122 @@ fn interleaved_kv_decode() -> Result<()> {
     let out = out.unsqueeze(0)?;
     assert_close(&out, &expected, 1e-5, "interleaved_kv_decode")
 }
+
+#[test]
+fn f16kv_headmajor_prefill() -> Result<()> {
+    use candle_nn::attention::cpu_flash::causal::causal_prefill_f16kv_headmajor;
+    use half::f16;
+
+    let (h_q, h_kv, d, s) = (8, 2, 16, 200);
+    let scale = 1.0 / (d as f32).sqrt();
+    let dev = &Device::Cpu;
+
+    let q = Tensor::randn(0f32, 1f32, (1, h_q, s, d), dev)?;
+    let k = Tensor::randn(0f32, 1f32, (1, h_kv, s, d), dev)?;
+    let v = Tensor::randn(0f32, 1f32, (1, h_kv, s, d), dev)?;
+
+    // Reference on the f16-rounded K/V so we measure kernel error, not storage error.
+    let k_h = k
+        .to_dtype(candle::DType::F16)?
+        .to_dtype(candle::DType::F32)?;
+    let v_h = v
+        .to_dtype(candle::DType::F16)?
+        .to_dtype(candle::DType::F32)?;
+    let reps = h_q / h_kv;
+    let k_exp = k_h
+        .reshape((1, h_kv, 1, s, d))?
+        .broadcast_as((1, h_kv, reps, s, d))?
+        .reshape((1, h_q, s, d))?;
+    let v_exp = v_h
+        .reshape((1, h_kv, 1, s, d))?
+        .broadcast_as((1, h_kv, reps, s, d))?
+        .reshape((1, h_q, s, d))?;
+    let expected = reference_causal_sdpa(&q, &k_exp, &v_exp, scale)?;
+
+    // Pack K/V into the head-major interleaved f16 layout: [head][pos][K(d), V(d)].
+    let k_v: Vec<f32> = k.flatten_all()?.to_vec1()?; // (h_kv, s, d)
+    let v_v: Vec<f32> = v.flatten_all()?.to_vec1()?;
+    let head_stride = s * 2 * d;
+    let mut kv = vec![f16::ZERO; h_kv * head_stride];
+    for h in 0..h_kv {
+        for pos in 0..s {
+            for t in 0..d {
+                kv[h * head_stride + pos * 2 * d + t] = f16::from_f32(k_v[h * s * d + pos * d + t]);
+                kv[h * head_stride + pos * 2 * d + d + t] =
+                    f16::from_f32(v_v[h * s * d + pos * d + t]);
+            }
+        }
+    }
+
+    // Q as (s, h_q, d)
+    let q_seq: Vec<f32> = q
+        .squeeze(0)?
+        .transpose(0, 1)?
+        .contiguous()?
+        .flatten_all()?
+        .to_vec1()?;
+
+    let out =
+        causal_prefill_f16kv_headmajor(&q_seq, &kv, head_stride, s, h_q, h_kv, d, s, scale, 0)?
+            .unsqueeze(0)?; // (1, h_q, s, d) to match reference
+
+    assert_close(&out, &expected, 2e-2, "f16kv_headmajor_prefill")
+}
+
+#[test]
+fn interleaved_kv_decode_f16() -> Result<()> {
+    use candle_nn::attention::cpu_flash::causal::causal_decode_f16kv_interleaved;
+
+    let (h_q, h_kv, d, kv_len) = (8, 2, 16, 20);
+    let scale = 1.0 / (d as f32).sqrt();
+    let dev = &Device::Cpu;
+
+    let q = Tensor::randn(0f32, 1f32, (1, h_q, 1, d), dev)?;
+    let k = Tensor::randn(0f32, 1f32, (1, h_kv, kv_len, d), dev)?;
+    let v = Tensor::randn(0f32, 1f32, (1, h_kv, kv_len, d), dev)?;
+
+    // Reference with GQA expansion
+    let reps = h_q / h_kv;
+    let k_exp = k
+        .reshape((1, h_kv, 1, kv_len, d))?
+        .broadcast_as((1, h_kv, reps, kv_len, d))?
+        .reshape((1, h_q, kv_len, d))?;
+    let v_exp = v
+        .reshape((1, h_kv, 1, kv_len, d))?
+        .broadcast_as((1, h_kv, reps, kv_len, d))?
+        .reshape((1, h_q, kv_len, d))?;
+    let expected = reference_sdpa(&q, &k_exp, &v_exp, scale)?;
+
+    // Build head-major interleaved KV: (h_kv, kv_len, 2*d).
+    let k_seq = k.squeeze(0)?.contiguous()?;
+    let v_seq = v.squeeze(0)?.contiguous()?;
+    let kv = Tensor::cat(&[&k_seq, &v_seq], 2)?.contiguous()?; // (h_kv, kv_len, 2*d)
+
+    let kv_data: Vec<half::f16> = kv
+        .flatten_all()?
+        .to_vec1::<f32>()?
+        .into_iter()
+        .map(half::f16::from_f32)
+        .collect();
+    let q_flat: Vec<f32> = q
+        .squeeze(0)?
+        .squeeze(1)?
+        .contiguous()?
+        .flatten_all()?
+        .to_vec1()?;
+
+    let out = causal_decode_f16kv_interleaved(
+        &q_flat,
+        &kv_data,
+        kv_len * 2 * d,
+        h_q,
+        h_kv,
+        d,
+        kv_len,
+        scale,
+    )?;
+
+    let out = out.unsqueeze(0)?;
+    // f16 KV storage rounds K/V to ~1e-3 relative; the reference uses f32 throughout.
+    assert_close(&out, &expected, 2e-2, "interleaved_kv_decode")
+}

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -10,10 +10,22 @@ use super::with_tracing::QMatMul;
 use crate::{quantized_nn::RmsNorm, utils::repeat_kv};
 use candle::quantized::{gguf_file, QTensor};
 use candle::{DType, Device, Result, Storage, Tensor};
-use candle_nn::attention::cpu_flash::causal::causal_decode_f32_interleaved;
+use candle_nn::attention::cpu_flash::causal::{
+    causal_decode_f16kv_interleaved, causal_decode_f32_interleaved,
+};
 use candle_nn::attention::{flash_attn, AttnMask};
-use candle_nn::kv_cache::{ConcatKvCache, InterleavedKvCache, RawInterleavedKvCache};
+use candle_nn::kv_cache::{
+    ConcatKvCache, InterleavedKvCache, RawInterleavedKvCache, RawInterleavedKvCacheF16,
+};
 use candle_nn::{Activation, Embedding, Module};
+
+// f16 KV cache halves the decode cache bytes/token (memory/bandwidth win). Default
+// on; CANDLE_F16_KV=0 keeps the f32 cache for same-binary A/B.
+static F16_KV: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
+    std::env::var("CANDLE_F16_KV")
+        .map(|s| s != "0")
+        .unwrap_or(true)
+});
 use std::io::{Read, Seek};
 use std::sync::Arc;
 
@@ -228,6 +240,7 @@ struct AttentionWeights {
     kv_cache: Option<ConcatKvCache>,
     interleaved_cache: Option<InterleavedKvCache>,
     raw_cache: Option<RawInterleavedKvCache>,
+    raw_cache_f16: Option<RawInterleavedKvCacheF16>,
     span_attn: tracing::Span,
 }
 
@@ -267,8 +280,13 @@ impl AttentionWeights {
         } else {
             None
         };
-        let raw_cache = if on_cpu {
+        let raw_cache = if on_cpu && !*F16_KV {
             Some(RawInterleavedKvCache::new(num_kv_heads, head_dim, 4096))
+        } else {
+            None
+        };
+        let raw_cache_f16 = if on_cpu && *F16_KV {
+            Some(RawInterleavedKvCacheF16::new(num_kv_heads, head_dim, 4096))
         } else {
             None
         };
@@ -291,6 +309,7 @@ impl AttentionWeights {
             kv_cache,
             interleaved_cache,
             raw_cache,
+            raw_cache_f16,
             span_attn,
         })
     }
@@ -352,23 +371,35 @@ impl AttentionWeights {
                     _ => candle::bail!("Expected CPU storage"),
                 };
 
-                // Write K, V into raw cache (no tensor allocation)
+                // Write K, V into the raw cache (no tensor alloc) and run the
+                // interleaved decode kernel; f16 cache halves bytes/token.
                 let k_len = self.num_kv_heads * self.head_dim;
-                let rc = self.raw_cache.as_mut().unwrap();
-                rc.write_kv(&k_data[..k_len], &v_data[..k_len]);
-
-                // Run interleaved decode kernel
-                let kv_len = rc.len();
                 let q_len = self.num_heads * self.head_dim;
-                let ctx = causal_decode_f32_interleaved(
-                    &q_data[..q_len],
-                    rc.data(),
-                    self.num_heads,
-                    self.num_kv_heads,
-                    self.head_dim,
-                    kv_len,
-                    scale,
-                )?;
+                let ctx = if let Some(rc) = self.raw_cache_f16.as_mut() {
+                    rc.write_kv(&k_data[..k_len], &v_data[..k_len]);
+                    causal_decode_f16kv_interleaved(
+                        &q_data[..q_len],
+                        rc.data(),
+                        rc.head_stride(),
+                        self.num_heads,
+                        self.num_kv_heads,
+                        self.head_dim,
+                        rc.len(),
+                        scale,
+                    )?
+                } else {
+                    let rc = self.raw_cache.as_mut().unwrap();
+                    rc.write_kv(&k_data[..k_len], &v_data[..k_len]);
+                    causal_decode_f32_interleaved(
+                        &q_data[..q_len],
+                        rc.data(),
+                        self.num_heads,
+                        self.num_kv_heads,
+                        self.head_dim,
+                        rc.len(),
+                        scale,
+                    )?
+                };
 
                 ctx.reshape((b, l, self.hidden_size))?.apply(&self.o_proj)
             } else {
@@ -390,7 +421,11 @@ impl AttentionWeights {
                         Storage::Cpu(cpu) => &cpu.as_slice::<f32>()?[vl.start_offset()..],
                         _ => candle::bail!("Expected CPU"),
                     };
-                    self.raw_cache.as_mut().unwrap().write_kv_batch(k_d, v_d, l);
+                    if let Some(rc) = self.raw_cache_f16.as_mut() {
+                        rc.write_kv_batch(k_d, v_d, l);
+                    } else {
+                        self.raw_cache.as_mut().unwrap().write_kv_batch(k_d, v_d, l);
+                    }
                 }
 
                 let kv_k = kv.narrow(2, 0, self.head_dim)?.unsqueeze(0)?;
@@ -445,6 +480,9 @@ impl AttentionWeights {
             c.reset();
         }
         if let Some(c) = &mut self.raw_cache {
+            c.reset();
+        }
+        if let Some(c) = &mut self.raw_cache_f16 {
             c.reset();
         }
     }

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -164,6 +164,12 @@ impl RotaryEmbedding {
         let (b, h, t, d) = x.dims4()?;
         let half = d / 2;
         debug_assert_eq!(half, self.half_d);
+        // cos_sin_at slices the table unchecked; bail on out-of-range positions so
+        // the caller gets an error instead of a panic (matches the narrow() path).
+        let max_pos = self.cos_f32.len() / self.half_d;
+        if offset + t > max_pos {
+            candle::bail!("rope position {} exceeds max {max_pos}", offset + t);
+        }
         let xc = x.contiguous()?;
         let (storage, layout) = xc.storage_and_layout();
         let src: &[f32] = match &*storage {
@@ -664,6 +670,18 @@ mod tests {
                 want[i]
             );
         }
+        Ok(())
+    }
+
+    // Out-of-range positions must return an error, not panic on the table slice.
+    #[test]
+    fn fused_rope_rejects_out_of_range_position() -> Result<()> {
+        let dev = Device::Cpu;
+        let (b, h, t, d) = (1usize, 2usize, 4usize, 16usize);
+        let rope = RotaryEmbedding::new(DType::F32, d, 8, 1_000_000.0, &dev)?;
+        let q = Tensor::zeros((b, h, t, d), DType::F32, &dev)?;
+        // offset 6 + t 4 = 10 > max 8.
+        assert!(rope.rope_neox_f32(&q, 6).is_err());
         Ok(())
     }
 }

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -143,14 +143,16 @@ impl RotaryEmbedding {
 
     /// Apply RoPE (q, k shape: B x H x L x D)
     pub fn apply(&self, q: &Tensor, k: &Tensor, offset: usize) -> Result<(Tensor, Tensor)> {
-        // CPU f32 fast path: fused neox on raw slices, bit-identical to the op path.
-        if *FUSED_ROPE && q.device().is_cpu() && q.dtype() == DType::F32 {
+        let (_, _, seq_len, _) = q.dims4()?;
+        // CPU f32 decode (seq_len == 1) fast path: fused neox on raw slices, bit-
+        // identical to the op path. Prefill keeps the op path, which parallelizes
+        // over t while this serial loop would not.
+        if seq_len == 1 && *FUSED_ROPE && q.device().is_cpu() && q.dtype() == DType::F32 {
             return Ok((
                 self.rope_neox_f32(q, offset)?,
                 self.rope_neox_f32(k, offset)?,
             ));
         }
-        let (_, _, seq_len, _) = q.dims4()?;
         let cos = self.cos.narrow(0, offset, seq_len)?.to_dtype(q.dtype())?;
         let sin = self.sin.narrow(0, offset, seq_len)?.to_dtype(q.dtype())?;
         let q_embed = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -390,7 +390,10 @@ impl AttentionWeights {
                         Storage::Cpu(cpu) => &cpu.as_slice::<f32>()?[vl.start_offset()..],
                         _ => candle::bail!("Expected CPU"),
                     };
-                    self.raw_cache_f16.as_mut().unwrap().write_kv_batch(k_d, v_d, l);
+                    self.raw_cache_f16
+                        .as_mut()
+                        .unwrap()
+                        .write_kv_batch(k_d, v_d, l);
                 }
 
                 let kv_k = kv.narrow(2, 0, self.head_dim)?.unsqueeze(0)?;

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -10,22 +10,11 @@ use super::with_tracing::QMatMul;
 use crate::{quantized_nn::RmsNorm, utils::repeat_kv};
 use candle::quantized::{gguf_file, QTensor};
 use candle::{DType, Device, Result, Storage, Tensor};
-use candle_nn::attention::cpu_flash::causal::{
-    causal_decode_f16kv_interleaved, causal_decode_f32_interleaved,
-};
+use candle_nn::attention::cpu_flash::causal::causal_decode_f16kv_interleaved;
 use candle_nn::attention::{flash_attn, AttnMask};
-use candle_nn::kv_cache::{
-    ConcatKvCache, InterleavedKvCache, RawInterleavedKvCache, RawInterleavedKvCacheF16,
-};
+use candle_nn::kv_cache::{ConcatKvCache, InterleavedKvCache, RawInterleavedKvCacheF16};
 use candle_nn::{Activation, Embedding, Module};
 
-// f16 KV cache halves the decode cache bytes/token (memory/bandwidth win). Default
-// on; CANDLE_F16_KV=0 keeps the f32 cache for same-binary A/B.
-static F16_KV: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
-    std::env::var("CANDLE_F16_KV")
-        .map(|s| s != "0")
-        .unwrap_or(true)
-});
 use std::io::{Read, Seek};
 use std::sync::Arc;
 
@@ -97,12 +86,7 @@ impl Module for MlpWeights {
 
 // Fused CPU/f32 neox RoPE on raw slices, skipping the per-call narrow/to_dtype/
 // contiguous/apply_op3 chain (rope is ~13% of single-thread decode, nearly all
-// framework overhead). Default on; CANDLE_ROPE_FUSED=0 forces the original path.
-static FUSED_ROPE: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
-    std::env::var("CANDLE_ROPE_FUSED")
-        .map(|s| s != "0")
-        .unwrap_or(true)
-});
+// framework overhead).
 
 #[derive(Debug, Clone)]
 pub struct RotaryEmbedding {
@@ -159,7 +143,7 @@ impl RotaryEmbedding {
         // CPU f32 decode (seq_len == 1) fast path: fused neox on raw slices, bit-
         // identical to the op path. Prefill keeps the op path, which parallelizes
         // over t while this serial loop would not.
-        if seq_len == 1 && *FUSED_ROPE && q.device().is_cpu() && q.dtype() == DType::F32 {
+        if seq_len == 1 && q.device().is_cpu() && q.dtype() == DType::F32 {
             return Ok((
                 self.rope_neox_f32(q, offset)?,
                 self.rope_neox_f32(k, offset)?,
@@ -177,8 +161,13 @@ impl RotaryEmbedding {
     fn rope_neox_f32(&self, x: &Tensor, offset: usize) -> Result<Tensor> {
         let (b, h, t, d) = x.dims4()?;
         let half = d / 2;
-        // Runtime check (debug_assert is compiled out in release): a head dim that
-        // mismatches the table would index past cos[j]/sin[j] or use a partial table.
+        // Runtime checks (debug_assert is compiled out in release): RoPE needs a
+        // positive EVEN head dim - an odd d would leave the last coord unrotated and
+        // d <= 1 divides by half_d == 0 below - and it must match the table. The op
+        // path rejects these via cos_n_embd * 2 != n_embd.
+        if half == 0 || 2 * half != d {
+            candle::bail!("rope head dim {d} must be a positive even number");
+        }
         if half != self.half_d {
             candle::bail!(
                 "rope head dim {d} (half {half}) does not match table half_d {}",
@@ -239,7 +228,6 @@ struct AttentionWeights {
     rotary_emb: Arc<RotaryEmbedding>,
     kv_cache: Option<ConcatKvCache>,
     interleaved_cache: Option<InterleavedKvCache>,
-    raw_cache: Option<RawInterleavedKvCache>,
     raw_cache_f16: Option<RawInterleavedKvCacheF16>,
     span_attn: tracing::Span,
 }
@@ -280,12 +268,7 @@ impl AttentionWeights {
         } else {
             None
         };
-        let raw_cache = if on_cpu && !*F16_KV {
-            Some(RawInterleavedKvCache::new(num_kv_heads, head_dim, 4096))
-        } else {
-            None
-        };
-        let raw_cache_f16 = if on_cpu && *F16_KV {
+        let raw_cache_f16 = if on_cpu {
             Some(RawInterleavedKvCacheF16::new(num_kv_heads, head_dim, 4096))
         } else {
             None
@@ -308,7 +291,6 @@ impl AttentionWeights {
             rotary_emb,
             kv_cache,
             interleaved_cache,
-            raw_cache,
             raw_cache_f16,
             span_attn,
         })
@@ -375,31 +357,18 @@ impl AttentionWeights {
                 // interleaved decode kernel; f16 cache halves bytes/token.
                 let k_len = self.num_kv_heads * self.head_dim;
                 let q_len = self.num_heads * self.head_dim;
-                let ctx = if let Some(rc) = self.raw_cache_f16.as_mut() {
-                    rc.write_kv(&k_data[..k_len], &v_data[..k_len]);
-                    causal_decode_f16kv_interleaved(
-                        &q_data[..q_len],
-                        rc.data(),
-                        rc.head_stride(),
-                        self.num_heads,
-                        self.num_kv_heads,
-                        self.head_dim,
-                        rc.len(),
-                        scale,
-                    )?
-                } else {
-                    let rc = self.raw_cache.as_mut().unwrap();
-                    rc.write_kv(&k_data[..k_len], &v_data[..k_len]);
-                    causal_decode_f32_interleaved(
-                        &q_data[..q_len],
-                        rc.data(),
-                        self.num_heads,
-                        self.num_kv_heads,
-                        self.head_dim,
-                        rc.len(),
-                        scale,
-                    )?
-                };
+                let rc = self.raw_cache_f16.as_mut().unwrap();
+                rc.write_kv(&k_data[..k_len], &v_data[..k_len]);
+                let ctx = causal_decode_f16kv_interleaved(
+                    &q_data[..q_len],
+                    rc.data(),
+                    rc.head_stride(),
+                    self.num_heads,
+                    self.num_kv_heads,
+                    self.head_dim,
+                    rc.len(),
+                    scale,
+                )?;
 
                 ctx.reshape((b, l, self.hidden_size))?.apply(&self.o_proj)
             } else {
@@ -421,11 +390,7 @@ impl AttentionWeights {
                         Storage::Cpu(cpu) => &cpu.as_slice::<f32>()?[vl.start_offset()..],
                         _ => candle::bail!("Expected CPU"),
                     };
-                    if let Some(rc) = self.raw_cache_f16.as_mut() {
-                        rc.write_kv_batch(k_d, v_d, l);
-                    } else {
-                        self.raw_cache.as_mut().unwrap().write_kv_batch(k_d, v_d, l);
-                    }
+                    self.raw_cache_f16.as_mut().unwrap().write_kv_batch(k_d, v_d, l);
                 }
 
                 let kv_k = kv.narrow(2, 0, self.head_dim)?.unsqueeze(0)?;
@@ -477,9 +442,6 @@ impl AttentionWeights {
             c.reset();
         }
         if let Some(c) = &mut self.interleaved_cache {
-            c.reset();
-        }
-        if let Some(c) = &mut self.raw_cache {
             c.reset();
         }
         if let Some(c) = &mut self.raw_cache_f16 {
@@ -738,6 +700,17 @@ mod tests {
         let dev = Device::Cpu;
         let rope = RotaryEmbedding::new(DType::F32, 16, 64, 1_000_000.0, &dev)?;
         let q = Tensor::zeros((1usize, 2usize, 1usize, 8usize), DType::F32, &dev)?;
+        assert!(rope.rope_neox_f32(&q, 0).is_err());
+        Ok(())
+    }
+
+    // An odd head dim (here d=1, which also has half_d==0) must bail, not panic on
+    // the max_pos division or leave the last coordinate unrotated.
+    #[test]
+    fn fused_rope_rejects_odd_head_dim() -> Result<()> {
+        let dev = Device::Cpu;
+        let rope = RotaryEmbedding::new(DType::F32, 1, 8, 1_000_000.0, &dev)?;
+        let q = Tensor::zeros((1usize, 1usize, 1usize, 1usize), DType::F32, &dev)?;
         assert!(rope.rope_neox_f32(&q, 0).is_err());
         Ok(())
     }

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -83,6 +83,15 @@ impl Module for MlpWeights {
     }
 }
 
+// Fused CPU/f32 neox RoPE on raw slices, skipping the per-call narrow/to_dtype/
+// contiguous/apply_op3 chain (rope is ~13% of single-thread decode, nearly all
+// framework overhead). Default on; CANDLE_ROPE_FUSED=0 forces the original path.
+static FUSED_ROPE: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
+    std::env::var("CANDLE_ROPE_FUSED")
+        .map(|s| s != "0")
+        .unwrap_or(true)
+});
+
 #[derive(Debug, Clone)]
 pub struct RotaryEmbedding {
     sin: Tensor,
@@ -134,12 +143,48 @@ impl RotaryEmbedding {
 
     /// Apply RoPE (q, k shape: B x H x L x D)
     pub fn apply(&self, q: &Tensor, k: &Tensor, offset: usize) -> Result<(Tensor, Tensor)> {
+        // CPU f32 fast path: fused neox on raw slices, bit-identical to the op path.
+        if *FUSED_ROPE && q.device().is_cpu() && q.dtype() == DType::F32 {
+            return Ok((
+                self.rope_neox_f32(q, offset)?,
+                self.rope_neox_f32(k, offset)?,
+            ));
+        }
         let (_, _, seq_len, _) = q.dims4()?;
         let cos = self.cos.narrow(0, offset, seq_len)?.to_dtype(q.dtype())?;
         let sin = self.sin.narrow(0, offset, seq_len)?.to_dtype(q.dtype())?;
         let q_embed = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
         let k_embed = candle_nn::rotary_emb::rope(&k.contiguous()?, &cos, &sin)?;
         Ok((q_embed, k_embed))
+    }
+
+    // Fused neox RoPE on a CPU f32 tensor (B x H x L x D), bit-identical to
+    // candle_nn::rotary_emb::rope (same op order) but on raw slices, no apply_op3.
+    fn rope_neox_f32(&self, x: &Tensor, offset: usize) -> Result<Tensor> {
+        let (b, h, t, d) = x.dims4()?;
+        let half = d / 2;
+        debug_assert_eq!(half, self.half_d);
+        let xc = x.contiguous()?;
+        let (storage, layout) = xc.storage_and_layout();
+        let src: &[f32] = match &*storage {
+            Storage::Cpu(c) => &c.as_slice::<f32>()?[layout.start_offset()..],
+            _ => candle::bail!("rope_neox_f32: expected CPU storage"),
+        };
+        let mut dst = vec![0f32; b * h * t * d];
+        for bh in 0..b * h {
+            let chunk = bh * t * d;
+            for it in 0..t {
+                let (cos, sin) = self.cos_sin_at(offset + it);
+                let tb = chunk + it * d;
+                for j in 0..half {
+                    let a = src[tb + j];
+                    let bb = src[tb + half + j];
+                    dst[tb + j] = a * cos[j] - bb * sin[j];
+                    dst[tb + half + j] = a * sin[j] + bb * cos[j];
+                }
+            }
+        }
+        Tensor::from_vec(dst, (b, h, t, d), x.device())
     }
 
     /// Zero-allocation cos/sin slices for a single position.
@@ -585,5 +630,40 @@ impl ModelWeights {
         for layer in &mut self.layers {
             layer.clear_kv_cache();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Fused neox RoPE must be bit-identical to the candle_nn op path.
+    #[test]
+    fn fused_rope_matches_op_path() -> Result<()> {
+        let dev = Device::Cpu;
+        let (b, h, t, d) = (1usize, 4usize, 6usize, 16usize);
+        let offset = 3usize;
+        let rope = RotaryEmbedding::new(DType::F32, d, 64, 1_000_000.0, &dev)?;
+        let n = b * h * t * d;
+        let data: Vec<f32> = (0..n).map(|i| (i as f32 * 0.01).sin()).collect();
+        let q = Tensor::from_vec(data, (b, h, t, d), &dev)?;
+
+        let fused = rope.rope_neox_f32(&q, offset)?;
+        let cos = rope.cos.narrow(0, offset, t)?.to_dtype(DType::F32)?;
+        let sin = rope.sin.narrow(0, offset, t)?.to_dtype(DType::F32)?;
+        let want = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
+
+        let got: Vec<f32> = fused.flatten_all()?.to_vec1()?;
+        let want: Vec<f32> = want.flatten_all()?.to_vec1()?;
+        for i in 0..n {
+            assert_eq!(
+                got[i].to_bits(),
+                want[i].to_bits(),
+                "idx {i}: fused {} op {}",
+                got[i],
+                want[i]
+            );
+        }
+        Ok(())
     }
 }

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -165,7 +165,14 @@ impl RotaryEmbedding {
     fn rope_neox_f32(&self, x: &Tensor, offset: usize) -> Result<Tensor> {
         let (b, h, t, d) = x.dims4()?;
         let half = d / 2;
-        debug_assert_eq!(half, self.half_d);
+        // Runtime check (debug_assert is compiled out in release): a head dim that
+        // mismatches the table would index past cos[j]/sin[j] or use a partial table.
+        if half != self.half_d {
+            candle::bail!(
+                "rope head dim {d} (half {half}) does not match table half_d {}",
+                self.half_d
+            );
+        }
         // cos_sin_at slices the table unchecked; bail on out-of-range positions so
         // the caller gets an error instead of a panic (matches the narrow() path).
         let max_pos = self.cos_f32.len() / self.half_d;
@@ -684,6 +691,16 @@ mod tests {
         let q = Tensor::zeros((b, h, t, d), DType::F32, &dev)?;
         // offset 6 + t 4 = 10 > max 8.
         assert!(rope.rope_neox_f32(&q, 6).is_err());
+        Ok(())
+    }
+
+    // A head dim that mismatches the table must bail, not panic in release.
+    #[test]
+    fn fused_rope_rejects_head_dim_mismatch() -> Result<()> {
+        let dev = Device::Cpu;
+        let rope = RotaryEmbedding::new(DType::F32, 16, 64, 1_000_000.0, &dev)?;
+        let q = Tensor::zeros((1usize, 2usize, 1usize, 8usize), DType::F32, &dev)?;
+        assert!(rope.rope_neox_f32(&q, 0).is_err());
         Ok(())
     }
 }


### PR DESCRIPTION
This is the integration branch that folds the CPU optimization work into one deployable model-core stack for quantized Qwen3, tuned for the 6 vCPU Graviton2 (Neoverse-N1) Lambda target and tested against the M1. 

It bundles the kernel and runtime changes that were broken out into the individual cpu-optimized PRs #3664, #3665, #3666, #3667 and removes their review-time feature flags (except the opt-in CANDLE_VEC_SOFTMAX_EXP) so the optimized paths are the unconditional default on Q4_K_M. Tuned for the 6-vCPU Graviton2 (Neoverse-N1) Lambda target; correctness validated on Apple M1 (greedy decode identical). Depends on #3664–3667; intended to land after them as the flag-removal cleanup.

At the 6-vCPU tier, the full default stack is ~1.27× prefill / ~1.14× decode vs the same binary with every optimization disabled (weight-matched: Q4 lm_head + Q6 residuals).
