### PR TITLE
Add Llama 4 (Scout/Maverick) text-decoder model

### DIFF
--- a/candle-examples/examples/llama4/README.md
+++ b/candle-examples/examples/llama4/README.md
@@ -1,0 +1,20 @@
+# Llama 4
+
+Llama 4 is Meta's MoE-based LLM family (Scout / Maverick). This implementation covers
+the text-only decoder: iRoPE (alternating RoPE/NoPE attention layers), QK-norm,
+attention temperature tuning on NoPE layers, and a top-k sigmoid-gated MoE block with
+an always-on shared expert.
+
+- Scout: 17B active / 109B total params, 16 routed experts.
+- Maverick: 17B active / 400B total params, 128 routed experts.
+
+Both are very large checkpoints; running them requires significant RAM/VRAM.
+
+## Running the example
+
+```bash
+$ cargo run --example llama4 --release -- --prompt "Recursive fibonacci code in Rust:" --sample-len 150
+```
+
+By default this targets `meta-llama/Llama-4-Scout-17B-16E-Instruct` (gated on the Hub,
+requires `huggingface-cli login`); pass `--model-id` to point at a different checkpoint.

--- a/candle-examples/examples/llama4/main.rs
+++ b/candle-examples/examples/llama4/main.rs
@@ -1,0 +1,264 @@
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use anyhow::{Error as E, Result};
+use clap::Parser;
+
+use candle_transformers::models::llama4::{Config, EosToks, ModelForCausalLM};
+
+use candle::{DType, Device, Tensor};
+use candle_examples::token_output_stream::TokenOutputStream;
+use candle_nn::VarBuilder;
+use candle_transformers::generation::{LogitsProcessor, Sampling};
+use hf_hub::{api::sync::Api, Repo, RepoType};
+use tokenizers::Tokenizer;
+
+struct TextGeneration {
+    model: ModelForCausalLM,
+    device: Device,
+    tokenizer: TokenOutputStream,
+    logits_processor: LogitsProcessor,
+    repeat_penalty: f32,
+    repeat_last_n: usize,
+    eos_token_id: Option<EosToks>,
+}
+
+impl TextGeneration {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        model: ModelForCausalLM,
+        tokenizer: Tokenizer,
+        eos_token_id: Option<EosToks>,
+        seed: u64,
+        temp: Option<f64>,
+        top_p: Option<f64>,
+        top_k: Option<usize>,
+        repeat_penalty: f32,
+        repeat_last_n: usize,
+        device: &Device,
+    ) -> Self {
+        let logits_processor = {
+            let temperature = temp.unwrap_or(0.);
+            let sampling = if temperature <= 0. {
+                Sampling::ArgMax
+            } else {
+                match (top_k, top_p) {
+                    (None, None) => Sampling::All { temperature },
+                    (Some(k), None) => Sampling::TopK { k, temperature },
+                    (None, Some(p)) => Sampling::TopP { p, temperature },
+                    (Some(k), Some(p)) => Sampling::TopKThenTopP { k, p, temperature },
+                }
+            };
+            LogitsProcessor::from_sampling(seed, sampling)
+        };
+
+        Self {
+            model,
+            tokenizer: TokenOutputStream::new(tokenizer),
+            logits_processor,
+            repeat_penalty,
+            repeat_last_n,
+            eos_token_id,
+            device: device.clone(),
+        }
+    }
+
+    fn run(&mut self, prompt: &str, sample_len: usize) -> Result<()> {
+        use std::io::Write;
+        self.tokenizer.clear();
+        let mut tokens = self
+            .tokenizer
+            .tokenizer()
+            .encode(prompt, true)
+            .map_err(E::msg)?
+            .get_ids()
+            .to_vec();
+        for &t in tokens.iter() {
+            if let Some(t) = self.tokenizer.next_token(t)? {
+                print!("{t}")
+            }
+        }
+        std::io::stdout().flush()?;
+
+        let mut generated_tokens = 0usize;
+        let start_gen = std::time::Instant::now();
+        for index in 0..sample_len {
+            let context_size = if index > 0 { 1 } else { tokens.len() };
+            let start_pos = tokens.len().saturating_sub(context_size);
+            let ctxt = &tokens[start_pos..];
+            let input = Tensor::new(ctxt, &self.device)?.unsqueeze(0)?;
+            let logits = self.model.forward(&input, start_pos)?;
+            let logits = logits.squeeze(0)?.squeeze(0)?.to_dtype(DType::F32)?;
+            let logits = if self.repeat_penalty == 1. {
+                logits
+            } else {
+                let start_at = tokens.len().saturating_sub(self.repeat_last_n);
+                candle_transformers::utils::apply_repeat_penalty(
+                    &logits,
+                    self.repeat_penalty,
+                    &tokens[start_at..],
+                )?
+            };
+
+            let next_token = self.logits_processor.sample(&logits)?;
+            tokens.push(next_token);
+            generated_tokens += 1;
+            let is_eos = match &self.eos_token_id {
+                Some(EosToks::Single(eos)) => next_token == *eos,
+                Some(EosToks::Multiple(eos)) => eos.contains(&next_token),
+                None => false,
+            };
+            if is_eos {
+                break;
+            }
+            if let Some(t) = self.tokenizer.next_token(next_token)? {
+                print!("{t}");
+                std::io::stdout().flush()?;
+            }
+        }
+        let dt = start_gen.elapsed();
+        if let Some(rest) = self.tokenizer.decode_rest().map_err(E::msg)? {
+            print!("{rest}");
+        }
+        std::io::stdout().flush()?;
+        println!(
+            "\n{generated_tokens} tokens generated ({:.2} token/s)",
+            generated_tokens as f64 / dt.as_secs_f64(),
+        );
+        Ok(())
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Run on CPU rather than on GPU.
+    #[arg(long)]
+    cpu: bool,
+
+    /// Enable tracing (generates a trace-timestamp.json file).
+    #[arg(long)]
+    tracing: bool,
+
+    #[arg(long)]
+    prompt: String,
+
+    /// The temperature used to generate samples.
+    #[arg(long)]
+    temperature: Option<f64>,
+
+    /// Nucleus sampling probability cutoff.
+    #[arg(long)]
+    top_p: Option<f64>,
+
+    /// Only sample among the top K samples.
+    #[arg(long)]
+    top_k: Option<usize>,
+
+    /// The seed to use when generating random samples.
+    #[arg(long, default_value_t = 299792458)]
+    seed: u64,
+
+    /// The length of the sample to generate (in tokens).
+    #[arg(long, short = 'n', default_value_t = 10000)]
+    sample_len: usize,
+
+    /// The model to use, defaults to the Llama 4 Scout instruct checkpoint.
+    #[arg(long, default_value = "meta-llama/Llama-4-Scout-17B-16E-Instruct")]
+    model_id: String,
+
+    #[arg(long, default_value = "main")]
+    revision: String,
+
+    /// Penalty to be applied for repeating tokens, 1. means no penalty.
+    #[arg(long, default_value_t = 1.1)]
+    repeat_penalty: f32,
+
+    /// The context size to consider for the repeat penalty.
+    #[arg(long, default_value_t = 64)]
+    repeat_last_n: usize,
+}
+
+fn main() -> Result<()> {
+    use tracing_chrome::ChromeLayerBuilder;
+    use tracing_subscriber::prelude::*;
+
+    let args = Args::parse();
+
+    let _guard = if args.tracing {
+        let (chrome_layer, guard) = ChromeLayerBuilder::new().build();
+        tracing_subscriber::registry().with(chrome_layer).init();
+        Some(guard)
+    } else {
+        None
+    };
+    println!(
+        "avx: {}, neon: {}, simd128: {}, f16c: {}",
+        candle::utils::with_avx(),
+        candle::utils::with_neon(),
+        candle::utils::with_simd128(),
+        candle::utils::with_f16c()
+    );
+    println!(
+        "temp: {:.2} repeat-penalty: {:.2} repeat-last-n: {}",
+        args.temperature.unwrap_or(0.),
+        args.repeat_penalty,
+        args.repeat_last_n
+    );
+
+    let start = std::time::Instant::now();
+    let api = Api::new()?;
+    let repo = api.repo(Repo::with_revision(
+        args.model_id,
+        RepoType::Model,
+        args.revision,
+    ));
+    let tokenizer_filename = repo.get("tokenizer.json")?;
+    let filenames =
+        match candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json") {
+            Ok(filenames) => filenames,
+            Err(_) => vec![repo.get("model.safetensors")?],
+        };
+    println!("retrieved the files in {:?}", start.elapsed());
+    let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
+
+    let start = std::time::Instant::now();
+    let config: Config = {
+        let config_file = repo.get("config.json")?;
+        let config_value: serde_json::Value = serde_json::from_slice(&std::fs::read(config_file)?)?;
+        // Real Llama 4 checkpoints nest the text-decoder config under `text_config`.
+        let text_config = config_value.get("text_config").unwrap_or(&config_value);
+        serde_json::from_value(text_config.clone())?
+    };
+    let device = candle_examples::device(args.cpu)?;
+    let (model, device) = {
+        let dtype = if device.is_cpu() {
+            DType::F32
+        } else {
+            DType::BF16
+        };
+        let vb = unsafe { VarBuilder::from_mmaped_safetensors(&filenames, dtype, &device)? };
+        let model = ModelForCausalLM::new(&config, vb)?;
+        (model, device)
+    };
+
+    println!("loaded the model in {:?}", start.elapsed());
+
+    let mut pipeline = TextGeneration::new(
+        model,
+        tokenizer,
+        config.eos_token_id.clone(),
+        args.seed,
+        args.temperature,
+        args.top_p,
+        args.top_k,
+        args.repeat_penalty,
+        args.repeat_last_n,
+        &device,
+    );
+    pipeline.run(&args.prompt, args.sample_len)?;
+    Ok(())
+}

