### PR TITLE
Add clear_kv_cache to quantized gemma3, phi3, glm4 and lfm2

### DIFF
--- a/candle-transformers/src/models/quantized_gemma3.rs
+++ b/candle-transformers/src/models/quantized_gemma3.rs
@@ -436,6 +436,16 @@ impl ModelWeights {
         })
     }
 
+    /// Clear the KV cache across all layers.
+    ///
+    /// Call this between independent conversations to free cached attention
+    /// state without recreating the model.
+    pub fn clear_kv_cache(&mut self) {
+        for layer in self.layers.iter_mut() {
+            layer.kv_cache = None;
+        }
+    }
+
     pub fn forward(&mut self, x: &Tensor, index_pos: usize) -> Result<Tensor> {
         let (b_sz, seq_len) = x.dims2()?;
         let _enter = self.span.enter();

--- a/candle-transformers/src/models/quantized_glm4.rs
+++ b/candle-transformers/src/models/quantized_glm4.rs
@@ -454,6 +454,16 @@ impl ModelWeights {
         Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
     }
 
+    /// Clear the KV cache across all layers.
+    ///
+    /// Call this between independent conversations to free cached attention
+    /// state without recreating the model.
+    pub fn clear_kv_cache(&mut self) {
+        for layer in self.layers.iter_mut() {
+            layer.kv_cache.reset();
+        }
+    }
+
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
         let _enter = self.span.enter();
         let (b, l) = input.dims2()?;

--- a/candle-transformers/src/models/quantized_lfm2.rs
+++ b/candle-transformers/src/models/quantized_lfm2.rs
@@ -597,6 +597,23 @@ impl ModelWeights {
         }
     }
 
+    /// Clear the per-layer state across all layers: the KV cache of attention
+    /// layers and the conv state of short-conv layers.
+    ///
+    /// Call this between independent conversations to guarantee no state leaks
+    /// from one request into the next without recreating the model. Note that
+    /// `ShortConvLayer::forward` ignores `index_pos`, so a request whose first
+    /// forward has `seq_len == 1` would otherwise reuse the previous
+    /// conversation's conv state.
+    pub fn clear_kv_cache(&mut self) {
+        for layer in self.layers.iter_mut() {
+            match &mut layer.kind {
+                LayerKind::Attention(attn) => attn.kv_cache = None,
+                LayerKind::ShortConv(conv) => conv.cache = None,
+            }
+        }
+    }
+
     pub fn forward(&mut self, x: &Tensor, index_pos: usize) -> Result<Tensor> {
         let (_b_sz, seq_len) = x.dims2()?;
         let mask = if seq_len == 1 {

--- a/candle-transformers/src/models/quantized_phi3.rs
+++ b/candle-transformers/src/models/quantized_phi3.rs
@@ -312,6 +312,16 @@ impl ModelWeights {
         }
     }
 
+    /// Clear the KV cache across all layers.
+    ///
+    /// Call this between independent conversations to free cached attention
+    /// state without recreating the model.
+    pub fn clear_kv_cache(&mut self) {
+        for layer in self.layers.iter_mut() {
+            layer.kv_cache.reset();
+        }
+    }
+
     pub fn forward(&mut self, xs: &Tensor, index_pos: usize) -> Result<Tensor> {
         let (_b_sz, seq_len) = xs.dims2()?;
         let mask = if seq_len == 1 {


### PR DESCRIPTION
Adds a public `clear_kv_cache()` to the `ModelWeights` of `quantized_gemma3`, `quantized_phi3`, `quantized_glm4` and `quantized_lfm2`, mirroring the method already exposed by `quantized_llama`, `quantized_qwen2` and `quantized_qwen3`.

## Why

When a single loaded quantized model serves multiple independent requests, the caller needs an explicit way to drop cached attention state between conversations:

- gemma3/phi3/glm4 currently reset their cache only implicitly, when `forward` is called with `index_pos == 0`. That works, but it is an undocumented contract — downstream code that must *guarantee* request isolation (no tokens leaking across calls) has nothing explicit to call, unlike with the llama/qwen2/qwen3 siblings.
- `quantized_lfm2` is the strongest case: `ShortConvLayer::forward` ignores `index_pos` entirely, so its conv state has no implicit reset at all — a new conversation whose first forward has `seq_len == 1` silently reuses the previous conversation's conv state. Its `clear_kv_cache` clears both the attention KV pairs and the conv state.
- Parity across the quantized model family lets downstream code hold one enum over `ModelWeights` variants and clear state uniformly.
- For `quantized_gemma3` (per-layer `Option<(Tensor, Tensor)>`), the explicit clear also frees the cached tensors between requests instead of keeping the last conversation's KV alive until the next forward.

The implementation copies the exact pattern of `quantized_llama::ModelWeights::clear_kv_cache` (iterate layers, clear the K/V pair): `kv_cache = None` for gemma3, `KvCache::reset()` for phi3/glm4 (which use `candle_nn::kv_cache::KvCache`).

No behavior change for existing callers — the method is additive. Same pattern previously merged for the siblings in #3536 (quantized llama/qwen2) and #3189 (quantized qwen3).

Related CPU findings from the same embedding work, filed separately: #3707 (no batch path in the quantized matmul — prefill runs at decode speed) and #3708 (no lazy/mmap loading for GGUF).
