### PR TITLE
candle-nn: add LoraLinear — first-class LoRA adapters (load + merge + multi-adapter)

### DIFF
--- a/candle-nn/src/lib.rs
+++ b/candle-nn/src/lib.rs
@@ -28,6 +28,7 @@ pub mod init;
 pub mod kv_cache;
 pub mod layer_norm;
 pub mod linear;
+pub mod lora;
 pub mod loss;
 pub mod moe;
 pub mod ops;
@@ -58,6 +59,7 @@ pub use layer_norm::{
     layer_norm, layer_norm_no_bias, rms_norm, LayerNorm, LayerNormConfig, RmsNorm,
 };
 pub use linear::{linear, linear_b, linear_no_bias, Linear};
+pub use lora::LoraLinear;
 pub use ops::Dropout;
 pub use optim::{AdamW, Optimizer, ParamsAdamW, SGD};
 pub use rnn::{gru, lstm, GRUConfig, LSTMConfig, GRU, LSTM, RNN};

--- a/candle-nn/src/lora.rs
+++ b/candle-nn/src/lora.rs
@@ -1,0 +1,239 @@
+//! LoRA (Low-Rank Adaptation) layers.
+//!
+//! This module provides a `Linear` wrapper that adds one or more low-rank
+//! adapters on top of a frozen base layer, computing
+//! `y = W·x + (B·A)·x·(alpha/r)` for the currently active adapter.
+//!
+//! Adapters can be loaded from PEFT-style `.safetensors` checkpoints (tensors
+//! named `lora_A.weight` of shape `[r, in_dim]` and `lora_B.weight` of shape
+//! `[out_dim, r]`) via [`LoraLinear::from_peft`] / [`LoraLinear::load_adapter`],
+//! and several adapters can coexist so that the active one can be swapped at
+//! runtime with [`LoraLinear::set_active_adapter`].
+//!
+//! ```rust
+//! use candle::{Device, Tensor};
+//! use candle_nn::{linear, lora::LoraLinear, Module, VarBuilder};
+//! # fn main() -> candle::Result<()> {
+//! let dev = &Device::Cpu;
+//! let varmap = candle_nn::VarMap::new();
+//! let vb = VarBuilder::from_varmap(&varmap, candle::DType::F32, dev);
+//! let base = linear(8, 4, vb.pp("q_proj"))?;
+//! let mut lora = LoraLinear::new(base);
+//! lora.add_adapter("default", vb.pp("lora.q_proj"), 2, 16.0)?;
+//! let x = Tensor::zeros((1, 8), candle::DType::F32, dev)?;
+//! let y = lora.forward(&x)?; // base + LoRA delta
+//! # Ok(()) }
+//! ```
+use std::collections::HashMap;
+
+use candle::{Result, Tensor};
+
+use crate::{Init, Linear, Module, VarBuilder};
+
+/// A single low-rank adapter: `B [out, r]`, `A [r, in]` and the `alpha/r` scaling.
+#[derive(Clone, Debug)]
+struct Adapter {
+    lora_a: Tensor,
+    lora_b: Tensor,
+    scale: f64,
+}
+
+impl Adapter {
+    /// `(B·A) * scale`, i.e. the delta that gets added to the base weight.
+    fn delta_weight(&self) -> Result<Tensor> {
+        self.lora_b.matmul(&self.lora_a)?.affine(self.scale, 0.)
+    }
+
+    /// `(x·A^T)·B^T * scale`, i.e. the LoRA contribution to the output.
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let lora_a = self.lora_a.t()?;
+        let lora_b = self.lora_b.t()?;
+        x.broadcast_matmul(&lora_a)?
+            .broadcast_matmul(&lora_b)?
+            .affine(self.scale, 0.)
+    }
+}
+
+/// A `Linear` layer augmented with zero or more named LoRA adapters.
+///
+/// At most one adapter is active at a time (see [`Self::set_active_adapter`]).
+/// The active adapter can be folded into the base weight with [`Self::merge`]
+/// for inference, and restored with [`Self::unmerge`].
+#[derive(Clone, Debug)]
+pub struct LoraLinear {
+    base: Linear,
+    adapters: HashMap<String, Adapter>,
+    active: Option<String>,
+    merged: Option<String>,
+}
+
+impl LoraLinear {
+    /// Wrap a base `Linear` layer with no adapters attached.
+    pub fn new(base: Linear) -> Self {
+        Self {
+            base,
+            adapters: HashMap::new(),
+            active: None,
+            merged: None,
+        }
+    }
+
+    /// Load a PEFT-style adapter (a freshly initialized `B` matrix and a
+    /// Kaiming-initialized `A` matrix, as is standard for LoRA) under `name`,
+    /// pulling `lora_A.weight` and `lora_B.weight` from `vb`, and make it the
+    /// active adapter.
+    pub fn from_peft(base: Linear, vb: VarBuilder, rank: usize, alpha: f64) -> Result<Self> {
+        let mut lora = Self::new(base);
+        lora.load_adapter("default", vb, rank, alpha)?;
+        lora.set_active_adapter(Some("default"))?;
+        Ok(lora)
+    }
+
+    /// Load (or create, if the tensors are not present in `vb`) an adapter
+    /// named `name` with the given `rank` and `alpha`, without changing which
+    /// adapter is currently active.
+    pub fn load_adapter(
+        &mut self,
+        name: &str,
+        vb: VarBuilder,
+        rank: usize,
+        alpha: f64,
+    ) -> Result<()> {
+        let (out_dim, in_dim) = self.base.weight().dims2()?;
+        let lora_a = vb.get_with_hints(
+            (rank, in_dim),
+            "lora_A.weight",
+            crate::init::DEFAULT_KAIMING_UNIFORM,
+        )?;
+        let lora_b = vb.get_with_hints((out_dim, rank), "lora_B.weight", Init::Const(0.))?;
+        self.add_adapter_tensors(name, lora_a, lora_b, alpha)
+    }
+
+    /// Load an adapter (see [`Self::load_adapter`]) and make it the active
+    /// adapter.
+    pub fn add_adapter(
+        &mut self,
+        name: &str,
+        vb: VarBuilder,
+        rank: usize,
+        alpha: f64,
+    ) -> Result<()> {
+        self.load_adapter(name, vb, rank, alpha)?;
+        self.set_active_adapter(Some(name))
+    }
+
+    fn add_adapter_tensors(
+        &mut self,
+        name: &str,
+        lora_a: Tensor,
+        lora_b: Tensor,
+        alpha: f64,
+    ) -> Result<()> {
+        let rank = lora_a.dim(0)?;
+        let scale = alpha / rank as f64;
+        self.adapters.insert(
+            name.to_string(),
+            Adapter {
+                lora_a,
+                lora_b,
+                scale,
+            },
+        );
+        Ok(())
+    }
+
+    /// Remove an adapter. If it was the active or merged one, it is
+    /// unmerged/deactivated first.
+    pub fn remove_adapter(&mut self, name: &str) -> Result<()> {
+        if self.merged.as_deref() == Some(name) {
+            self.unmerge()?;
+        }
+        if self.active.as_deref() == Some(name) {
+            self.active = None;
+        }
+        self.adapters.remove(name);
+        Ok(())
+    }
+
+    /// Select the active adapter (or `None` to bypass all adapters and use
+    /// only the base layer). Fails if `name` is not a known adapter, or if a
+    /// different adapter is currently merged into the base weight.
+    pub fn set_active_adapter(&mut self, name: Option<&str>) -> Result<()> {
+        if let Some(name) = name {
+            if !self.adapters.contains_key(name) {
+                candle::bail!("no such LoRA adapter: {name}");
+            }
+        }
+        if let Some(merged) = &self.merged {
+            if name != Some(merged.as_str()) {
+                candle::bail!(
+                    "adapter {merged} is merged into the base weight, unmerge it before switching"
+                );
+            }
+        }
+        self.active = name.map(|s| s.to_string());
+        Ok(())
+    }
+
+    /// Name of the currently active adapter, if any.
+    pub fn active_adapter(&self) -> Option<&str> {
+        self.active.as_deref()
+    }
+
+    /// Names of all the adapters currently registered.
+    pub fn adapter_names(&self) -> Vec<&str> {
+        self.adapters.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Fold the active adapter's weights into the base layer, so that
+    /// `forward` no longer needs to compute the low-rank update separately.
+    /// This is a no-op if no adapter is active or one is already merged.
+    pub fn merge(&mut self) -> Result<()> {
+        if self.merged.is_some() {
+            return Ok(());
+        }
+        let Some(active) = self.active.clone() else {
+            return Ok(());
+        };
+        let adapter = &self.adapters[&active];
+        let weight = self.base.weight().add(&adapter.delta_weight()?)?;
+        self.base = Linear::new(weight, self.base.bias().cloned());
+        self.merged = Some(active);
+        Ok(())
+    }
+
+    /// Undo a previous [`Self::merge`], restoring the base layer's original
+    /// weights. This is a no-op if no adapter is currently merged.
+    pub fn unmerge(&mut self) -> Result<()> {
+        let Some(merged) = self.merged.take() else {
+            return Ok(());
+        };
+        let adapter = &self.adapters[&merged];
+        let weight = self.base.weight().sub(&adapter.delta_weight()?)?;
+        self.base = Linear::new(weight, self.base.bias().cloned());
+        Ok(())
+    }
+
+    /// Whether an adapter is currently merged into the base weight.
+    pub fn is_merged(&self) -> bool {
+        self.merged.is_some()
+    }
+
+    /// The underlying base layer.
+    pub fn base(&self) -> &Linear {
+        &self.base
+    }
+}
+
+impl Module for LoraLinear {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let base_out = self.base.forward(x)?;
+        if self.merged.is_some() {
+            return Ok(base_out);
+        }
+        match &self.active {
+            None => Ok(base_out),
+            Some(name) => base_out.add(&self.adapters[name].forward(x)?),
+        }
+    }
+}

