### PR TITLE
Metal: reject non-contiguous source in gather

### DIFF
--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -1457,6 +1457,12 @@ impl BackendStorage for MetalStorage {
         if !ids_l.is_contiguous() {
             return Err(crate::Error::RequiresContiguous { op: "gather" }.bt());
         };
+        // The Metal gather kernel indexes the source assuming a contiguous
+        // layout, so a strided source silently produced wrong results. Require a
+        // contiguous source, matching the CPU backend and the `ids` check above.
+        if !src_l.is_contiguous() {
+            return Err(crate::Error::RequiresContiguous { op: "gather" }.bt());
+        };
         let ids_el = ids_l.dims()[dim];
         let dst_el = ids_l.shape().elem_count();
         let dtype = self.dtype;

--- a/candle-core/tests/metal_gather_contiguous.rs
+++ b/candle-core/tests/metal_gather_contiguous.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "metal")]
+//! Metal gather indexes the source assuming a contiguous layout; a strided
+//! source silently returned wrong values. It now errors like the CPU backend.
+use candle_core::{Device, Result, Tensor};
+
+#[test]
+fn gather_strided_source_errors_like_cpu() -> Result<()> {
+    let dev = Device::new_metal(0)?;
+    let (r, c) = (4usize, 6usize);
+    let data: Vec<f32> = (0..r * c).map(|i| i as f32).collect();
+    let strided = Tensor::from_vec(data, (c, r), &dev)?.transpose(0, 1)?; // (r,c), non-contiguous
+    assert!(!strided.is_contiguous());
+    let ids: Vec<u32> = (0..r * c).map(|i| ((i * 5 + 2) % c) as u32).collect();
+    let idx = Tensor::from_vec(ids, (r, c), &dev)?;
+    // Was: silently wrong. Now: a clear error (as on CPU).
+    assert!(strided.gather(&idx, 1).is_err());
+    // A contiguous source still gathers correctly.
+    let out: Vec<f32> = strided
+        .contiguous()?
+        .gather(&idx, 1)?
+        .flatten_all()?
+        .to_vec1()?;
+    let cpu = Device::Cpu;
+    let sc = Tensor::from_vec(
+        (0..r * c).map(|i| i as f32).collect::<Vec<_>>(),
+        (c, r),
+        &cpu,
+    )?
+    .t()?
+    .contiguous()?;
+    let ic = Tensor::from_vec(
+        (0..r * c)
+            .map(|i| ((i * 5 + 2) % c) as u32)
+            .collect::<Vec<_>>(),
+        (r, c),
+        &cpu,
+    )?;
+    let want: Vec<f32> = sc.gather(&ic, 1)?.flatten_all()?.to_vec1()?;
+    assert_eq!(out, want);
+    Ok(())
+}


### PR DESCRIPTION
## Problem

`gather` on a **non-contiguous source** silently returns wrong values on the Metal backend, while the CPU backend errors with `gather only supports contiguous tensors`.

Reproduced with a transposed `(4, 6)` source: Metal returns values gathered from a contiguous interpretation of the strided buffer, diverging from the CPU result.

## Cause

The Metal gather kernel computes the source offset assuming a contiguous layout (`src_i = (left_rank_i * src_dim_size + input_i) * right_size + right_rank_i`; no strides). The dispatch checks `ids` for contiguity but never the source, so a strided source is read with the wrong offsets.

## Fix

Require a contiguous source in the Metal `gather` dispatch, mirroring the existing `ids` check right above it and the CPU backend's contract. This turns silent corruption into the same clear `RequiresContiguous` error.

## Tests

`candle-core/tests/metal_gather_contiguous.rs`: a strided-source gather now errors, and a contiguous gather still matches the CPU reference.

```
cargo test --features metal -p candle-core --test tensor_tests   # gather_* green, 83 passed
cargo fmt / clippy                                                # clean
```
