### PR TITLE
Optimize Tensor::cumsum with CPU/CUDA custom op

### DIFF
--- a/candle-core/src/cumsum.rs
+++ b/candle-core/src/cumsum.rs
@@ -1,0 +1,313 @@
+use crate::{CpuStorage, DType, Layout, Result, Shape, Storage, Tensor, WithDType};
+use num_traits::Zero;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Cumsum {
+    dim: usize,
+}
+
+impl Cumsum {
+    pub(crate) fn new(dim: usize) -> Self {
+        Self { dim }
+    }
+
+    #[cfg_attr(not(feature = "cuda"), allow(dead_code))]
+    pub(crate) fn is_cuda_dtype_supported(dtype: DType) -> bool {
+        matches!(dtype, DType::F32 | DType::F64 | DType::U32 | DType::I64)
+    }
+
+    pub(crate) fn is_supported(t: &Tensor, dim: usize) -> bool {
+        #[cfg(not(feature = "cuda"))]
+        let _ = dim;
+        if matches!(
+            t.dtype(),
+            DType::F6E2M3 | DType::F6E3M2 | DType::F4 | DType::F8E8M0
+        ) {
+            return false;
+        }
+        match &*t.storage() {
+            Storage::Cpu(_) => true,
+            #[cfg(feature = "cuda")]
+            // This is the exact CUDA kernel contract. Tensor::cumsum may adapt
+            // other CUDA layouts into this shape before calling the CustomOp.
+            Storage::Cuda(_) => {
+                Self::is_cuda_dtype_supported(t.dtype())
+                    && t.is_contiguous()
+                    && dim + 1 == t.rank()
+                    && t.shape().elem_count() > 0
+                    && t.dims().last().copied().unwrap_or(0) > 0
+            }
+            #[cfg(not(feature = "cuda"))]
+            Storage::Cuda(_) => false,
+            Storage::Metal(_) => false,
+        }
+    }
+
+    // The CPU path honors arbitrary input layouts and returns contiguous storage.
+    fn cpu_cumsum<T: WithDType + Zero>(src: &[T], layout: &Layout, dim: usize) -> Vec<T> {
+        let shape = layout.shape();
+        let dims = shape.dims();
+        let elem_count = shape.elem_count();
+        let rank = dims.len();
+        if elem_count == 0 {
+            return Vec::new();
+        }
+        if rank == 0 {
+            return vec![src[layout.start_offset()]];
+        }
+
+        let mut dst = vec![T::zero(); elem_count];
+        let mut dst_stride = vec![1; rank];
+        for i in (0..rank.saturating_sub(1)).rev() {
+            dst_stride[i] = dst_stride[i + 1] * dims[i + 1];
+        }
+        let outer_count = elem_count / dims[dim];
+        for outer_idx in 0..outer_count {
+            let mut rem = outer_idx;
+            let mut src_base = layout.start_offset();
+            let mut dst_base = 0usize;
+            for d in (0..rank).rev() {
+                if d == dim {
+                    continue;
+                }
+                let coord = rem % dims[d];
+                rem /= dims[d];
+                src_base += coord * layout.stride()[d];
+                dst_base += coord * dst_stride[d];
+            }
+
+            let mut acc = T::zero();
+            for i in 0..dims[dim] {
+                acc += src[src_base + i * layout.stride()[dim]];
+                dst[dst_base + i * dst_stride[dim]] = acc;
+            }
+        }
+        dst
+    }
+}
+
+impl crate::CustomOp1 for Cumsum {
+    fn name(&self) -> &'static str {
+        "cumsum"
+    }
+
+    fn cpu_fwd(&self, storage: &CpuStorage, layout: &Layout) -> Result<(CpuStorage, Shape)> {
+        let dst = match storage {
+            CpuStorage::U8(v) => CpuStorage::U8(Self::cpu_cumsum(v, layout, self.dim)),
+            CpuStorage::U32(v) => CpuStorage::U32(Self::cpu_cumsum(v, layout, self.dim)),
+            CpuStorage::I16(v) => CpuStorage::I16(Self::cpu_cumsum(v, layout, self.dim)),
+            CpuStorage::I32(v) => CpuStorage::I32(Self::cpu_cumsum(v, layout, self.dim)),
+            CpuStorage::I64(v) => CpuStorage::I64(Self::cpu_cumsum(v, layout, self.dim)),
+            CpuStorage::BF16(v) => CpuStorage::BF16(Self::cpu_cumsum(v, layout, self.dim)),
+            CpuStorage::F16(v) => CpuStorage::F16(Self::cpu_cumsum(v, layout, self.dim)),
+            CpuStorage::F32(v) => CpuStorage::F32(Self::cpu_cumsum(v, layout, self.dim)),
+            CpuStorage::F64(v) => CpuStorage::F64(Self::cpu_cumsum(v, layout, self.dim)),
+            CpuStorage::F8E4M3(v) => CpuStorage::F8E4M3(Self::cpu_cumsum(v, layout, self.dim)),
+            CpuStorage::F6E2M3(_) => {
+                return Err(crate::Error::UnsupportedDTypeForOp(DType::F6E2M3, "cumsum").bt())
+            }
+            CpuStorage::F6E3M2(_) => {
+                return Err(crate::Error::UnsupportedDTypeForOp(DType::F6E3M2, "cumsum").bt())
+            }
+            CpuStorage::F4(_) => {
+                return Err(crate::Error::UnsupportedDTypeForOp(DType::F4, "cumsum").bt())
+            }
+            CpuStorage::F8E8M0(_) => {
+                return Err(crate::Error::UnsupportedDTypeForOp(DType::F8E8M0, "cumsum").bt())
+            }
+        };
+        Ok((dst, layout.shape().clone()))
+    }
+
+    #[cfg(feature = "cuda")]
+    fn cuda_fwd(
+        &self,
+        storage: &crate::CudaStorage,
+        layout: &Layout,
+    ) -> Result<(crate::CudaStorage, Shape)> {
+        use crate::backend::BackendStorage;
+        use crate::cuda_backend::cudarc::driver::{
+            CudaSlice, DeviceRepr, LaunchConfig, PushKernelArg, ValidAsZeroBits,
+        };
+        use crate::cuda_backend::{kernel_name, kernels, CudaDevice, CudaStorageSlice, WrapErr};
+
+        // Tile size is also the dispatch threshold: smaller rows avoid the extra
+        // multi-kernel launch overhead, larger rows get row-level parallelism.
+        const MULTI_BLOCK_TILE_SIZE: usize = 4096;
+        const MULTI_BLOCK_THREADS: usize = 256;
+        // Keep the first version bounded; larger rows remain correct via the
+        // single-block fallback and can use recursive tile-sum scan later.
+        const MAX_TILES_PER_ROW: usize = 1024;
+
+        fn launch_single_block<T>(
+            src: &CudaSlice<T>,
+            dev: &CudaDevice,
+            layout: &Layout,
+            start: usize,
+            end: usize,
+        ) -> Result<CudaSlice<T>>
+        where
+            T: DeviceRepr + ValidAsZeroBits + WithDType,
+        {
+            let elem_count = layout.shape().elem_count();
+            let last_dim = layout.dims().last().copied().unwrap_or(1);
+            let rows = elem_count / last_dim;
+            let dst = unsafe { dev.alloc::<T>(elem_count)? };
+            let block_dim = last_dim.next_power_of_two().min(1024);
+            let cfg = LaunchConfig {
+                grid_dim: (rows as u32, 1, 1),
+                block_dim: (block_dim as u32, 1, 1),
+                shared_mem_bytes: (block_dim * std::mem::size_of::<T>()) as u32,
+            };
+            let func =
+                dev.get_or_load_func(&kernel_name::<T>("cumsum_last_dim"), &kernels::CUMSUM)?;
+            let src = src.slice(start..end);
+            let mut builder = func.builder();
+            let last_dim = last_dim as i32;
+            let block_dim = block_dim as i32;
+            builder.arg(&src);
+            builder.arg(&dst);
+            builder.arg(&last_dim);
+            builder.arg(&block_dim);
+            unsafe { builder.launch(cfg) }.w()?;
+            Ok(dst)
+        }
+
+        // First pass writes local prefix sums into dst and one total per tile into
+        // block_sums. The scanned tile totals are then added back as per-tile offsets.
+        fn launch_multi_block<T>(
+            src: &CudaSlice<T>,
+            dev: &CudaDevice,
+            layout: &Layout,
+            start: usize,
+            end: usize,
+        ) -> Result<CudaSlice<T>>
+        where
+            T: DeviceRepr + ValidAsZeroBits + WithDType,
+        {
+            let elem_count = layout.shape().elem_count();
+            let last_dim = layout.dims().last().copied().unwrap_or(1);
+            let rows = elem_count / last_dim;
+            let ntiles = last_dim.div_ceil(MULTI_BLOCK_TILE_SIZE);
+            if ntiles > MAX_TILES_PER_ROW {
+                return launch_single_block(src, dev, layout, start, end);
+            }
+
+            let dst = unsafe { dev.alloc::<T>(elem_count)? };
+            let block_sums = unsafe { dev.alloc::<T>(rows * ntiles)? };
+            let scanned_block_sums = unsafe { dev.alloc::<T>(rows * ntiles)? };
+            let src = src.slice(start..end);
+            let tile_func =
+                dev.get_or_load_func(&kernel_name::<T>("cumsum_tile"), &kernels::CUMSUM)?;
+            let tile_cfg = LaunchConfig {
+                grid_dim: (rows as u32, ntiles as u32, 1),
+                block_dim: (MULTI_BLOCK_THREADS as u32, 1, 1),
+                shared_mem_bytes: (MULTI_BLOCK_THREADS * std::mem::size_of::<T>()) as u32,
+            };
+            let mut builder = tile_func.builder();
+            let last_dim_i32 = last_dim as i32;
+            let tile_size_i32 = MULTI_BLOCK_TILE_SIZE as i32;
+            let ntiles_i32 = ntiles as i32;
+            let threads_i32 = MULTI_BLOCK_THREADS as i32;
+            builder.arg(&src);
+            builder.arg(&dst);
+            builder.arg(&block_sums);
+            builder.arg(&last_dim_i32);
+            builder.arg(&tile_size_i32);
+            builder.arg(&ntiles_i32);
+            builder.arg(&threads_i32);
+            unsafe { builder.launch(tile_cfg) }.w()?;
+
+            // Scan the per-tile sums once per row. The first multi-block version
+            // keeps this bounded to one CUDA block per row.
+            let scan_threads = ntiles.next_power_of_two().min(1024);
+            let scan_func =
+                dev.get_or_load_func(&kernel_name::<T>("cumsum_last_dim"), &kernels::CUMSUM)?;
+            let scan_cfg = LaunchConfig {
+                grid_dim: (rows as u32, 1, 1),
+                block_dim: (scan_threads as u32, 1, 1),
+                shared_mem_bytes: (scan_threads * std::mem::size_of::<T>()) as u32,
+            };
+            let mut builder = scan_func.builder();
+            let ntiles_i32 = ntiles as i32;
+            let scan_threads_i32 = scan_threads as i32;
+            builder.arg(&block_sums);
+            builder.arg(&scanned_block_sums);
+            builder.arg(&ntiles_i32);
+            builder.arg(&scan_threads_i32);
+            unsafe { builder.launch(scan_cfg) }.w()?;
+
+            let add_func =
+                dev.get_or_load_func(&kernel_name::<T>("cumsum_add_offsets"), &kernels::CUMSUM)?;
+            let add_cfg = LaunchConfig {
+                grid_dim: (rows as u32, ntiles as u32, 1),
+                block_dim: (MULTI_BLOCK_THREADS as u32, 1, 1),
+                shared_mem_bytes: 0,
+            };
+            let mut builder = add_func.builder();
+            builder.arg(&dst);
+            builder.arg(&scanned_block_sums);
+            builder.arg(&last_dim_i32);
+            builder.arg(&tile_size_i32);
+            builder.arg(&ntiles_i32);
+            unsafe { builder.launch(add_cfg) }.w()?;
+            Ok(dst)
+        }
+
+        fn launch<T>(
+            src: &CudaSlice<T>,
+            dev: &CudaDevice,
+            layout: &Layout,
+            start: usize,
+            end: usize,
+        ) -> Result<CudaSlice<T>>
+        where
+            T: DeviceRepr + ValidAsZeroBits + WithDType,
+        {
+            let last_dim = layout.dims().last().copied().unwrap_or(1);
+            if last_dim > MULTI_BLOCK_TILE_SIZE {
+                launch_multi_block(src, dev, layout, start, end)
+            } else {
+                launch_single_block(src, dev, layout, start, end)
+            }
+        }
+
+        if !layout.is_contiguous() {
+            return Err(crate::Error::RequiresContiguous { op: "cumsum" }.bt());
+        }
+        if self.dim + 1 != layout.dims().len() {
+            crate::bail!("cuda cumsum only supports the last dimension")
+        }
+
+        let dev = storage.device();
+        let (start, end) = layout.contiguous_offsets().unwrap();
+        let slice = match &storage.slice {
+            CudaStorageSlice::F32(src) => {
+                CudaStorageSlice::F32(launch(src, dev, layout, start, end)?)
+            }
+            CudaStorageSlice::F64(src) => {
+                CudaStorageSlice::F64(launch(src, dev, layout, start, end)?)
+            }
+            CudaStorageSlice::U32(src) => {
+                CudaStorageSlice::U32(launch(src, dev, layout, start, end)?)
+            }
+            CudaStorageSlice::I64(src) => {
+                CudaStorageSlice::I64(launch(src, dev, layout, start, end)?)
+            }
+            _ => return Err(crate::Error::UnsupportedDTypeForOp(storage.dtype(), "cumsum").bt()),
+        };
+        let dst = crate::CudaStorage {
+            slice,
+            device: dev.clone(),
+        };
+        Ok((dst, layout.shape().clone()))
+    }
+
+    fn bwd(&self, _arg: &Tensor, _res: &Tensor, grad_res: &Tensor) -> Result<Option<Tensor>> {
+        let grad = grad_res
+            .flip(&[self.dim])?
+            .cumsum(self.dim)?
+            .flip(&[self.dim])?;
+        Ok(Some(grad))
+    }
+}

