### PR TITLE
candle-kernels: pass /Zc:preprocessor on MSVC for CUDA 13.x

### DIFF
--- a/candle-kernels/build.rs
+++ b/candle-kernels/build.rs
@@ -8,16 +8,24 @@ fn main() -> Result<()> {
     println!("cargo::rerun-if-changed=src/cuda_utils.cuh");
     println!("cargo::rerun-if-changed=src/binary_op_macros.cuh");
 
+    let is_target_msvc = std::env::var("TARGET")
+        .map(|t| t.contains("msvc"))
+        .unwrap_or(false);
+
     // Build for PTX
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let ptx_path = out_dir.join("ptx.rs");
-    let bindings = KernelBuilder::new()
+    let mut ptx_builder = KernelBuilder::new()
         .source_dir("src") // Scan src/ for .cu files
         .exclude(&["moe_*.cu", "mmvq_gguf.cu", "mmq_*.cu"]) // Exclude statically compiled kernels from ptx build
         .arg("--expt-relaxed-constexpr")
         .arg("-std=c++17")
-        .arg("-O3")
-        .build_ptx()?;
+        .arg("-O3");
+    // CUDA 13.x CCCL headers hard-error unless cl.exe is in /Zc:preprocessor mode.
+    if is_target_msvc {
+        ptx_builder = ptx_builder.arg("-Xcompiler=/Zc:preprocessor");
+    }
+    let bindings = ptx_builder.build_ptx()?;
 
     bindings.write(&ptx_path)?;
 
@@ -52,12 +60,10 @@ fn main() -> Result<()> {
         moe_builder = moe_builder.arg("-DNO_BF16_KERNEL");
     }
 
-    let mut is_target_msvc = false;
-    if let Ok(target) = std::env::var("TARGET") {
-        if target.contains("msvc") {
-            is_target_msvc = true;
-            moe_builder = moe_builder.arg("-D_USE_MATH_DEFINES");
-        }
+    if is_target_msvc {
+        moe_builder = moe_builder
+            .arg("-D_USE_MATH_DEFINES")
+            .arg("-Xcompiler=/Zc:preprocessor");
     }
 
     if !is_target_msvc {


### PR DESCRIPTION
Closes #3686.

## Symptom

On Windows with CUDA 13.x, building anything that pulls in `candle-kernels` fails during PTX compilation:

```
fatal error C1189:
#error: MSVC/cl.exe with traditional preprocessor is used.
Please switch to the standard conforming preprocessor by passing
/Zc:preprocessor to cl.exe.

Error: CompilationFailed { path: "src\reduce.cu", message: "nvcc error" }
```

## Root cause

CUDA 13.x ships CCCL headers (`include/cccl/cuda/std/__cccl/preprocessor.h`) that emit a hard `#error` when MSVC's `cl.exe` is invoked in traditional-preprocessor mode. nvcc invokes `cl.exe` as its host compiler, but does not forward `/Zc:preprocessor` by default, so the CCCL include explodes before any kernel source is touched.

The same class of build failure was reported downstream (e.g. mistral.rs #2082) with the same workaround: `NVCC_PREPEND_FLAGS="-Xcompiler /Zc:preprocessor"`. Encoding this in the kernel build script removes the per-user environment dance.

## Fix

`candle-kernels/build.rs` already branches on `TARGET.contains("msvc")` to add `-D_USE_MATH_DEFINES` to the moe builder, and on the non-msvc branch to add `-Xcompiler -fPIC`. The fix follows the same shape:

- Hoist the msvc detection to the top of `main()`.
- On the PTX builder, conditionally append `-Xcompiler=/Zc:preprocessor`.
- On the moe builder, fold the new flag into the existing msvc block alongside `-D_USE_MATH_DEFINES`.

```rust
let is_target_msvc = std::env::var("TARGET")
    .map(|t| t.contains("msvc"))
    .unwrap_or(false);

let mut ptx_builder = KernelBuilder::new()
    .source_dir("src")
    ...;
if is_target_msvc {
    ptx_builder = ptx_builder.arg("-Xcompiler=/Zc:preprocessor");
}
```

`-Xcompiler=...` is the standard nvcc form for forwarding flags to the host compiler. On non-msvc hosts the conditional is false, so the flag is never emitted - no risk of regressing Linux / macOS builds.

## Verification

- `cargo check` in `candle-kernels/` compiles the modified `build.rs` cleanly (failure beyond that is unrelated: cudaforge correctly errors with `NvccNotFound` when no CUDA toolkit is present on the build host).
- The diff is contained to `build.rs`. No `.cu` source changed, no public Rust changed, no downstream crate API change.

End-to-end verification of the Windows + CUDA 13.x build path requires that toolchain, which I do not have available locally. The flag itself is the documented CCCL requirement, called out in the CUDA 13 release notes and in the error message the compiler emits.