### PR TITLE
fix examples build on symphonia feature

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -42,7 +42,11 @@ jobs:
         if: matrix.os == 'ubuntu-24.04-arm'
         run: |
           export RUSTFLAGS="-C target-feature=neon"
-          cargo check --workspace 
+          cargo check --workspace
+
+      - name: Check examples on symphonia feature
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'
+        run: cargo check --examples --features="symphonia" 
 
   test:
     name: Test Suite

--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -159,7 +159,7 @@ required-features = ["pdf2image"]
 
 [[example]]
 name = "voxtral"
-required-features = ["symphonia"]
+required-features = ["symphonia", "rubato", "tekken"]
 
 [[example]]
 name = "bert_single_file_binary"

--- a/candle-examples/src/audio.rs
+++ b/candle-examples/src/audio.rs
@@ -30,18 +30,21 @@ pub fn normalize_loudness(
 
 #[cfg(feature = "symphonia")]
 pub fn pcm_decode<P: AsRef<std::path::Path>>(path: P) -> Result<(Vec<f32>, u32)> {
-    use symphonia::core::audio::{AudioBufferRef, Signal};
-    use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
-    use symphonia::core::conv::FromSample;
+    use symphonia::core::audio::conv::FromSample;
+    use symphonia::core::audio::Audio;
+    use symphonia::core::audio::GenericAudioBufferRef;
+    use symphonia::core::codecs::audio::AudioDecoderOptions;
 
     fn conv<T>(
         samples: &mut Vec<f32>,
         data: std::borrow::Cow<symphonia::core::audio::AudioBuffer<T>>,
     ) where
-        T: symphonia::core::sample::Sample,
-        f32: symphonia::core::conv::FromSample<T>,
+        T: symphonia::core::audio::sample::Sample,
+        f32: symphonia::core::audio::conv::FromSample<T>,
     {
-        samples.extend(data.chan(0).iter().map(|v| f32::from_sample(*v)))
+        if let Some(ch0) = data.plane(0) {
+            samples.extend(ch0.iter().map(|v| f32::from_sample(*v)))
+        }
     }
 
     // Open the media source.
@@ -51,58 +54,68 @@ pub fn pcm_decode<P: AsRef<std::path::Path>>(path: P) -> Result<(Vec<f32>, u32)>
     let mss = symphonia::core::io::MediaSourceStream::new(Box::new(src), Default::default());
 
     // Create a probe hint using the file's extension. [Optional]
-    let hint = symphonia::core::probe::Hint::new();
+    let hint = symphonia::core::formats::probe::Hint::new();
 
     // Use the default options for metadata and format readers.
     let meta_opts: symphonia::core::meta::MetadataOptions = Default::default();
     let fmt_opts: symphonia::core::formats::FormatOptions = Default::default();
 
     // Probe the media source.
-    let probed = symphonia::default::get_probe()
-        .format(&hint, mss, &fmt_opts, &meta_opts)
+    let mut format = symphonia::default::get_probe()
+        .probe(&hint, mss, fmt_opts, meta_opts)
         .map_err(candle::Error::wrap)?;
-    // Get the instantiated format reader.
-    let mut format = probed.format;
 
     // Find the first audio track with a known (decodable) codec.
     let track = format
         .tracks()
         .iter()
-        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+        .find(|t| t.codec_params.as_ref().is_some_and(|s| s.is_audio()))
         .ok_or_else(|| candle::Error::Msg("no supported audio tracks".to_string()))?;
 
     // Use the default options for the decoder.
-    let dec_opts: DecoderOptions = Default::default();
+    let dec_opts: AudioDecoderOptions = Default::default();
+
+    let codec_params = track
+        .codec_params
+        .as_ref()
+        .and_then(|p| p.audio())
+        .ok_or_else(|| candle::Error::Msg("codec parameters missing".to_string()))?;
 
     // Create a decoder for the track.
     let mut decoder = symphonia::default::get_codecs()
-        .make(&track.codec_params, &dec_opts)
+        .make_audio_decoder(&codec_params, &dec_opts)
         .map_err(|_| candle::Error::Msg("unsupported codec".to_string()))?;
     let track_id = track.id;
-    let sample_rate = track.codec_params.sample_rate.unwrap_or(0);
+    let sample_rate = codec_params.sample_rate.unwrap_or(0);
     let mut pcm_data = Vec::new();
     // The decode loop.
-    while let Ok(packet) = format.next_packet() {
+    while let Ok(Some(packet)) = format.next_packet() {
         // Consume any new metadata that has been read since the last packet.
+
+        use std::borrow::Cow;
         while !format.metadata().is_latest() {
             format.metadata().pop();
         }
 
         // If the packet does not belong to the selected track, skip over it.
-        if packet.track_id() != track_id {
+        if packet.track_id != track_id {
             continue;
         }
         match decoder.decode(&packet).map_err(candle::Error::wrap)? {
-            AudioBufferRef::F32(buf) => pcm_data.extend(buf.chan(0)),
-            AudioBufferRef::U8(data) => conv(&mut pcm_data, data),
-            AudioBufferRef::U16(data) => conv(&mut pcm_data, data),
-            AudioBufferRef::U24(data) => conv(&mut pcm_data, data),
-            AudioBufferRef::U32(data) => conv(&mut pcm_data, data),
-            AudioBufferRef::S8(data) => conv(&mut pcm_data, data),
-            AudioBufferRef::S16(data) => conv(&mut pcm_data, data),
-            AudioBufferRef::S24(data) => conv(&mut pcm_data, data),
-            AudioBufferRef::S32(data) => conv(&mut pcm_data, data),
-            AudioBufferRef::F64(data) => conv(&mut pcm_data, data),
+            GenericAudioBufferRef::F32(buf) => {
+                if let Some(ch0) = buf.plane(0) {
+                    pcm_data.extend(ch0)
+                }
+            }
+            GenericAudioBufferRef::U8(data) => conv(&mut pcm_data, Cow::Borrowed(data)),
+            GenericAudioBufferRef::U16(data) => conv(&mut pcm_data, Cow::Borrowed(data)),
+            GenericAudioBufferRef::U24(data) => conv(&mut pcm_data, Cow::Borrowed(data)),
+            GenericAudioBufferRef::U32(data) => conv(&mut pcm_data, Cow::Borrowed(data)),
+            GenericAudioBufferRef::S8(data) => conv(&mut pcm_data, Cow::Borrowed(data)),
+            GenericAudioBufferRef::S16(data) => conv(&mut pcm_data, Cow::Borrowed(data)),
+            GenericAudioBufferRef::S24(data) => conv(&mut pcm_data, Cow::Borrowed(data)),
+            GenericAudioBufferRef::S32(data) => conv(&mut pcm_data, Cow::Borrowed(data)),
+            GenericAudioBufferRef::F64(data) => conv(&mut pcm_data, Cow::Borrowed(data)),
         }
     }
     Ok((pcm_data, sample_rate))
@@ -112,27 +125,29 @@ pub fn pcm_decode<P: AsRef<std::path::Path>>(path: P) -> Result<(Vec<f32>, u32)>
 pub fn resample(pcm_in: &[f32], sr_in: u32, sr_out: u32) -> Result<Vec<f32>> {
     use rubato::Resampler;
 
-    let mut pcm_out =
-        Vec::with_capacity((pcm_in.len() as f64 * sr_out as f64 / sr_in as f64) as usize + 1024);
-
-    let mut resampler = rubato::FftFixedInOut::<f32>::new(sr_in as usize, sr_out as usize, 1024, 1)
+    let input = rubato::audioadapter_buffers::owned::InterleavedOwned::new_from(
+        pcm_in.to_vec(),
+        1,
+        pcm_in.len(),
+    )
+    .map_err(candle::Error::wrap)?;
+    let mut resampler = rubato::Fft::<f32>::new(
+        sr_in as usize,
+        sr_out as usize,
+        1024,
+        1,
+        1,
+        rubato::FixedSync::Input,
+    )
+    .map_err(candle::Error::wrap)?;
+    let output_len = resampler.process_all_needed_output_len(pcm_in.len());
+    let mut output =
+        rubato::audioadapter_buffers::owned::InterleavedOwned::new(0f32, 1, output_len);
+    let (_in_len, out_len) = resampler
+        .process_all_into_buffer(&input, &mut output, pcm_in.len(), None)
         .map_err(candle::Error::wrap)?;
-    let mut output_buffer = resampler.output_buffer_allocate(true);
-    let mut pos_in = 0;
-    while pos_in + resampler.input_frames_next() < pcm_in.len() {
-        let (in_len, out_len) = resampler
-            .process_into_buffer(&[&pcm_in[pos_in..]], &mut output_buffer, None)
-            .map_err(candle::Error::wrap)?;
-        pos_in += in_len;
-        pcm_out.extend_from_slice(&output_buffer[0][..out_len]);
-    }
-
-    if pos_in < pcm_in.len() {
-        let (_in_len, out_len) = resampler
-            .process_partial_into_buffer(Some(&[&pcm_in[pos_in..]]), &mut output_buffer, None)
-            .map_err(candle::Error::wrap)?;
-        pcm_out.extend_from_slice(&output_buffer[0][..out_len]);
-    }
+    let mut pcm_out = output.take_data();
+    pcm_out.truncate(out_len);
 
     Ok(pcm_out)
 }


### PR DESCRIPTION
As the examples seem currently unchecked by CI an update of "symphonia" to `0.6` has left the examples, in particular `whisper` broken. This patch fixes it and adds a check to the CI run.

```
cargo check --examples --features="symphonia"

error[E0432]: unresolved imports `symphonia::core::audio::AudioBufferRef`, `symphonia::core::audio::Signal`
  --> candle-examples/src/audio.rs:33:34
   |
33 |     use symphonia::core::audio::{AudioBufferRef, Signal};
   |                                  ^^^^^^^^^^^^^^  ^^^^^^ no `Signal` in `audio`
   |                                  |
   |                                  no `AudioBufferRef` in `audio`
   |
help: a similar name exists in the module
   |
33 -     use symphonia::core::audio::{AudioBufferRef, Signal};
33 +     use symphonia::core::audio::{AudioBuffer, Signal};
   |

error[E0432]: unresolved imports `symphonia::core::codecs::DecoderOptions`, `symphonia::core::codecs::CODEC_TYPE_NULL`
  --> candle-examples/src/audio.rs:34:35
   |
...

```