### PR TITLE
candle-core: free Q4_K source weights after building the aarch64 matmul repack (~2x -> ~1x weight memory)

### DIFF
--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -709,6 +709,45 @@ impl QTensor {
         }
     }
 
+    // Build-once cached BlockQ4Kx8 repack of a Q4_K weight with n output rows.
+    // Later calls return it without reading storage, so the original can be freed.
+    #[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
+    fn q4kx8_repack(&self, n: usize) -> &Option<Vec<u8>> {
+        use zerocopy::IntoBytes;
+        self.repacked_qs.get_or_init(|| {
+            let s = match &self.storage {
+                QStorage::Cpu(s) => s,
+                _ => return None,
+            };
+            let total_blocks = s.storage_size_in_bytes() / std::mem::size_of::<BlockQ4K>();
+            if total_blocks == 0 {
+                return None;
+            }
+            let blocks =
+                unsafe { std::slice::from_raw_parts(s.as_ptr() as *const BlockQ4K, total_blocks) };
+            Some(k_quants::pack_to_q4kx8(blocks, n).as_bytes().to_vec())
+        })
+    }
+
+    // Build the aarch64 Q4_K matmul repack and free the original blocks; the matmul
+    // then runs from the cached repack alone. Caller must not use this tensor for
+    // dequantize/embedding afterward (e.g. a tied lm_head). No-op off aarch64/Q4_K.
+    pub fn drop_source_after_repack(&mut self) {
+        #[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
+        if let Ok((n, _k)) = self.shape.dims2() {
+            if self.storage.dtype() == GgmlDType::Q4K
+                && n.is_multiple_of(8)
+                && self.q4kx8_repack(n).is_some()
+            {
+                let dtype = self.storage.dtype();
+                let device = self.storage.device();
+                if let Ok(empty) = device.qzeros(0, dtype) {
+                    self.storage = empty;
+                }
+            }
+        }
+    }
+
     pub fn embedding(&self, ids: &Tensor) -> Result<Tensor> {
         let (rows, hidden) = self.shape.dims2()?;
         if !hidden.is_multiple_of(self.dtype().block_size()) {
@@ -934,24 +973,12 @@ impl crate::CustomOp1 for QTensor {
                     &slice[layout.start_offset()..layout.start_offset() + src_shape.elem_count()];
                 let mut dst_storage = vec![0f32; dst_shape.elem_count()];
 
-                // Try the 8-column BlockQ4Kx8 repacked path.
+                // 8-column BlockQ4Kx8 path; the cached repack stays valid even
+                // after the original Q4_K blocks are released.
                 #[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
                 if self_storage.dtype() == GgmlDType::Q4K && n.is_multiple_of(8) {
-                    use zerocopy::{FromBytes, IntoBytes};
-
-                    let total_blocks =
-                        self_storage.storage_size_in_bytes() / std::mem::size_of::<BlockQ4K>();
-                    let repacked = self.repacked_qs.get_or_init(|| {
-                        let blocks = unsafe {
-                            std::slice::from_raw_parts(
-                                self_storage.as_ptr() as *const BlockQ4K,
-                                total_blocks,
-                            )
-                        };
-                        let packed = k_quants::pack_to_q4kx8(blocks, n);
-                        Some(packed.as_bytes().to_vec())
-                    });
-                    if let Some(repacked_bytes) = repacked {
+                    use zerocopy::FromBytes;
+                    if let Some(repacked_bytes) = self.q4kx8_repack(n) {
                         let block_x8: &[BlockQ4Kx8] =
                             <[BlockQ4Kx8]>::ref_from_bytes(repacked_bytes).map_err(|_| {
                                 crate::Error::Msg(

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -730,16 +730,13 @@ impl QTensor {
     }
 
     // Build the aarch64 Q4_K matmul repack and free the original blocks; the matmul
-    // then runs from the cached repack alone. Caller must not use this tensor for
-    // dequantize/embedding afterward (e.g. a tied lm_head). No-op off aarch64/Q4_K.
-    pub fn drop_source_after_repack(&mut self) {
+    // then runs from the cached repack alone. No-op off aarch64/Q4_K. Private: only
+    // from_arc calls it, on a uniquely-owned tensor that has ruled out dequant.
+    fn drop_source_after_repack(&mut self) {
         #[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
         if let Ok((n, _k)) = self.shape.dims2() {
-            if self.storage.dtype() == GgmlDType::Q4K
-                && n.is_multiple_of(8)
-                && self.q4kx8_repack(n).is_some()
-            {
-                let dtype = self.storage.dtype();
+            let dtype = self.storage.dtype();
+            if dtype == GgmlDType::Q4K && n.is_multiple_of(8) && self.q4kx8_repack(n).is_some() {
                 let device = self.storage.device();
                 if let Ok(empty) = device.qzeros(0, dtype) {
                     self.storage = empty;
@@ -885,6 +882,14 @@ impl QMatMul {
             let tensor = qtensor.dequantize_f16(&qtensor.device())?;
             Self::TensorF16(tensor)
         } else {
+            // Staying quantized (dequantization ruled out above): on aarch64 build
+            // the Q4_K matmul repack and free the original blocks. Only when we
+            // uniquely own the tensor -- a shared one (e.g. a tied lm_head reusing
+            // the embedding) keeps its blocks for embedding/dequantize.
+            let mut qtensor = qtensor;
+            if let Some(qt) = std::sync::Arc::get_mut(&mut qtensor) {
+                qt.drop_source_after_repack();
+            }
             Self::QTensor(qtensor)
         };
         Ok(t)

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -29,9 +29,7 @@ impl<R: Read + Seek> Gguf<R> {
     }
 
     pub fn qmatmul(&mut self, name: &str) -> Result<QMatMul> {
-        let mut ws = self.ct.tensor(&mut self.reader, name, &self.device)?;
-        // Matmul-only weight: release the original Q4_K blocks after repacking.
-        ws.drop_source_after_repack();
+        let ws = self.ct.tensor(&mut self.reader, name, &self.device)?;
         QMatMul::from_weights(ws.into())
     }
 
@@ -517,13 +515,11 @@ impl ModelWeights {
         }
 
         let norm = gg.rms_norm("output_norm.weight", rms_norm_eps)?;
-        // Load output projection, falling back to tied embeddings like gemma3.
-        // Matmul-only here (embed_tokens has its own dequantized copy), so release.
-        let mut lm_head_tensor = match gg.tensor("output.weight") {
+        // Load output projection tensor, falling back to tied embeddings like gemma3
+        let lm_head_tensor = match gg.tensor("output.weight") {
             Ok(tensor) => tensor,
             Err(_) => gg.tensor("token_embd.weight")?,
         };
-        lm_head_tensor.drop_source_after_repack();
         let lm_head = QMatMul::from_weights(lm_head_tensor.into())?;
         let span = tracing::span!(tracing::Level::TRACE, "model");
         let span_output = tracing::span!(tracing::Level::TRACE, "output");

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -29,7 +29,9 @@ impl<R: Read + Seek> Gguf<R> {
     }
 
     pub fn qmatmul(&mut self, name: &str) -> Result<QMatMul> {
-        let ws = self.ct.tensor(&mut self.reader, name, &self.device)?;
+        let mut ws = self.ct.tensor(&mut self.reader, name, &self.device)?;
+        // Matmul-only weight: release the original Q4_K blocks after repacking.
+        ws.drop_source_after_repack();
         QMatMul::from_weights(ws.into())
     }
 
@@ -515,11 +517,13 @@ impl ModelWeights {
         }
 
         let norm = gg.rms_norm("output_norm.weight", rms_norm_eps)?;
-        // Load output projection tensor, falling back to tied embeddings like gemma3
-        let lm_head_tensor = match gg.tensor("output.weight") {
+        // Load output projection, falling back to tied embeddings like gemma3.
+        // Matmul-only here (embed_tokens has its own dequantized copy), so release.
+        let mut lm_head_tensor = match gg.tensor("output.weight") {
             Ok(tensor) => tensor,
             Err(_) => gg.tensor("token_embd.weight")?,
         };
+        lm_head_tensor.drop_source_after_repack();
         let lm_head = QMatMul::from_weights(lm_head_tensor.into())?;
         let span = tracing::span!(tracing::Level::TRACE, "model");
         let span_output = tracing::span!(tracing::Level::TRACE, "output");


### PR DESCRIPTION
On aarch64+dotprod, the Q4_K matmul fast path repacks each weight into `BlockQ4Kx8` and caches it on the `QTensor`. The original Q4_K blocks were kept alongside that repack for the tensor's lifetime, so every Q4_K matmul weight was held in memory twice. For Qwen3-0.6B that's ~320 MB of pure duplication.

This change builds the repack eagerly in `QMatMul::from_arc` (the moment we commit to the quantized path) and frees the original blocks, so only the repack is retained.

## How

In `QMatMul::from_arc`, in the branch where the tensor stays quantized (after the `CANDLE_DEQUANTIZE_ALL`/`_F16` dequantize paths are ruled out):

```rust
let mut qtensor = qtensor;
if let Some(qt) = Arc::get_mut(&mut qtensor) {
    qt.drop_source_after_repack();
}
Self::QTensor(qtensor)
```

drop_source_after_repack (private) builds the BlockQ4Kx8 repack via the existing path, then swaps storage for an empty same-dtype buffer. No-op off aarch64/dotprod and for non-Q4_K tensors.
Arc::get_mut means we only release when we uniquely own the tensor. A shared tensor (e.g. a tied lm_head reusing the token-embedding Arc) is left intact, so it keeps the blocks it still needs for embedding/dequantize.
Because the release sits after the dequantize branches, models run under CANDLE_DEQUANTIZE_ALL[_F16] are unaffected (they never take this branch).

The matmul cpu_fwd was refactored to fetch the repack via a small q4kx8_repack() helper (build-once, cached) rather than inline, so it no longer reads storage once the repack exists, which is what lets the source be freed.

Effects
Resident memory: ~2x -> ~1x for Q4_K matmul weights. Qwen3-0.6B (M1): 639.5 MB -> 319.7 MB across the 197 matmul weights.
First-token latency is lower -- the repack moved off the first matmul onto load.
Load time is marginally higher (the repack work shifts to load); total work unchanged.
Peak memory is lower -- the transient 2x during first-forward no longer occurs.

Scope
aarch64 + dotprod only (Graviton, Apple Silicon); no-op and zero overhead on x86/wasm/CUDA/Metal.
Lives entirely in candle-core (QMatMul::from_arc), so it benefits every quantized model with no per-model changes.