### PR TITLE
Support ONNX DynamicQuantizeLinear

### DIFF
--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -358,6 +358,19 @@ fn simple_eval_(
                 let output = input0.broadcast_div(input1)?;
                 values.insert(node.output[0].clone(), output);
             }
+            "DynamicQuantizeLinear" => {
+                if node.output.len() != 3 {
+                    bail!(
+                        "DynamicQuantizeLinear expects 3 outputs, got {}",
+                        node.output.len()
+                    )
+                }
+                let input = get(&node.input[0])?;
+                let (y, y_scale, y_zero_point) = dynamic_quantize_linear(input)?;
+                values.insert(node.output[0].clone(), y);
+                values.insert(node.output[1].clone(), y_scale);
+                values.insert(node.output[2].clone(), y_zero_point);
+            }
             "Pow" => {
                 let input0 = get(&node.input[0])?;
                 let input1 = get(&node.input[1])?;
@@ -2558,6 +2571,62 @@ fn simple_eval_(
             Some(value) => Ok((output.name.clone(), value)),
         })
         .collect()
+}
+
+fn round_ties_to_even(v: f32) -> f32 {
+    let floor = v.floor();
+    let fraction = v - floor;
+    if fraction < 0.5 {
+        floor
+    } else if fraction > 0.5 {
+        floor + 1.0
+    } else if floor as i64 % 2 == 0 {
+        floor
+    } else {
+        floor + 1.0
+    }
+}
+
+fn dynamic_quantize_linear(input: &Tensor) -> Result<(Tensor, Tensor, Tensor)> {
+    if input.dtype() != DType::F32 {
+        bail!(
+            "DynamicQuantizeLinear expects F32 input, got {:?}",
+            input.dtype()
+        )
+    }
+
+    let input_data = input.flatten_all()?.to_vec1::<f32>()?;
+    if input_data.is_empty() {
+        bail!("DynamicQuantizeLinear does not support empty input")
+    }
+
+    let mut x_min = f32::INFINITY;
+    let mut x_max = f32::NEG_INFINITY;
+    for &v in input_data.iter() {
+        if v < x_min {
+            x_min = v;
+        }
+        if v > x_max {
+            x_max = v;
+        }
+    }
+
+    let x_min = x_min.min(0.0);
+    let x_max = x_max.max(0.0);
+    let range = if x_max == x_min { 1.0 } else { x_max - x_min };
+    let y_scale = range / 255.0;
+    let zero_point = round_ties_to_even((-x_min / y_scale).clamp(0.0, 255.0)) as u8;
+    let zero_point_f32 = zero_point as f32;
+
+    let output = input_data
+        .iter()
+        .map(|&v| (round_ties_to_even(v / y_scale) + zero_point_f32).clamp(0.0, 255.0) as u8)
+        .collect::<Vec<_>>();
+
+    let output = Tensor::from_vec(output, input.shape(), input.device())?;
+    let y_scale = Tensor::new(y_scale, input.device())?;
+    let y_zero_point = Tensor::new(zero_point, input.device())?;
+    Ok((output, y_scale, y_zero_point))
 }
 
 fn broadcast_shape(shape_a: &[usize], shape_b: &[usize]) -> Result<Vec<usize>> {

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -3790,6 +3790,118 @@ fn test_min() -> Result<()> {
     Ok(())
 }
 
+// "DynamicQuantizeLinear"
+#[test]
+fn test_dynamic_quantize_linear() -> Result<()> {
+    test(
+        &[0f32, 2., -3., -2.5, 1.34, 0.5],
+        &[153u8, 255, 0, 26, 221, 179],
+        0.019607844,
+        153,
+    )?;
+    test(
+        &[-1f32, -2.1, -1.3, -2.5, -3.34, -4.],
+        &[191u8, 121, 172, 96, 42, 0],
+        0.015686275,
+        255,
+    )?;
+    test(
+        &[
+            [1f32, 2.1, 1.3, 2.5],
+            [3.34, 4., 1.5, 2.6],
+            [3.9, 4., 3., 2.345],
+        ],
+        &[
+            [64u8, 134, 83, 159],
+            [213, 255, 96, 166],
+            [249, 255, 191, 149],
+        ],
+        0.015686275,
+        0,
+    )?;
+    test(&[0f32, 0.], &[0u8, 0], 0.003921569, 0)?;
+    test(&[0.0019607844f32, 1.], &[0u8, 255], 0.003921569, 0)?;
+
+    fn test(
+        input: impl NdArray,
+        expected_y: impl NdArray,
+        expected_scale: f32,
+        expected_zero_point: u8,
+    ) -> Result<()> {
+        let manual_graph = create_model_proto_with_graph(Some(GraphProto {
+            node: vec![NodeProto {
+                op_type: "DynamicQuantizeLinear".to_string(),
+                domain: "".to_string(),
+                attribute: vec![],
+                input: vec![INPUT_X.to_string()],
+                output: vec![
+                    "y".to_string(),
+                    "y_scale".to_string(),
+                    "y_zero_point".to_string(),
+                ],
+                name: "".to_string(),
+                doc_string: "".to_string(),
+            }],
+            name: "".to_string(),
+            initializer: vec![],
+            input: vec![],
+            output: vec![
+                ValueInfoProto {
+                    name: "y".to_string(),
+                    doc_string: "".to_string(),
+                    r#type: None,
+                },
+                ValueInfoProto {
+                    name: "y_scale".to_string(),
+                    doc_string: "".to_string(),
+                    r#type: None,
+                },
+                ValueInfoProto {
+                    name: "y_zero_point".to_string(),
+                    doc_string: "".to_string(),
+                    r#type: None,
+                },
+            ],
+            value_info: vec![],
+            doc_string: "".to_string(),
+            sparse_initializer: vec![],
+            quantization_annotation: vec![],
+        }));
+
+        let mut inputs: HashMap<String, Tensor> = HashMap::new();
+        inputs.insert(INPUT_X.to_string(), Tensor::new(input, &Device::Cpu)?);
+
+        let eval = simple_eval(&manual_graph, inputs)?;
+        assert_eq!(eval.len(), 3);
+
+        let y = eval.get("y").expect("Output 'y' not found");
+        let expected_y = Tensor::new(expected_y, &Device::Cpu)?;
+        assert_eq!(y.dtype(), DType::U8);
+        assert_eq!(y.dims(), expected_y.dims());
+        assert_eq!(
+            y.flatten_all()?.to_vec1::<u8>()?,
+            expected_y.flatten_all()?.to_vec1::<u8>()?
+        );
+
+        let y_scale = eval.get("y_scale").expect("Output 'y_scale' not found");
+        assert_eq!(y_scale.dtype(), DType::F32);
+        assert!(y_scale.dims().is_empty());
+        let actual_scale = y_scale.to_vec0::<f32>()?;
+        assert!((actual_scale - expected_scale).abs() < 1e-7);
+
+        let y_zero_point = eval
+            .get("y_zero_point")
+            .expect("Output 'y_zero_point' not found");
+        assert_eq!(y_zero_point.dtype(), DType::U8);
+        assert!(y_zero_point.dims().is_empty());
+        assert_eq!(y_zero_point.to_vec0::<u8>()?, expected_zero_point);
+
+        Ok(())
+    }
+
+    Ok(())
+}
+
 // "Where"
 #[test]
 fn test_where() -> Result<()> {


### PR DESCRIPTION
## Summary

Adds `DynamicQuantizeLinear` support to `candle-onnx`.

This implements the ONNX v11 function semantics for F32 input to U8 output:
- computes the adjusted min/max range including zero
- returns scalar `y_scale`
- returns scalar `y_zero_point`
- quantizes output to `U8`
- uses ties-to-even rounding to match ONNX / NumPy `rint`

Fixes #3290.

## Tests

Added `test_dynamic_quantize_linear` covering:
- mixed positive/negative input
- all-negative input
- all-positive input
- zero-range input
- ties-to-even rounding behavior

Validation run:

```sh
cargo test --manifest-path candle-onnx/Cargo.toml --test ops test_dynamic_quantize_linear
cargo test --manifest-path candle-onnx/Cargo.toml --test ops -- --skip test_gelu_operation
cargo test --manifest-path candle-onnx/Cargo.toml --lib
cargo check --manifest-path candle-onnx/Cargo.toml
cargo fmt --manifest-path candle-onnx/Cargo.toml -- --check
git --no-pager diff --check
```

Known unrelated local failures:
- full `cargo test --manifest-path candle-onnx/Cargo.toml --test ops` still fails only in existing `test_gelu_operation` exact-float mismatch: `0.8413447` vs `0.8413448`
- `cargo clippy --manifest-path candle-onnx/Cargo.toml --tests -- -D warnings` is blocked by pre-existing generated-code / existing `eval.rs` warnings
