### PR TITLE
MetalDevice::new: return Err instead of panicking on empty device list

### DIFF
--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -441,6 +441,15 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_new_metal_returns_err_on_empty_or_out_of_range() {
+        // Calling Device::new_metal with a very high ordinal should never panic.
+        // It should return Err (no such device), which lets users fall back
+        // gracefully via the normal Result contract instead of unwinding.
+        let result = crate::Device::new_metal(9999);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_buf_size_exact_powers_of_two() {
         assert_eq!(buf_size(1), 1);
         assert_eq!(buf_size(2), 2);

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -2023,7 +2023,15 @@ impl BackendDevice for MetalDevice {
     type Storage = MetalStorage;
 
     fn new(ordinal: usize) -> Result<Self> {
-        let device = Device::all().swap_remove(ordinal);
+        let mut devices = Device::all();
+        if ordinal >= devices.len() {
+            return Err(MetalError::Message(format!(
+                "no Metal device at ordinal {ordinal} (MTLCopyAllDevices returned {} devices)",
+                devices.len()
+            ))
+            .into());
+        }
+        let device = devices.swap_remove(ordinal);
         let command_queue = device.new_command_queue().map_err(MetalError::from)?;
         #[cfg(feature = "metal-debug-labels")]
         command_queue.setLabel(Some(&NSString::from_str("candle-metal")));


### PR DESCRIPTION
Fixes #3566

`MetalDevice::new` calls `Device::all().swap_remove(ordinal)` which panics when `MTLCopyAllDevices()` returns an empty Vec (e.g. headless macOS, CI, SSH sessions, sandboxed contexts).

This change checks the bounds first and returns a proper `Err(MetalError::Message)` instead of panicking, so callers can gracefully fall back via normal `Result` handling.