### PR TITLE
Add CUDA Graph capture for decode + FlashInfer-style decode-attention backend (CUDA/Metal/CPU) (#3651)

### DIFF
--- a/.github/workflows/ci_cuda.yaml
+++ b/.github/workflows/ci_cuda.yaml
@@ -28,10 +28,10 @@ jobs:
       security-events: write
     env:
       CUDA_COMPUTE_CAP: 86
-      # Scoping the test step to GPU-relevant crates (below) wasn't enough on its own: this
-      # runner still OOM-kills (exit 137) while compiling candle-transformers at full rustc
-      # parallelism. Cap parallel rustc jobs to reduce peak memory; the two fixes address
-      # different causes (crate count vs. per-crate codegen parallelism) and are both needed.
+      # `cargo test --features cuda` at the workspace root builds every member, including
+      # candle-pyo3 and the wasm/yew examples, which pulls in pyo3/wasm-bindgen/yew and OOM-kills
+      # (exit 137) this runner. Scope to the GPU-relevant crates instead, and cap parallel rustc
+      # jobs to further reduce peak memory.
       CARGO_BUILD_JOBS: 2
     steps:
       - name: Checkout repository
@@ -44,7 +44,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Test (cuda)
-        run: cargo test --features cuda
+        run: cargo test --features cuda -p candle-core -p candle-nn -p candle-transformers -p candle-examples
       - name: Build+test (cuda) - CudaGraph capture/replay
         run: cargo test -p candle-core --features cuda --test cuda_graph_tests
       - name: Build+test (cuda) - FlashInfer-style decode attention kernel

--- a/.github/workflows/ci_cuda.yaml
+++ b/.github/workflows/ci_cuda.yaml
@@ -2,6 +2,11 @@ name: CI / cuda
 
 on:
   workflow_dispatch:
+    inputs:
+      test_ref:
+        description: 'Branch/tag/SHA to checkout and test (defaults to the dispatched ref)'
+        required: false
+        type: string
   pull_request:
 
 jobs:
@@ -9,10 +14,10 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
-    runs-on:
-      group: aws-g5-4xlarge-cache
+    runs-on: arc-gpu-candle
     container:
       image: nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04
+      options: --gpus all
     if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
     permissions:
       contents: write
@@ -23,9 +28,16 @@ jobs:
       security-events: write
     env:
       CUDA_COMPUTE_CAP: 86
+      # Scoping the test step to GPU-relevant crates (below) wasn't enough on its own: this
+      # runner still OOM-kills (exit 137) while compiling candle-transformers at full rustc
+      # parallelism. Cap parallel rustc jobs to reduce peak memory; the two fixes address
+      # different causes (crate count vs. per-crate codegen parallelism) and are both needed.
+      CARGO_BUILD_JOBS: 2
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.test_ref || github.ref }}
       - name: Install dependencies
         run: apt update && apt install curl build-essential libssl-dev protobuf-compiler pkg-config -y
       - name: Install Rust Stable
@@ -33,3 +45,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Test (cuda)
         run: cargo test --features cuda
+      - name: Build+test (cuda) - CudaGraph capture/replay
+        run: cargo test -p candle-core --features cuda --test cuda_graph_tests
+      - name: Build+test (cuda) - FlashInfer-style decode attention kernel
+        run: cargo test --manifest-path candle-flashinfer-kernels/Cargo.toml

--- a/.github/workflows/ci_cuda.yaml
+++ b/.github/workflows/ci_cuda.yaml
@@ -62,4 +62,7 @@ jobs:
       - name: Build+test (cuda) - CudaGraph capture/replay
         run: cargo test -p candle-core --features cuda --test cuda_graph_tests
       - name: Build+test (cuda) - FlashInfer-style decode attention kernel
-        run: cargo test --manifest-path candle-flashinfer-kernels/Cargo.toml
+        # `--features cuda` compiles and exercises the GPU kernel; the crate also builds
+        # CPU-only (default features), and the CPU reference fwd is covered by the
+        # decode_attention_cpu_matches_reference test either way.
+        run: cargo test --manifest-path candle-flashinfer-kernels/Cargo.toml --features cuda

--- a/.github/workflows/ci_cuda.yaml
+++ b/.github/workflows/ci_cuda.yaml
@@ -30,9 +30,17 @@ jobs:
       CUDA_COMPUTE_CAP: 86
       # `cargo test --features cuda` at the workspace root builds every member, including
       # candle-pyo3 and the wasm/yew examples, which pulls in pyo3/wasm-bindgen/yew and OOM-kills
-      # (exit 137) this runner. Scope to the GPU-relevant crates instead, and cap parallel rustc
-      # jobs to further reduce peak memory.
-      CARGO_BUILD_JOBS: 2
+      # (exit 137) this runner. Scope to the GPU-relevant crates instead.
+      #
+      # Even scoped, linking the candle-examples test binaries (nalgebra, imageproc, criterion,
+      # zip, ureq, on top of candle-core/transformers) alongside the other crates' test binaries
+      # is itself enough to OOM-kill (exit 137) this runner during the link step, with no test
+      # output ever printed. Serialize rustc jobs (CARGO_BUILD_JOBS: 1) and drop debug info from
+      # test/bench binaries (CARGO_PROFILE_TEST_DEBUG: 0) to cut peak linker memory, and run each
+      # crate's tests in its own step so a failure is isolated and memory from one crate's test
+      # binaries is freed before the next crate builds.
+      CARGO_BUILD_JOBS: 1
+      CARGO_PROFILE_TEST_DEBUG: 0
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -43,8 +51,14 @@ jobs:
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
-      - name: Test (cuda)
-        run: cargo test --features cuda -p candle-core -p candle-nn -p candle-transformers -p candle-examples
+      - name: Test (cuda) - candle-core
+        run: cargo test --features cuda -p candle-core
+      - name: Test (cuda) - candle-nn
+        run: cargo test --features cuda -p candle-nn
+      - name: Test (cuda) - candle-transformers
+        run: cargo test --features cuda -p candle-transformers
+      - name: Test (cuda) - candle-examples
+        run: cargo test --features cuda -p candle-examples
       - name: Build+test (cuda) - CudaGraph capture/replay
         run: cargo test -p candle-core --features cuda --test cuda_graph_tests
       - name: Build+test (cuda) - FlashInfer-style decode attention kernel

--- a/.github/workflows/ci_cuda.yaml
+++ b/.github/workflows/ci_cuda.yaml
@@ -2,11 +2,6 @@ name: CI / cuda
 
 on:
   workflow_dispatch:
-    inputs:
-      test_ref:
-        description: 'Branch/tag/SHA to checkout and test (defaults to the dispatched ref)'
-        required: false
-        type: string
   pull_request:
 
 jobs:
@@ -14,10 +9,10 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
-    runs-on: arc-gpu-candle
+    runs-on:
+      group: aws-g5-4xlarge-cache
     container:
       image: nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04
-      options: --gpus all
     if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
     permissions:
       contents: write
@@ -28,39 +23,16 @@ jobs:
       security-events: write
     env:
       CUDA_COMPUTE_CAP: 86
-      # `cargo test --features cuda` at the workspace root builds every member, including
-      # candle-pyo3 and the wasm/yew examples, which pulls in pyo3/wasm-bindgen/yew and OOM-kills
-      # (exit 137) this runner. Scope to the GPU-relevant crates instead.
-      #
-      # Even scoped, linking the candle-examples test binaries (nalgebra, imageproc, criterion,
-      # zip, ureq, on top of candle-core/transformers) alongside the other crates' test binaries
-      # is itself enough to OOM-kill (exit 137) this runner during the link step, with no test
-      # output ever printed. Serialize rustc jobs (CARGO_BUILD_JOBS: 1) and drop debug info from
-      # test/bench binaries (CARGO_PROFILE_TEST_DEBUG: 0) to cut peak linker memory, and run each
-      # crate's tests in its own step so a failure is isolated and memory from one crate's test
-      # binaries is freed before the next crate builds.
-      CARGO_BUILD_JOBS: 1
-      CARGO_PROFILE_TEST_DEBUG: 0
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ github.event.inputs.test_ref || github.ref }}
       - name: Install dependencies
         run: apt update && apt install curl build-essential libssl-dev protobuf-compiler pkg-config -y
       - name: Install Rust Stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
-      - name: Test (cuda) - candle-core
-        run: cargo test --features cuda -p candle-core
-      - name: Test (cuda) - candle-nn
-        run: cargo test --features cuda -p candle-nn
-      - name: Test (cuda) - candle-transformers
-        run: cargo test --features cuda -p candle-transformers
-      - name: Test (cuda) - candle-examples
-        run: cargo test --features cuda -p candle-examples
-      - name: Build+test (cuda) - CudaGraph capture/replay
-        run: cargo test -p candle-core --features cuda --test cuda_graph_tests
+      - name: Test (cuda)
+        run: cargo test --features cuda
       - name: Build+test (cuda) - FlashInfer-style decode attention kernel
         # `--features cuda` compiles and exercises the GPU kernel; the crate also builds
         # CPU-only (default features), and the CPU reference fwd is covered by the

--- a/.github/workflows/ci_metal.yaml
+++ b/.github/workflows/ci_metal.yaml
@@ -1,0 +1,40 @@
+name: CI / metal
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_ref:
+        description: 'Branch/tag/SHA to checkout and test (defaults to the dispatched ref)'
+        required: false
+        type: string
+  pull_request:
+
+jobs:
+  test-metal:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+    # GitHub-hosted Apple Silicon runner (free for public repos), exposes a
+    # real Metal GPU. macOS 15 is required: candle's Metal backend uses the
+    # MTLResidencySet API (Metal 3.2), which is absent on macos-14.
+    runs-on: macos-15
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+    env:
+      # Turn a missing Metal device into a hard failure so a green run
+      # guarantees the Metal path actually executed (see the metal test).
+      CANDLE_METAL_REQUIRED: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.test_ref || github.ref }}
+      - name: Remove cargo config (macOS ring crate fix)
+        run: rm -f .cargo/config.toml
+      - name: Install Rust Stable
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Test (metal) - FlashInfer-style decode attention kernel
+        # The crate is CPU-only by default; `--features metal` compiles (at runtime) and runs the
+        # Metal kernel. This step exercises both the Metal forward pass and the CPU reference fwd
+        # (decode_attention_cpu_matches_reference), which run side by side here.
+        run: cargo test --manifest-path candle-flashinfer-kernels/Cargo.toml --features metal -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [
     "candle-book",
     "candle-flash-attn",
     "candle-flash-attn-v3",
+    "candle-flashinfer-kernels",
     "candle-kernels",
     "candle-metal-kernels",
     "candle-onnx",
@@ -39,6 +40,7 @@ candle = { path = "./candle-core", package = "candle-core", version = "0.11.0" }
 candle-datasets = { path = "./candle-datasets", version = "0.11.0" }
 candle-flash-attn = { path = "./candle-flash-attn", version = "0.11.0" }
 candle-flash-attn-v3 = { path = "./candle-flash-attn-v3", version = "0.11.0" }
+candle-flashinfer-kernels = { path = "./candle-flashinfer-kernels", version = "0.11.0" }
 candle-kernels = { path = "./candle-kernels", version = "0.11.0" }
 candle-metal-kernels = { path = "./candle-metal-kernels", version = "0.11.0" }
 candle-nn = { path = "./candle-nn", version = "0.11.0" }

--- a/candle-core/src/cuda_backend/device.rs
+++ b/candle-core/src/cuda_backend/device.rs
@@ -51,6 +51,24 @@ impl Drop for CudaGraphHtodCacheGuard {
     }
 }
 
+/// Restores cudarc's event-tracking setting when dropped.
+/// Created by [`CudaDevice::pause_event_tracking`].
+#[must_use]
+pub(crate) struct EventTrackingGuard {
+    context: Arc<cudarc::driver::CudaContext>,
+    restore_to_enabled: bool,
+}
+
+impl Drop for EventTrackingGuard {
+    fn drop(&mut self) {
+        if self.restore_to_enabled {
+            // SAFETY: re-enabling the tracking that `pause_event_tracking` disabled,
+            // restoring the context to the state it was in before the guard.
+            unsafe { self.context.enable_event_tracking() };
+        }
+    }
+}
+
 pub struct ModuleStore {
     mdls: [Option<Arc<cudarc::driver::CudaModule>>; kernels::ALL_IDS.len()],
 }
@@ -305,6 +323,36 @@ impl CudaDevice {
 
     pub fn is_event_tracking(&self) -> bool {
         self.context.is_event_tracking()
+    }
+
+    /// Disables cudarc's per-tensor CUDA-event dependency tracking for as long as
+    /// the returned guard is alive, restoring the previous setting on drop.
+    ///
+    /// candle runs cudarc in multi-stream mode, so by default every kernel launch
+    /// issues `cuStreamWaitEvent`/`cuEventRecord` against each tensor's read/write
+    /// events to order work across streams. Those event waits are illegal during
+    /// CUDA graph capture (they reference events recorded outside the capture
+    /// region) and make capture fail with `CUDA_ERROR_INVALID_VALUE`. Since a
+    /// captured graph encodes its own ordering and is replayed on a single stream,
+    /// the tracking is unnecessary while capturing.
+    ///
+    /// # Safety
+    ///
+    /// While tracking is paused the caller must not rely on event-based
+    /// cross-stream synchronization for tensors used in this scope (see
+    /// [`CudaDevice::disable_event_tracking`]). [`CudaGraph::capture`] only ever
+    /// uses this around a single-stream capture, where ordering is guaranteed by
+    /// the stream itself, so this holds.
+    pub(crate) fn pause_event_tracking(&self) -> EventTrackingGuard {
+        let was_enabled = self.context.is_event_tracking();
+        if was_enabled {
+            // SAFETY: restored to `was_enabled` when the guard is dropped.
+            unsafe { self.context.disable_event_tracking() };
+        }
+        EventTrackingGuard {
+            context: self.context.clone(),
+            restore_to_enabled: was_enabled,
+        }
     }
 
     #[cfg(all(feature = "ug", not(target_arch = "wasm32")))]

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use cudarc::driver::sys;
 
 use super::{CudaDevice, WrapErr};
-use crate::Result;
+use crate::{Context, Result};
 
 /// A captured, replayable sequence of CUDA operations.
 ///
@@ -53,7 +53,8 @@ impl CudaGraph {
             )
         }
         .result()
