### PR TITLE
Harden the GGML loader against crafted files

### DIFF
--- a/candle-core/src/quantized/ggml_file.rs
+++ b/candle-core/src/quantized/ggml_file.rs
@@ -5,6 +5,19 @@ use crate::{Device, Result};
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::collections::HashMap;
 
+// GGML tensors carry at most GGML_MAX_DIMS (4) dimensions, see ggml.h. Values
+// read from an untrusted file are validated against this before being used as
+// an allocation length, mirroring the GGUF caps in huggingface/candle#3533.
+const GGML_MAX_DIMS: u32 = 4;
+
+// `file_size` is the byte length captured once up front so length-prefixed
+// fields read from the file can be rejected before they drive an allocation,
+// without seeking to the end and back on every read.
+fn remaining_bytes<R: std::io::Seek>(reader: &mut R, file_size: u64) -> Result<u64> {
+    let cur = reader.stream_position()?;
+    Ok(file_size.saturating_sub(cur))
+}
+
 // https://github.com/ggerganov/llama.cpp/blob/468ea24fb4633a0d681f7ac84089566c1c6190cb/llama.h#L37
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Magic {
@@ -103,11 +116,26 @@ pub struct Vocab {
 }
 
 impl Vocab {
-    fn read<R: std::io::Read>(reader: &mut R, n_vocab: usize) -> Result<Self> {
+    fn read<R: std::io::Read + std::io::Seek>(
+        reader: &mut R,
+        n_vocab: usize,
+        file_size: u64,
+    ) -> Result<Self> {
         // https://github.com/ggerganov/llama.cpp/blob/468ea24fb4633a0d681f7ac84089566c1c6190cb/llama.cpp#L556
+        // Every entry is at least 8 bytes on disk (u32 length + f32 score), so a
+        // n_vocab larger than remaining/8 cannot be backed by the file. Reject it
+        // before reserving, so a crafted header can't request a huge allocation.
+        let remaining = remaining_bytes(reader, file_size)?;
+        if n_vocab as u64 > remaining / 8 {
+            crate::bail!("ggml: vocab size {n_vocab} exceeds remaining file bytes {remaining}")
+        }
         let mut token_score_pairs = Vec::with_capacity(n_vocab);
         for _index in 0..n_vocab {
             let len = reader.read_u32::<LittleEndian>()? as usize;
+            let remaining = remaining_bytes(reader, file_size)?;
+            if len as u64 > remaining {
+                crate::bail!("ggml: token length {len} exceeds remaining file bytes {remaining}")
+            }
             let mut word = vec![0u8; len];
             reader.read_exact(&mut word)?;
             let score = reader.read_f32::<LittleEndian>()?;
@@ -192,8 +220,12 @@ fn read_one_tensor<R: std::io::Seek + std::io::Read>(
     reader: &mut R,
     magic: VersionedMagic,
     device: &Device,
+    file_size: u64,
 ) -> Result<(String, super::QTensor)> {
     let n_dims = reader.read_u32::<LittleEndian>()?;
+    if n_dims > GGML_MAX_DIMS {
+        crate::bail!("ggml: tensor n_dims {n_dims} exceeds max {GGML_MAX_DIMS}")
+    }
     let name_len = reader.read_u32::<LittleEndian>()?;
     let ggml_dtype = reader.read_u32::<LittleEndian>()?;
     let ggml_dtype = GgmlDType::from_u32(ggml_dtype)?;
@@ -202,6 +234,10 @@ fn read_one_tensor<R: std::io::Seek + std::io::Read>(
     // The dimensions are stored in reverse order, see for example:
     // https://github.com/ggerganov/llama.cpp/blob/b5ffb2849d23afe73647f68eec7b68187af09be6/convert.py#L969
     dims.reverse();
+    let remaining = remaining_bytes(reader, file_size)?;
+    if name_len as u64 > remaining {
+        crate::bail!("ggml: tensor name length {name_len} exceeds remaining file bytes {remaining}")
+    }
     let mut name = vec![0u8; name_len as usize];
     reader.read_exact(&mut name)?;
     let name = String::from_utf8_lossy(&name).into_owned();
@@ -211,8 +247,21 @@ fn read_one_tensor<R: std::io::Seek + std::io::Read>(
         reader.seek(std::io::SeekFrom::Current(((32 - pos % 32) % 32) as i64))?;
     }
     let dims = dims.iter().map(|&u| u as usize).collect::<Vec<_>>();
-    let tensor_elems = dims.iter().product::<usize>();
-    let size_in_bytes = tensor_elems * ggml_dtype.type_size() / ggml_dtype.block_size();
+    // Dimensions come from the file: fold with checked_mul so a crafted shape
+    // reports an error instead of panicking (debug) or wrapping (release) into a
+    // bogus, too-small `size_in_bytes`.
+    let size_in_bytes = dims
+        .iter()
+        .try_fold(1usize, |acc, &d| acc.checked_mul(d))
+        .and_then(|elems| elems.checked_mul(ggml_dtype.type_size()))
+        .map(|nbytes| nbytes / ggml_dtype.block_size())
+        .ok_or_else(|| crate::Error::Msg(format!("ggml: tensor shape {dims:?} size overflow")))?;
+    // Validate against the file before allocating so a crafted size can't force
+    // a huge up-front allocation.
+    let remaining = remaining_bytes(reader, file_size)?;
+    if size_in_bytes as u64 > remaining {
+        crate::bail!("ggml: tensor needs {size_in_bytes} bytes, only {remaining} remaining in file")
+    }
     // TODO: Mmap version to avoid copying the data around?
     let mut raw_data = vec![0u8; size_in_bytes];
     reader.read_exact(&mut raw_data)?;
@@ -240,11 +289,11 @@ impl Content {
         reader.seek(std::io::SeekFrom::Start(0))?;
         let magic = VersionedMagic::read(reader)?;
         let hparams = HParams::read(reader)?;
-        let vocab = Vocab::read(reader, hparams.n_vocab as usize)?;
+        let vocab = Vocab::read(reader, hparams.n_vocab as usize, last_position)?;
         let mut tensors = HashMap::new();
 
         while reader.stream_position()? != last_position {
-            let (name, tensor) = read_one_tensor(reader, magic, device)?;
+            let (name, tensor) = read_one_tensor(reader, magic, device, last_position)?;
             tensors.insert(name, tensor);
         }
         let device = device.clone();

--- a/candle-core/tests/ggml_tests.rs
+++ b/candle-core/tests/ggml_tests.rs
@@ -1,0 +1,62 @@
+//! Regression tests hardening the legacy GGML loader against crafted files,
+//! mirroring the GGUF caps added in huggingface/candle#3533.
+
+use candle_core::quantized::ggml_file::Content;
+use candle_core::Device;
+use std::io::Cursor;
+
+const GGML_MAGIC: u32 = 0x67676d6c; // "ggml", unversioned (no align32).
+
+fn u32(v: u32) -> [u8; 4] {
+    v.to_le_bytes()
+}
+
+/// Build a minimal unversioned GGML file: magic, 7 hparam u32s (n_vocab = 0 so
+/// the vocab section is empty), followed by a single crafted tensor header.
+fn ggml_with_tensor(n_dims: u32, name_len: u32, dtype: u32, dims: &[u32]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&u32(GGML_MAGIC));
+    for _ in 0..7 {
+        buf.extend_from_slice(&u32(0)); // hparams, n_vocab = 0
+    }
+    buf.extend_from_slice(&u32(n_dims));
+    buf.extend_from_slice(&u32(name_len));
+    buf.extend_from_slice(&u32(dtype));
+    for &d in dims {
+        buf.extend_from_slice(&u32(d));
+    }
+    buf
+}
+
+fn assert_rejects(buf: Vec<u8>, msg_contains: &str) {
+    let mut cursor = Cursor::new(buf);
+    let msg = match Content::read(&mut cursor, &Device::Cpu) {
+        Ok(_) => panic!("expected Err, got Ok"),
+        Err(e) => format!("{e}"),
+    };
+    assert!(msg.contains(msg_contains), "unexpected error: {msg}");
+}
+
+#[test]
+fn rejects_tensor_shape_overflow() {
+    // Four dims of u32::MAX overflow `dims.iter().product::<usize>()`, which
+    // used to panic ("attempt to multiply with overflow") in debug builds and
+    // wrap in release builds.
+    let buf = ggml_with_tensor(4, 0, 0, &[u32::MAX, u32::MAX, u32::MAX, u32::MAX]);
+    assert_rejects(buf, "overflow");
+}
+
+#[test]
+fn rejects_tensor_size_exceeding_file() {
+    // A single [1_073_741_824] F32 tensor claims 4 GiB but the file carries no
+    // tensor data; it must be rejected rather than allocating 4 GiB up front.
+    let buf = ggml_with_tensor(1, 0, 0, &[1_073_741_824]);
+    assert_rejects(buf, "remaining");
+}
+
+#[test]
+fn rejects_oversized_tensor_name() {
+    // name_len far exceeds the file; must be rejected before allocating.
+    let buf = ggml_with_tensor(1, 1u32 << 30, 0, &[1]);
+    assert_rejects(buf, "name");
+}


### PR DESCRIPTION
## What

The legacy GGML reader (`candle-core/src/quantized/ggml_file.rs`) trusts several length/size fields straight from the file, unlike the GGUF reader which was hardened in #3533. A crafted `.ggml`/`.bin` file can therefore panic or force huge up-front allocations on load:

1. **Shape-arithmetic overflow (panic / wrap).** `read_one_tensor` computes
   ```rust
   let tensor_elems = dims.iter().product::<usize>();
   let size_in_bytes = tensor_elems * ggml_dtype.type_size() / ggml_dtype.block_size();
   ```
   with unchecked arithmetic. A shape of four `u32::MAX` dims overflows `product()` and panics with `attempt to multiply with overflow` in debug builds (and wraps to a bogus small size in release, feeding an inconsistent `size_in_bytes` into the unsafe reinterpret in `from_raw_data`).
2. **Unbounded allocations.** `size_in_bytes`, `name_len`, per-token `len`, and `n_vocab` are used directly as allocation lengths with no check against the bytes remaining in the file, so a few-dozen-byte header can request multi-GiB `vec![0u8; …]` / `Vec::with_capacity(…)` allocations (allocation-abort DoS).
3. **Unbounded `n_dims`.** An arbitrary `u32` used as a `Vec` length.

## Fix

Mirror the GGUF hardening (#3533):
- Cap `n_dims` at `GGML_MAX_DIMS` (4, per `ggml.h`).
- Fold the shape with `checked_mul` (shape → `* type_size` → `/ block_size`) and error on overflow instead of panicking/wrapping.
- Add a `remaining_bytes` helper and validate every file-derived length (`n_vocab`, per-token `len`, `name_len`, tensor `size_in_bytes`) against the remaining file size before allocating.

Behavior is unchanged for valid files: for a real model every tensor's data (and each vocab entry, ≥ 8 bytes) is present in the file, so the `remaining` checks always pass and the checked arithmetic returns the same values as before.

## Tests

New `candle-core/tests/ggml_tests.rs` (hand-rolled crafted headers, same style as `gguf_tests.rs`):
- `rejects_tensor_shape_overflow` — four `u32::MAX` dims now error instead of panicking.
- `rejects_tensor_size_exceeding_file` — a 4 GiB tensor claim with no data is rejected before allocating.
- `rejects_oversized_tensor_name` — an oversized `name_len` is rejected before allocating.

Existing `quantized_tests` (39) and `gguf_tests` (11) stay green; `cargo fmt`/`clippy` clean on the changed files.

cc @ivarflakstad @EricLBuehler