### PR TITLE
Ensure contiguous q/k/v in sdpa

### DIFF
--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -1314,9 +1314,18 @@ pub fn sdpa(
     scale: f32,
     softcapping: f32,
 ) -> Result<Tensor> {
+    // The fused Metal SDPA kernels assume contiguous q/k/v: they receive a single
+    // per-head stride and otherwise index by the packed head-dim, so a strided
+    // input (e.g. the `transpose(1, 2)` layout every caller produces) makes the
+    // kernel read the wrong memory and silently return incorrect results. Enforce
+    // the invariant here instead of relying on each call site. `contiguous` is a
+    // no-op when the tensor already is, so the common path pays nothing.
+    let q = q.contiguous()?;
+    let k = k.contiguous()?;
+    let v = v.contiguous()?;
     q.apply_op3_no_bwd(
-        k,
-        v,
+        &k,
+        &v,
         &Sdpa {
             scale,
             softcapping,

--- a/candle-nn/tests/sdpa.rs
+++ b/candle-nn/tests/sdpa.rs
@@ -155,6 +155,101 @@ mod metal_sdpa_tests {
         Ok(())
     }
 
+    // Expand grouped KV heads to full Q head count so a reference attention can be
+    // computed with a dense matmul. Mirrors quantized_llama's repeat_kv.
+    fn repeat_kv(x: &Tensor, gqa_factor: usize) -> Result<Tensor> {
+        let (bs, n_kv, seq, dk) = x.dims4()?;
+        x.unsqueeze(2)?
+            .broadcast_as((bs, n_kv, gqa_factor, seq, dk))?
+            .reshape((bs, n_kv * gqa_factor, seq, dk))
+    }
+
+    // Dense (un-fused) grouped-query attention reference.
+    fn reference_gqa(q: &Tensor, k: &Tensor, v: &Tensor, scale: f64) -> Result<Tensor> {
+        let (_, h_q, _, _) = q.dims4()?;
+        let (_, h_kv, _, _) = k.dims4()?;
+        let k = repeat_kv(&k.contiguous()?, h_q / h_kv)?;
+        let v = repeat_kv(&v.contiguous()?, h_q / h_kv)?;
+        let att = (q.contiguous()? * scale)?.matmul(&k.t()?)?;
+        let att =
+            candle_nn::ops::softmax_last_dim(&att.to_dtype(DType::F32)?)?.to_dtype(q.dtype())?;
+        att.matmul(&v)
+    }
+
+    #[test]
+    fn sdpa_vector_gqa_decode() -> Result<()> {
+        // GQA decode (seq_len == 1, n_head != n_kv_head) through the fused Metal
+        // vector kernel. Every other test in this file uses equal head counts, so
+        // the grouped-query path was otherwise unexercised.
+        const BS: usize = 1;
+        const R: usize = 1; // decode: single next token
+        const L: usize = 24; // accumulated KV cache length
+        const DK: usize = 64;
+        const H_Q: usize = 8;
+        const H_KV: usize = 2; // gqa_factor = 4
+
+        let scale: f64 = f64::from(DK as u32).sqrt().recip();
+        let device = Device::new_metal(0)?;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(31337);
+        let q = randn(&mut rng, (BS, H_Q, R, DK), &device)?;
+        let k = randn(&mut rng, (BS, H_KV, L, DK), &device)?;
+        let v = randn(&mut rng, (BS, H_KV, L, DK), &device)?;
+        let reference = reference_gqa(&q, &k, &v, scale)?;
+        let sdpa_output = candle_nn::ops::sdpa(&q, &k, &v, None, false, scale as f32, 1.)?;
+        assert_eq!(reference.shape(), sdpa_output.shape());
+        let error: f32 = ((&reference - &sdpa_output)?.abs()? / &reference.abs()?)?
+            .sum_all()?
+            .to_scalar()?;
+        assert!(error <= 0.0013, "{}", error);
+        Ok(())
+    }
+
+    #[test]
+    fn sdpa_non_contiguous() -> Result<()> {
+        // The fused Metal SDPA kernels require contiguous q/k/v. Callers build the
+        // attention inputs with `transpose(1, 2)`, which is non-contiguous, so they
+        // must remember to `.contiguous()` by hand -- otherwise the kernel walks the
+        // wrong strides and silently returns garbage. Assert that layout does not
+        // change the result, across both the vector (decode) and full (prefill)
+        // paths, using TinyLlama's GQA shape (32 q-heads, 4 kv-heads).
+        const BS: usize = 1;
+        const DK: usize = 64;
+        const H_Q: usize = 32;
+        const H_KV: usize = 4; // gqa_factor = 8 (TinyLlama)
+
+        let scale: f64 = f64::from(DK as u32).sqrt().recip();
+        let device = Device::new_metal(0)?;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0xC0FFEE);
+        // (q_seq, k_seq): decode routes through the vector kernel, prefill the full one.
+        for (q_seq, k_seq) in [(1usize, 24usize), (5, 5)] {
+            // Lay out as (bs, seq, heads, dk) then transpose(1, 2) -> non-contiguous,
+            // exactly as the transformer models produce their attention inputs.
+            let q = randn(&mut rng, (BS, q_seq, H_Q, DK), &device)?.transpose(1, 2)?;
+            let k = randn(&mut rng, (BS, k_seq, H_KV, DK), &device)?.transpose(1, 2)?;
+            let v = randn(&mut rng, (BS, k_seq, H_KV, DK), &device)?.transpose(1, 2)?;
+            assert!(!k.is_contiguous() && !v.is_contiguous());
+
+            let out = candle_nn::ops::sdpa(&q, &k, &v, None, false, scale as f32, 1.)?;
+            let out_contig = candle_nn::ops::sdpa(
+                &q.contiguous()?,
+                &k.contiguous()?,
+                &v.contiguous()?,
+                None,
+                false,
+                scale as f32,
+                1.,
+            )?;
+            assert_eq!(out.shape(), out_contig.shape());
+            // Same math on the same values: strided and contiguous must agree.
+            let error: f32 = (&out - &out_contig)?.abs()?.max_all()?.to_scalar()?;
+            assert!(
+                error <= 1e-4,
+                "q_seq={q_seq} k_seq={k_seq} max_abs_diff={error}"
+            );
+        }
+        Ok(())
+    }
+
     #[test]
     fn sdpa_vector_cross() -> Result<()> {
         // Allow vectorized, seqlen = 1. Simulat cross attention case where R != L, R = 1


### PR DESCRIPTION
## What

The fused Metal SDPA kernels (`call_sdpa_vector`, `call_sdpa_vector_2pass`, `call_sdpa_full`) assume contiguous `q`/`k`/`v` — they receive a single per-head stride and otherwise index by the packed head dimension. When `candle_nn::ops::sdpa` is called with non-contiguous inputs (the `transpose(1, 2)` layout attention code naturally produces), the kernel walks the wrong strides and **silently returns incorrect results** instead of erroring.

Both in-tree callers already work around this by calling `.contiguous()` by hand right before `sdpa` — `quantized_llama.rs` (with the comment *"ensures that the fast kernel can be called"*) and `z_image/transformer.rs`. This moves the invariant into the op itself so the public API is correct regardless of how it is called. `contiguous()` is a no-op when the input already is, so the common path is unchanged.

This is the class of bug behind #3522 — the original panic reported there is already resolved on `main`; what remained was the silent incorrectness on strided inputs.

## Tests

Adds Metal SDPA coverage that was missing (the existing tests only used equal head counts with contiguous tensors):

- `sdpa_vector_gqa_decode` — grouped-query decode (`n_head != n_kv_head`).
- `sdpa_non_contiguous` — strided `q`/`k`/`v` across both the vector (decode) and full (prefill) paths; asserts that layout does not change the result. Fails at `max_abs_diff ≈ 1.7` before the fix, `≤ 1e-4` after.

## Verification (Apple M4 Pro, Metal)

- `cargo test --features metal -p candle-nn` — all green (sdpa 7/7, full crate suite green).
- End-to-end: `cargo run --release --features metal --example quantized -- --which SmoLM2-360M-Instruct` (a GQA model) decodes correctly, with no perf change (the guard is a no-op on the model's already-contiguous path).