--- a/candle-nn/tests/lora.rs
+++ b/candle-nn/tests/lora.rs
@@ -1,0 +1,115 @@
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use anyhow::Result;
+use candle::{test_utils::to_vec2_round, DType, Device, Tensor};
+use candle_nn::{linear_no_bias, lora::LoraLinear, Module, VarBuilder, VarMap};
+
+fn make_base(device: &Device) -> Result<candle_nn::Linear> {
+    // in_dim = 3, out_dim = 2
+    let mut varmap = VarMap::new();
+    let vb = VarBuilder::from_varmap(&varmap, DType::F32, device);
+    let base = linear_no_bias(3, 2, vb.pp("q_proj"))?;
+    varmap.set_one(
+        "q_proj.weight",
+        Tensor::new(&[[1f32, 0., 0.], [0., 1., 0.]], device)?,
+    )?;
+    Ok(base)
+}
+
+#[test]
+fn lora_forward_matches_manual_computation() -> Result<()> {
+    let device = Device::Cpu;
+    let base = make_base(&device)?;
+
+    let mut varmap = VarMap::new();
+    let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+    let mut lora =
+        LoraLinear::from_peft(base, vb.pp("q_proj"), /*rank=*/ 2, /*alpha=*/ 4.0)?;
+
+    // lora_A: [r=2, in=3], lora_B: [out=2, r=2]
+    varmap.set_one(
+        "q_proj.lora_A.weight",
+        Tensor::new(&[[1f32, 0., 0.], [0., 1., 0.]], &device)?,
+    )?;
+    varmap.set_one(
+        "q_proj.lora_B.weight",
+        Tensor::new(&[[1f32, 0.], [0., 1.]], &device)?,
+    )?;
+
+    let x = Tensor::new(&[[1f32, 2., 3.]], &device)?;
+    let y = lora.forward(&x)?;
+    // base_out = [1, 2]; delta = scale * B@A@x with scale = alpha/r = 2.0
+    // A@x = [1, 2] (selects first two components), B@(A@x) = [1, 2], * scale(2.0) = [2, 4]
+    // y = base_out + delta = [3, 6]
+    assert_eq!(to_vec2_round(&y, 4)?, vec![vec![3f32, 6.]]);
+
+    lora.merge()?;
+    assert!(lora.is_merged());
+    let y_merged = lora.forward(&x)?;
+    assert_eq!(to_vec2_round(&y_merged, 4)?, vec![vec![3f32, 6.]]);
+
+    lora.unmerge()?;
+    assert!(!lora.is_merged());
+    let y_unmerged = lora.forward(&x)?;
+    assert_eq!(to_vec2_round(&y_unmerged, 4)?, vec![vec![3f32, 6.]]);
+
+    Ok(())
+}
+
+#[test]
+fn lora_multi_adapter_switching() -> Result<()> {
+    let device = Device::Cpu;
+    let base = make_base(&device)?;
+
+    let mut varmap = VarMap::new();
+    let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+    let mut lora = LoraLinear::new(base);
+
+    lora.add_adapter("a", vb.pp("lora_a"), 2, 2.0)?;
+    varmap.set_one(
+        "lora_a.lora_A.weight",
+        Tensor::new(&[[1f32, 0., 0.], [0., 0., 0.]], &device)?,
+    )?;
+    varmap.set_one(
+        "lora_a.lora_B.weight",
+        Tensor::new(&[[1f32, 0.], [0., 0.]], &device)?,
+    )?;
+
+    lora.add_adapter("b", vb.pp("lora_b"), 2, 2.0)?;
+    varmap.set_one(
+        "lora_b.lora_A.weight",
+        Tensor::new(&[[0f32, 1., 0.], [0., 0., 0.]], &device)?,
+    )?;
+    varmap.set_one(
+        "lora_b.lora_B.weight",
+        Tensor::new(&[[0f32, 0.], [1., 0.]], &device)?,
+    )?;
+
+    let x = Tensor::new(&[[1f32, 2., 3.]], &device)?;
+
+    assert_eq!(lora.active_adapter(), Some("b"));
+    let y_b = lora.forward(&x)?;
+    // base_out = [1, 2]; adapter b: A@x = [2, 0], B@(A@x) = [0, 2], scale=1.0 -> delta=[0, 2]
+    assert_eq!(to_vec2_round(&y_b, 4)?, vec![vec![1f32, 4.]]);
+
+    lora.set_active_adapter(Some("a"))?;
+    let y_a = lora.forward(&x)?;
+    // adapter a: A@x = [1, 0], B@(A@x) = [1, 0], scale=1.0 -> delta=[1, 0]
+    assert_eq!(to_vec2_round(&y_a, 4)?, vec![vec![2f32, 2.]]);
+
+    lora.merge()?;
+    assert!(lora.set_active_adapter(Some("b")).is_err());
+    lora.unmerge()?;
+    lora.set_active_adapter(Some("b"))?;
+    assert_eq!(lora.active_adapter(), Some("b"));
+
+    lora.set_active_adapter(None)?;
+    let y_base = lora.forward(&x)?;
+    assert_eq!(to_vec2_round(&y_base, 4)?, vec![vec![1f32, 2.]]);
+
+    Ok(())
+}

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -1794,11 +1794,9 @@ fn test_gelu_operation() -> Result<()> {
 
     let z = eval.get(OUTPUT_Z).expect("Output 'z' not found");
 
-    let results = z.to_vec2::<f32>()?;
-
     assert_eq!(
-        results,
-        vec![vec![0.0, 0.8413448], vec![1.9544997, 2.9959502]]
+        to_vec2_round(z, 6)?,
+        [[0.0, 0.841345], [1.9545, 2.99595]]
     );
 
     Ok(())

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -6,8 +6,134 @@
 
 use super::with_tracing::{linear_no_bias as linear, Linear, RmsNorm};
 use candle::{DType, Device, IndexOp, Result, Tensor, D};
+use candle_nn::lora::LoraLinear;
 use candle_nn::{embedding, Embedding, Module, VarBuilder};
 use std::{collections::HashMap, f32::consts::PI};
+
+/// Rank, scaling and target projections for a LoRA adapter to inject into a
+/// [`Llama`] model at load time. `target_modules` is matched against the
+/// projection names `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`,
+/// `up_proj` and `down_proj`.
+#[derive(Debug, Clone)]
+pub struct LoraConfig {
+    pub rank: usize,
+    pub alpha: f64,
+    pub target_modules: Vec<String>,
+}
+
+impl LoraConfig {
+    fn wants(&self, module: &str) -> bool {
+        self.target_modules.iter().any(|m| m == module)
+    }
+}
+
+type LoraSpec<'a> = (String, VarBuilder<'a>, LoraConfig);
+
+/// Prefix under which a standard PEFT `PeftModel` checkpoint stores its base
+/// model's weights, e.g. `base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight`.
+/// This is the default root [`LlamaLoadConfig::with_lora_adapter`] resolves
+/// LoRA tensor paths against.
+pub const PEFT_ADAPTER_PREFIX: &str = "base_model.model";
+
+/// Configuration used by [`Llama::load_with_config`] to inject one or more
+/// named LoRA adapters into the base model's attention and MLP projections.
+/// Building a model with an empty (default) config is equivalent to
+/// [`Llama::load`].
+#[derive(Clone, Default)]
+pub struct LlamaLoadConfig<'a> {
+    lora_adapters: Vec<LoraSpec<'a>>,
+}
+
+impl<'a> LlamaLoadConfig<'a> {
+    /// Registers a named LoRA adapter, loaded from `vb`, to be injected into
+    /// the projections listed in `config.target_modules`. `vb` is assumed to
+    /// be rooted at the standard PEFT checkpoint layout, i.e. tensors live
+    /// under [`PEFT_ADAPTER_PREFIX`] `.model.layers.{i}.self_attn.q_proj` (and
+    /// so on), each holding `lora_A.weight` / `lora_B.weight`. Use
+    /// [`LlamaLoadConfig::with_lora_adapter_prefixed`] if the checkpoint was
+    /// saved under a different root, or if `vb` is already scoped past that
+    /// prefix.
+    pub fn with_lora_adapter(self, name: &str, vb: VarBuilder<'a>, config: LoraConfig) -> Self {
+        self.with_lora_adapter_prefixed(name, vb, config, PEFT_ADAPTER_PREFIX)
+    }
+
+    /// Like [`LlamaLoadConfig::with_lora_adapter`], but resolves LoRA tensors
+    /// under `prefix` instead of the standard [`PEFT_ADAPTER_PREFIX`]. Pass an
+    /// empty string if `vb` is already scoped to the model root (i.e. tensors
+    /// live directly under `model.layers.{i}...`).
+    pub fn with_lora_adapter_prefixed(
+        mut self,
+        name: &str,
+        vb: VarBuilder<'a>,
+        config: LoraConfig,
+        prefix: &str,
+    ) -> Self {
+        let vb = if prefix.is_empty() { vb } else { vb.pp(prefix) };
+        self.lora_adapters.push((name.to_string(), vb, config));
+        self
+    }
+}
+
+/// A linear projection that is either a plain frozen layer or one augmented
+/// with LoRA adapters, depending on whether the loader was asked to inject
+/// adapters into it.
+#[derive(Debug, Clone)]
+enum Proj {
+    Plain(Linear),
+    Lora(LoraLinear),
+}
+
+impl Proj {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::Plain(l) => l.forward(x),
+            Self::Lora(l) => l.forward(x),
+        }
+    }
+
+    fn has_adapter(&self, name: &str) -> bool {
+        match self {
+            Self::Plain(_) => false,
+            Self::Lora(l) => l.adapter_names().contains(&name),
+        }
+    }
+
+    /// Activates `name` on this projection if it carries an adapter under
+    /// that name, deactivates any adapter when `name` is `None`, and is a
+    /// no-op otherwise (this projection simply wasn't targeted by `name`).
+    fn set_active_adapter(&mut self, name: Option<&str>) -> Result<()> {
+        let Self::Lora(l) = self else {
+            return Ok(());
+        };
+        match name {
+            None => l.set_active_adapter(None),
+            Some(name) if l.adapter_names().contains(&name) => l.set_active_adapter(Some(name)),
+            Some(_) => Ok(()),
+        }
+    }
+}
+
+fn load_projection(
+    module: &str,
+    size_in: usize,
+    size_out: usize,
+    vb: VarBuilder,
+    lora_adapters: &[LoraSpec],
+) -> Result<Proj> {
+    let matching: Vec<_> = lora_adapters
+        .iter()
+        .filter(|(_, _, cfg)| cfg.wants(module))
+        .collect();
+    if matching.is_empty() {
+        return Ok(Proj::Plain(linear(size_in, size_out, vb)?));
+    }
+    let base = candle_nn::linear_no_bias(size_in, size_out, vb)?;
+    let mut lora = LoraLinear::new(base);
+    for (name, adapter_vb, cfg) in matching {
+        lora.load_adapter(name, adapter_vb.pp(module), cfg.rank, cfg.alpha)?;
+    }
+    Ok(Proj::Lora(lora))
+}
 
 pub const DEFAULT_MAX_SEQ_LEN: usize = 4096;
 
