### PR TITLE
fix(metal-sdpa): guard final division against 0/0 NaN with GQA + non-…

### DIFF
--- a/candle-metal-kernels/src/metal_src/scaled_dot_product_attention.metal
+++ b/candle-metal-kernels/src/metal_src/scaled_dot_product_attention.metal
@@ -2275,6 +2275,10 @@ template <
     loader_v.next();
   }
 
+  // Guard against 0/0 when entire row is fully masked (sum_score == 0)
+  for (short i = 0; i < kRowsPT; ++i) {
+    if (sum_score[i] == 0) sum_score[i] = 1;
+  }
   // Normalize output
   Otile.template row_bin_op<DivOp>(sum_score);
   threadgroup_barrier(mem_flags::mem_none);

--- a/candle-nn/tests/sdpa.rs
+++ b/candle-nn/tests/sdpa.rs
@@ -155,6 +155,110 @@ mod metal_sdpa_tests {
         Ok(())
     }
 
+    fn make_gqa_ground_truth(
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        mask: Option<&Tensor>,
+        scale: f64,
+    ) -> Result<Tensor> {
+        let att = (q.clone() * scale)?.matmul(&k.clone().t()?)?;
+        let att = match mask {
+            Some(m) => att.broadcast_add(m)?,
+            None => att,
+        };
+        let att = candle_nn::ops::softmax_last_dim(&att.to_dtype(DType::F32)?)?
+            .to_dtype(q.dtype())?;
+        att.matmul(&v.clone())
+    }
+
+    #[test]
+    fn sdpa_full_gqa_square_mask() -> Result<()> {
+        // GQA with square mask: MHA head count varies, Q == K
+        const BS: usize = 2;
+        const H_Q: usize = 6; // query heads
+        const H_K: usize = 3; // kv heads
+        const R: usize = 8;
+        const L: usize = 8;
+        const DK: usize = 64;
+
+        let scale: f64 = f64::from(DK as u32).sqrt().recip();
+        let device = Device::new_metal(0)?;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(4242424242);
+        let q = randn(&mut rng, (BS, H_Q, R, DK), &device)?;
+        let k = randn(&mut rng, (BS, H_K, L, DK), &device)?;
+        let v = randn(&mut rng, (BS, H_K, L, DK), &device)?;
+        let mask = randn(&mut rng, (BS, H_Q, R, L), &device)?;
+
+        let ground_truth = make_gqa_ground_truth(&q, &k, &v, Some(&mask), scale)?;
+        let sdpa_output =
+            candle_nn::ops::sdpa(&q, &k, &v, Some(&mask), false, scale as f32, 1.)?;
+        assert_eq!(ground_truth.shape(), sdpa_output.shape());
+        let error: f32 = ((&ground_truth - &sdpa_output)?.abs()? / &ground_truth.abs()?)?
+            .sum_all()?
+            .to_scalar()?;
+        assert!(error <= 0.005, "GQA square mask error: {}", error);
+        Ok(())
+    }
+
+    #[test]
+    fn sdpa_full_gqa_nonsquare_mask() -> Result<()> {
+        // GQA with non-square mask: H_Q != H_K, Q != K (KV cache reuse scenario)
+        const BS: usize = 2;
+        const H_Q: usize = 6;
+        const H_K: usize = 3;
+        const R: usize = 8; // q_seq
+        const L: usize = 16; // k_seq (longer, like cached KV)
+        const DK: usize = 64;
+
+        let scale: f64 = f64::from(DK as u32).sqrt().recip();
+        let device = Device::new_metal(0)?;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(4242424242);
+        let q = randn(&mut rng, (BS, H_Q, R, DK), &device)?;
+        let k = randn(&mut rng, (BS, H_K, L, DK), &device)?;
+        let v = randn(&mut rng, (BS, H_K, L, DK), &device)?;
+        let mask = randn(&mut rng, (BS, H_Q, R, L), &device)?;
+
+        let ground_truth = make_gqa_ground_truth(&q, &k, &v, Some(&mask), scale)?;
+        let sdpa_output =
+            candle_nn::ops::sdpa(&q, &k, &v, Some(&mask), false, scale as f32, 1.)?;
+        assert_eq!(ground_truth.shape(), sdpa_output.shape());
+        let error: f32 = ((&ground_truth - &sdpa_output)?.abs()? / &ground_truth.abs()?)?
+            .sum_all()?
+            .to_scalar()?;
+        assert!(error <= 0.005, "GQA non-square mask error: {}", error);
+        Ok(())
+    }
+
+    #[test]
+    fn sdpa_full_gqa_nonsquare_causal() -> Result<()> {
+        // GQA with non-square mask + do_causal
+        const BS: usize = 2;
+        const H_Q: usize = 6;
+        const H_K: usize = 3;
+        const R: usize = 8;
+        const L: usize = 16;
+        const DK: usize = 64;
+
+        let scale: f64 = f64::from(DK as u32).sqrt().recip();
+        let device = Device::new_metal(0)?;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(4242424242);
+        let q = randn(&mut rng, (BS, H_Q, R, DK), &device)?;
+        let k = randn(&mut rng, (BS, H_K, L, DK), &device)?;
+        let v = randn(&mut rng, (BS, H_K, L, DK), &device)?;
+        let mask = randn(&mut rng, (BS, H_Q, R, L), &device)?;
+
+        let ground_truth = make_gqa_ground_truth(&q, &k, &v, Some(&mask), scale)?;
+        let sdpa_output =
+            candle_nn::ops::sdpa(&q, &k, &v, Some(&mask), true, scale as f32, 1.)?;
+        assert_eq!(ground_truth.shape(), sdpa_output.shape());
+        let error: f32 = ((&ground_truth - &sdpa_output)?.abs()? / &ground_truth.abs()?)?
+            .sum_all()?
+            .to_scalar()?;
+        assert!(error <= 0.005, "GQA non-square causal error: {}", error);
+        Ok(())
+    }
+
     #[test]
     fn sdpa_vector_cross() -> Result<()> {
         // Allow vectorized, seqlen = 1. Simulat cross attention case where R != L, R = 1


### PR DESCRIPTION
…square mask

Metal SDPA full kernel's unguarded O /= sum_score produces NaN when the entire attention row is masked (sum_score == 0). This is triggered when GQA (H_q != H_kv) is combined with a non-square attention mask (Q != K).

Root cause: the DivOp at the final normalization step was unguarded. Intermediate softmax rescaling (ExpSubOp, actor) had guards for -inf, but the final division by zero was unprotected.

Changes:
- Guard Otile.row_bin_op<DivOp>(sum_score) with a zero-check on each row's sum_score, clamping to 1 to prevent 0/0 = NaN
- Add 3 new SDPA tests exercising the full kernel with GQA + mask:
  - square mask (Q=K)
  - non-square mask (Q=8, K=16) — the reported failing combination
  - non-square mask + do_causal

Closes #3388