### PR TITLE
Fix test_gelu_operation precision on Apple Silicon

### DIFF
--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -1794,11 +1794,11 @@ fn test_gelu_operation() -> Result<()> {
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
 
-    let results = z.to_vec2::<f32>()?;
+    let results = to_vec2_round(z, 4)?;
 
     assert_eq!(
         results,
-        vec![vec![0.0, 0.8413448], vec![1.9544997, 2.9959502]]
+        vec![vec![0.0, 0.8413], vec![1.9545, 2.996]]
     );
 
     Ok(())


### PR DESCRIPTION
Fixes #3679

Use `to_vec2_round(z, 4)` instead of exact `to_vec2::<f32>` comparison to handle 1 ULP differences between x86 and Apple Silicon's `erf` implementation.

```
 left: [[0.0, 0.8413447], [1.9544997, 2.9959502]]   # Apple Silicon
right: [[0.0, 0.8413448], [1.9544997, 2.9959502]]   # expected (x86)
```

Matches the pattern already used by `test_sin_operation` and `test_cos_operation`.