### PR TITLE
Fix Metal argsort silently corrupting rows longer than one threadgroup (#2570)

### DIFF
--- a/candle-core/src/sort.rs
+++ b/candle-core/src/sort.rs
@@ -229,18 +229,52 @@ impl crate::CustomOp1 for ArgSort {
         while ncols_pad < ncols {
             ncols_pad *= 2;
         }
-        candle_metal_kernels::call_arg_sort(
-            device.metal_device(),
-            &command_encoder,
-            kernels,
-            name,
-            nrows,
-            ncols,
-            ncols_pad,
-            src,
-            &dst,
-        )
-        .map_err(crate::Error::wrap)?;
+        // The bitonic kernel sorts a whole row inside a single threadgroup, so it
+        // is capped at ncols_pad <= the Metal max threads per threadgroup (1024 on
+        // Apple GPUs). Past that the dispatch silently returned wrong indices
+        // (issue #2570). Route large ascending sorts through the multi-block MLX
+        // kernel where it is supported, and error clearly otherwise rather than
+        // corrupting the output.
+        const MAX_THREADS_PER_THREADGROUP: usize = 1024;
+        if ncols_pad <= MAX_THREADS_PER_THREADGROUP {
+            candle_metal_kernels::call_arg_sort(
+                device.metal_device(),
+                &command_encoder,
+                kernels,
+                name,
+                nrows,
+                ncols,
+                ncols_pad,
+                src,
+                &dst,
+            )
+            .map_err(crate::Error::wrap)?;
+        } else if self.asc && matches!(storage.dtype(), DType::F32 | DType::U32) {
+            let mlx_dtype = match storage.dtype() {
+                DType::F32 => candle_metal_kernels::DType::F32,
+                DType::U32 => candle_metal_kernels::DType::U32,
+                _ => unreachable!("guarded by the matches! above"),
+            };
+            candle_metal_kernels::call_mlx_arg_sort(
+                device.metal_device(),
+                &command_encoder,
+                kernels,
+                mlx_dtype,
+                nrows,
+                ncols,
+                src,
+                &dst,
+            )
+            .map_err(crate::Error::wrap)?;
+        } else {
+            crate::bail!(
+                "Metal argsort is limited to {MAX_THREADS_PER_THREADGROUP} elements per row for \
+                 dtype {:?} with ascending={}; got ncols={ncols}. Rows longer than that are \
+                 currently only supported for ascending F32/U32 sorts.",
+                storage.dtype(),
+                self.asc
+            );
+        }
         let dst = crate::MetalStorage::new(dst, device.clone(), el, DType::U32);
         Ok((dst, layout.shape().clone()))
     }

--- a/candle-core/tests/metal_argsort_tests.rs
+++ b/candle-core/tests/metal_argsort_tests.rs
@@ -1,0 +1,114 @@
+#![cfg(feature = "metal")]
+//! Regression tests for Metal `arg_sort` on rows longer than a single
+//! threadgroup (issue #2570). The bitonic kernel sorts a whole row inside one
+//! threadgroup and silently returned wrong indices past ~1024 elements; large
+//! ascending F32/U32 sorts now go through the multi-block MLX kernel, and the
+//! cases that remain unsupported error instead of corrupting the output.
+
+use candle_core::{DType, Device, Result, Tensor};
+
+// Assert that `idx` is a valid ascending argsort of `values`: the indices form
+// a permutation of 0..n and gather the values in non-decreasing order.
+fn assert_valid_ascending_argsort(values: &[f32], idx: &[u32]) {
+    assert_eq!(values.len(), idx.len(), "index length mismatch");
+    let n = values.len();
+    let mut seen = vec![false; n];
+    let mut prev = f32::NEG_INFINITY;
+    for &i in idx {
+        let i = i as usize;
+        assert!(i < n, "index {i} out of range for n={n}");
+        assert!(!seen[i], "index {i} returned twice (not a permutation)");
+        seen[i] = true;
+        let v = values[i];
+        assert!(v >= prev, "not sorted ascending: {v} < {prev}");
+        prev = v;
+    }
+}
+
+#[test]
+fn argsort_large_ascending_f32() -> Result<()> {
+    let device = Device::new_metal(0)?;
+    // Straddle the single-threadgroup limit and the block/multi-block MLX paths.
+    for n in [1024usize, 1025, 2048, 4096, 4097, 130_000] {
+        let d = Tensor::rand(-256f32, 255., (1, n), &device)?;
+        let idx = d.arg_sort_last_dim(true)?;
+        let values: Vec<f32> = d.get(0)?.to_vec1()?;
+        let order: Vec<u32> = idx.get(0)?.to_vec1()?;
+        assert_valid_ascending_argsort(&values, &order);
+    }
+    Ok(())
+}
+
+#[test]
+fn argsort_large_ascending_multi_row_f32() -> Result<()> {
+    // nrows > 1: each row must be sorted independently.
+    let device = Device::new_metal(0)?;
+    let (rows, n) = (3usize, 5000usize);
+    let d = Tensor::rand(-10f32, 10., (rows, n), &device)?;
+    let idx = d.arg_sort_last_dim(true)?;
+    for r in 0..rows {
+        let values: Vec<f32> = d.get(r)?.to_vec1()?;
+        let order: Vec<u32> = idx.get(r)?.to_vec1()?;
+        assert_valid_ascending_argsort(&values, &order);
+    }
+    Ok(())
+}
+
+#[test]
+fn argsort_large_ascending_u32() -> Result<()> {
+    let device = Device::new_metal(0)?;
+    let n = 3000usize;
+    let vals: Vec<u32> = (0..n as u32).rev().collect(); // strictly descending input
+    let d = Tensor::from_vec(vals, (1, n), &device)?;
+    let idx = d.arg_sort_last_dim(true)?;
+    let order: Vec<u32> = idx.get(0)?.to_vec1()?;
+    // Ascending argsort of a reversed range is the reversed index range.
+    let expected: Vec<u32> = (0..n as u32).rev().collect();
+    assert_eq!(order, expected);
+    Ok(())
+}
+
+#[test]
+fn argsort_large_descending_errors_not_corrupts() -> Result<()> {
+    // Descending large sorts are not supported by the multi-block path; they must
+    // return a clear error rather than silently producing wrong indices.
+    let device = Device::new_metal(0)?;
+    let d = Tensor::rand(-1f32, 1., (1, 2048), &device)?;
+    let res = d.arg_sort_last_dim(false);
+    assert!(
+        res.is_err(),
+        "expected an error for a large descending Metal argsort, got Ok"
+    );
+    Ok(())
+}
+
+#[test]
+fn argsort_large_unsupported_dtype_errors() -> Result<()> {
+    // A dtype the multi-block path does not cover (F16) must error above the
+    // threadgroup limit instead of returning garbage.
+    let device = Device::new_metal(0)?;
+    let d = Tensor::rand(-1f32, 1., (1, 2048), &device)?.to_dtype(DType::F16)?;
+    let res = d.arg_sort_last_dim(true);
+    assert!(
+        res.is_err(),
+        "expected an error for a large F16 Metal argsort, got Ok"
+    );
+    Ok(())
+}
+
+#[test]
+fn argsort_small_still_works_all_paths() -> Result<()> {
+    // The <=1024 bitonic path must be unaffected, ascending and descending.
+    let device = Device::new_metal(0)?;
+    let d = Tensor::rand(-1f32, 1., (1, 512), &device)?;
+    let values: Vec<f32> = d.get(0)?.to_vec1()?;
+
+    let asc: Vec<u32> = d.arg_sort_last_dim(true)?.get(0)?.to_vec1()?;
+    assert_valid_ascending_argsort(&values, &asc);
+
+    // Descending: values gathered in non-increasing order, still a permutation.
+    let desc: Vec<u32> = d.arg_sort_last_dim(false)?.get(0)?.to_vec1()?;
+    let neg: Vec<f32> = values.iter().map(|v| -v).collect();
+    assert_valid_ascending_argsort(&neg, &desc);
+    Ok(())
+}

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -221,21 +221,23 @@ fn asort(device: &Device) -> Result<()> {
 
 /// Test sorting a large tensor that exceeds 1024 elements.
 fn asort_big(device: &Device) -> Result<()> {
-    // Skip on metal for now
-    if device.is_metal() {
-        return Ok(());
-    }
-    const SIZE: usize = 2000;
+    const SIZE: usize = 2000; // > 1024, exceeds the single-threadgroup bitonic path
     let data: Vec<f32> = (0..SIZE).map(|x| (SIZE - x) as f32).collect();
     let tensor = Tensor::new(data.as_slice(), device)?;
 
+    // Ascending argsort of a strictly descending input is the reversed index range.
     let indexes = tensor.arg_sort_last_dim(true)?;
     let expected_indexes: Vec<u32> = (0..SIZE).rev().map(|x| x as u32).collect();
     assert_eq!(indexes.to_vec1::<u32>()?, expected_indexes);
 
-    let indexes = tensor.arg_sort_last_dim(false)?;
-    let expected_indexes: Vec<u32> = (0..SIZE).map(|x| x as u32).collect();
-    assert_eq!(indexes.to_vec1::<u32>()?, expected_indexes);
+    // Large descending sorts are not yet supported on Metal: the multi-block MLX
+    // kernel that handles rows past the single-threadgroup limit is ascending-only,
+    // so the Metal path returns an error there instead of a wrong result.
+    if !device.is_metal() {
+        let indexes = tensor.arg_sort_last_dim(false)?;
+        let expected_indexes: Vec<u32> = (0..SIZE).map(|x| x as u32).collect();
+        assert_eq!(indexes.to_vec1::<u32>()?, expected_indexes);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Problem

Metal `arg_sort` uses a bitonic sort that sorts an entire row inside a single threadgroup, so it only works while `ncols_pad <= max threads per threadgroup` (1024 on Apple GPUs). Past that the dispatch returned **silently-wrong** indices rather than erroring — e.g. `arg_sort_last_dim(true)` on a `(1, 2048)` tensor returns a garbage, non-permutation index array (all zeros). Reported in #2570.

```rust
let d = Tensor::rand(-256f32, 255., (1, 2048), &Device::new_metal(0)?)?;
let i = d.arg_sort_last_dim(true)?; // [[0, 0, 0, ..., 0]] — wrong
```

## Fix

`candle-metal-kernels` already ships a multi-block sort (`call_mlx_arg_sort`, the MLX kernels) that handles arbitrary row lengths; it just wasn't wired into `arg_sort`. This routes large **ascending F32/U32** sorts through it. Cases the multi-block path does not cover — descending order, or dtypes other than F32/U32 — now return a **clear error** instead of corrupting the output (as @LaurentMazare noted on the issue, these should fail loudly). Rows that still fit a single threadgroup keep using the existing bitonic kernel unchanged (all dtypes, ascending and descending).

The ascending-F32/U32 path covers the motivating case (large logit vectors, e.g. token sampling). Descending large sorts and the remaining dtypes are a natural follow-up (the MLX kernels are currently instantiated ascending-only).

## Tests

- `candle-core/tests/metal_argsort_tests.rs` (new): large ascending F32 across the single-block/multi-block boundary (1024–130000), multi-row, U32, and the error paths for large descending and large F16.
- `asort_big` previously early-returned on Metal (`// Skip on metal for now`); its ascending half now runs on Metal and passes.

## Verification (Apple M4 Pro, Metal)

- `cargo test --features metal -p candle-core --test metal_argsort_tests` — green.
- `cargo test --features metal -p candle-core --test tensor_tests asort` — `asort_big_metal` now passes; full sort suite green.
- `cargo fmt` / `cargo clippy` clean.