-        .w()?;
+        .w()
+        .context("cuStreamBeginCapture_v2 failed")?;
 
         let value = match f() {
             Ok(value) => value,
@@ -70,7 +71,8 @@ impl CudaGraph {
         let mut cu_graph: sys::CUgraph = std::ptr::null_mut();
         unsafe { sys::cuStreamEndCapture(stream.cu_stream(), &mut cu_graph) }
             .result()
-            .w()?;
+            .w()
+            .context("cuStreamEndCapture failed")?;
         if cu_graph.is_null() {
             crate::bail!("cuda graph capture recorded no operations");
         }
@@ -78,7 +80,8 @@ impl CudaGraph {
         let mut cu_graph_exec: sys::CUgraphExec = std::ptr::null_mut();
         let instantiate = unsafe { sys::cuGraphInstantiateWithFlags(&mut cu_graph_exec, cu_graph, 0) }
             .result()
-            .w();
+            .w()
+            .context("cuGraphInstantiateWithFlags failed");
         if let Err(err) = instantiate {
             let _ = unsafe { sys::cuGraphDestroy(cu_graph) };
             return Err(err);
@@ -99,6 +102,7 @@ impl CudaGraph {
         unsafe { sys::cuGraphLaunch(self.cu_graph_exec, self.stream.cu_stream()) }
             .result()
             .w()
+            .context("cuGraphLaunch failed")
     }
 }
 

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -34,6 +34,14 @@ impl CudaGraph {
     /// constants are served from a cache (see
     /// [`CudaDevice::enable_cuda_graph_htod_cache`]) since a fresh upload
     /// cannot be recorded as a replayable graph node.
+    ///
+    /// Callers must run the same operations `f` will perform at least once,
+    /// outside of capture, before calling this function. That warm-up run
+    /// JIT-loads any CUDA modules the operations need and populates the
+    /// host-to-device upload cache; both module loading and uncached uploads
+    /// are disallowed once capture starts and invalidate the capture
+    /// (`CUDA_ERROR_STREAM_CAPTURE_INVALIDATED`) if attempted while it is
+    /// active.
     pub fn capture<T>(device: &CudaDevice, f: impl FnOnce() -> Result<T>) -> Result<(Self, T)> {
         let stream = device.cuda_stream();
         let _cache_guard = device.enable_cuda_graph_htod_cache();

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use cudarc::driver::sys;
 
+use super::device::EventTrackingGuard;
 use super::{CudaDevice, WrapErr};
 use crate::{Context, Result};
 
@@ -23,6 +24,12 @@ pub struct CudaGraph {
     cu_graph: sys::CUgraph,
     cu_graph_exec: sys::CUgraphExec,
     stream: Arc<cudarc::driver::CudaStream>,
+    // Kept paused for the graph's entire lifetime (capture, every replay, and
+    // its eventual destruction), not just the recording call: see the doc
+    // comment on `capture` for why re-enabling tracking in between lets
+    // cudarc re-record a tensor's dependency event outside of the graph that
+    // already owns a captured node for that same event.
+    _event_tracking_guard: EventTrackingGuard,
 }
 
 impl CudaGraph {
@@ -49,6 +56,20 @@ impl CudaGraph {
     /// graph-owned allocation node whose device memory is only valid while the
     /// graph is executing, so reading it outside of a replay fails with
     /// `CUDA_ERROR_INVALID_VALUE`.
+    ///
+    /// Event tracking stays paused for the returned [`CudaGraph`]'s entire
+    /// lifetime, not just for this call: cudarc unconditionally re-records a
+    /// tensor's read/write dependency event on every access to it, regardless
+    /// of whether tracking is enabled. A tensor allocated before capture
+    /// (e.g. a model-level KV cache written into by every capture) already
+    /// owns such events, and recording one from inside a capture turns that
+    /// recording into a node of *this* graph. If tracking were re-enabled as
+    /// soon as `capture` returns, any later access to that same tensor --
+    /// between replays, or by a second, independent `capture` on the same
+    /// device -- would record a plain (non-captured) update to an event this
+    /// graph still owns a captured node for. Holding the guard until the
+    /// graph (and its captured nodes) are destroyed keeps every access to
+    /// those tensors ordered by the graph itself for as long as it exists.
     pub fn capture<T>(device: &CudaDevice, f: impl FnOnce() -> Result<T>) -> Result<(Self, T)> {
         let stream = device.cuda_stream();
         let _cache_guard = device.enable_cuda_graph_htod_cache();
@@ -56,8 +77,9 @@ impl CudaGraph {
         // otherwise emit cuStreamWaitEvent/cuEventRecord against the tensors'
         // dependency-tracking events. Those event waits reference events recorded
         // outside the capture region and make capture fail with
-        // CUDA_ERROR_INVALID_VALUE, so pause event tracking for the capture.
-        let _event_tracking_guard = device.pause_event_tracking();
+        // CUDA_ERROR_INVALID_VALUE, so pause event tracking for the capture (and,
+        // per the doc comment above, for the whole lifetime of the resulting graph).
+        let event_tracking_guard = device.pause_event_tracking();
 
         unsafe {
             sys::cuStreamBeginCapture_v2(
@@ -105,6 +127,7 @@ impl CudaGraph {
                 cu_graph,
                 cu_graph_exec,
                 stream,
+                _event_tracking_guard: event_tracking_guard,
             },
             value,
         ))
@@ -125,6 +148,8 @@ impl Drop for CudaGraph {
             let _ = sys::cuGraphExecDestroy(self.cu_graph_exec);
             let _ = sys::cuGraphDestroy(self.cu_graph);
         }
+        // `_event_tracking_guard` is dropped after this body runs, restoring
+        // event tracking only once the captured graph is fully destroyed.
     }
 }
 

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -147,6 +147,18 @@ impl Drop for CudaGraph {
         unsafe {
             let _ = sys::cuGraphExecDestroy(self.cu_graph_exec);
             let _ = sys::cuGraphDestroy(self.cu_graph);
+            // A tensor allocated *inside* the captured closure (see `capture`'s
+            // doc comment) becomes a graph memory-alloc/free node pair rather
+            // than a plain `cuMemAllocAsync`/`cuMemFreeAsync` call, backed by
+            // the driver's per-device graph memory pool. That pool retains the
+            // physical memory a destroyed graph exec used, for reuse by future
+            // graph launches, instead of releasing it immediately -- by design,
+            // as a performance optimization. Trim it explicitly once this graph
+            // exec is gone so a later, independent capture (or any other
+            // stream-ordered allocation on this device) starts from a pool the
+            // driver has fully reconciled, rather than one still carrying this
+            // graph's now-orphaned reservations.
+            let _ = sys::cuDeviceGraphMemTrim(self.stream.context().cu_device());
         }
         // `_event_tracking_guard` is dropped after this body runs, restoring
         // event tracking only once the captured graph is fully destroyed.

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -45,6 +45,12 @@ impl CudaGraph {
     pub fn capture<T>(device: &CudaDevice, f: impl FnOnce() -> Result<T>) -> Result<(Self, T)> {
         let stream = device.cuda_stream();
         let _cache_guard = device.enable_cuda_graph_htod_cache();
+        // candle drives cudarc in multi-stream mode, so each kernel launch would
+        // otherwise emit cuStreamWaitEvent/cuEventRecord against the tensors'
+        // dependency-tracking events. Those event waits reference events recorded
+        // outside the capture region and make capture fail with
+        // CUDA_ERROR_INVALID_VALUE, so pause event tracking for the capture.
+        let _event_tracking_guard = device.pause_event_tracking();
 
         unsafe {
             sys::cuStreamBeginCapture_v2(

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -70,7 +70,7 @@ impl CudaGraph {
                 if !cu_graph.is_null() {
                     let _ = unsafe { sys::cuGraphDestroy(cu_graph) };
                 }
-                return Err(err);
+                return Err(err).context("operation inside cuda graph capture closure failed");
             }
         };
 

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -42,6 +42,13 @@ impl CudaGraph {
     /// are disallowed once capture starts and invalidate the capture
     /// (`CUDA_ERROR_STREAM_CAPTURE_INVALIDATED`) if attempted while it is
     /// active.
+    ///
+    /// Any buffer whose contents you need to read between replays must be
+    /// allocated *before* capture and written in place by `f` (e.g. via
+    /// `Tensor::slice_set`). A tensor allocated *inside* `f` becomes a
+    /// graph-owned allocation node whose device memory is only valid while the
+    /// graph is executing, so reading it outside of a replay fails with
+    /// `CUDA_ERROR_INVALID_VALUE`.
     pub fn capture<T>(device: &CudaDevice, f: impl FnOnce() -> Result<T>) -> Result<(Self, T)> {
         let stream = device.cuda_stream();
         let _cache_guard = device.enable_cuda_graph_htod_cache();

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -1,0 +1,111 @@
+//! CUDA Graph capture and replay.
+//!
+//! During autoregressive decoding the same fixed-shape sequence of kernels is
+//! launched once per generated token, and per-kernel launch overhead can
+//! dominate once the model is small relative to the GPU. [`CudaGraph`] lets
+//! that sequence be captured once and replayed with a single `cuGraphLaunch`
+//! call instead of relaunching every individual kernel.
+use std::sync::Arc;
+
+use cudarc::driver::sys;
+
+use super::{CudaDevice, WrapErr};
+use crate::Result;
+
+/// A captured, replayable sequence of CUDA operations.
+///
+/// Build one with [`CudaGraph::capture`], then call [`CudaGraph::replay`] as
+/// many times as needed. The shapes and buffer addresses touched by the
+/// captured closure must stay the same across replays: a CUDA graph records
+/// the exact kernel launches and memory addresses used during capture, it
+/// does not re-derive them.
+pub struct CudaGraph {
+    cu_graph: sys::CUgraph,
+    cu_graph_exec: sys::CUgraphExec,
+    stream: Arc<cudarc::driver::CudaStream>,
+}
+
+impl CudaGraph {
+    /// Captures the CUDA operations issued by `f` on `device`'s stream.
+    ///
+    /// `f` is run exactly once, with the stream in capture mode so that the
+    /// kernels it launches are recorded into a graph rather than executed
+    /// immediately. While capturing, host-to-device uploads of small
+    /// constants are served from a cache (see
+    /// [`CudaDevice::enable_cuda_graph_htod_cache`]) since a fresh upload
+    /// cannot be recorded as a replayable graph node.
+    pub fn capture<T>(device: &CudaDevice, f: impl FnOnce() -> Result<T>) -> Result<(Self, T)> {
+        let stream = device.cuda_stream();
+        let _cache_guard = device.enable_cuda_graph_htod_cache();
+
+        unsafe {
+            sys::cuStreamBeginCapture_v2(
+                stream.cu_stream(),
+                sys::CUstreamCaptureMode::CU_STREAM_CAPTURE_MODE_THREAD_LOCAL,
+            )
+        }
+        .result()
+        .w()?;
+
+        let value = match f() {
+            Ok(value) => value,
+            Err(err) => {
+                let mut cu_graph: sys::CUgraph = std::ptr::null_mut();
+                let _ = unsafe { sys::cuStreamEndCapture(stream.cu_stream(), &mut cu_graph) };
+                if !cu_graph.is_null() {
+                    let _ = unsafe { sys::cuGraphDestroy(cu_graph) };
+                }
+                return Err(err);
+            }
+        };
+
+        let mut cu_graph: sys::CUgraph = std::ptr::null_mut();
+        unsafe { sys::cuStreamEndCapture(stream.cu_stream(), &mut cu_graph) }
+            .result()
+            .w()?;
+        if cu_graph.is_null() {
+            crate::bail!("cuda graph capture recorded no operations");
+        }
+
+        let mut cu_graph_exec: sys::CUgraphExec = std::ptr::null_mut();
+        let instantiate = unsafe { sys::cuGraphInstantiateWithFlags(&mut cu_graph_exec, cu_graph, 0) }
+            .result()
+            .w();
+        if let Err(err) = instantiate {
+            let _ = unsafe { sys::cuGraphDestroy(cu_graph) };
+            return Err(err);
+        }
+
+        Ok((
+            Self {
+                cu_graph,
+                cu_graph_exec,
+                stream,
+            },
+            value,
+        ))
+    }
+
+    /// Replays the captured operations on the stream they were captured on.
+    pub fn replay(&self) -> Result<()> {
+        unsafe { sys::cuGraphLaunch(self.cu_graph_exec, self.stream.cu_stream()) }
+            .result()
+            .w()
+    }
+}
+
+impl Drop for CudaGraph {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = sys::cuGraphExecDestroy(self.cu_graph_exec);
+            let _ = sys::cuGraphDestroy(self.cu_graph);
+        }
+    }
+}
+
+// SAFETY: the underlying CUgraph/CUgraphExec handles are only ever
+// dereferenced through the CUDA driver API while holding `&self`/`&mut self`,
+// matching the thread-safety story of the other cudarc driver handles
+// (CudaStream, CudaModule, ...) that candle already shares across threads.
+unsafe impl Send for CudaGraph {}
+unsafe impl Sync for CudaGraph {}

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -113,10 +113,11 @@ impl CudaGraph {
         }
 
         let mut cu_graph_exec: sys::CUgraphExec = std::ptr::null_mut();
-        let instantiate = unsafe { sys::cuGraphInstantiateWithFlags(&mut cu_graph_exec, cu_graph, 0) }
-            .result()
-            .w()
-            .context("cuGraphInstantiateWithFlags failed");
+        let instantiate =
+            unsafe { sys::cuGraphInstantiateWithFlags(&mut cu_graph_exec, cu_graph, 0) }
+                .result()
+                .w()
+                .context("cuGraphInstantiateWithFlags failed");
         if let Err(err) = instantiate {
             let _ = unsafe { sys::cuGraphDestroy(cu_graph) };
             return Err(err);

--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -17,9 +17,11 @@ use std::sync::{Arc, Mutex, OnceLock};
 pub mod cudnn;
 mod device;
 mod error;
+mod graph;
 mod utils;
 pub use device::{CudaDevice, DeviceId};
 pub use error::{CudaError, WrapErr};
+pub use graph::CudaGraph;
 pub use utils::{Map1, Map1Any, Map2, Map2Any, Map2InPlace, Map3, S};
 
 type ParamCache = HashMap<(DeviceId, Vec<usize>), Arc<CudaSlice<usize>>>;

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -315,3 +315,15 @@ pub fn gemm_reduced_precision_f32() -> bool {
 /// This bool controls whether reduced precision reductions (e.g., with tf32 accumulation type) are
 /// allowed with f32 GEMMs.
 pub fn set_gemm_reduced_precision_f32(_b: bool) {}
+
+pub struct CudaGraph;
+
+impl CudaGraph {
+    pub fn capture<T>(_device: &CudaDevice, _f: impl FnOnce() -> Result<T>) -> Result<(Self, T)> {
+        Err(Error::NotCompiledWithCudaSupport)
+    }
+
+    pub fn replay(&self) -> Result<()> {
+        Err(Error::NotCompiledWithCudaSupport)
+    }
+}

--- a/candle-core/src/lib.rs
+++ b/candle-core/src/lib.rs
@@ -116,7 +116,7 @@ pub use cuda_backend as cuda;
 #[cfg(not(feature = "cuda"))]
 pub use dummy_cuda_backend as cuda;
 
-pub use cuda::{CudaDevice, CudaStorage};
+pub use cuda::{CudaDevice, CudaGraph, CudaStorage};
 
 #[cfg(feature = "metal")]
 pub use metal_backend::{MetalDevice, MetalError, MetalStorage};

--- a/candle-core/tests/cuda_graph_tests.rs
+++ b/candle-core/tests/cuda_graph_tests.rs
@@ -143,3 +143,127 @@ fn second_independent_capture_after_first_graph_dropped() -> Result<()> {
     assert_eq!(shared.to_vec2::<f32>()?, lhs2.to_vec2::<f32>()?);
     Ok(())
 }
+
+const MANY_ALLOCATIONS_LAYERS: usize = 8;
+
+// Runs `x` through several "layers", each allocating and immediately
+// consuming a handful of intermediates (an identity transform in value, to
+// keep the numbers bounded) instead of the single intermediate the other
+// tests in this file use. Called from inside a capture, each intermediate
+// becomes its own graph-owned memory-alloc/free node pair, so this exercises
+// the driver's per-device graph memory pool across many nodes instead of one.
+fn identity_through_many_temporaries(x: &Tensor, ones: &Tensor) -> Result<Tensor> {
+    let mut acc = x.affine(1.0, 0.0)?;
+    for _ in 0..MANY_ALLOCATIONS_LAYERS {
+        let zeros_layer = Tensor::zeros((4, 4), DType::F32, x.device())?;
+        let a = (&acc * ones)?;
+        let b = (&a + &zeros_layer)?;
+        acc = b.affine(1.0, 0.0)?;
+    }
+    Ok(acc)
+}
+
+// Regression test: `second_independent_capture_after_first_graph_dropped`
+// passing was not enough to fix Tachyon-Mesh's real production scenario
+// (astorise/candle#17, reopened) -- a multi-layer `Llama::forward()` capture,
+// where many intermediates per layer are allocated inside the closure. Their
+// working hypothesis was that this exercises the driver's per-device graph
+// memory pool (reconciling many stream-ordered allocations on graph
+// destruction) rather than just the per-tensor event-tracking guard. This
+// test reproduces that shape at the candle-core level: many graph-owned
+// allocations per capture, and several new (non-captured) allocations in the
+// unrelated op between the two captures, standing in for a RoPE cos/sin
+// table build.
+#[test]
+fn second_independent_capture_with_many_graph_owned_allocations() -> Result<()> {
+    let device = match Device::new_cuda(0) {
+        Ok(device) => device,
+        Err(_) => return Ok(()),
+    };
+    let Device::Cuda(cuda_device) = &device else {
+        unreachable!()
+    };
+
+    // Stands in for a model-level buffer (e.g. a paged-attention KV cache)
+    // allocated once, before either capture, and written into by both.
+    let shared = Tensor::zeros((4, 4), DType::F32, &device)?;
+    let ones = Tensor::ones((4, 4), DType::F32, &device)?;
+
+    {
+        let lhs = Tensor::arange(0f32, 16f32, &device)?.reshape((4, 4))?;
+        let out = Tensor::zeros((4, 4), DType::F32, &device)?;
+        let zeros = Tensor::zeros((4, 4), DType::F32, &device)?;
+
+        // Warm-up outside of capture, then reset back to zeros.
+        let warm = identity_through_many_temporaries(&lhs, &ones)?;
+        shared.slice_set(&warm, 0, 0)?;
+        out.slice_set(&warm, 0, 0)?;
+        shared.slice_set(&zeros, 0, 0)?;
+        out.slice_set(&zeros, 0, 0)?;
+        device.synchronize()?;
+
+        let (graph, ()) = CudaGraph::capture(cuda_device, || {
+            let result = identity_through_many_temporaries(&lhs, &ones)?;
+            shared.slice_set(&result, 0, 0)?;
+            out.slice_set(&result, 0, 0)?;
+            Ok(())
+        })?;
+        graph.replay()?;
+        device.synchronize()?;
+        assert_eq!(out.to_vec2::<f32>()?, lhs.to_vec2::<f32>()?);
+        assert_eq!(shared.to_vec2::<f32>()?, lhs.to_vec2::<f32>()?);
+        // `graph` (and its many graph-owned allocation nodes) is dropped at
+        // the end of this scope, before the second, independent request
+        // below runs.
+    }
+
+    // A brand new, unrelated request against the same already-loaded model,
+    // building several new tensors via a short op chain (standing in for a
+    // RoPE cos/sin table) instead of a single `Tensor::zeros`: fresh
+    // buffers, no reference to the first request's `out`/`lhs`/graph.
+    let positions = Tensor::arange(0f32, 4f32, &device)?.reshape((4, 1))?;
+    let freqs = Tensor::arange(1f32, 5f32, &device)?.reshape((1, 4))?;
+    let angles = positions.broadcast_mul(&freqs)?;
+    let cos = angles.cos()?;
+    let sin = angles.sin()?;
+    device.synchronize()?;
+    let expected_angles: Vec<Vec<f32>> = (0..4)
+        .map(|p| (0..4).map(|f| (p as f32) * (f as f32 + 1.0)).collect())
+        .collect();
+    let expected_cos: Vec<Vec<f32>> = expected_angles
+        .iter()
+        .map(|row| row.iter().map(|a| a.cos()).collect())
+        .collect();
+    let expected_sin: Vec<Vec<f32>> = expected_angles
+        .iter()
+        .map(|row| row.iter().map(|a| a.sin()).collect())
+        .collect();
+    assert_eq!(cos.to_vec2::<f32>()?, expected_cos);
+    assert_eq!(sin.to_vec2::<f32>()?, expected_sin);
+
+    // The second request then runs its own independent capture/replay cycle
+    // against the same device, reusing the shared model-level buffer, again
+    // through the many-graph-owned-allocations closure.
+    let lhs2 = Tensor::arange(16f32, 32f32, &device)?.reshape((4, 4))?;
+    let out2 = Tensor::zeros((4, 4), DType::F32, &device)?;
+    let zeros = Tensor::zeros((4, 4), DType::F32, &device)?;
+
+    let warm = identity_through_many_temporaries(&lhs2, &ones)?;
+    shared.slice_set(&warm, 0, 0)?;
+    out2.slice_set(&warm, 0, 0)?;
+    shared.slice_set(&zeros, 0, 0)?;
+    out2.slice_set(&zeros, 0, 0)?;
+    device.synchronize()?;
+
+    let (graph2, ()) = CudaGraph::capture(cuda_device, || {
+        let result = identity_through_many_temporaries(&lhs2, &ones)?;
+        shared.slice_set(&result, 0, 0)?;
+        out2.slice_set(&result, 0, 0)?;
+        Ok(())
+    })?;
+    graph2.replay()?;
+    device.synchronize()?;
+    assert_eq!(out2.to_vec2::<f32>()?, lhs2.to_vec2::<f32>()?);
+    assert_eq!(shared.to_vec2::<f32>()?, lhs2.to_vec2::<f32>()?);
+    Ok(())
+}

--- a/candle-core/tests/cuda_graph_tests.rs
+++ b/candle-core/tests/cuda_graph_tests.rs
@@ -13,11 +13,9 @@ fn capture_and_replay_decode_step() -> Result<()> {
 
     let lhs = Tensor::arange(0f32, 16f32, &device)?.reshape((4, 4))?;
     let rhs = Tensor::ones((4, 4), candle_core::DType::F32, &device)?;
-    let mut out = Tensor::zeros((4, 4), candle_core::DType::F32, &device)?;
-
     // Warm-up run outside of capture: JIT-loads the multiply kernel's module so that
     // capture only ever records already-loaded kernel launches (see CudaGraph::capture).
-    out = (&lhs * &rhs)?;
+    let mut out = (&lhs * &rhs)?;
     device.synchronize()?;
 
     let (graph, ()) = CudaGraph::capture(cuda_device, || {

--- a/candle-core/tests/cuda_graph_tests.rs
+++ b/candle-core/tests/cuda_graph_tests.rs
@@ -1,6 +1,15 @@
 #![cfg(feature = "cuda")]
-use candle_core::{CudaGraph, Device, Result, Tensor};
+use candle_core::{CudaGraph, DType, Device, Result, Tensor};
 
+// Captures a small "decode step" (an elementwise multiply written into a
+// persistent output buffer) and checks that replaying the graph reproduces it.
+//
+// The output buffer `out` is allocated *before* capture and written in place
+// with `slice_set`, so the captured graph only records kernel launches and a
+// device-to-device copy into already-existing memory. Allocating the result
+// *inside* capture would instead make it a graph-owned allocation node whose
+// memory is only valid while the graph runs, which is not what a decode loop
+// wants (and cannot be read back between replays).
 #[test]
 fn capture_and_replay_decode_step() -> Result<()> {
     let device = match Device::new_cuda(0) {
@@ -12,28 +21,39 @@ fn capture_and_replay_decode_step() -> Result<()> {
     };
 
     let lhs = Tensor::arange(0f32, 16f32, &device)?.reshape((4, 4))?;
-    let rhs = Tensor::ones((4, 4), candle_core::DType::F32, &device)?;
+    let rhs = Tensor::ones((4, 4), DType::F32, &device)?;
+    let zeros = Tensor::zeros((4, 4), DType::F32, &device)?;
+    let out = Tensor::zeros((4, 4), DType::F32, &device)?;
 
-    // Warm-up run outside of capture: JIT-loads the multiply kernel's module so that
-    // capture only ever records already-loaded kernel launches (see CudaGraph::capture).
-    let mut out = (&lhs * &rhs)?;
+    // Warm-up run outside of capture: JIT-loads the multiply and copy kernels so
+    // that capture only ever records already-loaded launches (see
+    // CudaGraph::capture), then reset `out` back to zeros.
+    let tmp = (&lhs * &rhs)?;
+    out.slice_set(&tmp, 0, 0)?;
+    out.slice_set(&zeros, 0, 0)?;
     device.synchronize()?;
-    println!("warmup complete, event_tracking={}", cuda_device.is_event_tracking());
+
+    // Before replay the captured work has not run, so `out` is still zeros.
+    let before = out.to_vec2::<f32>()?;
+    assert_eq!(before, vec![vec![0f32; 4]; 4]);
 
     let (graph, ()) = CudaGraph::capture(cuda_device, || {
-        println!("closure: before mul");
-        let r = &lhs * &rhs;
-        println!("closure: mul ok={}", r.is_ok());
-        out = r?;
-        println!("closure: after assign");
+        let tmp = (&lhs * &rhs)?;
+        out.slice_set(&tmp, 0, 0)?;
         Ok(())
     })?;
-    println!("capture returned ok");
 
-    let before = out.to_vec2::<f32>()?;
+    // Capture records but does not execute, so `out` is unchanged until replay.
+    assert_eq!(out.to_vec2::<f32>()?, vec![vec![0f32; 4]; 4]);
+
     graph.replay()?;
+    device.synchronize()?;
     let after = out.to_vec2::<f32>()?;
-    assert_eq!(before, after);
     assert_eq!(after, lhs.to_vec2::<f32>()?);
+
+    // Replaying again is idempotent for this graph.
+    graph.replay()?;
+    device.synchronize()?;
+    assert_eq!(out.to_vec2::<f32>()?, lhs.to_vec2::<f32>()?);
     Ok(())
 }

--- a/candle-core/tests/cuda_graph_tests.rs
+++ b/candle-core/tests/cuda_graph_tests.rs
@@ -238,8 +238,27 @@ fn second_independent_capture_with_many_graph_owned_allocations() -> Result<()> 
         .iter()
         .map(|row| row.iter().map(|a| a.sin()).collect())
         .collect();
-    assert_eq!(cos.to_vec2::<f32>()?, expected_cos);
-    assert_eq!(sin.to_vec2::<f32>()?, expected_sin);
+    // The GPU's cos/sin intrinsics aren't required to be bit-identical to the
+    // host's, so compare with a tolerance rather than exact equality -- this
+    // step only needs to prove the allocation chain ran and produced sane
+    // values, not to pin down transcendental-function precision.
+    let close = |actual: &[Vec<f32>], expected: &[Vec<f32>]| {
+        actual
+            .iter()
+            .flatten()
+            .zip(expected.iter().flatten())
+            .all(|(a, e)| (a - e).abs() < 1e-4)
+    };
+    let cos_actual = cos.to_vec2::<f32>()?;
+    let sin_actual = sin.to_vec2::<f32>()?;
+    assert!(
+        close(&cos_actual, &expected_cos),
+        "cos mismatch: {cos_actual:?} vs {expected_cos:?}"
+    );
+    assert!(
+        close(&sin_actual, &expected_sin),
+        "sin mismatch: {sin_actual:?} vs {expected_sin:?}"
+    );
 
     // The second request then runs its own independent capture/replay cycle
     // against the same device, reusing the shared model-level buffer, again

--- a/candle-core/tests/cuda_graph_tests.rs
+++ b/candle-core/tests/cuda_graph_tests.rs
@@ -15,6 +15,11 @@ fn capture_and_replay_decode_step() -> Result<()> {
     let rhs = Tensor::ones((4, 4), candle_core::DType::F32, &device)?;
     let mut out = Tensor::zeros((4, 4), candle_core::DType::F32, &device)?;
 
+    // Warm-up run outside of capture: JIT-loads the multiply kernel's module so that
+    // capture only ever records already-loaded kernel launches (see CudaGraph::capture).
+    out = (&lhs * &rhs)?;
+    device.synchronize()?;
+
     let (graph, ()) = CudaGraph::capture(cuda_device, || {
         out = (&lhs * &rhs)?;
         Ok(())

--- a/candle-core/tests/cuda_graph_tests.rs
+++ b/candle-core/tests/cuda_graph_tests.rs
@@ -57,3 +57,89 @@ fn capture_and_replay_decode_step() -> Result<()> {
     assert_eq!(out.to_vec2::<f32>()?, lhs.to_vec2::<f32>()?);
     Ok(())
 }
+
+// Regression test: on real hardware, a second, independent `CudaGraph::capture`
+// on the same device broke a later, completely unrelated allocation with
+// `CUDA_ERROR_INVALID_VALUE` -- the very first op of the second capture's
+// caller, before any of its own capture/replay code ran. Reproducing it needs
+// a tensor allocated before either capture and written into by both (standing
+// in for a model-level KV cache reused across independent requests), plus a
+// plain, unrelated allocation after the first graph is dropped.
+#[test]
+fn second_independent_capture_after_first_graph_dropped() -> Result<()> {
+    let device = match Device::new_cuda(0) {
+        Ok(device) => device,
+        Err(_) => return Ok(()),
+    };
+    let Device::Cuda(cuda_device) = &device else {
+        unreachable!()
+    };
+
+    // Stands in for a model-level buffer (e.g. a paged-attention KV cache)
+    // allocated once, before either capture, and written into by both.
+    let shared = Tensor::zeros((4, 4), DType::F32, &device)?;
+    let rhs = Tensor::ones((4, 4), DType::F32, &device)?;
+
+    {
+        let lhs = Tensor::arange(0f32, 16f32, &device)?.reshape((4, 4))?;
+        let out = Tensor::zeros((4, 4), DType::F32, &device)?;
+        let zeros = Tensor::zeros((4, 4), DType::F32, &device)?;
+
+        // Warm-up outside of capture, then reset back to zeros.
+        let tmp = (&lhs * &rhs)?;
+        shared.slice_set(&tmp, 0, 0)?;
+        out.slice_set(&tmp, 0, 0)?;
+        shared.slice_set(&zeros, 0, 0)?;
+        out.slice_set(&zeros, 0, 0)?;
+        device.synchronize()?;
+
+        let (graph, ()) = CudaGraph::capture(cuda_device, || {
+            let tmp = (&lhs * &rhs)?;
+            shared.slice_set(&tmp, 0, 0)?;
+            out.slice_set(&tmp, 0, 0)?;
+            Ok(())
+        })?;
+        graph.replay()?;
+        graph.replay()?;
+        device.synchronize()?;
+        assert_eq!(out.to_vec2::<f32>()?, lhs.to_vec2::<f32>()?);
+        assert_eq!(shared.to_vec2::<f32>()?, lhs.to_vec2::<f32>()?);
+        // `graph` is dropped at the end of this scope, before the second,
+        // independent request below runs -- matching the production sequence
+        // (capture, replay, request completes, graph and its per-request
+        // buffers are dropped) that preceded the real-hardware failure.
+    }
+
+    // A brand new, unrelated request against the same already-loaded model:
+    // fresh buffer, no reference to the first request's `out`/`lhs`/graph.
+    // This is the operation that failed on real hardware, before any of the
+    // second request's own capture/replay code ran.
+    let unrelated = Tensor::zeros((4, 4), DType::F32, &device)?;
+    device.synchronize()?;
+    assert_eq!(unrelated.to_vec2::<f32>()?, vec![vec![0f32; 4]; 4]);
+
+    // The second request then runs its own independent capture/replay cycle
+    // against the same device, reusing the shared model-level buffer.
+    let lhs2 = Tensor::arange(16f32, 32f32, &device)?.reshape((4, 4))?;
+    let out2 = Tensor::zeros((4, 4), DType::F32, &device)?;
+    let zeros = Tensor::zeros((4, 4), DType::F32, &device)?;
+
+    let tmp = (&lhs2 * &rhs)?;
+    shared.slice_set(&tmp, 0, 0)?;
+    out2.slice_set(&tmp, 0, 0)?;
+    shared.slice_set(&zeros, 0, 0)?;
+    out2.slice_set(&zeros, 0, 0)?;
+    device.synchronize()?;
+
+    let (graph2, ()) = CudaGraph::capture(cuda_device, || {
+        let tmp = (&lhs2 * &rhs)?;
+        shared.slice_set(&tmp, 0, 0)?;
+        out2.slice_set(&tmp, 0, 0)?;
+        Ok(())
+    })?;
+    graph2.replay()?;
+    device.synchronize()?;
+    assert_eq!(out2.to_vec2::<f32>()?, lhs2.to_vec2::<f32>()?);
+    assert_eq!(shared.to_vec2::<f32>()?, lhs2.to_vec2::<f32>()?);
+    Ok(())
+}

--- a/candle-core/tests/cuda_graph_tests.rs
+++ b/candle-core/tests/cuda_graph_tests.rs
@@ -1,0 +1,29 @@
+#![cfg(feature = "cuda")]
+use candle_core::{CudaGraph, Device, Result, Tensor};
+
+#[test]
+fn capture_and_replay_decode_step() -> Result<()> {
+    let device = match Device::new_cuda(0) {
+        Ok(device) => device,
+        Err(_) => return Ok(()),
+    };
+    let Device::Cuda(cuda_device) = &device else {
+        unreachable!()
+    };
+
+    let lhs = Tensor::arange(0f32, 16f32, &device)?.reshape((4, 4))?;
+    let rhs = Tensor::ones((4, 4), candle_core::DType::F32, &device)?;
+    let mut out = Tensor::zeros((4, 4), candle_core::DType::F32, &device)?;
+
+    let (graph, ()) = CudaGraph::capture(cuda_device, || {
+        out = (&lhs * &rhs)?;
+        Ok(())
+    })?;
+
+    let before = out.to_vec2::<f32>()?;
+    graph.replay()?;
+    let after = out.to_vec2::<f32>()?;
+    assert_eq!(before, after);
+    assert_eq!(after, lhs.to_vec2::<f32>()?);
+    Ok(())
+}

--- a/candle-core/tests/cuda_graph_tests.rs
+++ b/candle-core/tests/cuda_graph_tests.rs
@@ -13,15 +13,22 @@ fn capture_and_replay_decode_step() -> Result<()> {
 
     let lhs = Tensor::arange(0f32, 16f32, &device)?.reshape((4, 4))?;
     let rhs = Tensor::ones((4, 4), candle_core::DType::F32, &device)?;
+
     // Warm-up run outside of capture: JIT-loads the multiply kernel's module so that
     // capture only ever records already-loaded kernel launches (see CudaGraph::capture).
     let mut out = (&lhs * &rhs)?;
     device.synchronize()?;
+    println!("warmup complete, event_tracking={}", cuda_device.is_event_tracking());
 
     let (graph, ()) = CudaGraph::capture(cuda_device, || {
-        out = (&lhs * &rhs)?;
+        println!("closure: before mul");
+        let r = &lhs * &rhs;
+        println!("closure: mul ok={}", r.is_ok());
+        out = r?;
+        println!("closure: after assign");
         Ok(())
     })?;
+    println!("capture returned ok");
 
     let before = out.to_vec2::<f32>()?;
     graph.replay()?;

--- a/candle-flashinfer-kernels/Cargo.toml
+++ b/candle-flashinfer-kernels/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [dependencies]
 candle = { path = "../candle-core", default-features = false, package = "candle-core", version = "0.11.0" }
 half = { version = "2.3.1", features = ["num-traits"] }
+rayon = "1.7"
+candle-metal-kernels = { path = "../candle-metal-kernels", version = "0.11.0", optional = true }
+objc2-metal = { version = "0.3.2", optional = true }
 
 [build-dependencies]
 cudaforge = { version = "0.1.2", optional = true }
@@ -23,6 +26,8 @@ default = []
 # Compiles and links the CUDA decode-attention kernel and enables the GPU forward
 # pass. Without it the crate builds CPU-only and uses the reference `cpu_fwd`.
 cuda = ["dep:cudaforge", "candle/cuda"]
+# Compiles (at runtime) and runs the Metal decode-attention kernel on Apple Silicon.
+metal = ["candle/metal", "dep:candle-metal-kernels", "dep:objc2-metal"]
 
 [dev-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/candle-flashinfer-kernels/Cargo.toml
+++ b/candle-flashinfer-kernels/Cargo.toml
@@ -11,13 +11,18 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-candle = { path = "../candle-core", features = ["cuda"], package = "candle-core", version = "0.11.0" }
+candle = { path = "../candle-core", default-features = false, package = "candle-core", version = "0.11.0" }
 half = { version = "2.3.1", features = ["num-traits"] }
 
 [build-dependencies]
-cudaforge = "0.1.2"
+cudaforge = { version = "0.1.2", optional = true }
 anyhow = { version = "1", features = ["backtrace"] }
+
+[features]
+default = []
+# Compiles and links the CUDA decode-attention kernel and enables the GPU forward
+# pass. Without it the crate builds CPU-only and uses the reference `cpu_fwd`.
+cuda = ["dep:cudaforge", "candle/cuda"]
 
 [dev-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
-candle-nn = { path = "../candle-nn", features = ["cuda"] }

--- a/candle-flashinfer-kernels/Cargo.toml
+++ b/candle-flashinfer-kernels/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "candle-flashinfer-kernels"
+version = "0.11.0"
+edition = "2021"
+
+description = "Optional FlashInfer-style single-token decode attention kernel for the candle ML framework."
+repository = "https://github.com/huggingface/candle"
+keywords = ["blas", "tensor", "machine-learning"]
+categories = ["science"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+
+[dependencies]
+candle = { path = "../candle-core", features = ["cuda"], package = "candle-core", version = "0.11.0" }
+half = { version = "2.3.1", features = ["num-traits"] }
+
+[build-dependencies]
+cudaforge = "0.1.2"
+anyhow = { version = "1", features = ["backtrace"] }
+
+[dev-dependencies]
+anyhow = { version = "1", features = ["backtrace"] }
+candle-nn = { path = "../candle-nn", features = ["cuda"] }

--- a/candle-flashinfer-kernels/README.md
+++ b/candle-flashinfer-kernels/README.md
@@ -28,8 +28,11 @@ let out = candle_flashinfer_kernels::flashinfer_decode_attention(
 
 - **`cuda`** (off by default): compiles and links the CUDA kernel and enables the
   GPU forward pass. Requires the CUDA toolchain (`nvcc`).
+- **`metal`** (off by default): enables the Metal forward pass on Apple Silicon
+  (`f32`/`f16`). The shader is compiled at runtime, so no extra toolchain is needed.
 
-Without the `cuda` feature the crate builds CPU-only and the same
+With no GPU feature the crate builds CPU-only and the same
 `flashinfer_decode_attention` entry point runs a reference CPU implementation
-(`cpu_fwd`, `f32`/`f16`/`bf16`). This makes the backend usable as a CPU fallback
-and testable without a GPU; enable `cuda` to run the GPU kernel on CUDA tensors.
+(`cpu_fwd`, `f32`/`f16`/`bf16`, parallelized across `(batch, head)` with rayon).
+This makes the backend usable as a CPU fallback and testable without a GPU;
+enable `cuda` or `metal` to run the corresponding GPU kernel.

--- a/candle-flashinfer-kernels/README.md
+++ b/candle-flashinfer-kernels/README.md
@@ -1,0 +1,25 @@
+# candle-flashinfer-kernels
+
+Optional, feature-gated decode-attention backend for candle, alongside
+`candle-flash-attn`. See
+[huggingface/candle#3651](https://github.com/huggingface/candle/issues/3651).
+
+`candle-flash-attn` targets the prefill (multi-token query) case. This crate
+targets the decode case: each sequence in the batch contributes exactly one
+new query token, attending over an arbitrarily long key/value cache, which is
+the workload FlashInfer's batch-decode kernels are built for. The kernel
+shipped here is a reference, numerically-stable (streaming softmax)
+implementation of that same shape contract — one CUDA block per
+`(batch, query head)`, looping sequentially over the KV cache. It is not a
+port of FlashInfer's tensor-core / split-KV kernels, so it should not be
+expected to match FlashInfer's own throughput; it exists to give candle a
+working, swappable decode-attention entry point with the right API shape.
+
+```rust
+let out = candle_flashinfer_kernels::flashinfer_decode_attention(
+    &q, // (batch, num_heads_q, head_dim)
+    &k, // (batch, num_heads_kv, seqlen_k, head_dim)
+    &v, // (batch, num_heads_kv, seqlen_k, head_dim)
+    softmax_scale,
+)?;
+```

--- a/candle-flashinfer-kernels/README.md
+++ b/candle-flashinfer-kernels/README.md
@@ -23,3 +23,13 @@ let out = candle_flashinfer_kernels::flashinfer_decode_attention(
     softmax_scale,
 )?;
 ```
+
+## Features
+
+- **`cuda`** (off by default): compiles and links the CUDA kernel and enables the
+  GPU forward pass. Requires the CUDA toolchain (`nvcc`).
+
+Without the `cuda` feature the crate builds CPU-only and the same
+`flashinfer_decode_attention` entry point runs a reference CPU implementation
+(`cpu_fwd`, `f32`/`f16`/`bf16`). This makes the backend usable as a CPU fallback
+and testable without a GPU; enable `cuda` to run the GPU kernel on CUDA tensors.

--- a/candle-flashinfer-kernels/build.rs
+++ b/candle-flashinfer-kernels/build.rs
@@ -1,0 +1,42 @@
+// Build script compiling the single-token decode attention CUDA kernel into a static lib.
+use cudaforge::KernelBuilder;
+use std::path::PathBuf;
+
+fn main() -> anyhow::Result<()> {
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=kernels/decode_attention.cu");
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR not set"));
+
+    let mut builder = KernelBuilder::new()
+        .source_files(vec!["kernels/decode_attention.cu"])
+        .out_dir(&out_dir)
+        .arg("-std=c++17")
+        .arg("-O3")
+        .arg("-U__CUDA_NO_HALF_OPERATORS__")
+        .arg("-U__CUDA_NO_HALF_CONVERSIONS__")
+        .arg("-U__CUDA_NO_BFLOAT16_CONVERSIONS__")
+        .arg("--expt-relaxed-constexpr");
+
+    let mut is_target_msvc = false;
+    if let Ok(target) = std::env::var("TARGET") {
+        if target.contains("msvc") {
+            is_target_msvc = true;
+            builder = builder.arg("-D_USE_MATH_DEFINES");
+        }
+    }
+    if !is_target_msvc {
+        builder = builder.arg("-Xcompiler").arg("-fPIC");
+    }
+
+    let out_file = out_dir.join("libflashinferkernels.a");
+    builder.build_lib(out_file)?;
+
+    println!("cargo::rustc-link-search={}", out_dir.display());
+    println!("cargo::rustc-link-lib=flashinferkernels");
+    println!("cargo::rustc-link-lib=dylib=cudart");
+    if !is_target_msvc {
+        println!("cargo::rustc-link-lib=dylib=stdc++");
+    }
+    Ok(())
+}

--- a/candle-flashinfer-kernels/build.rs
+++ b/candle-flashinfer-kernels/build.rs
@@ -1,10 +1,21 @@
 // Build script compiling the single-token decode attention CUDA kernel into a static lib.
-use cudaforge::KernelBuilder;
-use std::path::PathBuf;
+// The kernel is only compiled and linked when the `cuda` feature is enabled; otherwise the
+// crate builds CPU-only and relies on the reference `cpu_fwd` implementation.
 
 fn main() -> anyhow::Result<()> {
     println!("cargo::rerun-if-changed=build.rs");
     println!("cargo::rerun-if-changed=kernels/decode_attention.cu");
+
+    #[cfg(feature = "cuda")]
+    compile_cuda_kernel()?;
+
+    Ok(())
+}
+
+#[cfg(feature = "cuda")]
+fn compile_cuda_kernel() -> anyhow::Result<()> {
+    use cudaforge::KernelBuilder;
+    use std::path::PathBuf;
 
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR not set"));
 

--- a/candle-flashinfer-kernels/kernels/decode_attention.cu
+++ b/candle-flashinfer-kernels/kernels/decode_attention.cu
@@ -1,0 +1,158 @@
+// Single-token (decode) attention kernel: each sequence in the batch contributes exactly one
+// new query token, which attends over its full key/value cache. This is the computational
+// pattern FlashInfer's batch-decode kernels target, and is the workload referenced by
+// https://github.com/huggingface/candle/issues/3651. The kernel below is a straightforward,
+// numerically-stable (streaming softmax) reference implementation: one CUDA block per
+// (batch, query head), one thread per head-dimension element, looping sequentially over the
+// key/value cache. It is not a tensor-core / split-KV kernel, so it should not be expected to
+// match FlashInfer's own throughput, but it gives candle a working, feature-gated decode-attention
+// backend with the same shape contract.
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <math.h>
+
+template <typename T>
+__device__ __forceinline__ float to_f32(T x);
+template <>
+__device__ __forceinline__ float to_f32<float>(float x) {
+  return x;
+}
+template <>
+__device__ __forceinline__ float to_f32<__half>(__half x) {
+  return __half2float(x);
+}
+template <>
+__device__ __forceinline__ float to_f32<__nv_bfloat16>(__nv_bfloat16 x) {
+  return __bfloat162float(x);
+}
+
+template <typename T>
+__device__ __forceinline__ T from_f32(float x);
+template <>
+__device__ __forceinline__ float from_f32<float>(float x) {
+  return x;
+}
+template <>
+__device__ __forceinline__ __half from_f32<__half>(float x) {
+  return __float2half(x);
+}
+template <>
+__device__ __forceinline__ __nv_bfloat16 from_f32<__nv_bfloat16>(float x) {
+  return __float2bfloat16(x);
+}
+
+// grid = (batch, num_query_heads), block = next_pow2(head_dim) threads (<= 1024).
+template <typename T>
+__global__ void decode_attention_kernel(
+    const T *__restrict__ q, const T *__restrict__ k, const T *__restrict__ v,
+    T *__restrict__ out, int hkv_group, int seqlen_k, int head_dim,
+    int64_t q_b_stride, int64_t q_h_stride, int64_t k_b_stride,
+    int64_t k_h_stride, int64_t k_l_stride, int64_t v_b_stride,
+    int64_t v_h_stride, int64_t v_l_stride, int64_t o_b_stride,
+    int64_t o_h_stride, float scale) {
+  const int b = blockIdx.x;
+  const int h = blockIdx.y;
+  const int hkv = h / hkv_group;
+  const int tid = threadIdx.x;
+
+  extern __shared__ float red[];
+
+  const T *q_ptr = q + (int64_t)b * q_b_stride + (int64_t)h * q_h_stride;
+  const T *k_base = k + (int64_t)b * k_b_stride + (int64_t)hkv * k_h_stride;
+  const T *v_base = v + (int64_t)b * v_b_stride + (int64_t)hkv * v_h_stride;
+  T *o_ptr = out + (int64_t)b * o_b_stride + (int64_t)h * o_h_stride;
+
+  const float qd = (tid < head_dim) ? to_f32<T>(q_ptr[tid]) : 0.f;
+
+  float m = -INFINITY;
+  float l = 0.f;
+  float acc = 0.f;
+
+  for (int t = 0; t < seqlen_k; ++t) {
+    const T *k_row = k_base + (int64_t)t * k_l_stride;
+    red[tid] = (tid < head_dim) ? qd * to_f32<T>(k_row[tid]) : 0.f;
+    __syncthreads();
+    for (int offset = blockDim.x / 2; offset > 0; offset >>= 1) {
+      if (tid < offset) {
+        red[tid] += red[tid + offset];
+      }
+      __syncthreads();
+    }
+    const float score = red[0] * scale;
+    __syncthreads();
+
+    const float new_m = fmaxf(m, score);
+    const float corr = __expf(m - new_m);
+    const float p = __expf(score - new_m);
+    l = l * corr + p;
+
+    const T *v_row = v_base + (int64_t)t * v_l_stride;
+    const float vd = (tid < head_dim) ? to_f32<T>(v_row[tid]) : 0.f;
+    acc = acc * corr + p * vd;
+    m = new_m;
+  }
+
+  if (tid < head_dim) {
+    o_ptr[tid] = from_f32<T>(acc / l);
+  }
+}
+
+template <typename T>
+static void launch(const T *q, const T *k, const T *v, T *out, int batch,
+                    int num_heads, int num_heads_k, int seqlen_k,
+                    int head_dim, int64_t q_b_stride, int64_t q_h_stride,
+                    int64_t k_b_stride, int64_t k_h_stride,
+                    int64_t k_l_stride, int64_t v_b_stride,
+                    int64_t v_h_stride, int64_t v_l_stride,
+                    int64_t o_b_stride, int64_t o_h_stride, float scale,
+                    cudaStream_t stream) {
+  int block = 1;
+  while (block < head_dim) {
+    block <<= 1;
+  }
+  if (block > 1024) {
+    block = 1024;
+  }
+  const dim3 grid(batch, num_heads);
+  const size_t smem = (size_t)block * sizeof(float);
+  decode_attention_kernel<T><<<grid, block, smem, stream>>>(
+      q, k, v, out, num_heads / num_heads_k, seqlen_k, head_dim, q_b_stride,
+      q_h_stride, k_b_stride, k_h_stride, k_l_stride, v_b_stride, v_h_stride,
+      v_l_stride, o_b_stride, o_h_stride, scale);
+}
+
+extern "C" void run_decode_attention(
+    const void *q, const void *k, const void *v, void *out, int32_t dtype,
+    int32_t batch, int32_t num_heads, int32_t num_heads_k, int32_t seqlen_k,
+    int32_t head_dim, int64_t q_b_stride, int64_t q_h_stride,
+    int64_t k_b_stride, int64_t k_h_stride, int64_t k_l_stride,
+    int64_t v_b_stride, int64_t v_h_stride, int64_t v_l_stride,
+    int64_t o_b_stride, int64_t o_h_stride, float scale,
+    cudaStream_t stream) {
+  switch (dtype) {
+  case 0:
+    launch<float>((const float *)q, (const float *)k, (const float *)v,
+                  (float *)out, batch, num_heads, num_heads_k, seqlen_k,
+                  head_dim, q_b_stride, q_h_stride, k_b_stride, k_h_stride,
+                  k_l_stride, v_b_stride, v_h_stride, v_l_stride, o_b_stride,
+                  o_h_stride, scale, stream);
+    break;
+  case 1:
+    launch<__half>((const __half *)q, (const __half *)k, (const __half *)v,
+                    (__half *)out, batch, num_heads, num_heads_k, seqlen_k,
+                    head_dim, q_b_stride, q_h_stride, k_b_stride, k_h_stride,
+                    k_l_stride, v_b_stride, v_h_stride, v_l_stride,
+                    o_b_stride, o_h_stride, scale, stream);
+    break;
+  default:
+    launch<__nv_bfloat16>((const __nv_bfloat16 *)q, (const __nv_bfloat16 *)k,
+                           (const __nv_bfloat16 *)v, (__nv_bfloat16 *)out,
+                           batch, num_heads, num_heads_k, seqlen_k, head_dim,
+                           q_b_stride, q_h_stride, k_b_stride, k_h_stride,
+                           k_l_stride, v_b_stride, v_h_stride, v_l_stride,
+                           o_b_stride, o_h_stride, scale, stream);
+    break;
+  }
+}

--- a/candle-flashinfer-kernels/kernels/decode_attention.metal
+++ b/candle-flashinfer-kernels/kernels/decode_attention.metal
@@ -1,0 +1,114 @@
+// Metal port of the single-token (decode) attention kernel (see decode_attention.cu).
+// One threadgroup per (batch, query head), one thread per head-dimension element, looping
+// sequentially over the key/value cache with a numerically-stable streaming softmax. The
+// per-key dot product is a threadgroup reduction. This mirrors the CUDA reference path on
+// Apple Silicon; it is not a tensor-core / split-KV kernel.
+#include <metal_stdlib>
+using namespace metal;
+
+// Must match `struct DecodeParams` in src/metal.rs (13 × i32 then 1 × f32).
+struct DecodeParams {
+    int hkv_group;
+    int seqlen_k;
+    int head_dim;
+    int q_b_stride;
+    int q_h_stride;
+    int k_b_stride;
+    int k_h_stride;
+    int k_l_stride;
+    int v_b_stride;
+    int v_h_stride;
+    int v_l_stride;
+    int o_b_stride;
+    int o_h_stride;
+    float scale;
+};
+
+template <typename T>
+inline void decode_attention_impl(
+    device const T *q,
+    device const T *k,
+    device const T *v,
+    device T *out,
+    constant DecodeParams &p,
+    threadgroup float *red,
+    uint2 tg_pos,
+    uint tid,
+    uint tcount) {
+    const int b = int(tg_pos.y);
+    const int h = int(tg_pos.x);
+    const int hkv = h / p.hkv_group;
+    const uint hd = uint(p.head_dim);
+
+    device const T *q_ptr = q + (long)b * p.q_b_stride + (long)h * p.q_h_stride;
+    device const T *k_base = k + (long)b * p.k_b_stride + (long)hkv * p.k_h_stride;
+    device const T *v_base = v + (long)b * p.v_b_stride + (long)hkv * p.v_h_stride;
+    device T *o_ptr = out + (long)b * p.o_b_stride + (long)h * p.o_h_stride;
+
+    if (p.seqlen_k == 0) {
+        if (tid < hd) {
+            o_ptr[tid] = T(0.0f);
+        }
+        return;
+    }
+
+    const float qd = (tid < hd) ? float(q_ptr[tid]) : 0.0f;
+
+    float m = -INFINITY;
+    float l = 0.0f;
+    float acc = 0.0f;
+
+    for (int t = 0; t < p.seqlen_k; ++t) {
+        device const T *k_row = k_base + (long)t * p.k_l_stride;
+        red[tid] = (tid < hd) ? qd * float(k_row[tid]) : 0.0f;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint offset = tcount / 2; offset > 0; offset >>= 1) {
+            if (tid < offset) {
+                red[tid] += red[tid + offset];
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+        const float score = red[0] * p.scale;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        const float new_m = max(m, score);
+        const float corr = exp(m - new_m);
+        const float pscore = exp(score - new_m);
+        l = l * corr + pscore;
+
+        device const T *v_row = v_base + (long)t * p.v_l_stride;
+        const float vd = (tid < hd) ? float(v_row[tid]) : 0.0f;
+        acc = acc * corr + pscore * vd;
+        m = new_m;
+    }
+
+    if (tid < hd) {
+        o_ptr[tid] = T(acc / l);
+    }
+}
+
+kernel void decode_attention_f32(
+    device const float *q [[buffer(0)]],
+    device const float *k [[buffer(1)]],
+    device const float *v [[buffer(2)]],
+    device float *out [[buffer(3)]],
+    constant DecodeParams &p [[buffer(4)]],
+    uint2 tg_pos [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tcount [[threads_per_threadgroup]]) {
+    threadgroup float red[1024];
+    decode_attention_impl<float>(q, k, v, out, p, red, tg_pos, tid, tcount);
+}
+
+kernel void decode_attention_f16(
+    device const half *q [[buffer(0)]],
+    device const half *k [[buffer(1)]],
+    device const half *v [[buffer(2)]],
+    device half *out [[buffer(3)]],
+    constant DecodeParams &p [[buffer(4)]],
+    uint2 tg_pos [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint tcount [[threads_per_threadgroup]]) {
+    threadgroup float red[1024];
+    decode_attention_impl<half>(q, k, v, out, p, red, tg_pos, tid, tcount);
+}

--- a/candle-flashinfer-kernels/kernels/decode_attention.metal
+++ b/candle-flashinfer-kernels/kernels/decode_attention.metal
@@ -87,6 +87,9 @@ inline void decode_attention_impl(
     }
 }
 
+// Metal requires all thread-position attributes in a kernel to share the same
+// dimensionality, so every position attribute below is `uint2` and the threadgroup-local
+// index/size use the `.x` component (the threadgroup is 1-D).
 kernel void decode_attention_f32(
     device const float *q [[buffer(0)]],
     device const float *k [[buffer(1)]],
@@ -94,10 +97,10 @@ kernel void decode_attention_f32(
     device float *out [[buffer(3)]],
     constant DecodeParams &p [[buffer(4)]],
     uint2 tg_pos [[threadgroup_position_in_grid]],
-    uint tid [[thread_position_in_threadgroup]],
-    uint tcount [[threads_per_threadgroup]]) {
+    uint2 tid [[thread_position_in_threadgroup]],
+    uint2 tcount [[threads_per_threadgroup]]) {
     threadgroup float red[1024];
-    decode_attention_impl<float>(q, k, v, out, p, red, tg_pos, tid, tcount);
+    decode_attention_impl<float>(q, k, v, out, p, red, tg_pos, tid.x, tcount.x);
 }
 
 kernel void decode_attention_f16(
@@ -107,8 +110,8 @@ kernel void decode_attention_f16(
     device half *out [[buffer(3)]],
     constant DecodeParams &p [[buffer(4)]],
     uint2 tg_pos [[threadgroup_position_in_grid]],
-    uint tid [[thread_position_in_threadgroup]],
-    uint tcount [[threads_per_threadgroup]]) {
+    uint2 tid [[thread_position_in_threadgroup]],
+    uint2 tcount [[threads_per_threadgroup]]) {
     threadgroup float red[1024];
-    decode_attention_impl<half>(q, k, v, out, p, red, tg_pos, tid, tcount);
+    decode_attention_impl<half>(q, k, v, out, p, red, tg_pos, tid.x, tcount.x);
 }

--- a/candle-flashinfer-kernels/src/ffi.rs
+++ b/candle-flashinfer-kernels/src/ffi.rs
@@ -1,0 +1,28 @@
+use core::ffi::c_void;
+
+extern "C" {
+    pub(crate) fn run_decode_attention(
+        q_ptr: *const c_void,
+        k_ptr: *const c_void,
+        v_ptr: *const c_void,
+        out_ptr: *const c_void,
+        dtype: i32,
+        batch: i32,
+        num_heads: i32,
+        num_heads_k: i32,
+        seqlen_k: i32,
+        head_dim: i32,
+        q_b_stride: i64,
+        q_h_stride: i64,
+        k_b_stride: i64,
+        k_h_stride: i64,
+        k_l_stride: i64,
+        v_b_stride: i64,
+        v_h_stride: i64,
+        v_l_stride: i64,
+        o_b_stride: i64,
+        o_h_stride: i64,
+        scale: f32,
+        stream: *mut c_void,
+    );
+}

--- a/candle-flashinfer-kernels/src/lib.rs
+++ b/candle-flashinfer-kernels/src/lib.rs
@@ -1,0 +1,170 @@
+//! Optional, feature-gated decode-attention backend for the autoregressive decode path,
+//! alongside `candle-flash-attn`. See https://github.com/huggingface/candle/issues/3651.
+//!
+//! Unlike `candle-flash-attn`, which targets the prefill (multi-token) case, this crate
+//! targets the decode case: each sequence in the batch contributes exactly one new query
+//! token, attending over an arbitrarily long key/value cache. The kernel here is a reference,
+//! numerically-stable implementation of that workload (the one FlashInfer's batch-decode
+//! kernels optimize); it is not a port of FlashInfer's own tensor-core/split-KV kernels.
+mod ffi;
+
+use candle::backend::BackendStorage;
+use candle::cuda_backend::cudarc::driver::{DevicePtr, DevicePtrMut};
+use candle::{CpuStorage, DType, Layout, Result, Shape, Tensor};
+use half::{bf16, f16};
+
+pub struct DecodeAttention {
+    pub softmax_scale: f32,
+}
+
+impl DecodeAttention {
+    fn cuda_fwd_t<
+        T: candle::cuda_backend::CudaDType + candle::cuda_backend::cudarc::driver::DeviceRepr,
+    >(
+        &self,
+        q: &candle::CudaStorage,
+        q_l: &Layout,
+        k: &candle::CudaStorage,
+        k_l: &Layout,
+        v: &candle::CudaStorage,
+        v_l: &Layout,
+        dtype_tag: i32,
+    ) -> Result<(candle::CudaStorage, Shape)> {
+        let dev = q.device();
+        let (b_sz, num_heads, head_dim) = q_l.shape().dims3()?;
+        let (b_sz_k, num_heads_k, seqlen_k, head_dim_k) = k_l.shape().dims4()?;
+        if k_l.shape() != v_l.shape() {
+            candle::bail!(
+                "shape mismatch between k {:?} and v {:?}",
+                k_l.shape(),
+                v_l.shape()
+            );
+        }
+        if b_sz_k != b_sz || head_dim_k != head_dim {
+            candle::bail!(
+                "shape mismatch between q {:?} and k {:?}",
+                q_l.shape(),
+                k_l.shape()
+            );
+        }
+        if num_heads % num_heads_k != 0 {
+            candle::bail!(
+                "number of kv heads {num_heads_k} must divide the number of query heads {num_heads}"
+            )
+        }
+
+        let q_stride = q_l.stride();
+        let k_stride = k_l.stride();
+        let v_stride = v_l.stride();
+        if q_stride[2] != 1 {
+            candle::bail!("the head dimension of q must be contiguous {q_stride:?}")
+        }
+        if k_stride[3] != 1 {
+            candle::bail!("the head dimension of k must be contiguous {k_stride:?}")
+        }
+        if v_stride[3] != 1 {
+            candle::bail!("the head dimension of v must be contiguous {v_stride:?}")
+        }
+
+        let out_shape = q_l.shape().clone();
+        let elem_count = out_shape.elem_count();
+        let stream = dev.cuda_stream();
+        let mut dst = unsafe { dev.alloc::<T>(elem_count)? };
+
+        let q = q.as_cuda_slice::<T>()?.slice(q_l.start_offset()..);
+        let k = k.as_cuda_slice::<T>()?.slice(k_l.start_offset()..);
+        let v = v.as_cuda_slice::<T>()?.slice(v_l.start_offset()..);
+
+        unsafe {
+            let (q_ptr, _guard) = q.device_ptr(&stream);
+            let (k_ptr, _guard) = k.device_ptr(&stream);
+            let (v_ptr, _guard) = v.device_ptr(&stream);
+            let (dst_ptr, _guard) = dst.device_ptr_mut(&stream);
+            ffi::run_decode_attention(
+                q_ptr as *const core::ffi::c_void,
+                k_ptr as *const core::ffi::c_void,
+                v_ptr as *const core::ffi::c_void,
+                dst_ptr as *const core::ffi::c_void,
+                dtype_tag,
+                b_sz as i32,
+                num_heads as i32,
+                num_heads_k as i32,
+                seqlen_k as i32,
+                head_dim as i32,
+                q_stride[0] as i64,
+                q_stride[1] as i64,
+                k_stride[0] as i64,
+                k_stride[1] as i64,
+                k_stride[2] as i64,
+                v_stride[0] as i64,
+                v_stride[1] as i64,
+                v_stride[2] as i64,
+                (num_heads * head_dim) as i64,
+                head_dim as i64,
+                self.softmax_scale,
+                stream.cu_stream() as *mut core::ffi::c_void,
+            )
+        }
+
+        let dst = candle::CudaStorage::wrap_cuda_slice(dst, dev.clone());
+        Ok((dst, out_shape))
+    }
+}
+
+impl candle::CustomOp3 for DecodeAttention {
+    fn name(&self) -> &'static str {
+        "flashinfer-decode-attention"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+    ) -> Result<(CpuStorage, Shape)> {
+        candle::bail!("no cpu support for flashinfer-decode-attention")
+    }
+
+    fn cuda_fwd(
+        &self,
+        q: &candle::CudaStorage,
+        q_l: &Layout,
+        k: &candle::CudaStorage,
+        k_l: &Layout,
+        v: &candle::CudaStorage,
+        v_l: &Layout,
+    ) -> Result<(candle::CudaStorage, Shape)> {
+        match q.dtype() {
+            DType::F32 => self.cuda_fwd_t::<f32>(q, q_l, k, k_l, v, v_l, 0),
+            DType::F16 => self.cuda_fwd_t::<f16>(q, q_l, k, k_l, v, v_l, 1),
+            DType::BF16 => self.cuda_fwd_t::<bf16>(q, q_l, k, k_l, v, v_l, 2),
+            dt => candle::bail!("flashinfer-decode-attention is only supported for f32/f16/bf16 ({dt:?})"),
+        }
+    }
+}
+
+/// Single-token decode attention: `softmax(q @ k^T * softmax_scale) @ v`, where each sequence
+/// in the batch contributes exactly one query token attending over its key/value cache.
+///
+/// Grouped-query attention is supported: `k`/`v` may use fewer heads than `q`, as long as
+/// `num_heads_q` is a multiple of `num_heads_kv`.
+///
+/// # Arguments
+///
+/// * `q` - Query tensor with shape `(batch, num_heads_q, head_dim)`, i.e. one token per sequence.
+/// * `k` - Key cache with shape `(batch, num_heads_kv, seqlen_k, head_dim)`.
+/// * `v` - Value cache with shape `(batch, num_heads_kv, seqlen_k, head_dim)`.
+///
+/// The resulting tensor has shape `(batch, num_heads_q, head_dim)`.
+pub fn flashinfer_decode_attention(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    softmax_scale: f32,
+) -> Result<Tensor> {
+    let op = DecodeAttention { softmax_scale };
+    q.apply_op3(k, v, op)
+}

--- a/candle-flashinfer-kernels/src/lib.rs
+++ b/candle-flashinfer-kernels/src/lib.rs
@@ -8,6 +8,8 @@
 //! kernels optimize); it is not a port of FlashInfer's own tensor-core/split-KV kernels.
 #[cfg(feature = "cuda")]
 mod ffi;
+#[cfg(feature = "metal")]
+mod metal;
 
 #[cfg(feature = "cuda")]
 use candle::backend::BackendStorage;
@@ -17,6 +19,7 @@ use candle::cuda_backend::cudarc::driver::{DevicePtr, DevicePtrMut};
 use candle::DType;
 use candle::{CpuStorage, Layout, Result, Shape, Tensor};
 use half::{bf16, f16};
+use rayon::prelude::*;
 
 pub struct DecodeAttention {
     pub softmax_scale: f32,
@@ -26,8 +29,10 @@ pub struct DecodeAttention {
 /// per sequence, with grouped-query attention (`num_heads` a multiple of `num_heads_kv`).
 ///
 /// Computes in f32 regardless of the storage type for numerical stability, honoring the
-/// arbitrary strides/offsets of the input layouts.
-fn cpu_decode_attention<T: Copy>(
+/// arbitrary strides/offsets of the input layouts. The independent `(batch, head)` outputs
+/// are computed in parallel with rayon, which matters on the many-core CPUs (incl. Apple
+/// Silicon) this serves as a fallback for.
+fn cpu_decode_attention<T: Copy + Send + Sync>(
     softmax_scale: f32,
     q: &[T],
     q_l: &Layout,
@@ -35,8 +40,8 @@ fn cpu_decode_attention<T: Copy>(
     k_l: &Layout,
     v: &[T],
     v_l: &Layout,
-    to_f32: impl Fn(T) -> f32,
-    from_f32: impl Fn(f32) -> T,
+    to_f32: impl Fn(T) -> f32 + Sync,
+    from_f32: impl Fn(f32) -> T + Sync,
 ) -> Result<(Vec<T>, Shape)> {
     let (b_sz, num_heads, head_dim) = q_l.shape().dims3()?;
     let (b_sz_k, num_heads_k, seqlen_k, head_dim_k) = k_l.shape().dims4()?;
@@ -65,14 +70,19 @@ fn cpu_decode_attention<T: Copy>(
     let (v_o, v_s) = (v_l.start_offset(), v_l.stride());
 
     let mut out = vec![from_f32(0f32); b_sz * num_heads * head_dim];
-    let mut scores = vec![0f32; seqlen_k];
-    for bi in 0..b_sz {
-        for h in 0..num_heads {
+    // Each `(batch, head)` writes a disjoint `head_dim`-sized slice of `out`, so they can run
+    // concurrently. Chunk index `c` maps back to `bi = c / num_heads`, `h = c % num_heads`.
+    out.par_chunks_mut(head_dim)
+        .enumerate()
+        .for_each(|(c, out_chunk)| {
+            let bi = c / num_heads;
+            let h = c % num_heads;
             let h_kv = h / group;
             // scores[l] = scale * dot(q[bi, h], k[bi, h_kv, l]), tracking the max for a
             // numerically-stable softmax.
+            let mut scores = vec![0f32; seqlen_k];
             let mut max = f32::NEG_INFINITY;
-            for l in 0..seqlen_k {
+            for (l, score) in scores.iter_mut().enumerate() {
                 let mut dot = 0f32;
                 for i in 0..head_dim {
                     let qv = to_f32(q[q_o + bi * q_s[0] + h * q_s[1] + i * q_s[2]]);
@@ -80,7 +90,7 @@ fn cpu_decode_attention<T: Copy>(
                     dot += qv * kv;
                 }
                 let s = dot * softmax_scale;
-                scores[l] = s;
+                *score = s;
                 if s > max {
                     max = s;
                 }
@@ -93,16 +103,15 @@ fn cpu_decode_attention<T: Copy>(
             }
             let inv = if denom > 0f32 { 1f32 / denom } else { 0f32 };
             // out[bi, h, i] = sum_l softmax[l] * v[bi, h_kv, l, i]
-            for i in 0..head_dim {
+            for (i, out_i) in out_chunk.iter_mut().enumerate() {
                 let mut acc = 0f32;
-                for l in 0..seqlen_k {
+                for (l, &p) in scores.iter().enumerate() {
                     let vv = to_f32(v[v_o + bi * v_s[0] + h_kv * v_s[1] + l * v_s[2] + i * v_s[3]]);
-                    acc += scores[l] * vv;
+                    acc += p * vv;
                 }
-                out[(bi * num_heads + h) * head_dim + i] = from_f32(acc * inv);
+                *out_i = from_f32(acc * inv);
             }
-        }
-    }
+        });
     Ok((out, (b_sz, num_heads, head_dim).into()))
 }
 
@@ -254,6 +263,19 @@ impl candle::CustomOp3 for DecodeAttention {
                 "flashinfer-decode-attention cpu: q/k/v must share dtype (f32/f16/bf16)"
             ),
         }
+    }
+
+    #[cfg(feature = "metal")]
+    fn metal_fwd(
+        &self,
+        q: &candle::MetalStorage,
+        q_l: &Layout,
+        k: &candle::MetalStorage,
+        k_l: &Layout,
+        v: &candle::MetalStorage,
+        v_l: &Layout,
+    ) -> Result<(candle::MetalStorage, Shape)> {
+        metal::decode_attention_metal_fwd(self, q, q_l, k, k_l, v, v_l)
     }
 
     #[cfg(feature = "cuda")]

--- a/candle-flashinfer-kernels/src/lib.rs
+++ b/candle-flashinfer-kernels/src/lib.rs
@@ -6,18 +6,108 @@
 //! token, attending over an arbitrarily long key/value cache. The kernel here is a reference,
 //! numerically-stable implementation of that workload (the one FlashInfer's batch-decode
 //! kernels optimize); it is not a port of FlashInfer's own tensor-core/split-KV kernels.
+#[cfg(feature = "cuda")]
 mod ffi;
 
+#[cfg(feature = "cuda")]
 use candle::backend::BackendStorage;
+#[cfg(feature = "cuda")]
 use candle::cuda_backend::cudarc::driver::{DevicePtr, DevicePtrMut};
-use candle::{CpuStorage, DType, Layout, Result, Shape, Tensor};
+#[cfg(feature = "cuda")]
+use candle::DType;
+use candle::{CpuStorage, Layout, Result, Shape, Tensor};
 use half::{bf16, f16};
 
 pub struct DecodeAttention {
     pub softmax_scale: f32,
 }
 
+/// Reference CPU decode attention: `softmax(q @ k^T * scale) @ v` for a single query token
+/// per sequence, with grouped-query attention (`num_heads` a multiple of `num_heads_kv`).
+///
+/// Computes in f32 regardless of the storage type for numerical stability, honoring the
+/// arbitrary strides/offsets of the input layouts.
+fn cpu_decode_attention<T: Copy>(
+    softmax_scale: f32,
+    q: &[T],
+    q_l: &Layout,
+    k: &[T],
+    k_l: &Layout,
+    v: &[T],
+    v_l: &Layout,
+    to_f32: impl Fn(T) -> f32,
+    from_f32: impl Fn(f32) -> T,
+) -> Result<(Vec<T>, Shape)> {
+    let (b_sz, num_heads, head_dim) = q_l.shape().dims3()?;
+    let (b_sz_k, num_heads_k, seqlen_k, head_dim_k) = k_l.shape().dims4()?;
+    if k_l.shape() != v_l.shape() {
+        candle::bail!(
+            "shape mismatch between k {:?} and v {:?}",
+            k_l.shape(),
+            v_l.shape()
+        );
+    }
+    if b_sz_k != b_sz || head_dim_k != head_dim {
+        candle::bail!(
+            "shape mismatch between q {:?} and k {:?}",
+            q_l.shape(),
+            k_l.shape()
+        );
+    }
+    if num_heads % num_heads_k != 0 {
+        candle::bail!(
+            "number of kv heads {num_heads_k} must divide the number of query heads {num_heads}"
+        )
+    }
+    let group = num_heads / num_heads_k;
+    let (q_o, q_s) = (q_l.start_offset(), q_l.stride());
+    let (k_o, k_s) = (k_l.start_offset(), k_l.stride());
+    let (v_o, v_s) = (v_l.start_offset(), v_l.stride());
+
+    let mut out = vec![from_f32(0f32); b_sz * num_heads * head_dim];
+    let mut scores = vec![0f32; seqlen_k];
+    for bi in 0..b_sz {
+        for h in 0..num_heads {
+            let h_kv = h / group;
+            // scores[l] = scale * dot(q[bi, h], k[bi, h_kv, l]), tracking the max for a
+            // numerically-stable softmax.
+            let mut max = f32::NEG_INFINITY;
+            for l in 0..seqlen_k {
+                let mut dot = 0f32;
+                for i in 0..head_dim {
+                    let qv = to_f32(q[q_o + bi * q_s[0] + h * q_s[1] + i * q_s[2]]);
+                    let kv = to_f32(k[k_o + bi * k_s[0] + h_kv * k_s[1] + l * k_s[2] + i * k_s[3]]);
+                    dot += qv * kv;
+                }
+                let s = dot * softmax_scale;
+                scores[l] = s;
+                if s > max {
+                    max = s;
+                }
+            }
+            let mut denom = 0f32;
+            for s in scores.iter_mut() {
+                let e = (*s - max).exp();
+                *s = e;
+                denom += e;
+            }
+            let inv = if denom > 0f32 { 1f32 / denom } else { 0f32 };
+            // out[bi, h, i] = sum_l softmax[l] * v[bi, h_kv, l, i]
+            for i in 0..head_dim {
+                let mut acc = 0f32;
+                for l in 0..seqlen_k {
+                    let vv = to_f32(v[v_o + bi * v_s[0] + h_kv * v_s[1] + l * v_s[2] + i * v_s[3]]);
+                    acc += scores[l] * vv;
+                }
+                out[(bi * num_heads + h) * head_dim + i] = from_f32(acc * inv);
+            }
+        }
+    }
+    Ok((out, (b_sz, num_heads, head_dim).into()))
+}
+
 impl DecodeAttention {
+    #[cfg(feature = "cuda")]
     fn cuda_fwd_t<
         T: candle::cuda_backend::CudaDType + candle::cuda_backend::cudarc::driver::DeviceRepr,
     >(
@@ -118,16 +208,55 @@ impl candle::CustomOp3 for DecodeAttention {
 
     fn cpu_fwd(
         &self,
-        _: &CpuStorage,
-        _: &Layout,
-        _: &CpuStorage,
-        _: &Layout,
-        _: &CpuStorage,
-        _: &Layout,
+        q: &CpuStorage,
+        q_l: &Layout,
+        k: &CpuStorage,
+        k_l: &Layout,
+        v: &CpuStorage,
+        v_l: &Layout,
     ) -> Result<(CpuStorage, Shape)> {
-        candle::bail!("no cpu support for flashinfer-decode-attention")
+        let scale = self.softmax_scale;
+        match (q, k, v) {
+            (CpuStorage::F32(q), CpuStorage::F32(k), CpuStorage::F32(v)) => {
+                let (out, shape) =
+                    cpu_decode_attention(scale, q, q_l, k, k_l, v, v_l, |x| x, |x| x)?;
+                Ok((CpuStorage::F32(out), shape))
+            }
+            (CpuStorage::F16(q), CpuStorage::F16(k), CpuStorage::F16(v)) => {
+                let (out, shape) = cpu_decode_attention(
+                    scale,
+                    q,
+                    q_l,
+                    k,
+                    k_l,
+                    v,
+                    v_l,
+                    |x: f16| x.to_f32(),
+                    f16::from_f32,
+                )?;
+                Ok((CpuStorage::F16(out), shape))
+            }
+            (CpuStorage::BF16(q), CpuStorage::BF16(k), CpuStorage::BF16(v)) => {
+                let (out, shape) = cpu_decode_attention(
+                    scale,
+                    q,
+                    q_l,
+                    k,
+                    k_l,
+                    v,
+                    v_l,
+                    |x: bf16| x.to_f32(),
+                    bf16::from_f32,
+                )?;
+                Ok((CpuStorage::BF16(out), shape))
+            }
+            _ => candle::bail!(
+                "flashinfer-decode-attention cpu: q/k/v must share dtype (f32/f16/bf16)"
+            ),
+        }
     }
 
+    #[cfg(feature = "cuda")]
     fn cuda_fwd(
         &self,
         q: &candle::CudaStorage,
@@ -141,7 +270,9 @@ impl candle::CustomOp3 for DecodeAttention {
             DType::F32 => self.cuda_fwd_t::<f32>(q, q_l, k, k_l, v, v_l, 0),
             DType::F16 => self.cuda_fwd_t::<f16>(q, q_l, k, k_l, v, v_l, 1),
             DType::BF16 => self.cuda_fwd_t::<bf16>(q, q_l, k, k_l, v, v_l, 2),
-            dt => candle::bail!("flashinfer-decode-attention is only supported for f32/f16/bf16 ({dt:?})"),
+            dt => candle::bail!(
+                "flashinfer-decode-attention is only supported for f32/f16/bf16 ({dt:?})"
+            ),
         }
     }
 }

--- a/candle-flashinfer-kernels/src/metal.rs
+++ b/candle-flashinfer-kernels/src/metal.rs
@@ -1,0 +1,190 @@
+//! Metal backend for the single-token decode attention kernel.
+//!
+//! Mirrors the CUDA reference path (`decode_attention.cu`) on Apple Silicon: the kernel source
+//! (`kernels/decode_attention.metal`) is compiled at runtime the first time it runs on a given
+//! device and the resulting pipeline is cached per (device, function).
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use candle::backend::BackendStorage;
+use candle::metal_backend::DeviceId;
+use candle::{DType, Layout, MetalStorage, Result, Shape};
+use candle_metal_kernels::metal::{ComputeCommandEncoder, ComputePipeline};
+use objc2_metal::MTLSize;
+
+use crate::DecodeAttention;
+
+const KERNEL_SRC: &str = include_str!("../kernels/decode_attention.metal");
+
+/// Scalar arguments, laid out to match `struct DecodeParams` in `decode_attention.metal`
+/// (13 × i32 then 1 × f32).
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct DecodeParams {
+    hkv_group: i32,
+    seqlen_k: i32,
+    head_dim: i32,
+    q_b_stride: i32,
+    q_h_stride: i32,
+    k_b_stride: i32,
+    k_h_stride: i32,
+    k_l_stride: i32,
+    v_b_stride: i32,
+    v_h_stride: i32,
+    v_l_stride: i32,
+    o_b_stride: i32,
+    o_h_stride: i32,
+    scale: f32,
+}
+
+/// One compiled pipeline per (Metal device, kernel function), compiled on first use.
+fn pipeline_for(device: &candle::MetalDevice, function: &'static str) -> Result<ComputePipeline> {
+    static CACHE: OnceLock<Mutex<HashMap<(DeviceId, &'static str), ComputePipeline>>> =
+        OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let key = (device.id(), function);
+    {
+        let guard = cache.lock().unwrap();
+        if let Some(p) = guard.get(&key) {
+            return Ok(p.clone());
+        }
+    }
+    let mdev = device.metal_device();
+    let lib = mdev
+        .new_library_with_source(KERNEL_SRC, None)
+        .map_err(candle::Error::wrap)?;
+    let func = lib
+        .get_function(function, None)
+        .map_err(candle::Error::wrap)?;
+    let pipeline = mdev
+        .new_compute_pipeline_state_with_function(&func)
+        .map_err(candle::Error::wrap)?;
+    cache.lock().unwrap().insert(key, pipeline.clone());
+    Ok(pipeline)
+}
+
+fn offset_bytes(layout: &Layout, dtype: DType) -> usize {
+    layout.start_offset() * dtype.size_in_bytes()
+}
+
+pub(crate) fn decode_attention_metal_fwd(
+    op: &DecodeAttention,
+    q: &MetalStorage,
+    q_l: &Layout,
+    k: &MetalStorage,
+    k_l: &Layout,
+    v: &MetalStorage,
+    v_l: &Layout,
+) -> Result<(MetalStorage, Shape)> {
+    let function = match q.dtype() {
+        DType::F32 => "decode_attention_f32",
+        DType::F16 => "decode_attention_f16",
+        dt => {
+            candle::bail!("flashinfer-decode-attention (metal) only supports f32/f16, got {dt:?}")
+        }
+    };
+    if k.dtype() != q.dtype() || v.dtype() != q.dtype() {
+        candle::bail!(
+            "flashinfer-decode-attention (metal): q/k/v must share dtype ({:?}/{:?}/{:?})",
+            q.dtype(),
+            k.dtype(),
+            v.dtype()
+        );
+    }
+
+    let (b_sz, num_heads, head_dim) = q_l.shape().dims3()?;
+    let (b_sz_k, num_heads_k, seqlen_k, head_dim_k) = k_l.shape().dims4()?;
+    if k_l.shape() != v_l.shape() {
+        candle::bail!(
+            "shape mismatch between k {:?} and v {:?}",
+            k_l.shape(),
+            v_l.shape()
+        );
+    }
+    if b_sz_k != b_sz || head_dim_k != head_dim {
+        candle::bail!(
+            "shape mismatch between q {:?} and k {:?}",
+            q_l.shape(),
+            k_l.shape()
+        );
+    }
+    if num_heads % num_heads_k != 0 {
+        candle::bail!(
+            "number of kv heads {num_heads_k} must divide the number of query heads {num_heads}"
+        )
+    }
+    if head_dim > 1024 {
+        candle::bail!("flashinfer-decode-attention (metal): head_dim {head_dim} exceeds 1024");
+    }
+
+    let q_s = q_l.stride();
+    let k_s = k_l.stride();
+    let v_s = v_l.stride();
+    if q_s[2] != 1 {
+        candle::bail!("the head dimension of q must be contiguous {q_s:?}");
+    }
+    if k_s[3] != 1 {
+        candle::bail!("the head dimension of k must be contiguous {k_s:?}");
+    }
+    if v_s[3] != 1 {
+        candle::bail!("the head dimension of v must be contiguous {v_s:?}");
+    }
+
+    let device = q.device().clone();
+    let pipeline = pipeline_for(&device, function)?;
+    let elem_count = b_sz * num_heads * head_dim;
+    let output = device.new_buffer(elem_count, q.dtype(), "flashinfer-decode-out")?;
+
+    let params = DecodeParams {
+        hkv_group: (num_heads / num_heads_k) as i32,
+        seqlen_k: seqlen_k as i32,
+        head_dim: head_dim as i32,
+        q_b_stride: q_s[0] as i32,
+        q_h_stride: q_s[1] as i32,
+        k_b_stride: k_s[0] as i32,
+        k_h_stride: k_s[1] as i32,
+        k_l_stride: k_s[2] as i32,
+        v_b_stride: v_s[0] as i32,
+        v_h_stride: v_s[1] as i32,
+        v_l_stride: v_s[2] as i32,
+        o_b_stride: (num_heads * head_dim) as i32,
+        o_h_stride: head_dim as i32,
+        scale: op.softmax_scale,
+    };
+
+    // One threadgroup per (batch, query head); threads = next_pow2(head_dim), capped at 1024 to
+    // match the fixed-size threadgroup reduction buffer in the shader.
+    let mut threads = 1usize;
+    while threads < head_dim {
+        threads <<= 1;
+    }
+    if threads > 1024 {
+        threads = 1024;
+    }
+
+    let encoder = device.command_encoder()?;
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_label("flashinfer-decode-attention");
+    encoder.set_compute_pipeline_state(&pipeline);
+    encoder.set_input_buffer(0, Some(q.buffer()), offset_bytes(q_l, q.dtype()));
+    encoder.set_input_buffer(1, Some(k.buffer()), offset_bytes(k_l, k.dtype()));
+    encoder.set_input_buffer(2, Some(v.buffer()), offset_bytes(v_l, v.dtype()));
+    encoder.set_output_buffer(3, Some(output.as_ref()), 0);
+    encoder.set_bytes(4, &params);
+
+    let groups = MTLSize {
+        width: num_heads,
+        height: b_sz,
+        depth: 1,
+    };
+    let threads_per_group = MTLSize {
+        width: threads,
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_thread_groups(groups, threads_per_group);
+
+    let out = MetalStorage::new(output, device.clone(), elem_count, q.dtype());
+    Ok((out, q_l.shape().clone()))
+}

--- a/candle-flashinfer-kernels/tests/decode_attention_tests.rs
+++ b/candle-flashinfer-kernels/tests/decode_attention_tests.rs
@@ -65,3 +65,10 @@ fn decode_attention_cuda_matches_reference() -> Result<()> {
     };
     run_case(&device)
 }
+
+#[cfg(feature = "metal")]
+#[test]
+fn decode_attention_metal_matches_reference() -> Result<()> {
+    let device = Device::new_metal(0)?;
+    run_case(&device)
+}

--- a/candle-flashinfer-kernels/tests/decode_attention_tests.rs
+++ b/candle-flashinfer-kernels/tests/decode_attention_tests.rs
@@ -2,6 +2,13 @@ use anyhow::Result;
 use candle::{DType, Device, Tensor, D};
 use candle_flashinfer_kernels::flashinfer_decode_attention;
 
+fn softmax_last_dim(att: &Tensor) -> Result<Tensor> {
+    let max = att.max_keepdim(D::Minus1)?;
+    let e = att.broadcast_sub(&max)?.exp()?;
+    let sum = e.sum_keepdim(D::Minus1)?;
+    Ok(e.broadcast_div(&sum)?)
+}
+
 // Naive reference: softmax(q @ k^T * scale) @ v, with q holding a single query token per
 // sequence and k/v fewer heads than q (grouped-query attention) repeated to match.
 fn decode_attention_reference(
@@ -25,22 +32,16 @@ fn decode_attention_reference(
         .to_dtype(DType::F32)?;
     let q = q.to_dtype(DType::F32)?.unsqueeze(2)?; // (b, hq, 1, d)
     let att = (q.matmul(&k.transpose(D::Minus1, D::Minus2)?)? * softmax_scale as f64)?;
-    let att = candle_nn::ops::softmax(&att, D::Minus1)?;
+    let att = softmax_last_dim(&att)?;
     let out = att.matmul(&v)?.squeeze(2)?;
     Ok(out)
 }
 
-#[test]
-fn decode_attention_matches_reference() -> Result<()> {
-    let device = match Device::new_cuda(0) {
-        Ok(device) => device,
-        Err(_) => return Ok(()),
-    };
-
+fn run_case(device: &Device) -> Result<()> {
     let (b, hq, hkv, lk, d) = (2usize, 4usize, 2usize, 17usize, 32usize);
-    let q = Tensor::randn(0f32, 1f32, (b, hq, d), &device)?;
-    let k = Tensor::randn(0f32, 1f32, (b, hkv, lk, d), &device)?;
-    let v = Tensor::randn(0f32, 1f32, (b, hkv, lk, d), &device)?;
+    let q = Tensor::randn(0f32, 1f32, (b, hq, d), device)?;
+    let k = Tensor::randn(0f32, 1f32, (b, hkv, lk, d), device)?;
+    let v = Tensor::randn(0f32, 1f32, (b, hkv, lk, d), device)?;
     let scale = 1f32 / (d as f32).sqrt();
 
     let got = flashinfer_decode_attention(&q, &k, &v, scale)?;
@@ -49,4 +50,18 @@ fn decode_attention_matches_reference() -> Result<()> {
     let diff = (got - want)?.abs()?.max_all()?.to_scalar::<f32>()?;
     assert!(diff < 1e-3, "max abs diff {diff}");
     Ok(())
+}
+
+#[test]
+fn decode_attention_cpu_matches_reference() -> Result<()> {
+    run_case(&Device::Cpu)
+}
+
+#[test]
+fn decode_attention_cuda_matches_reference() -> Result<()> {
+    let device = match Device::new_cuda(0) {
+        Ok(device) => device,
+        Err(_) => return Ok(()),
+    };
+    run_case(&device)
 }

--- a/candle-flashinfer-kernels/tests/decode_attention_tests.rs
+++ b/candle-flashinfer-kernels/tests/decode_attention_tests.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+use candle::{DType, Device, Tensor, D};
+use candle_flashinfer_kernels::flashinfer_decode_attention;
+
+// Naive reference: softmax(q @ k^T * scale) @ v, with q holding a single query token per
+// sequence and k/v fewer heads than q (grouped-query attention) repeated to match.
+fn decode_attention_reference(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    softmax_scale: f32,
+) -> Result<Tensor> {
+    let (b, hq, d) = q.dims3()?;
+    let (_, hkv, lk, _) = k.dims4()?;
+    let group = hq / hkv;
+    let k = k
+        .unsqueeze(2)?
+        .broadcast_as((b, hkv, group, lk, d))?
+        .reshape((b, hq, lk, d))?
+        .to_dtype(DType::F32)?;
+    let v = v
+        .unsqueeze(2)?
+        .broadcast_as((b, hkv, group, lk, d))?
+        .reshape((b, hq, lk, d))?
+        .to_dtype(DType::F32)?;
+    let q = q.to_dtype(DType::F32)?.unsqueeze(2)?; // (b, hq, 1, d)
+    let att = (q.matmul(&k.transpose(D::Minus1, D::Minus2)?)? * softmax_scale as f64)?;
+    let att = candle_nn::ops::softmax(&att, D::Minus1)?;
+    let out = att.matmul(&v)?.squeeze(2)?;
+    Ok(out)
+}
+
+#[test]
+fn decode_attention_matches_reference() -> Result<()> {
+    let device = match Device::new_cuda(0) {
+        Ok(device) => device,
+        Err(_) => return Ok(()),
+    };
+
+    let (b, hq, hkv, lk, d) = (2usize, 4usize, 2usize, 17usize, 32usize);
+    let q = Tensor::randn(0f32, 1f32, (b, hq, d), &device)?;
+    let k = Tensor::randn(0f32, 1f32, (b, hkv, lk, d), &device)?;
+    let v = Tensor::randn(0f32, 1f32, (b, hkv, lk, d), &device)?;
+    let scale = 1f32 / (d as f32).sqrt();
+
+    let got = flashinfer_decode_attention(&q, &k, &v, scale)?;
+    let want = decode_attention_reference(&q, &k, &v, scale)?;
+
+    let diff = (got - want)?.abs()?.max_all()?.to_scalar::<f32>()?;
+    assert!(diff < 1e-3, "max abs diff {diff}");
+    Ok(())
+}


### PR DESCRIPTION
## What this does

Implements both halves of #3651:

1. **CUDA Graph capture/replay for autoregressive decode** — a new
   `candle_core::CudaGraph` API that captures the fixed-shape sequence of
   kernels issued during a decode step once and replays it with a single
   `cuGraphLaunch`, avoiding per-token launch overhead.

2. **Optional FlashInfer-style decode-attention backend** — a new
   `candle-flashinfer-kernels` crate exposing
   `flashinfer_decode_attention(q, k, v, scale)` for the single-new-token
   decode workload (one query token per sequence attending over a KV cache,
   GQA supported). This is a reference, numerically-stable (streaming softmax)
   kernel with the same shape contract FlashInfer's batch-decode kernels
   target — not a port of their tensor-core/split-KV kernels.

## CudaGraph (candle-core)

- `CudaGraph::capture(device, |f|)` / `replay()` built on the raw driver API
  (`cuStreamBeginCapture_v2` / `cuStreamEndCapture` / `cuGraphInstantiateWithFlags`
  / `cuGraphLaunch`).
- Event tracking is paused during capture: candle drives cudarc in multi-stream
  mode, so every launch would otherwise emit `cuStreamWaitEvent`/`cuEventRecord`
  against per-tensor dependency events, which is illegal during capture
  (`CUDA_ERROR_INVALID_VALUE`).
- Documented usage constraints: callers must (a) warm up the ops once before
  capturing so module loads / HtoD uploads don't happen mid-capture, and
  (b) write into **persistent, pre-allocated** buffers — a tensor allocated
  inside the closure becomes a graph-owned allocation node whose memory is only
  valid during a replay.

## FlashInfer decode-attention backend

- **CUDA** kernel (`f32`/`f16`/`bf16`), one block per `(batch, query head)`.
- **Metal** kernel for Apple Silicon (`f32`/`f16`), compiled at runtime; mirrors
  the CUDA path (threadgroup-reduced dot product + streaming softmax).
- **CPU** reference `cpu_fwd` (`f32`/`f16`/`bf16`, GQA, stride/offset aware),
  parallelized across `(batch, head)` with rayon.
- `cuda` and `metal` are **opt-in features**; with neither, the crate builds
  CPU-only (no toolchain needed) and the CPU fallback runs. This also lets the
  workspace build without a CUDA toolchain.

## Testing

- **CUDA**: `cuda_graph_tests` and the decode-attention kernel validated on a
  real GPU runner (`ci_cuda.yaml`).
- **Metal**: decode-attention validated on a GitHub-hosted `macos-15` Apple
  Silicon runner with `CANDLE_METAL_REQUIRED=1` (`ci_metal.yaml`).
- **CPU**: `decode_attention_cpu_matches_reference` runs everywhere, no GPU
  required.

Closes #3651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)