### PR TITLE
Adds tanh activation to candle-nn

### DIFF
--- a/candle-nn/src/activation.rs
+++ b/candle-nn/src/activation.rs
@@ -24,6 +24,7 @@ pub enum Activation {
     LeakyRelu(f64),
     #[serde(alias = "gelu_pytorch_tanh")]
     GeluPytorchTanh,
+    Tanh,
 }
 
 impl super::Module for Activation {
@@ -45,6 +46,7 @@ impl super::Module for Activation {
             &Self::Elu(alpha) => xs.elu(alpha),
             &Self::LeakyRelu(negative_slope) => crate::ops::leaky_relu(xs, negative_slope),
             Self::GeluPytorchTanh => xs.gelu(),
+            Self::Tanh => xs.tanh(),
         }
     }
 }


### PR DESCRIPTION
While working on my [rl lib](https://github.com/afgTheCat/r2l), I discovered that `candle_nn::activation::Activation` does not have a tanh. I suppose it would be nice to support this. The alternative would be to implement  `Module` on a ZST.

I checked the issue tracker and the PRs if there is already an implementation/discussion on this, but found nothing relevant. Apologies if I missed something.