--- a/candle-examples/examples/llama4/main.rs
+++ b/candle-examples/examples/llama4/main.rs
@@ -226,13 +226,16 @@ fn main() -> Result<()> {
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
 
     let start = std::time::Instant::now();
-    let config: Config = {
+    let config_value: serde_json::Value = {
         let config_file = repo.get("config.json")?;
-        let config_value: serde_json::Value = serde_json::from_slice(&std::fs::read(config_file)?)?;
-        // Real Llama 4 checkpoints nest the text-decoder config under `text_config`.
-        let text_config = config_value.get("text_config").unwrap_or(&config_value);
-        serde_json::from_value(text_config.clone())?
+        serde_json::from_slice(&std::fs::read(config_file)?)?
     };
+    // Real Llama 4 checkpoints are multimodal (`Llama4ForConditionalGeneration`): the
+    // text-decoder config lives under `text_config` and its weights are prefixed with
+    // `language_model.` in the checkpoint.
+    let is_multimodal = config_value.get("text_config").is_some();
+    let text_config = config_value.get("text_config").unwrap_or(&config_value);
+    let config: Config = serde_json::from_value(text_config.clone())?;
     let device = candle_examples::device(args.cpu)?;
     let (model, device) = {
         let dtype = if device.is_cpu() {
@@ -241,6 +244,11 @@ fn main() -> Result<()> {
             DType::BF16
         };
         let vb = unsafe { VarBuilder::from_mmaped_safetensors(&filenames, dtype, &device)? };
+        let vb = if is_multimodal {
+            vb.pp("language_model")
+        } else {
+            vb
+        };
         let model = ModelForCausalLM::new(&config, vb)?;
         (model, device)
     };

--- a/candle-examples/tests/llama4_integration.rs
+++ b/candle-examples/tests/llama4_integration.rs
@@ -1,0 +1,105 @@
+//! End-to-end smoke test for the Llama 4 model against a tiny,
+//! randomly-initialized checkpoint that uses the real Llama 4 architecture
+//! (iRoPE, QK-norm, attention temperature tuning, sigmoid-gated MoE with a
+//! shared expert) at a size small enough to download and run anywhere,
+//! unlike the real 109B/400B-parameter models.
+//!
+//! Network access required, so this is `#[ignore]`d by default. Run with:
+//!   cargo test -p candle-examples --release --test llama4_integration -- --ignored
+#![cfg(not(target_arch = "wasm32"))]
+
+use anyhow::Result;
+use candle::{DType, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::llama4::{Config, ModelForCausalLM};
+use hf_hub::{api::sync::Api, Repo, RepoType};
+use tokenizers::Tokenizer;
+
+const MODEL_ID: &str = "yujiepan/llama-4-tiny-random";
+
+#[test]
+#[ignore]
+fn llama4_tiny_random_generates() -> Result<()> {
+    let api = Api::new()?;
+    let repo = api.repo(Repo::with_revision(
+        MODEL_ID.to_string(),
+        RepoType::Model,
+        "main".to_string(),
+    ));
+
+    let tokenizer_filename = repo.get("tokenizer.json")?;
+    let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(anyhow::Error::msg)?;
+
+    let config_value: serde_json::Value = {
+        let config_file = repo.get("config.json")?;
+        serde_json::from_slice(&std::fs::read(config_file)?)?
+    };
+    // The real checkpoint is multimodal (`Llama4ForConditionalGeneration`): the
+    // text-decoder config lives under `text_config` and its weights are prefixed
+    // with `language_model.`.
+    let is_multimodal = config_value.get("text_config").is_some();
+    let text_config = config_value.get("text_config").unwrap_or(&config_value);
+    let config: Config = serde_json::from_value(text_config.clone())?;
+
+    let filenames =
+        match candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json") {
+            Ok(filenames) => filenames,
+            Err(_) => vec![repo.get("model.safetensors")?],
+        };
+
+    let device = candle_examples::device(false)?;
+    let dtype = if device.is_cpu() {
+        DType::F32
+    } else {
+        DType::BF16
+    };
+    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&filenames, dtype, &device)? };
+    let vb = if is_multimodal {
+        vb.pp("language_model")
+    } else {
+        vb
+    };
+    let mut model = ModelForCausalLM::new(&config, vb)?;
+
+    let prompt_ids = tokenizer
+        .encode("The quick brown fox", true)
+        .map_err(anyhow::Error::msg)?
+        .get_ids()
+        .to_vec();
+
+    // Prefill: forward the whole prompt and check the logits are well-formed.
+    let input = Tensor::new(prompt_ids.as_slice(), &device)?.unsqueeze(0)?;
+    let logits = model.forward(&input, 0)?;
+    assert_eq!(logits.dims(), &[1, 1, config.vocab_size]);
+    let logits = logits
+        .to_dtype(DType::F32)?
+        .flatten_all()?
+        .to_vec1::<f32>()?;
+    assert!(
+        logits.iter().all(|v| v.is_finite()),
+        "prefill logits contain NaN/Inf"
+    );
+    let next_token = logits
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.total_cmp(b))
+        .map(|(idx, _)| idx as u32)
+        .unwrap();
+    assert!((next_token as usize) < config.vocab_size);
+
+    // Decode step: forward a single new token using the KV cache populated above.
+    let next_input = Tensor::new(&[next_token], &device)?.unsqueeze(0)?;
+    let logits = model.forward(&next_input, prompt_ids.len())?;
+    assert_eq!(logits.dims(), &[1, 1, config.vocab_size]);
+    let logits = logits
+        .to_dtype(DType::F32)?
+        .flatten_all()?
+        .to_vec1::<f32>()?;
+    assert!(
+        logits.iter().all(|v| v.is_finite()),
+        "decode-step logits contain NaN/Inf"
+    );
+
+    model.clear_kv_cache();
+    Ok(())
+}

