### PR TITLE
Support ONNX Mod

### DIFF
--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -231,6 +231,66 @@ pub fn get_tensor(t: &onnx::TensorProto, name: &str) -> Result<Tensor> {
     }
 }
 
+fn python_mod_i64(lhs: i64, rhs: i64) -> Result<i64> {
+    if rhs == 0 {
+        bail!("Mod divisor contains zero")
+    }
+    if lhs == i64::MIN && rhs == -1 {
+        return Ok(0);
+    }
+    let rem = lhs % rhs;
+    if rem != 0 && ((rem < 0) != (rhs < 0)) {
+        Ok(rem + rhs)
+    } else {
+        Ok(rem)
+    }
+}
+
+fn onnx_mod(lhs: &Tensor, rhs: &Tensor, fmod: bool) -> Result<Tensor> {
+    if lhs.dtype() != rhs.dtype() {
+        bail!(
+            "Mod inputs must have the same dtype, got {:?} and {:?}",
+            lhs.dtype(),
+            rhs.dtype()
+        )
+    }
+    let dtype = lhs.dtype();
+    let device = lhs.device();
+    let shape = broadcast_shape(lhs.dims(), rhs.dims())?;
+    let lhs = lhs.broadcast_as(shape.clone())?;
+    let rhs = rhs.broadcast_as(shape.clone())?;
+
+    match (fmod, dtype) {
+        (false, DType::U8 | DType::U32 | DType::I16 | DType::I32 | DType::I64) => {
+            let lhs = lhs.to_dtype(DType::I64)?.flatten_all()?.to_vec1::<i64>()?;
+            let rhs = rhs.to_dtype(DType::I64)?.flatten_all()?.to_vec1::<i64>()?;
+            let output = lhs
+                .iter()
+                .zip(rhs.iter())
+                .map(|(&lhs, &rhs)| python_mod_i64(lhs, rhs))
+                .collect::<Result<Vec<_>>>()?;
+            Tensor::from_vec(output, shape.as_slice(), device)?.to_dtype(dtype)
+        }
+        (false, DType::BF16 | DType::F16 | DType::F32 | DType::F64) => {
+            bail!("Mod with fmod=0 only supports integer dtypes, got {dtype:?}")
+        }
+        (true, DType::BF16 | DType::F16 | DType::F32 | DType::F64) => {
+            let lhs = lhs.to_dtype(DType::F64)?.flatten_all()?.to_vec1::<f64>()?;
+            let rhs = rhs.to_dtype(DType::F64)?.flatten_all()?.to_vec1::<f64>()?;
+            let output = lhs
+                .iter()
+                .zip(rhs.iter())
+                .map(|(&lhs, &rhs)| lhs % rhs)
+                .collect::<Vec<_>>();
+            Tensor::from_vec(output, shape.as_slice(), device)?.to_dtype(dtype)
+        }
+        (true, DType::U8 | DType::U32 | DType::I16 | DType::I32 | DType::I64) => {
+            bail!("Mod with fmod=1 only supports floating dtypes, got {dtype:?}")
+        }
+        (_, dtype) => bail!("unsupported dtype {dtype:?} for Mod"),
+    }
+}
+
 // This function provides a direct evaluation of the proto.
 // Longer-term, we should first convert the proto to an intermediate representation of the compute
 // graph so as to make multiple evaluations more efficient.
