### PR TITLE
Harden the GGUF and GGML loaders against crafted files

### DIFF
--- a/candle-core/src/quantized/ggml_file.rs
+++ b/candle-core/src/quantized/ggml_file.rs
@@ -5,6 +5,19 @@ use crate::{Device, Result};
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::collections::HashMap;
 
+// GGML tensors carry at most GGML_MAX_DIMS (4) dimensions, see ggml.h. Values
+// read from an untrusted file are validated against this before being used as
+// an allocation length, mirroring the GGUF caps in huggingface/candle#3533.
+const GGML_MAX_DIMS: u32 = 4;
+
+// `file_size` is the byte length captured once up front so length-prefixed
+// fields read from the file can be rejected before they drive an allocation,
+// without seeking to the end and back on every read.
+fn remaining_bytes<R: std::io::Seek>(reader: &mut R, file_size: u64) -> Result<u64> {
+    let cur = reader.stream_position()?;
+    Ok(file_size.saturating_sub(cur))
+}
+
 // https://github.com/ggerganov/llama.cpp/blob/468ea24fb4633a0d681f7ac84089566c1c6190cb/llama.h#L37
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Magic {
@@ -103,11 +116,26 @@ pub struct Vocab {
 }
 
 impl Vocab {
-    fn read<R: std::io::Read>(reader: &mut R, n_vocab: usize) -> Result<Self> {
+    fn read<R: std::io::Read + std::io::Seek>(
+        reader: &mut R,
+        n_vocab: usize,
+        file_size: u64,
+    ) -> Result<Self> {
         // https://github.com/ggerganov/llama.cpp/blob/468ea24fb4633a0d681f7ac84089566c1c6190cb/llama.cpp#L556
+        // Every entry is at least 8 bytes on disk (u32 length + f32 score), so a
+        // n_vocab larger than remaining/8 cannot be backed by the file. Reject it
+        // before reserving, so a crafted header can't request a huge allocation.
+        let remaining = remaining_bytes(reader, file_size)?;
+        if n_vocab as u64 > remaining / 8 {
+            crate::bail!("ggml: vocab size {n_vocab} exceeds remaining file bytes {remaining}")
+        }
         let mut token_score_pairs = Vec::with_capacity(n_vocab);
         for _index in 0..n_vocab {
             let len = reader.read_u32::<LittleEndian>()? as usize;
+            let remaining = remaining_bytes(reader, file_size)?;
+            if len as u64 > remaining {
+                crate::bail!("ggml: token length {len} exceeds remaining file bytes {remaining}")
+            }
             let mut word = vec![0u8; len];
             reader.read_exact(&mut word)?;
             let score = reader.read_f32::<LittleEndian>()?;
@@ -192,8 +220,12 @@ fn read_one_tensor<R: std::io::Seek + std::io::Read>(
     reader: &mut R,
     magic: VersionedMagic,
     device: &Device,
+    file_size: u64,
 ) -> Result<(String, super::QTensor)> {
     let n_dims = reader.read_u32::<LittleEndian>()?;
+    if n_dims > GGML_MAX_DIMS {
+        crate::bail!("ggml: tensor n_dims {n_dims} exceeds max {GGML_MAX_DIMS}")
+    }
     let name_len = reader.read_u32::<LittleEndian>()?;
     let ggml_dtype = reader.read_u32::<LittleEndian>()?;
     let ggml_dtype = GgmlDType::from_u32(ggml_dtype)?;
@@ -202,6 +234,10 @@ fn read_one_tensor<R: std::io::Seek + std::io::Read>(
     // The dimensions are stored in reverse order, see for example:
     // https://github.com/ggerganov/llama.cpp/blob/b5ffb2849d23afe73647f68eec7b68187af09be6/convert.py#L969
     dims.reverse();
+    let remaining = remaining_bytes(reader, file_size)?;
+    if name_len as u64 > remaining {
+        crate::bail!("ggml: tensor name length {name_len} exceeds remaining file bytes {remaining}")
+    }
     let mut name = vec![0u8; name_len as usize];
     reader.read_exact(&mut name)?;
     let name = String::from_utf8_lossy(&name).into_owned();
@@ -211,8 +247,21 @@ fn read_one_tensor<R: std::io::Seek + std::io::Read>(
         reader.seek(std::io::SeekFrom::Current(((32 - pos % 32) % 32) as i64))?;
     }
     let dims = dims.iter().map(|&u| u as usize).collect::<Vec<_>>();
-    let tensor_elems = dims.iter().product::<usize>();
-    let size_in_bytes = tensor_elems * ggml_dtype.type_size() / ggml_dtype.block_size();
+    // Dimensions come from the file: fold with checked_mul so a crafted shape
+    // reports an error instead of panicking (debug) or wrapping (release) into a
+    // bogus, too-small `size_in_bytes`.
+    let size_in_bytes = dims
+        .iter()
+        .try_fold(1usize, |acc, &d| acc.checked_mul(d))
+        .and_then(|elems| elems.checked_mul(ggml_dtype.type_size()))
+        .map(|nbytes| nbytes / ggml_dtype.block_size())
+        .ok_or_else(|| crate::Error::Msg(format!("ggml: tensor shape {dims:?} size overflow")))?;
+    // Validate against the file before allocating so a crafted size can't force
+    // a huge up-front allocation.
+    let remaining = remaining_bytes(reader, file_size)?;
+    if size_in_bytes as u64 > remaining {
+        crate::bail!("ggml: tensor needs {size_in_bytes} bytes, only {remaining} remaining in file")
+    }
     // TODO: Mmap version to avoid copying the data around?
     let mut raw_data = vec![0u8; size_in_bytes];
     reader.read_exact(&mut raw_data)?;
@@ -240,11 +289,11 @@ impl Content {
         reader.seek(std::io::SeekFrom::Start(0))?;
         let magic = VersionedMagic::read(reader)?;
         let hparams = HParams::read(reader)?;
-        let vocab = Vocab::read(reader, hparams.n_vocab as usize)?;
+        let vocab = Vocab::read(reader, hparams.n_vocab as usize, last_position)?;
         let mut tensors = HashMap::new();
 
         while reader.stream_position()? != last_position {
-            let (name, tensor) = read_one_tensor(reader, magic, device)?;
+            let (name, tensor) = read_one_tensor(reader, magic, device, last_position)?;
             tensors.insert(name, tensor);
         }
         let device = device.clone();

--- a/candle-core/src/quantized/gguf_file.rs
+++ b/candle-core/src/quantized/gguf_file.rs
@@ -557,6 +557,15 @@ impl Content {
             Some(Value::I32(v)) if *v >= 0 => *v as u64,
             _ => DEFAULT_ALIGNMENT,
         };
+        // `general.alignment` comes from untrusted metadata. The guards above
+        // only reject negative values, so a zero would reach `div_ceil(0)` and
+        // panic. Per the GGUF spec the alignment must be a non-zero power of
+        // two; reject anything else with a clear error instead of panicking.
+        if alignment == 0 || !alignment.is_power_of_two() {
+            crate::bail!(
+                "gguf: invalid general.alignment {alignment}, must be a non-zero power of two"
+            )
+        }
         let tensor_data_offset = position.div_ceil(alignment) * alignment;
         Ok(Self {
             magic,

--- a/candle-core/src/quantized/gguf_file.rs
+++ b/candle-core/src/quantized/gguf_file.rs
@@ -91,14 +91,26 @@ impl TensorInfo {
         tensor_data_offset: u64,
         device: &Device,
     ) -> Result<QTensor> {
-        let tensor_elems = self.shape.elem_count();
+        // The shape dimensions are read from an untrusted file. Fold the product
+        // with checked_mul so a crafted shape reports an error instead of
+        // panicking (debug) or wrapping (release) into a bogus, too-small
+        // size_in_bytes. Mirrors the GGML loader hardening in #3713.
+        let dims = self.shape.dims();
+        let tensor_elems = dims
+            .iter()
+            .try_fold(1usize, |acc, &d| acc.checked_mul(d))
+            .ok_or_else(|| crate::Error::Msg(format!("gguf: tensor shape {dims:?} overflows")))?;
         let block_size = self.ggml_dtype.block_size();
         if !tensor_elems.is_multiple_of(block_size) {
             crate::bail!(
             "the number of elements {tensor_elems} is not divisible by the block size {block_size}"
         )
         }
-        let size_in_bytes = tensor_elems / block_size * self.ggml_dtype.type_size();
+        let size_in_bytes = (tensor_elems / block_size)
+            .checked_mul(self.ggml_dtype.type_size())
+            .ok_or_else(|| {
+                crate::Error::Msg(format!("gguf: tensor shape {dims:?} size overflows"))
+            })?;
         let tensor_start = tensor_data_offset.saturating_add(self.offset);
         let file_size = reader.seek(std::io::SeekFrom::End(0))?;
         let remaining = file_size.saturating_sub(tensor_start);

--- a/candle-core/src/quantized/gguf_file.rs
+++ b/candle-core/src/quantized/gguf_file.rs
@@ -571,11 +571,13 @@ impl Content {
         };
         // `general.alignment` comes from untrusted metadata. The guards above
         // only reject negative values, so a zero would reach `div_ceil(0)` and
-        // panic. Per the GGUF spec the alignment must be a non-zero power of
-        // two; reject anything else with a clear error instead of panicking.
-        if alignment == 0 || !alignment.is_power_of_two() {
+        // panic. Per the GGUF spec the alignment must be a non-zero multiple of
+        // 8 (not necessarily a power of two); reject anything else with a clear
+        // error instead of panicking. `div_ceil(alignment) * alignment` below is
+        // correct for any positive alignment.
+        if alignment == 0 || alignment % 8 != 0 {
             crate::bail!(
-                "gguf: invalid general.alignment {alignment}, must be a non-zero power of two"
+                "gguf: invalid general.alignment {alignment}, must be a non-zero multiple of 8"
             )
         }
         let tensor_data_offset = position.div_ceil(alignment) * alignment;

--- a/candle-core/tests/ggml_tests.rs
+++ b/candle-core/tests/ggml_tests.rs
@@ -1,0 +1,62 @@
+//! Regression tests hardening the legacy GGML loader against crafted files,
+//! mirroring the GGUF caps added in huggingface/candle#3533.
+
+use candle_core::quantized::ggml_file::Content;
+use candle_core::Device;
+use std::io::Cursor;
+
+const GGML_MAGIC: u32 = 0x67676d6c; // "ggml", unversioned (no align32).
+
+fn u32(v: u32) -> [u8; 4] {
+    v.to_le_bytes()
+}
+
+/// Build a minimal unversioned GGML file: magic, 7 hparam u32s (n_vocab = 0 so
+/// the vocab section is empty), followed by a single crafted tensor header.
+fn ggml_with_tensor(n_dims: u32, name_len: u32, dtype: u32, dims: &[u32]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&u32(GGML_MAGIC));
+    for _ in 0..7 {
+        buf.extend_from_slice(&u32(0)); // hparams, n_vocab = 0
+    }
+    buf.extend_from_slice(&u32(n_dims));
+    buf.extend_from_slice(&u32(name_len));
+    buf.extend_from_slice(&u32(dtype));
+    for &d in dims {
+        buf.extend_from_slice(&u32(d));
+    }
+    buf
+}
+
+fn assert_rejects(buf: Vec<u8>, msg_contains: &str) {
+    let mut cursor = Cursor::new(buf);
+    let msg = match Content::read(&mut cursor, &Device::Cpu) {
+        Ok(_) => panic!("expected Err, got Ok"),
+        Err(e) => format!("{e}"),
+    };
+    assert!(msg.contains(msg_contains), "unexpected error: {msg}");
+}
+
+#[test]
+fn rejects_tensor_shape_overflow() {
+    // Four dims of u32::MAX overflow `dims.iter().product::<usize>()`, which
+    // used to panic ("attempt to multiply with overflow") in debug builds and
+    // wrap in release builds.
+    let buf = ggml_with_tensor(4, 0, 0, &[u32::MAX, u32::MAX, u32::MAX, u32::MAX]);
+    assert_rejects(buf, "overflow");
+}
+
+#[test]
+fn rejects_tensor_size_exceeding_file() {
+    // A single [1_073_741_824] F32 tensor claims 4 GiB but the file carries no
+    // tensor data; it must be rejected rather than allocating 4 GiB up front.
+    let buf = ggml_with_tensor(1, 0, 0, &[1_073_741_824]);
+    assert_rejects(buf, "remaining");
+}
+
+#[test]
+fn rejects_oversized_tensor_name() {
+    // name_len far exceeds the file; must be rejected before allocating.
+    let buf = ggml_with_tensor(1, 1u32 << 30, 0, &[1]);
+    assert_rejects(buf, "name");
+}

--- a/candle-core/tests/gguf_tests.rs
+++ b/candle-core/tests/gguf_tests.rs
@@ -140,6 +140,28 @@ fn rejects_zero_general_alignment() {
 }
 
 #[test]
+fn accepts_non_power_of_two_general_alignment() {
+    // Per the GGUF spec `general.alignment` need only be a non-zero multiple of
+    // 8, not a power of two (e.g. 24). `div_ceil(alignment) * alignment` pads
+    // correctly for any positive value, so such files must still parse.
+    let mut buf = header(0, 1);
+    buf.extend(length_prefixed(b"general.alignment"));
+    buf.extend_from_slice(&4u32.to_le_bytes()); // value_type = U32
+    buf.extend_from_slice(&24u32.to_le_bytes()); // alignment = 24 (mult of 8, not pow2)
+    let mut cursor = Cursor::new(buf);
+    Content::read(&mut cursor).expect("alignment 24 (a multiple of 8) should parse");
+}
+
+#[test]
+fn rejects_general_alignment_not_multiple_of_8() {
+    let mut buf = header(0, 1);
+    buf.extend(length_prefixed(b"general.alignment"));
+    buf.extend_from_slice(&4u32.to_le_bytes()); // value_type = U32
+    buf.extend_from_slice(&12u32.to_le_bytes()); // alignment = 12 (not a multiple of 8)
+    assert_rejects(buf, "alignment");
+}
+
+#[test]
 fn rejects_tensor_shape_product_overflow() {
     // Two dims of 2^40 overflow `Shape::elem_count()` (their product is 2^80).
     // Loading the tensor used to panic ("attempt to multiply with overflow") in

--- a/candle-core/tests/gguf_tests.rs
+++ b/candle-core/tests/gguf_tests.rs
@@ -140,6 +140,27 @@ fn rejects_zero_general_alignment() {
 }
 
 #[test]
+fn rejects_tensor_shape_product_overflow() {
+    // Two dims of 2^40 overflow `Shape::elem_count()` (their product is 2^80).
+    // Loading the tensor used to panic ("attempt to multiply with overflow") in
+    // debug builds and wrap to a bogus small size in release builds.
+    let mut buf = header(1, 0);
+    buf.extend(length_prefixed(b"t"));
+    buf.extend_from_slice(&2u32.to_le_bytes()); // n dims
+    buf.extend_from_slice(&(1u64 << 40).to_le_bytes()); // dim 0
+    buf.extend_from_slice(&(1u64 << 40).to_le_bytes()); // dim 1
+    buf.extend_from_slice(&0u32.to_le_bytes()); // F32
+    buf.extend_from_slice(&0u64.to_le_bytes()); // offset
+    let mut cursor = Cursor::new(buf);
+    let content = Content::read(&mut cursor).expect("header should parse");
+    let err = content
+        .tensor(&mut cursor, "t", &Device::Cpu)
+        .expect_err("expected Err from overflowing tensor shape");
+    let msg = format!("{err}");
+    assert!(msg.contains("overflow"), "unexpected error: {msg}");
+}
+
+#[test]
 fn rejects_string_length_above_remaining_file_bytes() {
     let mut buf = header(1, 0);
     buf.extend_from_slice(&(1u64 << 20).to_le_bytes()); // 1 MB, below cap, above file size

--- a/candle-core/tests/gguf_tests.rs
+++ b/candle-core/tests/gguf_tests.rs
@@ -128,6 +128,18 @@ fn rejects_tensor_size_exceeding_file() {
 }
 
 #[test]
+fn rejects_zero_general_alignment() {
+    // `general.alignment` is read from untrusted metadata and only rejected
+    // when negative; a zero value used to reach `position.div_ceil(0)` and
+    // panic with "attempt to divide by zero". It must be rejected instead.
+    let mut buf = header(0, 1);
+    buf.extend(length_prefixed(b"general.alignment"));
+    buf.extend_from_slice(&4u32.to_le_bytes()); // value_type = U32
+    buf.extend_from_slice(&0u32.to_le_bytes()); // alignment = 0
+    assert_rejects(buf, "alignment");
+}
+
+#[test]
 fn rejects_string_length_above_remaining_file_bytes() {
     let mut buf = header(1, 0);
     buf.extend_from_slice(&(1u64 << 20).to_le_bytes()); // 1 MB, below cap, above file size


### PR DESCRIPTION
## What

The quantized model loaders take length/size/alignment fields straight from the file. Several are used unchecked, so a crafted `.gguf`/`.ggml` panics or over-allocates on load. This PR fixes three (each with a regression test in `gguf_tests`/`ggml_tests`):

| Loader | Crafted input | Was | Now |
|--------|--------------|-----|-----|
| GGUF | `general.alignment = 0` | `position.div_ceil(0)` → divide-by-zero panic | rejected (must be a non-zero power of two, per spec) |
| GGUF | tensor shape whose product overflows `usize` (e.g. two dims of 2^40) | `elem_count()`/`*type_size` overflow → panic (debug) / wrap-then-OOB (release) | `checked_mul` fold → clean error |
| GGML | overflowing shape, and `n_vocab`/`name_len`/per-token `len` used as alloc sizes | overflow panic + multi-GiB allocs | `checked_mul` + validate every length against remaining file bytes; `n_dims` capped |

The GGUF metadata reader was already hardened in #3533; this brings the tensor-load path and the GGML reader up to the same bar.

## Why one PR

All three are the same class (untrusted quantized-file field → panic/over-alloc) and use the same checked-arithmetic + remaining-bytes-validation approach; one coherent hardening pass is easier to review than three fragments.

## Tests

`rejects_zero_general_alignment`, `rejects_tensor_shape_product_overflow` (gguf_tests), and a new `ggml_tests.rs` (shape overflow, oversized tensor data, oversized name). Existing `gguf_tests`/`quantized_tests` stay green; `cargo fmt --all` + `clippy -D warnings` clean.

cc @LaurentMazare @ivarflakstad @EricLBuehler