--- a/candle-core/src/lib.rs
+++ b/candle-core/src/lib.rs
@@ -57,6 +57,7 @@ pub mod cpu;
 pub mod cpu_backend;
 #[cfg(feature = "cuda")]
 pub mod cuda_backend;
+mod cumsum;
 mod custom_op;
 mod device;
 pub mod display;

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -2806,8 +2806,25 @@ impl Tensor {
     pub fn cumsum<D: Dim>(&self, dim: D) -> Result<Self> {
         let dim = dim.to_index(self.shape(), "cumsum")?;
         let rank = self.rank();
-        if rank == 0 {
+        if rank == 0 || self.shape().elem_count() == 0 {
             return Ok(self.clone());
+        }
+        if crate::cumsum::Cumsum::is_supported(self, dim) {
+            return self.apply_op1(crate::cumsum::Cumsum::new(dim));
+        }
+        #[cfg(feature = "cuda")]
+        if matches!(&*self.storage(), Storage::Cuda(_))
+            && crate::cumsum::Cumsum::is_cuda_dtype_supported(self.dtype())
+        {
+            let last = rank - 1;
+            if dim == last {
+                return self
+                    .contiguous()?
+                    .apply_op1(crate::cumsum::Cumsum::new(dim));
+            }
+            let t = self.transpose(dim, last)?.contiguous()?;
+            let t = t.apply_op1(crate::cumsum::Cumsum::new(last))?;
+            return t.transpose(dim, last);
         }
         let n_axis = self.dim(dim)?;
         let triu = Tensor::triu2(n_axis, self.dtype(), self.device())?;

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -505,6 +505,19 @@ fn binary_grad(device: &Device) -> Result<()> {
     Ok(())
 }
 
+fn cumsum_grad(device: &Device) -> Result<()> {
+    let x = Var::from_slice(&[1f32, 2., 3., 4., 5., 6.], (2, 3), device)?;
+    let weights = Tensor::from_slice(&[1f32, 2., 3., 4., 5., 6.], (2, 3), device)?;
+    let y = (x.as_tensor().cumsum(1)? * weights)?.sum_all()?;
+    let grads = y.backward()?;
+    let grad_x = grads.get(&x).context("no grad for x")?;
+    assert_eq!(
+        grad_x.to_vec2::<f32>()?,
+        [[6.0, 5.0, 3.0], [15.0, 11.0, 6.0]]
+    );
+    Ok(())
+}
+
 #[test]
 fn test_flip_backprop() -> Result<()> {
     let device = &Device::Cpu;
@@ -542,6 +555,12 @@ test_device!(
     simple_grad_metal
 );
 test_device!(sum_grad, sum_grad_cpu, sum_grad_gpu, sum_grad_metal);
+test_device!(
+    cumsum_grad,
+    cumsum_grad_cpu,
+    cumsum_grad_gpu,
+    cumsum_grad_metal
+);
 test_device!(
     matmul_grad,
     matmul_grad_cpu,

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -1871,10 +1871,9 @@ fn tril_triu_eye() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn cumsum() -> Result<()> {
+fn cumsum(device: &Device) -> Result<()> {
     let t = &[3f32, 1., 4., 1., 5.];
-    let t = Tensor::new(t, &Device::Cpu)?;
+    let t = Tensor::new(t, device)?;
     assert_eq!(t.cumsum(0)?.to_vec1::<f32>()?, [3., 4., 8., 9., 14.]);
     let t = t.unsqueeze(1)?;
     assert_eq!(
@@ -1886,7 +1885,7 @@ fn cumsum() -> Result<()> {
         [[3.0], [1.0], [4.0], [1.0], [5.0]]
     );
     let t = &[[3f32, 1., 4., 1., 5.], [2., 1., 7., 8., 2.]];
-    let t = Tensor::new(t, &Device::Cpu)?;
+    let t = Tensor::new(t, device)?;
     assert_eq!(
         t.cumsum(1)?.to_vec2::<f32>()?,
         [[3.0, 4.0, 8.0, 9.0, 14.0], [2.0, 3.0, 10.0, 18.0, 20.0]],
@@ -1895,6 +1894,152 @@ fn cumsum() -> Result<()> {
         t.cumsum(0)?.to_vec2::<f32>()?,
         [[3.0, 1.0, 4.0, 1.0, 5.0], [5.0, 2.0, 11.0, 9.0, 7.0]]
     );
+    let t = Tensor::arange(0f32, 2060f32, device)?.reshape((2, 1030))?;
+    let c = t.cumsum(1)?;
+    assert_eq!(c.i((0, 0))?.to_scalar::<f32>()?, 0.0);
+    assert_eq!(c.i((0, 1029))?.to_scalar::<f32>()?, 529935.0);
+    assert_eq!(c.i((1, 0))?.to_scalar::<f32>()?, 1030.0);
+
+    let t = Tensor::zeros((2, 0, 4), DType::F32, device)?;
+    assert_eq!(t.cumsum(1)?.dims(), &[2, 0, 4]);
+    Ok(())
+}
+
+test_device!(cumsum, cumsum_cpu, cumsum_gpu, cumsum_metal);
+
+#[test]
+fn cumsum_cpu_non_contiguous() -> Result<()> {
+    let device = &Device::Cpu;
+    let t = Tensor::arange(0f32, 12f32, device)?.reshape((3, 4))?;
+    let t = t.t()?;
+    assert_eq!(
+        t.cumsum(1)?.to_vec2::<f32>()?,
+        [
+            [0.0, 4.0, 12.0],
+            [1.0, 6.0, 15.0],
+            [2.0, 8.0, 18.0],
+            [3.0, 10.0, 21.0]
+        ]
+    );
+
+    let t = Tensor::arange(0f32, 20f32, device)?.reshape((4, 5))?;
+    let t = t.narrow(1, 1, 3)?;
+    assert_eq!(
+        t.cumsum(1)?.to_vec2::<f32>()?,
+        [
+            [1.0, 3.0, 6.0],
+            [6.0, 13.0, 21.0],
+            [11.0, 23.0, 36.0],
+            [16.0, 33.0, 51.0]
+        ]
+    );
+    Ok(())
+}
+
+#[test]
+fn cumsum_cpu_integer_dtype() -> Result<()> {
+    let device = &Device::Cpu;
+    let t = Tensor::new(&[[1u32, 2, 3], [4, 5, 6]], device)?;
+    assert_eq!(t.cumsum(1)?.to_vec2::<u32>()?, [[1u32, 3, 6], [4, 9, 15]]);
+    let t = Tensor::new(&[-3i64, 1, 4, -1], device)?;
+    assert_eq!(t.cumsum(0)?.to_vec1::<i64>()?, [-3, -2, 2, 1]);
+    Ok(())
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn cumsum_cuda_adapts_layouts() -> Result<()> {
+    let device = Device::new_cuda(0)?;
+
+    let t = Tensor::arange(0f32, 12f32, &device)?.reshape((3, 4))?;
+    assert_eq!(
+        t.cumsum(0)?.to_vec2::<f32>()?,
+        [
+            [0.0, 1.0, 2.0, 3.0],
+            [4.0, 6.0, 8.0, 10.0],
+            [12.0, 15.0, 18.0, 21.0]
+        ]
+    );
+
+    let t = t.t()?;
+    assert_eq!(
+        t.cumsum(1)?.to_vec2::<f32>()?,
+        [
+            [0.0, 4.0, 12.0],
+            [1.0, 6.0, 15.0],
+            [2.0, 8.0, 18.0],
+            [3.0, 10.0, 21.0]
+        ]
+    );
+    assert_eq!(
+        t.cumsum(0)?.to_vec2::<f32>()?,
+        [
+            [0.0, 4.0, 8.0],
+            [1.0, 9.0, 17.0],
+            [3.0, 15.0, 27.0],
+            [6.0, 22.0, 38.0]
+        ]
+    );
+
+    let t = Tensor::arange(0f32, 20f32, &device)?.reshape((4, 5))?;
+    let t = t.narrow(1, 1, 3)?;
+    assert_eq!(
+        t.cumsum(1)?.to_vec2::<f32>()?,
+        [
+            [1.0, 3.0, 6.0],
+            [6.0, 13.0, 21.0],
+            [11.0, 23.0, 36.0],
+            [16.0, 33.0, 51.0]
+        ]
+    );
+    Ok(())
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn cumsum_cuda_supported_dtypes() -> Result<()> {
+    let device = Device::new_cuda(0)?;
+
+    let t = Tensor::new(&[[1f64, 2., 3.], [4., 5., 6.]], &device)?;
+    assert_eq!(
+        t.cumsum(1)?.to_vec2::<f64>()?,
+        [[1.0, 3.0, 6.0], [4.0, 9.0, 15.0]]
+    );
+
+    let t = Tensor::new(&[[1u32, 2, 3], [4, 5, 6]], &device)?;
+    assert_eq!(t.cumsum(1)?.to_vec2::<u32>()?, [[1u32, 3, 6], [4, 9, 15]]);
+
+    let t = Tensor::new(&[[-3i64, 1, 4], [2, -5, 7]], &device)?;
+    assert_eq!(t.cumsum(1)?.to_vec2::<i64>()?, [[-3, -2, 2], [2, -3, 4]]);
+    Ok(())
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn cumsum_cuda_multi_block_large_last_dim() -> Result<()> {
+    let device = Device::new_cuda(0)?;
+
+    let t = Tensor::ones((2, 4097), DType::F32, &device)?;
+    let c = t.cumsum(1)?;
+    assert_eq!(c.i((0, 0))?.to_scalar::<f32>()?, 1.0);
+    assert_eq!(c.i((0, 4095))?.to_scalar::<f32>()?, 4096.0);
+    assert_eq!(c.i((0, 4096))?.to_scalar::<f32>()?, 4097.0);
+    assert_eq!(c.i((1, 4096))?.to_scalar::<f32>()?, 4097.0);
+
+    let t = Tensor::ones((2, 4097), DType::F64, &device)?;
+    let c = t.cumsum(1)?;
+    assert_eq!(c.i((0, 4096))?.to_scalar::<f64>()?, 4097.0);
+    assert_eq!(c.i((1, 4096))?.to_scalar::<f64>()?, 4097.0);
+
+    let t = Tensor::arange(0u32, 8194, &device)?.reshape((2, 4097))?;
+    let c = t.cumsum(1)?;
+    assert_eq!(c.i((0, 4096))?.to_scalar::<u32>()?, 8390656);
+    assert_eq!(c.i((1, 4096))?.to_scalar::<u32>()?, 25176065);
+
+    let t = Tensor::ones((2, 4097), DType::I64, &device)?;
+    let c = t.cumsum(1)?;
+    assert_eq!(c.i((0, 4096))?.to_scalar::<i64>()?, 4097);
+    assert_eq!(c.i((1, 4096))?.to_scalar::<i64>()?, 4097);
     Ok(())
 }
 

--- a/candle-kernels/src/cumsum.cu
+++ b/candle-kernels/src/cumsum.cu
@@ -1,0 +1,144 @@
+#include <stdint.h>
+
+// One CUDA block scans one row. Each thread first scans a contiguous chunk,
+// then the block scans chunk sums and adds the preceding chunks as an offset.
+template<typename T>
+static __device__ void k_cumsum_last_dim(
+    const T *src,
+    T *dst,
+    const int ncols,
+    const int nthreads
+) {
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int chunk = (ncols + nthreads - 1) / nthreads;
+    const int start = tid * chunk;
+    const int end = min(start + chunk, ncols);
+    const int row_offset = row * ncols;
+
+    extern __shared__ char shared[];
+    T *sums = reinterpret_cast<T *>(shared);
+    T acc = T(0);
+    for (int col = start; col < end; ++col) {
+        acc += src[row_offset + col];
+        dst[row_offset + col] = acc;
+    }
+    sums[tid] = acc;
+    __syncthreads();
+
+    for (int offset = 1; offset < nthreads; offset <<= 1) {
+        T value = T(0);
+        if (tid >= offset) {
+            value = sums[tid - offset];
+        }
+        __syncthreads();
+        sums[tid] += value;
+        __syncthreads();
+    }
+
+    const T chunk_offset = tid == 0 ? T(0) : sums[tid - 1];
+    for (int col = start; col < end; ++col) {
+        dst[row_offset + col] += chunk_offset;
+    }
+}
+
+// Multi-block cumsum uses three kernels. This first pass scans a tile within a
+// row and stores one tile total per block; a later pass scans those totals.
+template<typename T>
+static __device__ void k_cumsum_tile(
+    const T *src,
+    T *dst,
+    T *block_sums,
+    const int ncols,
+    const int tile_size,
+    const int ntiles,
+    const int nthreads
+) {
+    const int row = blockIdx.x;
+    const int tile = blockIdx.y;
+    const int tid = threadIdx.x;
+    const int tile_start = tile * tile_size;
+    const int tile_cols = min(tile_size, ncols - tile_start);
+    const int chunk = (tile_cols + nthreads - 1) / nthreads;
+    const int start = tile_start + tid * chunk;
+    const int end = min(start + chunk, tile_start + tile_cols);
+    const int row_offset = row * ncols;
+
+    extern __shared__ char shared[];
+    T *sums = reinterpret_cast<T *>(shared);
+    T acc = T(0);
+    for (int col = start; col < end; ++col) {
+        acc += src[row_offset + col];
+        dst[row_offset + col] = acc;
+    }
+    sums[tid] = acc;
+    __syncthreads();
+
+    for (int offset = 1; offset < nthreads; offset <<= 1) {
+        T value = T(0);
+        if (tid >= offset) {
+            value = sums[tid - offset];
+        }
+        __syncthreads();
+        sums[tid] += value;
+        __syncthreads();
+    }
+
+    const T chunk_offset = tid == 0 ? T(0) : sums[tid - 1];
+    for (int col = start; col < end; ++col) {
+        dst[row_offset + col] += chunk_offset;
+    }
+    if (tid == nthreads - 1) {
+        block_sums[row * ntiles + tile] = sums[tid];
+    }
+}
+
+// Adds the sum of preceding tiles to each element in a tile. The offsets tensor
+// is the scanned version of block_sums from k_cumsum_tile.
+template<typename T>
+static __device__ void k_cumsum_add_offsets(
+    T *dst,
+    const T *offsets,
+    const int ncols,
+    const int tile_size,
+    const int ntiles
+) {
+    const int row = blockIdx.x;
+    const int tile = blockIdx.y;
+    if (tile == 0) {
+        return;
+    }
+
+    const int tid = threadIdx.x;
+    const int tile_start = tile * tile_size;
+    const int tile_end = min(tile_start + tile_size, ncols);
+    const int row_offset = row * ncols;
+    const T offset = offsets[row * ntiles + tile - 1];
+    for (int col = tile_start + tid; col < tile_end; col += blockDim.x) {
+        dst[row_offset + col] += offset;
+    }
+}
+
+#define CUMSUM_OP(TYPENAME, RUST_NAME) \
+extern "C" __global__ void cumsum_last_dim_##RUST_NAME( \
+    const TYPENAME *src, TYPENAME *dst, const int ncols, const int nthreads \
+) { \
+    k_cumsum_last_dim<TYPENAME>(src, dst, ncols, nthreads); \
+} \
+extern "C" __global__ void cumsum_tile_##RUST_NAME( \
+    const TYPENAME *src, TYPENAME *dst, TYPENAME *block_sums, \
+    const int ncols, const int tile_size, const int ntiles, const int nthreads \
+) { \
+    k_cumsum_tile<TYPENAME>(src, dst, block_sums, ncols, tile_size, ntiles, nthreads); \
+} \
+extern "C" __global__ void cumsum_add_offsets_##RUST_NAME( \
+    TYPENAME *dst, const TYPENAME *offsets, \
+    const int ncols, const int tile_size, const int ntiles \
+) { \
+    k_cumsum_add_offsets<TYPENAME>(dst, offsets, ncols, tile_size, ntiles); \
+}
+
+CUMSUM_OP(float, f32)
+CUMSUM_OP(double, f64)
+CUMSUM_OP(uint32_t, u32)
+CUMSUM_OP(int64_t, i64)

--- a/candle-kernels/src/lib.rs
+++ b/candle-kernels/src/lib.rs
@@ -8,6 +8,7 @@ pub enum Id {
     Affine,
     Binary,
     Cast,
+    Cumsum,
     Conv,
     Fill,
     Indexing,
@@ -18,10 +19,11 @@ pub enum Id {
     Unary,
 }
 
-pub const ALL_IDS: [Id; 11] = [
+pub const ALL_IDS: [Id; 12] = [
     Id::Affine,
     Id::Binary,
     Id::Cast,
+    Id::Cumsum,
     Id::Conv,
     Id::Fill,
     Id::Indexing,
@@ -70,6 +72,7 @@ macro_rules! mdl {
 mdl!(AFFINE, Affine);
 mdl!(BINARY, Binary);
 mdl!(CAST, Cast);
+mdl!(CUMSUM, Cumsum);
 mdl!(CONV, Conv);
 mdl!(FILL, Fill);
 mdl!(INDEXING, Indexing);


### PR DESCRIPTION
## Summary

Fixes #2948.

This PR adds a dedicated implementation for `Tensor::cumsum` instead of always lowering it to the triangular-matmul fallback.

The old implementation is compact, but on CUDA it can be much more expensive than the operation needs: cumsum over a vocab-sized dimension builds a triangular matrix and turns the scan into a matmul-shaped problem. I ran into this while looking at GPU-side sampling in mistral.rs, where cumulative sums are used in the token sampling path.

The public `Tensor::cumsum` API is unchanged. Supported CPU/CUDA cases take the new direct path, and unsupported cases keep using the existing fallback.

## What Changed

- Added a `cumsum` `CustomOp` in `candle-core`.
- Added a layout-aware CPU implementation that supports arbitrary input layouts and returns contiguous storage.
- Added CUDA kernels for contiguous last-dimension cumsum.
- Added CUDA support for `f32`, `f64`, `u32`, and `i64`.
- Added CUDA layout adaptation for supported dtypes:
  - contiguous last-dim inputs go straight to the kernel,
  - non-contiguous last-dim inputs are made contiguous first,
  - non-last-dim inputs are transposed to the last dim, made contiguous, scanned, and transposed back.
- Added a single-block CUDA scan path for shorter rows.
- Added a three-pass multi-block CUDA scan path for longer rows.
- Kept the existing triangular-matmul implementation as the fallback for unsupported dtypes/devices.
- Added autograd support via reverse cumsum of the output gradient.

The CUDA multi-block path uses three passes:

1. scan each row tile locally and write one tile total,
2. scan the per-row tile totals,
3. add the scanned tile offsets back into each tile.

## Performance

I used a temporary benchmark outside the repo to compare the old triangular-matmul implementation with the new CUDA paths.

For smaller rows, the new single-block scan avoids the triangular matrix and is much faster:

| dtype / shape | old triangular matmul | new single-block cumsum | speedup |
| --- | ---: | ---: | ---: |
| `f32 [8, 512]` | `0.0338 ms` | `0.0076 ms` | `4.4x` |
| `f32 [8, 1024]` | `0.0685 ms` | `0.0083 ms` | `8.3x` |
| `f32 [8, 2048]` | `0.2717 ms` | `0.0088 ms` | `31.0x` |

For longer rows, the multi-block path improves over the single-block CUDA scan:

| dtype / shape | single-block cumsum | multi-block cumsum |
| --- | ---: | ---: |
| `f32 [8, 32768]` | `0.2965 ms` | `0.0444 ms` |
| `f64 [8, 32768]` | - | `0.0660 ms` |
| `u32 [8, 32768]` | - | `0.0445 ms` |
| `i64 [8, 32768]` | - | `0.0653 ms` |

I did not benchmark the old triangular-matmul fallback at `[8, 32768]`; it would need a very large triangular matrix, which is the main case this PR avoids.

## Tests

Added or extended coverage for:

- CPU, CUDA, and Metal `cumsum`
- zero-sized tensors
- large last-dimension inputs
- CPU non-contiguous layouts
- CPU integer dtypes
- CUDA layout adaptation for non-last-dim and non-contiguous inputs
- CUDA `f64`, `u32`, and `i64`
- CUDA multi-block behavior across `f32`, `f64`, `u32`, and `i64`
- cumsum backward pass

## Why Not f16/bf16 Here?

I left `f16` and `bf16` out of this PR intentionally.

Supporting them well is not just adding two more kernel exports. We need to decide the accumulator semantics first. The likely design is `f16/bf16` input and output with `f32` accumulation internally, including `f32` tile sums in the multi-block path. That is a different design from the current same-type accumulator kernels, so I kept this PR focused and would rather handle half/bfloat16 in a follow-up.