--- a/candle-transformers/src/models/llama4.rs
+++ b/candle-transformers/src/models/llama4.rs
@@ -8,7 +8,7 @@
 //! Reference: <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/modeling_llama4.py>
 
 use super::with_tracing::{linear_b, linear_no_bias, Linear, RmsNorm};
-use candle::{DType, Device, Module, Result, Tensor, D};
+use candle::{DType, Device, IndexOp, Module, Result, Tensor, D};
 use candle_nn::{kv_cache::ConcatKvCache, Activation, VarBuilder};
 
 fn default_rope_theta() -> f64 {
@@ -41,6 +41,24 @@ fn default_no_rope_layer_interval() -> usize {
 
 fn default_hidden_act() -> Activation {
     Activation::Silu
+}
+
+/// Some real config.json files (e.g. `yujiepan/llama-4-tiny-random`) encode this flag as a
+/// raw JSON integer (`4`) rather than a boolean; treat any nonzero integer as `true`.
+fn deserialize_bool_like<'de, D>(deserializer: D) -> std::result::Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum BoolLike {
+        Bool(bool),
+        Int(i64),
+    }
+    match serde::Deserialize::deserialize(deserializer)? {
+        BoolLike::Bool(b) => Ok(b),
+        BoolLike::Int(i) => Ok(i != 0),
+    }
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -80,7 +98,7 @@ pub struct Config {
     pub no_rope_layer_interval: usize,
     #[serde(default)]
     pub no_rope_layers: Option<Vec<usize>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_bool_like")]
     pub attn_temperature_tuning: bool,
     #[serde(default = "default_attn_scale")]
     pub attn_scale: f64,
@@ -201,35 +219,55 @@ impl Module for Mlp {
 #[derive(Debug, Clone)]
 struct MoeBlock {
     router: Linear,
-    experts: Vec<Mlp>,
+    // Batched expert parameters, matching the reference implementation's `nn.Parameter`
+    // layout: experts are not separate named sub-modules, but stacked along dim 0 and
+    // applied with a per-expert matmul (no transpose, unlike a regular `nn.Linear` weight).
+    gate_up_proj: Tensor, // (num_local_experts, hidden_size, 2 * intermediate_size)
+    down_proj: Tensor,    // (num_local_experts, intermediate_size, hidden_size)
     shared_expert: Mlp,
     num_experts_per_tok: usize,
+    num_local_experts: usize,
+    intermediate_size: usize,
+    act_fn: Activation,
 }
 
 impl MoeBlock {
     fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
         let router = linear_no_bias(cfg.hidden_size, cfg.num_local_experts, vb.pp("router"))?;
-        let mut experts = Vec::with_capacity(cfg.num_local_experts);
         let vb_e = vb.pp("experts");
-        for idx in 0..cfg.num_local_experts {
-            experts.push(Mlp::new(
+        let gate_up_proj = vb_e.get(
+            (
+                cfg.num_local_experts,
                 cfg.hidden_size,
+                2 * cfg.intermediate_size,
+            ),
+            "gate_up_proj",
+        )?;
+        let down_proj = vb_e.get(
+            (
+                cfg.num_local_experts,
                 cfg.intermediate_size,
-                cfg.hidden_act,
-                vb_e.pp(idx),
-            )?);
-        }
+                cfg.hidden_size,
+            ),
+            "down_proj",
+        )?;
+        // The shared expert uses the routed-expert intermediate size, not the dense-layer
+        // `intermediate_size_mlp`.
         let shared_expert = Mlp::new(
             cfg.hidden_size,
-            cfg.intermediate_size_mlp(),
+            cfg.intermediate_size,
             cfg.hidden_act,
             vb.pp("shared_expert"),
         )?;
         Ok(Self {
             router,
-            experts,
+            gate_up_proj,
+            down_proj,
             shared_expert,
             num_experts_per_tok: cfg.num_experts_per_tok,
+            num_local_experts: cfg.num_local_experts,
+            intermediate_size: cfg.intermediate_size,
+            act_fn: cfg.hidden_act,
         })
     }
 }
@@ -254,8 +292,8 @@ impl Module for MoeBlock {
         let routing_weights = routing_weights.to_vec2::<f32>()?;
         let top_idxs = top_idxs.to_vec2::<u32>()?;
 
-        let mut top_x = vec![vec![]; self.experts.len()];
-        let mut selected_weights = vec![vec![]; self.experts.len()];
+        let mut top_x = vec![vec![]; self.num_local_experts];
+        let mut selected_weights = vec![vec![]; self.num_local_experts];
         for (row_idx, (rw, expert_idxs)) in routing_weights.iter().zip(top_idxs.iter()).enumerate()
         {
             for (&rw, &expert_idx) in rw.iter().zip(expert_idxs.iter()) {
@@ -265,7 +303,7 @@ impl Module for MoeBlock {
         }
 
         let mut ys = xs.zeros_like()?;
-        for (expert_idx, expert_layer) in self.experts.iter().enumerate() {
+        for expert_idx in 0..self.num_local_experts {
             let rows = &top_x[expert_idx];
             if rows.is_empty() {
                 continue;
@@ -275,7 +313,15 @@ impl Module for MoeBlock {
                 .reshape(((), 1))?
                 .to_dtype(xs.dtype())?;
             let current_state = xs.index_select(&rows, 0)?.reshape(((), hidden_dim))?;
-            let current_hidden_states = expert_layer.forward(&current_state)?;
+
+            // `gate_up_proj`/`down_proj` are raw parameter tensors already laid out for a
+            // direct (untransposed) matmul, unlike a regular `nn.Linear` weight.
+            let gate_up_w = self.gate_up_proj.i(expert_idx)?.to_dtype(xs.dtype())?;
+            let down_w = self.down_proj.i(expert_idx)?.to_dtype(xs.dtype())?;
+            let gate_up = current_state.matmul(&gate_up_w)?;
+            let gate = gate_up.narrow(D::Minus1, 0, self.intermediate_size)?;
+            let up = gate_up.narrow(D::Minus1, self.intermediate_size, self.intermediate_size)?;
+            let current_hidden_states = (gate.apply(&self.act_fn)? * up)?.matmul(&down_w)?;
             let current_hidden_states = current_hidden_states.broadcast_mul(&weights)?;
             ys = ys.index_add(&rows, &current_hidden_states, 0)?;
         }
@@ -680,23 +726,16 @@ mod tests {
                     format!("{p}.feed_forward.router.weight"),
                     var(&[cfg.num_local_experts, h], dev),
                 );
-                for e in 0..cfg.num_local_experts {
-                    let ep = format!("{p}.feed_forward.experts.{e}");
-                    w.insert(
-                        format!("{ep}.gate_proj.weight"),
-                        var(&[cfg.intermediate_size, h], dev),
-                    );
-                    w.insert(
-                        format!("{ep}.up_proj.weight"),
-                        var(&[cfg.intermediate_size, h], dev),
-                    );
-                    w.insert(
-                        format!("{ep}.down_proj.weight"),
-                        var(&[h, cfg.intermediate_size], dev),
-                    );
-                }
+                w.insert(
+                    format!("{p}.feed_forward.experts.gate_up_proj"),
+                    var(&[cfg.num_local_experts, h, 2 * cfg.intermediate_size], dev),
+                );
+                w.insert(
+                    format!("{p}.feed_forward.experts.down_proj"),
+                    var(&[cfg.num_local_experts, cfg.intermediate_size, h], dev),
+                );
                 let sp = format!("{p}.feed_forward.shared_expert");
-                let im = cfg.intermediate_size_mlp();
+                let im = cfg.intermediate_size;
                 w.insert(format!("{sp}.gate_proj.weight"), var(&[im, h], dev));
                 w.insert(format!("{sp}.up_proj.weight"), var(&[im, h], dev));
                 w.insert(format!("{sp}.down_proj.weight"), var(&[h, im], dev));

--- a/candle-transformers/src/models/llama4.rs
+++ b/candle-transformers/src/models/llama4.rs
@@ -1,0 +1,737 @@
+//! Llama 4 (text-only decoder) inference implementation.
+//!
+//! Implements the Scout/Maverick MoE architecture: alternating NoPE/RoPE
+//! attention layers (iRoPE), parameterless QK-norm, attention temperature
+//! tuning on NoPE layers, and a top-k sigmoid-gated MoE with an always-on
+//! shared expert.
+//!
+//! Reference: <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/modeling_llama4.py>
+
+use super::with_tracing::{linear_b, linear_no_bias, Linear, RmsNorm};
+use candle::{DType, Device, Module, Result, Tensor, D};
+use candle_nn::{kv_cache::ConcatKvCache, Activation, VarBuilder};
+
+fn default_rope_theta() -> f64 {
+    500_000.0
+}
+
+fn default_rms_norm_eps() -> f64 {
+    1e-5
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_attn_scale() -> f64 {
+    0.1
+}
+
+fn default_floor_scale() -> f64 {
+    8192.0
+}
+
+fn default_interleave_moe_layer_step() -> usize {
+    1
+}
+
+fn default_no_rope_layer_interval() -> usize {
+    4
+}
+
+fn default_hidden_act() -> Activation {
+    Activation::Silu
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(untagged)]
+pub enum EosToks {
+    Single(u32),
+    Multiple(Vec<u32>),
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct Config {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    #[serde(default)]
+    pub intermediate_size_mlp: Option<usize>,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f64,
+    #[serde(default = "default_rms_norm_eps")]
+    pub rms_norm_eps: f64,
+    #[serde(default)]
+    pub attention_bias: bool,
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+    pub max_position_embeddings: usize,
+    pub num_local_experts: usize,
+    pub num_experts_per_tok: usize,
+    #[serde(default = "default_interleave_moe_layer_step")]
+    pub interleave_moe_layer_step: usize,
+    #[serde(default = "default_true")]
+    pub use_qk_norm: bool,
+    #[serde(default = "default_no_rope_layer_interval")]
+    pub no_rope_layer_interval: usize,
+    #[serde(default)]
+    pub no_rope_layers: Option<Vec<usize>>,
+    #[serde(default)]
+    pub attn_temperature_tuning: bool,
+    #[serde(default = "default_attn_scale")]
+    pub attn_scale: f64,
+    #[serde(default = "default_floor_scale")]
+    pub floor_scale: f64,
+    #[serde(default = "default_hidden_act")]
+    pub hidden_act: Activation,
+    #[serde(default)]
+    pub eos_token_id: Option<EosToks>,
+}
+
+impl Config {
+    fn intermediate_size_mlp(&self) -> usize {
+        self.intermediate_size_mlp.unwrap_or(self.intermediate_size)
+    }
+
+    /// Whether layer `layer_idx` (0-indexed) gets RoPE applied. Layers where this is
+    /// false use no positional embedding at all (NoPE), per the iRoPE design.
+    fn use_rope(&self, layer_idx: usize) -> bool {
+        match &self.no_rope_layers {
+            Some(v) => v.get(layer_idx).copied().unwrap_or(1) != 0,
+            None => !(layer_idx + 1).is_multiple_of(self.no_rope_layer_interval),
+        }
+    }
+
+    /// Whether layer `layer_idx` (0-indexed) is a sparse MoE layer, as opposed to a
+    /// dense MLP layer.
+    fn is_moe_layer(&self, layer_idx: usize) -> bool {
+        self.interleave_moe_layer_step != 0
+            && (layer_idx + 1).is_multiple_of(self.interleave_moe_layer_step)
+    }
+}
+
+/// Parameterless L2 normalization, used for QK-norm.
+#[derive(Debug, Clone)]
+struct L2Norm {
+    eps: f64,
+}
+
+impl L2Norm {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let dtype = x.dtype();
+        let x32 = x.to_dtype(DType::F32)?;
+        let norm = (x32.sqr()?.mean_keepdim(D::Minus1)? + self.eps)?.sqrt()?;
+        x32.broadcast_div(&norm)?.to_dtype(dtype)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RotaryEmbedding {
+    cos: Tensor,
+    sin: Tensor,
+}
+
+impl RotaryEmbedding {
+    fn new(cfg: &Config, dtype: DType, dev: &Device) -> Result<Self> {
+        let dim = cfg.head_dim;
+        let max_seq_len = cfg.max_position_embeddings;
+        let inv_freq: Vec<f32> = (0..dim)
+            .step_by(2)
+            .map(|i| 1f32 / (cfg.rope_theta as f32).powf(i as f32 / dim as f32))
+            .collect();
+        let inv_freq_len = inv_freq.len();
+        let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?;
+        let t = Tensor::arange(0u32, max_seq_len as u32, dev)?
+            .to_dtype(DType::F32)?
+            .reshape((max_seq_len, 1))?;
+        let freqs = t.matmul(&inv_freq)?;
+        Ok(Self {
+            cos: freqs.cos()?.to_dtype(dtype)?,
+            sin: freqs.sin()?.to_dtype(dtype)?,
+        })
+    }
+
+    /// Apply the interleaved-pair (complex/polar style) RoPE used by Llama 4.
+    fn apply(&self, q: &Tensor, k: &Tensor, offset: usize) -> Result<(Tensor, Tensor)> {
+        let (_, _, seq_len, _) = q.dims4()?;
+        let cos = self.cos.narrow(0, offset, seq_len)?;
+        let sin = self.sin.narrow(0, offset, seq_len)?;
+        let q_embed = candle_nn::rotary_emb::rope_i(&q.contiguous()?, &cos, &sin)?;
+        let k_embed = candle_nn::rotary_emb::rope_i(&k.contiguous()?, &cos, &sin)?;
+        Ok((q_embed, k_embed))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Mlp {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+    act_fn: Activation,
+}
+
+impl Mlp {
+    fn new(
+        hidden_size: usize,
+        intermediate_size: usize,
+        act: Activation,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        Ok(Self {
+            gate_proj: linear_no_bias(hidden_size, intermediate_size, vb.pp("gate_proj"))?,
+            up_proj: linear_no_bias(hidden_size, intermediate_size, vb.pp("up_proj"))?,
+            down_proj: linear_no_bias(intermediate_size, hidden_size, vb.pp("down_proj"))?,
+            act_fn: act,
+        })
+    }
+}
+
+impl Module for Mlp {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let lhs = x.apply(&self.gate_proj)?.apply(&self.act_fn)?;
+        let rhs = x.apply(&self.up_proj)?;
+        (lhs * rhs)?.apply(&self.down_proj)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MoeBlock {
+    router: Linear,
+    experts: Vec<Mlp>,
+    shared_expert: Mlp,
+    num_experts_per_tok: usize,
+}
+
+impl MoeBlock {
+    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let router = linear_no_bias(cfg.hidden_size, cfg.num_local_experts, vb.pp("router"))?;
+        let mut experts = Vec::with_capacity(cfg.num_local_experts);
+        let vb_e = vb.pp("experts");
+        for idx in 0..cfg.num_local_experts {
+            experts.push(Mlp::new(
+                cfg.hidden_size,
+                cfg.intermediate_size,
+                cfg.hidden_act,
+                vb_e.pp(idx),
+            )?);
+        }
+        let shared_expert = Mlp::new(
+            cfg.hidden_size,
+            cfg.intermediate_size_mlp(),
+            cfg.hidden_act,
+            vb.pp("shared_expert"),
+        )?;
+        Ok(Self {
+            router,
+            experts,
+            shared_expert,
+            num_experts_per_tok: cfg.num_experts_per_tok,
+        })
+    }
+}
+
+impl Module for MoeBlock {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let (b_size, seq_len, hidden_dim) = xs.dims3()?;
+        let xs = xs.reshape(((), hidden_dim))?;
+
+        let shared = self.shared_expert.forward(&xs)?;
+
+        let router_logits = xs.apply(&self.router)?;
+        let top_idxs = router_logits
+            .arg_sort_last_dim(false)?
+            .narrow(D::Minus1, 0, self.num_experts_per_tok)?
+            .contiguous()?;
+        let top_logits = router_logits.gather(&top_idxs, D::Minus1)?;
+        // Llama 4 gates each selected expert independently with a sigmoid of its own
+        // logit (not a softmax over the top-k group), so per-entry weights don't need
+        // to be renormalized against each other.
+        let routing_weights = candle_nn::ops::sigmoid(&top_logits.to_dtype(DType::F32)?)?;
+        let routing_weights = routing_weights.to_vec2::<f32>()?;
+        let top_idxs = top_idxs.to_vec2::<u32>()?;
+
+        let mut top_x = vec![vec![]; self.experts.len()];
+        let mut selected_weights = vec![vec![]; self.experts.len()];
+        for (row_idx, (rw, expert_idxs)) in routing_weights.iter().zip(top_idxs.iter()).enumerate()
+        {
+            for (&rw, &expert_idx) in rw.iter().zip(expert_idxs.iter()) {
+                top_x[expert_idx as usize].push(row_idx as u32);
+                selected_weights[expert_idx as usize].push(rw);
+            }
+        }
+
+        let mut ys = xs.zeros_like()?;
+        for (expert_idx, expert_layer) in self.experts.iter().enumerate() {
+            let rows = &top_x[expert_idx];
+            if rows.is_empty() {
+                continue;
+            }
+            let rows = Tensor::new(rows.as_slice(), xs.device())?;
+            let weights = Tensor::new(selected_weights[expert_idx].as_slice(), xs.device())?
+                .reshape(((), 1))?
+                .to_dtype(xs.dtype())?;
+            let current_state = xs.index_select(&rows, 0)?.reshape(((), hidden_dim))?;
+            let current_hidden_states = expert_layer.forward(&current_state)?;
+            let current_hidden_states = current_hidden_states.broadcast_mul(&weights)?;
+            ys = ys.index_add(&rows, &current_hidden_states, 0)?;
+        }
+
+        (ys + shared)?.reshape((b_size, seq_len, hidden_dim))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Attention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    o_proj: Linear,
+    q_norm: Option<L2Norm>,
+    k_norm: Option<L2Norm>,
+    num_heads: usize,
+    num_kv_heads: usize,
+    num_kv_groups: usize,
+    head_dim: usize,
+    hidden_size: usize,
+    use_rope: bool,
+    attn_temperature_tuning: bool,
+    attn_scale: f64,
+    floor_scale: f64,
+    rotary_emb: std::sync::Arc<RotaryEmbedding>,
+    kv_cache: ConcatKvCache,
+}
+
+impl Attention {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        cfg: &Config,
+        layer_idx: usize,
+        rotary_emb: std::sync::Arc<RotaryEmbedding>,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let head_dim = cfg.head_dim;
+        let num_heads = cfg.num_attention_heads;
+        let num_kv_heads = cfg.num_key_value_heads;
+        let hidden_size = head_dim * num_heads;
+
+        let q_proj = linear_b(
+            cfg.hidden_size,
+            num_heads * head_dim,
+            cfg.attention_bias,
+            vb.pp("q_proj"),
+        )?;
+        let k_proj = linear_b(
+            cfg.hidden_size,
+            num_kv_heads * head_dim,
+            cfg.attention_bias,
+            vb.pp("k_proj"),
+        )?;
+        let v_proj = linear_b(
+            cfg.hidden_size,
+            num_kv_heads * head_dim,
+            cfg.attention_bias,
+            vb.pp("v_proj"),
+        )?;
+        let o_proj = linear_b(
+            num_heads * head_dim,
+            cfg.hidden_size,
+            cfg.attention_bias,
+            vb.pp("o_proj"),
+        )?;
+
+        let (q_norm, k_norm) = if cfg.use_qk_norm && cfg.use_rope(layer_idx) {
+            (Some(L2Norm { eps: 1e-6 }), Some(L2Norm { eps: 1e-6 }))
+        } else {
+            (None, None)
+        };
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            q_norm,
+            k_norm,
+            num_heads,
+            num_kv_heads,
+            num_kv_groups: num_heads / num_kv_heads,
+            head_dim,
+            hidden_size,
+            use_rope: cfg.use_rope(layer_idx),
+            attn_temperature_tuning: cfg.attn_temperature_tuning,
+            attn_scale: cfg.attn_scale,
+            floor_scale: cfg.floor_scale,
+            rotary_emb,
+            kv_cache: ConcatKvCache::new(2),
+        })
+    }
+
+    fn temperature_tune(&self, q: &Tensor, offset: usize, seq_len: usize) -> Result<Tensor> {
+        let scales: Vec<f32> = (0..seq_len)
+            .map(|i| {
+                let pos = (offset + i) as f64;
+                let scaled =
+                    (((pos + 1.0) / self.floor_scale).floor() + 1.0).ln() * self.attn_scale + 1.0;
+                scaled as f32
+            })
+            .collect();
+        let scales =
+            Tensor::from_vec(scales, (1, 1, seq_len, 1), q.device())?.to_dtype(q.dtype())?;
+        q.broadcast_mul(&scales)
+    }
+
+    fn forward(&mut self, x: &Tensor, attn_mask: Option<&Tensor>, offset: usize) -> Result<Tensor> {
+        let (b, l, _) = x.dims3()?;
+
+        let q = self.q_proj.forward(x)?;
+        let k = self.k_proj.forward(x)?;
+        let v = self.v_proj.forward(x)?;
+
+        let mut q = q
+            .reshape((b, l, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let mut k = k
+            .reshape((b, l, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let v = v
+            .reshape((b, l, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+
+        if let (Some(q_norm), Some(k_norm)) = (&self.q_norm, &self.k_norm) {
+            q = q_norm.forward(&q)?;
+            k = k_norm.forward(&k)?;
+        }
+
+        if self.use_rope {
+            let (q_r, k_r) = self.rotary_emb.apply(&q, &k, offset)?;
+            q = q_r;
+            k = k_r;
+        } else if self.attn_temperature_tuning {
+            q = self.temperature_tune(&q, offset, l)?;
+        }
+
+        let (k, v) = self.kv_cache.append(&k, &v)?;
+
+        let k = crate::utils::repeat_kv(k, self.num_kv_groups)?.contiguous()?;
+        let v = crate::utils::repeat_kv(v, self.num_kv_groups)?.contiguous()?;
+
+        let scale = 1.0 / (self.head_dim as f64).sqrt();
+        let mut scores = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
+        if let Some(m) = attn_mask {
+            scores = scores.broadcast_add(m)?;
+        }
+        let probs = candle_nn::ops::softmax_last_dim(&scores)?;
+        let ctx = probs.matmul(&v)?;
+
+        ctx.transpose(1, 2)?
+            .reshape((b, l, self.hidden_size))?
+            .apply(&self.o_proj)
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.kv_cache.reset();
+    }
+}
+
+#[derive(Debug, Clone)]
+enum FeedForward {
+    Dense(Mlp),
+    Moe(MoeBlock),
+}
+
+impl Module for FeedForward {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::Dense(m) => m.forward(xs),
+            Self::Moe(m) => m.forward(xs),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DecoderLayer {
+    self_attn: Attention,
+    feed_forward: FeedForward,
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+}
+
+impl DecoderLayer {
+    fn new(
+        cfg: &Config,
+        layer_idx: usize,
+        rotary_emb: std::sync::Arc<RotaryEmbedding>,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let self_attn = Attention::new(cfg, layer_idx, rotary_emb, vb.pp("self_attn"))?;
+        let feed_forward = if cfg.is_moe_layer(layer_idx) {
+            FeedForward::Moe(MoeBlock::new(cfg, vb.pp("feed_forward"))?)
+        } else {
+            FeedForward::Dense(Mlp::new(
+                cfg.hidden_size,
+                cfg.intermediate_size_mlp(),
+                cfg.hidden_act,
+                vb.pp("feed_forward"),
+            )?)
+        };
+        let input_layernorm =
+            RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
+        let post_attention_layernorm = RmsNorm::new(
+            cfg.hidden_size,
+            cfg.rms_norm_eps,
+            vb.pp("post_attention_layernorm"),
+        )?;
+        Ok(Self {
+            self_attn,
+            feed_forward,
+            input_layernorm,
+            post_attention_layernorm,
+        })
+    }
+
+    fn forward(&mut self, x: &Tensor, mask: Option<&Tensor>, offset: usize) -> Result<Tensor> {
+        let h = self.input_layernorm.forward(x)?;
+        let h = self.self_attn.forward(&h, mask, offset)?;
+        let x = (x + h)?;
+        let h2 = self.post_attention_layernorm.forward(&x)?;
+        let h2 = self.feed_forward.forward(&h2)?;
+        x + h2
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.self_attn.clear_kv_cache();
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Model {
+    embed_tokens: candle_nn::Embedding,
+    layers: Vec<DecoderLayer>,
+    norm: RmsNorm,
+    device: Device,
+    dtype: DType,
+}
+
+impl Model {
+    pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let embed_tokens =
+            candle_nn::embedding(cfg.vocab_size, cfg.hidden_size, vb.pp("model.embed_tokens"))?;
+        let rotary_emb = std::sync::Arc::new(RotaryEmbedding::new(cfg, vb.dtype(), vb.device())?);
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        let vb_l = vb.pp("model.layers");
+        for i in 0..cfg.num_hidden_layers {
+            layers.push(DecoderLayer::new(cfg, i, rotary_emb.clone(), vb_l.pp(i))?);
+        }
+        Ok(Self {
+            embed_tokens,
+            layers,
+            norm: RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("model.norm"))?,
+            device: vb.device().clone(),
+            dtype: vb.dtype(),
+        })
+    }
+
+    fn clear_kv_cache(&mut self) {
+        for l in &mut self.layers {
+            l.clear_kv_cache();
+        }
+    }
+
+    fn causal_mask(&self, b: usize, tgt: usize, offset: usize) -> Result<Tensor> {
+        let minf = f32::NEG_INFINITY;
+        let mask: Vec<_> = (0..tgt)
+            .flat_map(|i| (0..(tgt + offset)).map(move |j| if j <= i + offset { 0. } else { minf }))
+            .collect();
+        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
+    }
+
+    pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
+        let (b, l) = input.dims2()?;
+        let mut h = self.embed_tokens.forward(input)?;
+
+        let causal = if l == 1 {
+            None
+        } else {
+            Some(self.causal_mask(b, l, offset)?)
+        };
+
+        for layer in &mut self.layers {
+            h = layer.forward(&h, causal.as_ref(), offset)?;
+        }
+        self.norm.forward(&h)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ModelForCausalLM {
+    base: Model,
+    lm_head: Linear,
+}
+
+impl ModelForCausalLM {
+    pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let base = Model::new(cfg, vb.clone())?;
+        let lm_head = if cfg.tie_word_embeddings {
+            Linear::from_weights(base.embed_tokens.embeddings().clone(), None)
+        } else {
+            linear_no_bias(cfg.hidden_size, cfg.vocab_size, vb.pp("lm_head"))?
+        };
+        Ok(Self { base, lm_head })
+    }
+
+    pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
+        let (_, l) = input.dims2()?;
+        self.base
+            .forward(input, offset)?
+            .narrow(1, l - 1, 1)?
+            .apply(&self.lm_head)
+    }
+
+    pub fn clear_kv_cache(&mut self) {
+        self.base.clear_kv_cache();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::DType;
+    use std::collections::HashMap;
+
+    fn test_config() -> Config {
+        Config {
+            vocab_size: 32,
+            hidden_size: 16,
+            intermediate_size: 12,
+            intermediate_size_mlp: Some(20),
+            num_hidden_layers: 4,
+            num_attention_heads: 4,
+            num_key_value_heads: 2,
+            head_dim: 4,
+            rope_theta: 500_000.0,
+            rms_norm_eps: 1e-5,
+            attention_bias: false,
+            tie_word_embeddings: false,
+            max_position_embeddings: 64,
+            num_local_experts: 4,
+            num_experts_per_tok: 2,
+            interleave_moe_layer_step: 1,
+            use_qk_norm: true,
+            no_rope_layer_interval: 4,
+            no_rope_layers: None,
+            attn_temperature_tuning: true,
+            attn_scale: 0.1,
+            floor_scale: 8192.0,
+            hidden_act: Activation::Silu,
+            eos_token_id: None,
+        }
+    }
+
+    fn var(shape: &[usize], dev: &Device) -> Tensor {
+        let elems: usize = shape.iter().product();
+        let data: Vec<f32> = (0..elems).map(|i| ((i % 7) as f32 - 3.0) * 0.01).collect();
+        Tensor::from_vec(data, shape, dev).unwrap()
+    }
+
+    fn build_weights(cfg: &Config, dev: &Device) -> HashMap<String, Tensor> {
+        let mut w = HashMap::new();
+        let h = cfg.hidden_size;
+        let nh = cfg.num_attention_heads;
+        let nkv = cfg.num_key_value_heads;
+        let hd = cfg.head_dim;
+        w.insert(
+            "model.embed_tokens.weight".to_string(),
+            var(&[cfg.vocab_size, h], dev),
+        );
+        w.insert("model.norm.weight".to_string(), var(&[h], dev));
+        w.insert("lm_head.weight".to_string(), var(&[cfg.vocab_size, h], dev));
+        for i in 0..cfg.num_hidden_layers {
+            let p = format!("model.layers.{i}");
+            w.insert(format!("{p}.input_layernorm.weight"), var(&[h], dev));
+            w.insert(
+                format!("{p}.post_attention_layernorm.weight"),
+                var(&[h], dev),
+            );
+            w.insert(
+                format!("{p}.self_attn.q_proj.weight"),
+                var(&[nh * hd, h], dev),
+            );
+            w.insert(
+                format!("{p}.self_attn.k_proj.weight"),
+                var(&[nkv * hd, h], dev),
+            );
+            w.insert(
+                format!("{p}.self_attn.v_proj.weight"),
+                var(&[nkv * hd, h], dev),
+            );
+            w.insert(
+                format!("{p}.self_attn.o_proj.weight"),
+                var(&[h, nh * hd], dev),
+            );
+            if cfg.is_moe_layer(i) {
+                w.insert(
+                    format!("{p}.feed_forward.router.weight"),
+                    var(&[cfg.num_local_experts, h], dev),
+                );
+                for e in 0..cfg.num_local_experts {
+                    let ep = format!("{p}.feed_forward.experts.{e}");
+                    w.insert(
+                        format!("{ep}.gate_proj.weight"),
+                        var(&[cfg.intermediate_size, h], dev),
+                    );
+                    w.insert(
+                        format!("{ep}.up_proj.weight"),
+                        var(&[cfg.intermediate_size, h], dev),
+                    );
+                    w.insert(
+                        format!("{ep}.down_proj.weight"),
+                        var(&[h, cfg.intermediate_size], dev),
+                    );
+                }
+                let sp = format!("{p}.feed_forward.shared_expert");
+                let im = cfg.intermediate_size_mlp();
+                w.insert(format!("{sp}.gate_proj.weight"), var(&[im, h], dev));
+                w.insert(format!("{sp}.up_proj.weight"), var(&[im, h], dev));
+                w.insert(format!("{sp}.down_proj.weight"), var(&[h, im], dev));
+            } else {
+                let mp = format!("{p}.feed_forward");
+                let im = cfg.intermediate_size_mlp();
+                w.insert(format!("{mp}.gate_proj.weight"), var(&[im, h], dev));
+                w.insert(format!("{mp}.up_proj.weight"), var(&[im, h], dev));
+                w.insert(format!("{mp}.down_proj.weight"), var(&[h, im], dev));
+            }
+        }
+        w
+    }
+
+    #[test]
+    fn forward_smoke_test() -> Result<()> {
+        let dev = Device::Cpu;
+        let cfg = test_config();
+        let weights = build_weights(&cfg, &dev);
+        let vb = VarBuilder::from_tensors(weights, DType::F32, &dev);
+        let mut model = ModelForCausalLM::new(&cfg, vb)?;
+
+        let input = Tensor::new(&[1u32, 2, 3, 4, 5], &dev)?.unsqueeze(0)?;
+        let logits = model.forward(&input, 0)?;
+        assert_eq!(logits.dims(), &[1, 1, cfg.vocab_size]);
+        let logits = logits.flatten_all()?.to_vec1::<f32>()?;
+        assert!(logits.iter().all(|v| v.is_finite()));
+
+        let next = Tensor::new(&[6u32], &dev)?.unsqueeze(0)?;
+        let logits = model.forward(&next, 5)?;
+        assert_eq!(logits.dims(), &[1, 1, cfg.vocab_size]);
+        let logits = logits.flatten_all()?.to_vec1::<f32>()?;
+        assert!(logits.iter().all(|v| v.is_finite()));
+
+        model.clear_kv_cache();
+        Ok(())
+    }
+}

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -57,6 +57,7 @@ pub mod lfm2;
 pub mod llama;
 pub mod llama2_c;
 pub mod llama2_c_weights;
+pub mod llama4;
 pub mod llava;
 pub mod mamba;
 pub mod mamba2;


### PR DESCRIPTION
## Summary

Adds a Candle implementation of the Llama 4 text-only decoder (Scout / Maverick), Meta's MoE-based LLM family:

- iRoPE: alternating RoPE/NoPE attention layers, configurable via `no_rope_layers` or `no_rope_layer_interval`
- Parameterless QK-norm (L2 normalization), applied only on RoPE layers
- Attention temperature tuning on NoPE layers
- Interleaved-pair RoPE (`rope_i`) matching the reference implementation
- Top-k sigmoid-gated MoE block with an always-on shared expert, using the real checkpoint's batched expert parameter layout (`experts.gate_up_proj` / `experts.down_proj`, applied with a per-expert matmul rather than per-expert `nn.Linear` sub-modules)
- Dense-vs-MoE layer selection via `interleave_moe_layer_step`

Includes a new `llama4` example (`candle-examples/examples/llama4`) mirroring the existing `deepseekv2`/`llama` examples, plus a README.

## Testing

- Unit test (`forward_smoke_test`) exercising prefill + KV-cache decode with synthetic weights.
- New `#[ignore]`d end-to-end integration test (`candle-examples/tests/llama4_integration.rs`) that downloads `yujiepan/llama-4-tiny-random` — a randomly-initialized checkpoint using the real Llama 4 architecture — and runs a real prefill + decode step through the production model code:

  ```
  cargo test -p candle-examples --release --test llama4_integration -- --ignored
  ```

  This caught three real-checkpoint incompatibilities that synthetic-weight unit tests couldn't:
  - `attn_temperature_tuning` can be serialized as a raw integer rather than a JSON boolean in some configs
  - MoE expert weights are stored as batched parameter tensors, not per-expert named sub-weights
  - the shared expert uses `intermediate_size`, not `intermediate_size_mlp`
- `cargo fmt` / `cargo clippy` clean on `candle-transformers` and `candle-examples`.
- Manually ran `cargo run --example llama4 -- --model-id yujiepan/llama-4-tiny-random --prompt "Hello" --sample-len 5` end-to-end.

The real Scout (109B total / 17B active) and Maverick (400B total / 17B active) checkpoints are gated on the Hub and too large to exercise in CI; the tiny-random checkpoint validates the loading/shape/architecture path against the real Llama4ForConditionalGeneration weight layout instead.

## Test plan

- [x] `cargo test -p candle-transformers --lib llama4`
- [x] `cargo test -p candle-examples --release --test llama4_integration -- --ignored`
- [x] `cargo fmt --check` / `cargo clippy`
- [x] `cargo run --example llama4 -- --prompt "..." --sample-len ...` manually