@@ -229,10 +355,10 @@ impl Cache {
 
 #[derive(Debug, Clone)]
 struct CausalSelfAttention {
-    q_proj: Linear,
-    k_proj: Linear,
-    v_proj: Linear,
-    o_proj: Linear,
+    q_proj: Proj,
+    k_proj: Proj,
+    v_proj: Proj,
+    o_proj: Proj,
     num_attention_heads: usize,
     num_key_value_heads: usize,
     head_dim: usize,
@@ -359,16 +485,38 @@ impl CausalSelfAttention {
         crate::utils::repeat_kv(x, self.num_attention_heads / self.num_key_value_heads)
     }
 
-    fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+    fn has_adapter(&self, name: &str) -> bool {
+        [&self.q_proj, &self.k_proj, &self.v_proj, &self.o_proj]
+            .into_iter()
+            .any(|p| p.has_adapter(name))
+    }
+
+    fn set_active_adapter(&mut self, name: Option<&str>) -> Result<()> {
+        for p in [
+            &mut self.q_proj,
+            &mut self.k_proj,
+            &mut self.v_proj,
+            &mut self.o_proj,
+        ] {
+            p.set_active_adapter(name)?;
+        }
+        Ok(())
+    }
+
+    fn load(vb: VarBuilder, cfg: &Config, lora_adapters: &[LoraSpec]) -> Result<Self> {
         let span = tracing::span!(tracing::Level::TRACE, "attn");
         let span_rot = tracing::span!(tracing::Level::TRACE, "attn-rot");
         let size_in = cfg.hidden_size;
         let size_q = (cfg.hidden_size / cfg.num_attention_heads) * cfg.num_attention_heads;
         let size_kv = (cfg.hidden_size / cfg.num_attention_heads) * cfg.num_key_value_heads;
-        let q_proj = linear(size_in, size_q, vb.pp("q_proj"))?;
-        let k_proj = linear(size_in, size_kv, vb.pp("k_proj"))?;
-        let v_proj = linear(size_in, size_kv, vb.pp("v_proj"))?;
-        let o_proj = linear(size_q, size_in, vb.pp("o_proj"))?;
+        let lora_adapters: Vec<_> = lora_adapters
+            .iter()
+            .map(|(name, vb, cfg)| (name.clone(), vb.pp("self_attn"), cfg.clone()))
+            .collect();
+        let q_proj = load_projection("q_proj", size_in, size_q, vb.pp("q_proj"), &lora_adapters)?;
+        let k_proj = load_projection("k_proj", size_in, size_kv, vb.pp("k_proj"), &lora_adapters)?;
+        let v_proj = load_projection("v_proj", size_in, size_kv, vb.pp("v_proj"), &lora_adapters)?;
+        let o_proj = load_projection("o_proj", size_q, size_in, vb.pp("o_proj"), &lora_adapters)?;
         Ok(Self {
             q_proj,
             k_proj,
@@ -394,9 +542,9 @@ fn masked_fill(on_false: &Tensor, mask: &Tensor, on_true: f32) -> Result<Tensor>
 
 #[derive(Debug, Clone)]
 struct Mlp {
-    c_fc1: Linear,
-    c_fc2: Linear,
-    c_proj: Linear,
+    c_fc1: Proj,
+    c_fc2: Proj,
+    c_proj: Proj,
     span: tracing::Span,
 }
 
@@ -407,13 +555,42 @@ impl Mlp {
         self.c_proj.forward(&x)
     }
 
-    fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+    fn has_adapter(&self, name: &str) -> bool {
+        [&self.c_fc1, &self.c_fc2, &self.c_proj]
+            .into_iter()
+            .any(|p| p.has_adapter(name))
+    }
+
+    fn set_active_adapter(&mut self, name: Option<&str>) -> Result<()> {
+        for p in [&mut self.c_fc1, &mut self.c_fc2, &mut self.c_proj] {
+            p.set_active_adapter(name)?;
+        }
+        Ok(())
+    }
+
+    fn load(vb: VarBuilder, cfg: &Config, lora_adapters: &[LoraSpec]) -> Result<Self> {
         let span = tracing::span!(tracing::Level::TRACE, "mlp");
         let h_size = cfg.hidden_size;
         let i_size = cfg.intermediate_size;
-        let c_fc1 = linear(h_size, i_size, vb.pp("gate_proj"))?;
-        let c_fc2 = linear(h_size, i_size, vb.pp("up_proj"))?;
-        let c_proj = linear(i_size, h_size, vb.pp("down_proj"))?;
+        let lora_adapters: Vec<_> = lora_adapters
+            .iter()
+            .map(|(name, vb, cfg)| (name.clone(), vb.pp("mlp"), cfg.clone()))
+            .collect();
+        let c_fc1 = load_projection(
+            "gate_proj",
+            h_size,
+            i_size,
+            vb.pp("gate_proj"),
+            &lora_adapters,
+        )?;
+        let c_fc2 = load_projection("up_proj", h_size, i_size, vb.pp("up_proj"), &lora_adapters)?;
+        let c_proj = load_projection(
+            "down_proj",
+            i_size,
+            h_size,
+            vb.pp("down_proj"),
+            &lora_adapters,
+        )?;
         Ok(Self {
             c_fc1,
             c_fc2,
@@ -449,10 +626,34 @@ impl Block {
         Ok(x)
     }
 
-    fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+    fn has_adapter(&self, name: &str) -> bool {
+        self.attn.has_adapter(name) || self.mlp.has_adapter(name)
+    }
+
+    fn set_active_adapter(&mut self, name: Option<&str>) -> Result<()> {
+        self.attn.set_active_adapter(name)?;
+        self.mlp.set_active_adapter(name)
+    }
+
+    fn load(
+        vb: VarBuilder,
+        cfg: &Config,
+        layer_idx: usize,
+        lora_adapters: &[LoraSpec],
+    ) -> Result<Self> {
         let span = tracing::span!(tracing::Level::TRACE, "block");
-        let attn = CausalSelfAttention::load(vb.pp("self_attn"), cfg)?;
-        let mlp = Mlp::load(vb.pp("mlp"), cfg)?;
+        let block_lora: Vec<_> = lora_adapters
+            .iter()
+            .map(|(name, vb, cfg)| {
+                (
+                    name.clone(),
+                    vb.pp(format!("model.layers.{layer_idx}")),
+                    cfg.clone(),
+                )
+            })
+            .collect();
+        let attn = CausalSelfAttention::load(vb.pp("self_attn"), cfg, &block_lora)?;
+        let mlp = Mlp::load(vb.pp("mlp"), cfg, &block_lora)?;
         let rms_1 = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
         let rms_2 = RmsNorm::new(
             cfg.hidden_size,
@@ -513,6 +714,20 @@ impl Llama {
     }
 
     pub fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+        Self::load_with_config(vb, cfg, LlamaLoadConfig::default())
+    }
+
+    /// Like [`Llama::load`], but additionally injects the LoRA adapters
+    /// listed in `load_config` into the matching attention/MLP projections.
+    /// With no adapters registered this behaves exactly like `Llama::load`.
+    /// Use [`Llama::set_active_adapter`] to select which (if any) of the
+    /// registered adapters applies to subsequent forward passes.
+    pub fn load_with_config(
+        vb: VarBuilder,
+        cfg: &Config,
+        load_config: LlamaLoadConfig,
+    ) -> Result<Self> {
+        let lora_adapters = load_config.lora_adapters;
         let wte = embedding(cfg.vocab_size, cfg.hidden_size, vb.pp("model.embed_tokens"))?;
         let lm_head = if cfg.tie_word_embeddings {
             Linear::from_weights(wte.embeddings().clone(), None)
@@ -521,8 +736,8 @@ impl Llama {
         };
         let ln_f = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("model.norm"))?;
         let blocks: Vec<_> = (0..cfg.num_hidden_layers)
-            .map(|i| Block::load(vb.pp(format!("model.layers.{i}")), cfg).unwrap())
-            .collect();
+            .map(|i| Block::load(vb.pp(format!("model.layers.{i}")), cfg, i, &lora_adapters))
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(Self {
             wte,
@@ -530,5 +745,225 @@ impl Llama {
             ln_f,
             lm_head,
         })
+    }
+
+    /// Selects the LoRA adapter that subsequent calls to `forward` /
+    /// `forward_input_embed` should use, or falls back to the frozen base
+    /// weights when `name` is `None`. Switching adapters does not reload or
+    /// duplicate the base model weights.
+    pub fn set_active_adapter(&mut self, name: Option<&str>) -> Result<()> {
+        if let Some(name) = name {
+            if !self.blocks.iter().any(|b| b.has_adapter(name)) {
+                candle::bail!("no such LoRA adapter: {name}")
+            }
+        }
+        for block in &mut self.blocks {
+            block.set_active_adapter(name)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tiny_config() -> Config {
+        Config {
+            hidden_size: 4,
+            intermediate_size: 4,
+            vocab_size: 8,
+            num_hidden_layers: 1,
+            num_attention_heads: 2,
+            num_key_value_heads: 2,
+            use_flash_attn: false,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10_000.0,
+            bos_token_id: None,
+            eos_token_id: None,
+            rope_scaling: None,
+            max_position_embeddings: 16,
+            tie_word_embeddings: false,
+        }
+    }
+
+    fn base_weights(cfg: &Config, dev: &Device) -> HashMap<String, Tensor> {
+        let h = cfg.hidden_size;
+        let i = cfg.intermediate_size;
+        let v = cfg.vocab_size;
+        let mut ts = HashMap::new();
+        ts.insert(
+            "model.embed_tokens.weight".to_string(),
+            Tensor::ones((v, h), DType::F32, dev).unwrap(),
+        );
+        ts.insert(
+            "model.norm.weight".to_string(),
+            Tensor::ones(h, DType::F32, dev).unwrap(),
+        );
+        ts.insert(
+            "lm_head.weight".to_string(),
+            (Tensor::ones((v, h), DType::F32, dev).unwrap() * 0.1).unwrap(),
+        );
+        for i_layer in 0..cfg.num_hidden_layers {
+            let p = format!("model.layers.{i_layer}");
+            ts.insert(
+                format!("{p}.input_layernorm.weight"),
+                Tensor::ones(h, DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.post_attention_layernorm.weight"),
+                Tensor::ones(h, DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.self_attn.q_proj.weight"),
+                Tensor::zeros((h, h), DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.self_attn.k_proj.weight"),
+                Tensor::zeros((h, h), DType::F32, dev).unwrap(),
+            );
+            // Non-zero v_proj so the attention output (and thus o_proj's
+            // input) is non-zero, letting a LoRA adapter on o_proj have an
+            // observable effect even with a single-token sequence.
+            ts.insert(
+                format!("{p}.self_attn.v_proj.weight"),
+                (Tensor::ones((h, h), DType::F32, dev).unwrap() * 0.1).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.self_attn.o_proj.weight"),
+                Tensor::zeros((h, h), DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.mlp.gate_proj.weight"),
+                Tensor::zeros((i, h), DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.mlp.up_proj.weight"),
+                Tensor::zeros((i, h), DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.mlp.down_proj.weight"),
+                Tensor::zeros((h, i), DType::F32, dev).unwrap(),
+            );
+        }
+        ts
+    }
+
+    fn lora_adapter_weights(
+        cfg: &Config,
+        rank: usize,
+        dev: &Device,
+        prefix: &str,
+    ) -> HashMap<String, Tensor> {
+        let h = cfg.hidden_size;
+        let mut ts = HashMap::new();
+        for i_layer in 0..cfg.num_hidden_layers {
+            let p = if prefix.is_empty() {
+                format!("model.layers.{i_layer}.self_attn.o_proj")
+            } else {
+                format!("{prefix}.model.layers.{i_layer}.self_attn.o_proj")
+            };
+            ts.insert(
+                format!("{p}.lora_A.weight"),
+                Tensor::ones((rank, h), DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.lora_B.weight"),
+                Tensor::ones((h, rank), DType::F32, dev).unwrap(),
+            );
+        }
+        ts
+    }
+
+    #[test]
+    fn load_without_lora_matches_plain_load() -> Result<()> {
+        let dev = Device::Cpu;
+        let cfg = tiny_config();
+        let vb = VarBuilder::from_tensors(base_weights(&cfg, &dev), DType::F32, &dev);
+        let mut model = Llama::load(vb, &cfg)?;
+        let input = Tensor::new(&[[1u32, 2, 3]], &dev)?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        // Should run without error and produce the expected output shape.
+        let logits = model.forward(&input, 0, &mut cache)?;
+        assert_eq!(logits.dims(), &[1, cfg.vocab_size]);
+        // No adapters were registered, so activating one must fail.
+        assert!(model.set_active_adapter(Some("missing")).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn lora_adapter_changes_output_only_when_active() -> Result<()> {
+        let dev = Device::Cpu;
+        let cfg = tiny_config();
+        let base_vb = VarBuilder::from_tensors(base_weights(&cfg, &dev), DType::F32, &dev);
+        // Adapter weights follow the standard PEFT `base_model.model.` layout;
+        // `with_lora_adapter` should resolve them without any extra scoping.
+        let adapter_vb = VarBuilder::from_tensors(
+            lora_adapter_weights(&cfg, 2, &dev, PEFT_ADAPTER_PREFIX),
+            DType::F32,
+            &dev,
+        );
+        let load_config = LlamaLoadConfig::default().with_lora_adapter(
+            "adapter",
+            adapter_vb,
+            LoraConfig {
+                rank: 2,
+                alpha: 4.0,
+                target_modules: vec!["o_proj".to_string()],
+            },
+        );
+        let mut model = Llama::load_with_config(base_vb, &cfg, load_config)?;
+
+        let input = Tensor::new(&[[1u32, 2, 3]], &dev)?;
+
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let base_logits = model.forward(&input, 0, &mut cache)?.to_vec2::<f32>()?;
+
+        model.set_active_adapter(Some("adapter"))?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let adapter_logits = model.forward(&input, 0, &mut cache)?.to_vec2::<f32>()?;
+        assert_ne!(base_logits, adapter_logits);
+
+        model.set_active_adapter(None)?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let back_to_base_logits = model.forward(&input, 0, &mut cache)?.to_vec2::<f32>()?;
+        assert_eq!(base_logits, back_to_base_logits);
+
+        assert!(model.set_active_adapter(Some("missing")).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn lora_adapter_with_custom_prefix() -> Result<()> {
+        let dev = Device::Cpu;
+        let cfg = tiny_config();
+        let base_vb = VarBuilder::from_tensors(base_weights(&cfg, &dev), DType::F32, &dev);
+        // Adapter checkpoint saved without any wrapping prefix (tensors live
+        // directly under `model.layers.{i}...`), as if already unwrapped from
+        // a PeftModel. `with_lora_adapter` alone would look under
+        // `base_model.model.` and fail to find these tensors.
+        let adapter_vb =
+            VarBuilder::from_tensors(lora_adapter_weights(&cfg, 2, &dev, ""), DType::F32, &dev);
+        let load_config = LlamaLoadConfig::default().with_lora_adapter_prefixed(
+            "adapter",
+            adapter_vb,
+            LoraConfig {
+                rank: 2,
+                alpha: 4.0,
+                target_modules: vec!["o_proj".to_string()],
+            },
+            "",
+        );
+        let mut model = Llama::load_with_config(base_vb, &cfg, load_config)?;
+
+        let input = Tensor::new(&[[1u32, 2, 3]], &dev)?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let base_logits = model.forward(&input, 0, &mut cache)?.to_vec2::<f32>()?;
+
+        model.set_active_adapter(Some("adapter"))?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let adapter_logits = model.forward(&input, 0, &mut cache)?.to_vec2::<f32>()?;
+        assert_ne!(base_logits, adapter_logits);
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Closes #3652.

Adds `candle_nn::lora::LoraLinear`, a `Linear` wrapper that computes
`y = W·x + (B·A)·x·(alpha/r)`, so consumers no longer need to
re-implement LoRA and PEFT-adapter loading themselves.

- `LoraLinear::from_peft(base, vb, rank, alpha)` loads a PEFT-style
  `.safetensors` adapter (`lora_A.weight` `[r, in]` / `lora_B.weight`
  `[out, r]`) through a `VarBuilder`, matching the signature proposed
  in the issue.
- `merge()` / `unmerge()` fold the active adapter's delta into (and
  back out of) the base layer's weight, for adapter-free inference.
- Multiple named adapters can be registered on the same `LoraLinear`
  via `load_adapter` / `add_adapter`, with `set_active_adapter` /
  `active_adapter` / `remove_adapter` to hot-swap between them for
  multi-adapter serving. Switching is rejected while a different
  adapter is merged, to avoid silently mixing base weights from two
  adapters.

```rust
let base = linear(in_dim, out_dim, vb.pp("q_proj"))?;
let lora = LoraLinear::from_peft(base, vb_adapter.pp("q_proj"), /*rank=*/16, /*alpha=*/32.0)?;
let y = lora.forward(&x)?; // base + LoRA delta
```

## Test plan

- [x] `cargo test -p candle-nn --test lora` — forward output matches a
      manual `W·x + (B·A)·x·(alpha/r)` computation, merge/unmerge
      round-trips back to the original output, and multi-adapter
      switching (including the merged-adapter guard) behaves as
      expected.
- [x] `cargo test -p candle-nn --doc` — module-level doctest.
- [x] `cargo clippy -p candle-nn --all-targets` — clean.
- [x] `cargo fmt -p candle-nn -- --check` — clean.
- [x] `cargo test -p candle-nn --features cuda` — passing on a CUDA
      runner (RTX 3060).