@@ -356,6 +416,18 @@ fn simple_eval_(
                 let input0 = get(&node.input[0])?;
                 let input1 = get(&node.input[1])?;
                 let output = input0.broadcast_div(input1)?;
+                values.insert(node.output[0].clone(), output);
+            }
+            "Mod" => {
+                // https://onnx.ai/onnx/operators/onnx__Mod.html
+                let input0 = get(&node.input[0])?;
+                let input1 = get(&node.input[1])?;
+                let fmod = match get_attr_opt::<i64>(node, "fmod")?.copied().unwrap_or(0) {
+                    0 => false,
+                    1 => true,
+                    value => bail!("unsupported Mod fmod value {value}"),
+                };
+                let output = onnx_mod(input0, input1, fmod)?;
                 values.insert(node.output[0].clone(), output);
             }
             "Pow" => {

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -200,6 +200,100 @@ fn test_div_operation() -> Result<()> {
     Ok(())
 }
 
+// "Mod"
+#[test]
+fn test_mod_operation() -> Result<()> {
+    fn attr_int(name: &str, i: i64) -> AttributeProto {
+        AttributeProto {
+            name: name.to_string(),
+            r#type: AttributeType::Int.into(),
+            i,
+            ..AttributeProto::default()
+        }
+    }
+
+    fn test_i64(a: impl NdArray, b: impl NdArray, expected: impl NdArray) -> Result<()> {
+        let model = create_model_proto_with_graph(Some(GraphProto {
+            node: vec![NodeProto {
+                op_type: "Mod".to_string(),
+                attribute: vec![],
+                input: vec![INPUT_X.to_string(), INPUT_Y.to_string()],
+                output: vec![OUTPUT_Z.to_string()],
+                ..NodeProto::default()
+            }],
+            output: vec![ValueInfoProto {
+                name: OUTPUT_Z.to_string(),
+                ..ValueInfoProto::default()
+            }],
+            ..GraphProto::default()
+        }));
+
+        let inputs = HashMap::from_iter([
+            (INPUT_X.to_string(), Tensor::new(a, &Device::Cpu)?),
+            (INPUT_Y.to_string(), Tensor::new(b, &Device::Cpu)?),
+        ]);
+        let eval = simple_eval(&model, inputs)?;
+        let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+        let expected = Tensor::new(expected, &Device::Cpu)?;
+        assert_eq!(z.dims(), expected.dims());
+        assert_eq!(
+            z.flatten_all()?.to_vec1::<i64>()?,
+            expected.flatten_all()?.to_vec1::<i64>()?
+        );
+        Ok(())
+    }
+
+    fn test_f32(a: impl NdArray, b: impl NdArray, expected: impl NdArray) -> Result<()> {
+        let model = create_model_proto_with_graph(Some(GraphProto {
+            node: vec![NodeProto {
+                op_type: "Mod".to_string(),
+                attribute: vec![attr_int("fmod", 1)],
+                input: vec![INPUT_X.to_string(), INPUT_Y.to_string()],
+                output: vec![OUTPUT_Z.to_string()],
+                ..NodeProto::default()
+            }],
+            output: vec![ValueInfoProto {
+                name: OUTPUT_Z.to_string(),
+                ..ValueInfoProto::default()
+            }],
+            ..GraphProto::default()
+        }));
+
+        let inputs = HashMap::from_iter([
+            (INPUT_X.to_string(), Tensor::new(a, &Device::Cpu)?),
+            (INPUT_Y.to_string(), Tensor::new(b, &Device::Cpu)?),
+        ]);
+        let eval = simple_eval(&model, inputs)?;
+        let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
+        let expected = Tensor::new(expected, &Device::Cpu)?;
+        assert_eq!(z.dims(), expected.dims());
+        assert_eq!(
+            z.flatten_all()?.to_vec1::<f32>()?,
+            expected.flatten_all()?.to_vec1::<f32>()?
+        );
+        Ok(())
+    }
+
+    // fmod=0 follows Python % semantics: the result has the divisor sign.
+    test_i64(&[-5i64, -4, 5, 4], &[3i64, 3, -3, -3], &[1i64, 2, -1, -2])?;
+
+    // Multidirectional broadcasting is required by ONNX Mod.
+    test_i64(
+        &[[5i64, 6, 7], [8, 9, 10]],
+        &[2i64, 4, 5],
+        &[[1i64, 2, 2], [0, 1, 0]],
+    )?;
+
+    // fmod=1 follows C fmod semantics: the result has the dividend sign.
+    test_f32(
+        &[-5.5f32, 5.5, -5.5, 5.5],
+        &[2.0f32, 2.0, -2.0, -2.0],
+        &[-1.5f32, 1.5, -1.5, 1.5],
+    )?;
+
+    Ok(())
+}
+
 // "Exp"
 #[test]
 fn test_exp_operation() -> Result<()> {


### PR DESCRIPTION
## Summary

- add support for the ONNX `Mod` operator in `candle-onnx`
- support integer `fmod=0` semantics matching Python `%` where the result sign follows the divisor
- support floating `fmod=1` semantics where the result sign follows the dividend
- support ONNX multidirectional broadcasting for `Mod`

Fixes #2419

## Notes

This keeps the implementation local to `candle-onnx` instead of adding a broader `candle-core` remainder primitive. The issue is an ONNX evaluator unsupported-op gap, and the implementation follows the ONNX `Mod` spec for the supported dtype/`fmod` combinations.

## Tests

- `cargo test --manifest-path candle-onnx/Cargo.toml --test ops test_mod_operation`
- `cargo test --manifest-path candle-onnx/Cargo.toml --test ops -- --skip test_gelu_operation`
- `cargo test --manifest-path candle-onnx/Cargo.toml --lib`
- `cargo check --manifest-path candle-onnx/Cargo.toml`
- `cargo fmt --manifest-path candle-onnx/Cargo.toml -- --check`
- `git --no-pager diff --check`

`test_gelu_operation` is skipped in the broader ops run because it currently has an unrelated exact-float mismatch in this checkout.
