### PR TITLE
Support linear Resize in candle-onnx

### DIFF
--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -2284,7 +2284,7 @@ fn simple_eval_(
                 let input = get(&node.input[0])?;
 
                 if input.rank() != 4 {
-                    bail!("Unsupported rank for nearest resize: {}", input.rank());
+                    bail!("Unsupported rank for resize: {}", input.rank());
                 }
 
                 let scales = if node.input.len() > 2 && !node.input[2].is_empty() {
@@ -2329,24 +2329,40 @@ fn simple_eval_(
                 let nearest_mode =
                     get_attr_opt::<str>(node, "nearest_mode")?.unwrap_or("round_prefer_floor");
 
-                if mode != "nearest" {
-                    bail!("Unsupported resize mode: {}", mode);
-                }
-
-                if nearest_mode != "floor" {
-                    bail!("Unsupported nearest_mode for resize: {}", nearest_mode);
-                }
-
-                if coordinate_transformation_mode != "asymmetric" {
-                    bail!(
-                        "Unsupported coordinate_transformation_mode for resize: {}",
-                        coordinate_transformation_mode
-                    );
+                if output_dims.len() != 4 {
+                    bail!("Resize expects 4 output dimensions, got {output_dims:?}");
                 }
 
                 let h = output_dims[2];
                 let w = output_dims[3];
-                let output = input.upsample_nearest2d(h, w)?;
+                let output = match mode {
+                    "nearest" => {
+                        if nearest_mode != "floor" {
+                            bail!("Unsupported nearest_mode for resize: {}", nearest_mode);
+                        }
+
+                        if coordinate_transformation_mode != "asymmetric" {
+                            bail!(
+                                "Unsupported coordinate_transformation_mode for resize: {}",
+                                coordinate_transformation_mode
+                            );
+                        }
+
+                        input.upsample_nearest2d(h, w)?
+                    }
+                    "linear" => {
+                        let align_corners = match coordinate_transformation_mode {
+                            "half_pixel" => false,
+                            "align_corners" => true,
+                            mode => bail!(
+                                "Unsupported coordinate_transformation_mode for linear resize: {}",
+                                mode
+                            ),
+                        };
+                        input.upsample_bilinear2d(h, w, align_corners)?
+                    }
+                    mode => bail!("Unsupported resize mode: {}", mode),
+                };
 
                 values.insert(node.output[0].clone(), output);
             }

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -6521,6 +6521,106 @@ fn test_hard_swish() -> candle::Result<()> {
     Ok(())
 }
 
+fn resize_linear_graph(coordinate_transformation_mode: &str) -> ModelProto {
+    create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "Resize".to_string(),
+            input: vec![
+                INPUT_X.to_string(),
+                "".to_string(),
+                "".to_string(),
+                "sizes".to_string(),
+            ],
+            output: vec![OUTPUT_Z.to_string()],
+            attribute: vec![
+                AttributeProto {
+                    name: "mode".to_string(),
+                    r#type: AttributeType::String.into(),
+                    s: b"linear".to_vec(),
+                    ..Default::default()
+                },
+                AttributeProto {
+                    name: "coordinate_transformation_mode".to_string(),
+                    r#type: AttributeType::String.into(),
+                    s: coordinate_transformation_mode.as_bytes().to_vec(),
+                    ..Default::default()
+                },
+                AttributeProto {
+                    name: "nearest_mode".to_string(),
+                    r#type: AttributeType::String.into(),
+                    s: b"floor".to_vec(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }],
+        input: vec![
+            ValueInfoProto {
+                name: INPUT_X.to_string(),
+                ..Default::default()
+            },
+            ValueInfoProto {
+                name: "sizes".to_string(),
+                ..Default::default()
+            },
+        ],
+        output: vec![ValueInfoProto {
+            name: OUTPUT_Z.to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }))
+}
+
+fn assert_resize_linear(
+    coordinate_transformation_mode: &str,
+    sizes: [i64; 4],
+    expected_dims: &[usize],
+    expected: &[f32],
+) -> Result<()> {
+    let x = Tensor::from_vec(vec![1.0f32, 2.0, 3.0, 4.0], (1, 1, 2, 2), &Device::Cpu)?;
+    let sizes = Tensor::from_vec(sizes.to_vec(), (4,), &Device::Cpu)?;
+    let inputs = HashMap::from_iter([(INPUT_X.to_string(), x), ("sizes".to_string(), sizes)]);
+
+    let outputs = simple_eval(&resize_linear_graph(coordinate_transformation_mode), inputs)?;
+    let output = outputs.get(OUTPUT_Z).expect("missing output Z");
+    assert_eq!(output.dims(), expected_dims);
+
+    let actual = output.flatten_all()?.to_vec1::<f32>()?;
+    assert_eq!(actual.len(), expected.len());
+    for (idx, (actual, expected)) in actual.iter().zip(expected.iter()).enumerate() {
+        let diff = (actual - expected).abs();
+        assert!(
+            diff < 1e-6,
+            "Mismatch at index {idx}: got {actual}, expected {expected}, diff={diff}"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_resize_linear_half_pixel() -> Result<()> {
+    assert_resize_linear(
+        "half_pixel",
+        [1, 1, 4, 4],
+        &[1, 1, 4, 4],
+        &[
+            1.0, 1.25, 1.75, 2.0, 1.5, 1.75, 2.25, 2.5, 2.5, 2.75, 3.25, 3.5, 3.0, 3.25, 3.75, 4.0,
+        ],
+    )
+}
+
+#[test]
+fn test_resize_linear_align_corners() -> Result<()> {
+    assert_resize_linear(
+        "align_corners",
+        [1, 1, 3, 3],
+        &[1, 1, 3, 3],
+        &[1.0, 1.5, 2.0, 2.0, 2.5, 3.0, 3.0, 3.5, 4.0],
+    )
+}
+
 #[test]
 fn test_scatternd_operation() -> Result<()> {
     // Example 1 based on ONNX documentation


### PR DESCRIPTION
## Summary

Closes #3153.

This adds `linear` mode support for the 4D `Resize` operator in `candle-onnx`'s `simple_eval` path.

- keeps the existing `nearest` path and its current constraints unchanged
- maps `mode="linear"` + `coordinate_transformation_mode="half_pixel"` to `Tensor::upsample_bilinear2d(..., align_corners=false)`
- maps `mode="linear"` + `coordinate_transformation_mode="align_corners"` to `Tensor::upsample_bilinear2d(..., align_corners=true)`
- continues to reject unsupported `linear` coordinate transformation modes explicitly

## Tests

Added focused ONNX op tests in `candle-onnx/tests/ops.rs` for:

- `Resize` with `mode="linear"` and `coordinate_transformation_mode="half_pixel"`
- `Resize` with `mode="linear"` and `coordinate_transformation_mode="align_corners"`

Before the source change, the `half_pixel` regression test failed with:

```text
Unsupported resize mode: linear
```

After the change, the focused resize tests pass.

## Validation

Passed:

```sh
cargo test --manifest-path candle-onnx/Cargo.toml --test ops resize_linear
cargo test --manifest-path candle-onnx/Cargo.toml --test ops -- --skip test_gelu_operation
cargo test --manifest-path candle-onnx/Cargo.toml --lib
cargo fmt --manifest-path candle-onnx/Cargo.toml -- --check
git --no-pager diff --check
```

Notes:

- `cargo test --manifest-path candle-onnx/Cargo.toml` currently fails in unrelated `test_gelu_operation` due exact float equality (`0.8413447` vs `0.8413448`).
- `cargo clippy --manifest-path candle-onnx/Cargo.toml --tests -- -D warnings` is currently blocked by pre-existing generated-code/test lints in `candle-onnx`, not by this patch.

## Blast radius

This only changes the `Resize` arm in `candle-onnx/src/eval.rs`.

Existing `nearest` behavior remains constrained to the previous supported path (`nearest_mode="floor"`, `coordinate_transformation_mode="asymmetric"`). The new behavior is limited to 4D linear resize using Candle's existing bilinear resize primitive.
