### PR TITLE
Guard GGUF tensor shape against elem_count overflow

### DIFF
--- a/candle-core/src/quantized/gguf_file.rs
+++ b/candle-core/src/quantized/gguf_file.rs
@@ -91,14 +91,26 @@ impl TensorInfo {
         tensor_data_offset: u64,
         device: &Device,
     ) -> Result<QTensor> {
-        let tensor_elems = self.shape.elem_count();
+        // The shape dimensions are read from an untrusted file. Fold the product
+        // with checked_mul so a crafted shape reports an error instead of
+        // panicking (debug) or wrapping (release) into a bogus, too-small
+        // size_in_bytes. Mirrors the GGML loader hardening in #3713.
+        let dims = self.shape.dims();
+        let tensor_elems = dims
+            .iter()
+            .try_fold(1usize, |acc, &d| acc.checked_mul(d))
+            .ok_or_else(|| crate::Error::Msg(format!("gguf: tensor shape {dims:?} overflows")))?;
         let block_size = self.ggml_dtype.block_size();
         if !tensor_elems.is_multiple_of(block_size) {
             crate::bail!(
             "the number of elements {tensor_elems} is not divisible by the block size {block_size}"
         )
         }
-        let size_in_bytes = tensor_elems / block_size * self.ggml_dtype.type_size();
+        let size_in_bytes = (tensor_elems / block_size)
+            .checked_mul(self.ggml_dtype.type_size())
+            .ok_or_else(|| {
+                crate::Error::Msg(format!("gguf: tensor shape {dims:?} size overflows"))
+            })?;
         let tensor_start = tensor_data_offset.saturating_add(self.offset);
         let file_size = reader.seek(std::io::SeekFrom::End(0))?;
         let remaining = file_size.saturating_sub(tensor_start);

--- a/candle-core/tests/gguf_tests.rs
+++ b/candle-core/tests/gguf_tests.rs
@@ -128,6 +128,27 @@ fn rejects_tensor_size_exceeding_file() {
 }
 
 #[test]
+fn rejects_tensor_shape_product_overflow() {
+    // Two dims of 2^40 overflow `Shape::elem_count()` (their product is 2^80).
+    // Loading the tensor used to panic ("attempt to multiply with overflow") in
+    // debug builds and wrap to a bogus small size in release builds.
+    let mut buf = header(1, 0);
+    buf.extend(length_prefixed(b"t"));
+    buf.extend_from_slice(&2u32.to_le_bytes()); // n dims
+    buf.extend_from_slice(&(1u64 << 40).to_le_bytes()); // dim 0
+    buf.extend_from_slice(&(1u64 << 40).to_le_bytes()); // dim 1
+    buf.extend_from_slice(&0u32.to_le_bytes()); // F32
+    buf.extend_from_slice(&0u64.to_le_bytes()); // offset
+    let mut cursor = Cursor::new(buf);
+    let content = Content::read(&mut cursor).expect("header should parse");
+    let err = content
+        .tensor(&mut cursor, "t", &Device::Cpu)
+        .expect_err("expected Err from overflowing tensor shape");
+    let msg = format!("{err}");
+    assert!(msg.contains("overflow"), "unexpected error: {msg}");
+}
+
+#[test]
 fn rejects_string_length_above_remaining_file_bytes() {
     let mut buf = header(1, 0);
     buf.extend_from_slice(&(1u64 << 20).to_le_bytes()); // 1 MB, below cap, above file size


### PR DESCRIPTION
## What

`gguf_file::TensorInfo::read` sizes the tensor allocation with unchecked arithmetic:

```rust
let tensor_elems = self.shape.elem_count();               // dims.iter().product() — unchecked
let block_size = self.ggml_dtype.block_size();
if !tensor_elems.is_multiple_of(block_size) { ... }
let size_in_bytes = tensor_elems / block_size * self.ggml_dtype.type_size(); // unchecked *
```

Tensor dimensions are read straight from the file (up to `GGUF_MAX_TENSOR_DIMS` = 4, each a full `u64`). A crafted GGUF whose shape overflows `usize` — e.g. two dims of `2^40` (product `2^80`) — triggers this when the tensor is loaded via `content.tensor(...)`:

- **debug** builds panic with `attempt to multiply with overflow`;
- **release** builds wrap to a bogus small `size_in_bytes`, which passes the `remaining` file-size check and produces a `QTensor` whose huge declared shape disagrees with its handful of storage blocks — a later out-of-bounds in `QMatMul::forward`.

This is the same overflow class fixed for the GGML loader in #3713 (`read_one_tensor` now uses `try_fold(.., checked_mul)`); the GGUF `TensorInfo::read` path was missed.

## Fix

Fold the shape product with `checked_mul` and guard the `type_size` multiply, returning a clear error instead of panicking/wrapping:

```rust
let dims = self.shape.dims();
let tensor_elems = dims.iter()
    .try_fold(1usize, |acc, &d| acc.checked_mul(d))
    .ok_or_else(|| crate::Error::Msg(format!("gguf: tensor shape {dims:?} overflows")))?;
// ... divisibility check ...
let size_in_bytes = (tensor_elems / block_size)
    .checked_mul(self.ggml_dtype.type_size())
    .ok_or_else(|| crate::Error::Msg(format!("gguf: tensor shape {dims:?} size overflows")))?;
```

Behavior is unchanged for valid tensors (the checked ops return the same values).

## Tests

Adds `rejects_tensor_shape_product_overflow` to `candle-core/tests/gguf_tests.rs`: a tensor with two `2^40` dims now errors on load instead of panicking. Existing `gguf_tests` (11) and `quantized_tests` (39) stay green; `cargo fmt`/`clippy` clean.

cc @ivarflakstad @EricLBuehler