### PR TITLE
Accumulate f16/bf16 reductions in f32 (softmax, sum/mean, avg_pool2d)

### DIFF
--- a/candle-core/src/cpu/kernels.rs
+++ b/candle-core/src/cpu/kernels.rs
@@ -134,6 +134,19 @@ impl VecOps for half::f16 {
         super::vec_dot_f16(lhs, rhs, &mut res_f32, len);
         *res = half::f16::from_f32(res_f32);
     }
+
+    // Accumulate in f32: a sequential sum in f16 saturates on long axes (e.g. an
+    // f16 sum of 4096 ones stalls at 2048 once the running ULP exceeds 1),
+    // giving wrong `sum`/`mean` results that also disagree with the Metal
+    // backend. This mirrors the f32 accumulation already used by `vec_dot`.
+    #[inline(always)]
+    unsafe fn vec_reduce_sum(xs: *const Self, res: *mut Self, len: usize) {
+        let mut sum = 0f32;
+        for i in 0..len {
+            sum += (*xs.add(i)).to_f32();
+        }
+        *res = half::f16::from_f32(sum);
+    }
 }
 
 impl VecOps for f64 {
@@ -186,6 +199,19 @@ impl VecOps for half::bf16 {
         let mut res_f32 = 0f32;
         super::vec_dot_bf16(lhs, rhs, &mut res_f32, len);
         *res = half::bf16::from_f32(res_f32);
+    }
+
+    // Accumulate in f32: a sequential sum in bf16 saturates on long axes (bf16
+    // has only 8 mantissa bits, so the running sum stalls even sooner than
+    // f16), giving wrong `sum`/`mean` results that also disagree with the Metal
+    // backend. This mirrors the f32 accumulation already used by `vec_dot`.
+    #[inline(always)]
+    unsafe fn vec_reduce_sum(xs: *const Self, res: *mut Self, len: usize) {
+        let mut sum = 0f32;
+        for i in 0..len {
+            sum += (*xs.add(i)).to_f32();
+        }
+        *res = half::bf16::from_f32(sum);
     }
 }
 impl VecOps for u8 {

--- a/candle-core/src/cpu/kernels.rs
+++ b/candle-core/src/cpu/kernels.rs
@@ -2,6 +2,21 @@ pub trait VecOps: num_traits::NumAssign + Copy {
     fn min(self, rhs: Self) -> Self;
     fn max(self, rhs: Self) -> Self;
 
+    /// Wide accumulator used when summing many `Self` values one at a time (e.g. a
+    /// reduction over a non-contiguous or non-trailing axis). Narrow floats override
+    /// this with `f32` so long running sums don't saturate the way a plain `Self +=`
+    /// would; every other type just accumulates in itself.
+    type Accum: Copy;
+
+    /// Seed the accumulator from a starting `Self` value (usually `Self::zero()`).
+    fn to_accum(self) -> Self::Accum;
+
+    /// Fold `val` into `acc`.
+    fn accum_add(acc: &mut Self::Accum, val: Self);
+
+    /// Narrow the accumulator back down to `Self` once the reduction is complete.
+    fn from_accum(acc: Self::Accum) -> Self;
+
     /// Element-wise addition of two slices into a third.
     #[inline(always)]
     fn vec_add(lhs: &[Self], rhs: &[Self], res: &mut [Self]) {
@@ -85,6 +100,20 @@ impl VecOps for f32 {
         Self::max(self, other)
     }
 
+    type Accum = Self;
+    #[inline(always)]
+    fn to_accum(self) -> Self::Accum {
+        self
+    }
+    #[inline(always)]
+    fn accum_add(acc: &mut Self::Accum, val: Self) {
+        *acc += val;
+    }
+    #[inline(always)]
+    fn from_accum(acc: Self::Accum) -> Self {
+        acc
+    }
+
     fn vec_add(lhs: &[Self], rhs: &[Self], res: &mut [Self]) {
         #[cfg(feature = "mkl")]
         crate::mkl::vs_add(lhs, rhs, res);
@@ -147,6 +176,20 @@ impl VecOps for half::f16 {
         }
         *res = half::f16::from_f32(sum);
     }
+
+    type Accum = f32;
+    #[inline(always)]
+    fn to_accum(self) -> Self::Accum {
+        self.to_f32()
+    }
+    #[inline(always)]
+    fn accum_add(acc: &mut Self::Accum, val: Self) {
+        *acc += val.to_f32();
+    }
+    #[inline(always)]
+    fn from_accum(acc: Self::Accum) -> Self {
+        half::f16::from_f32(acc)
+    }
 }
 
 impl VecOps for f64 {
@@ -171,6 +214,20 @@ impl VecOps for f64 {
             .zip(rhs)
             .zip(res)
             .for_each(|((&a, &b), y)| *y = a + b)
+    }
+
+    type Accum = Self;
+    #[inline(always)]
+    fn to_accum(self) -> Self::Accum {
+        self
+    }
+    #[inline(always)]
+    fn accum_add(acc: &mut Self::Accum, val: Self) {
+        *acc += val;
+    }
+    #[inline(always)]
+    fn from_accum(acc: Self::Accum) -> Self {
+        acc
     }
 }
 impl VecOps for half::bf16 {
@@ -213,6 +270,20 @@ impl VecOps for half::bf16 {
         }
         *res = half::bf16::from_f32(sum);
     }
+
+    type Accum = f32;
+    #[inline(always)]
+    fn to_accum(self) -> Self::Accum {
+        self.to_f32()
+    }
+    #[inline(always)]
+    fn accum_add(acc: &mut Self::Accum, val: Self) {
+        *acc += val.to_f32();
+    }
+    #[inline(always)]
+    fn from_accum(acc: Self::Accum) -> Self {
+        half::bf16::from_f32(acc)
+    }
 }
 impl VecOps for u8 {
     #[inline(always)]
@@ -223,6 +294,20 @@ impl VecOps for u8 {
     #[inline(always)]
     fn max(self, other: Self) -> Self {
         <Self as Ord>::max(self, other)
+    }
+
+    type Accum = Self;
+    #[inline(always)]
+    fn to_accum(self) -> Self::Accum {
+        self
+    }
+    #[inline(always)]
+    fn accum_add(acc: &mut Self::Accum, val: Self) {
+        *acc += val;
+    }
+    #[inline(always)]
+    fn from_accum(acc: Self::Accum) -> Self {
+        acc
     }
 }
 impl VecOps for u32 {
@@ -235,6 +320,20 @@ impl VecOps for u32 {
     fn max(self, other: Self) -> Self {
         <Self as Ord>::max(self, other)
     }
+
+    type Accum = Self;
+    #[inline(always)]
+    fn to_accum(self) -> Self::Accum {
+        self
+    }
+    #[inline(always)]
+    fn accum_add(acc: &mut Self::Accum, val: Self) {
+        *acc += val;
+    }
+    #[inline(always)]
+    fn from_accum(acc: Self::Accum) -> Self {
+        acc
+    }
 }
 impl VecOps for i16 {
     #[inline(always)]
@@ -245,6 +344,20 @@ impl VecOps for i16 {
     #[inline(always)]
     fn max(self, other: Self) -> Self {
         <Self as Ord>::max(self, other)
+    }
+
+    type Accum = Self;
+    #[inline(always)]
+    fn to_accum(self) -> Self::Accum {
+        self
+    }
+    #[inline(always)]
+    fn accum_add(acc: &mut Self::Accum, val: Self) {
+        *acc += val;
+    }
+    #[inline(always)]
+    fn from_accum(acc: Self::Accum) -> Self {
+        acc
     }
 }
 impl VecOps for i32 {
@@ -257,6 +370,20 @@ impl VecOps for i32 {
     fn max(self, other: Self) -> Self {
         <Self as Ord>::max(self, other)
     }
+
+    type Accum = Self;
+    #[inline(always)]
+    fn to_accum(self) -> Self::Accum {
+        self
+    }
+    #[inline(always)]
+    fn accum_add(acc: &mut Self::Accum, val: Self) {
+        *acc += val;
+    }
+    #[inline(always)]
+    fn from_accum(acc: Self::Accum) -> Self {
+        acc
+    }
 }
 impl VecOps for i64 {
     #[inline(always)]
@@ -267,6 +394,20 @@ impl VecOps for i64 {
     #[inline(always)]
     fn max(self, other: Self) -> Self {
         <Self as Ord>::max(self, other)
+    }
+
+    type Accum = Self;
+    #[inline(always)]
+    fn to_accum(self) -> Self::Accum {
+        self
+    }
+    #[inline(always)]
+    fn accum_add(acc: &mut Self::Accum, val: Self) {
+        *acc += val;
+    }
+    #[inline(always)]
+    fn from_accum(acc: Self::Accum) -> Self {
+        acc
     }
 }
 
@@ -279,6 +420,20 @@ impl VecOps for float8::F8E4M3 {
     #[inline(always)]
     fn max(self, other: Self) -> Self {
         Self::max(self, other)
+    }
+
+    type Accum = Self;
+    #[inline(always)]
+    fn to_accum(self) -> Self::Accum {
+        self
+    }
+    #[inline(always)]
+    fn accum_add(acc: &mut Self::Accum, val: Self) {
+        *acc += val;
+    }
+    #[inline(always)]
+    fn from_accum(acc: Self::Accum) -> Self {
+        acc
     }
 }
 

--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -240,7 +240,6 @@ impl ReduceSum<'_> {
     where
         T: WithDType,
     {
-        let mut dst = vec![start_elt; self.dst_shape.elem_count()];
         match src_l.contiguous_offsets() {
             Some((o1, o2)) => {
                 let src = &src[o1..o2];
@@ -254,6 +253,7 @@ impl ReduceSum<'_> {
                     .enumerate()
                     .all(|(i, &v)| v == src_l.shape().rank() - 1 - i);
                 if reduce_over_last_dims {
+                    let mut dst = vec![start_elt; self.dst_shape.elem_count()];
                     let reduce_sz = self
                         .reduce_dims_and_stride
                         .iter()
@@ -271,6 +271,12 @@ impl ReduceSum<'_> {
                     }
                     return Ok(dst);
                 };
+                // Reducing over a non-trailing axis can't use the contiguous fast path above, so
+                // it used to add straight into a `Vec<T>` here. For f16/bf16 that saturates on
+                // long reductions the same way a scalar `+=` chain would (e.g. summing a column
+                // of 4096 ones stalls once the running value's f16 ULP exceeds 1). Accumulate in
+                // each dtype's wide `Accum` type instead and narrow back down once at the end.
+                let mut acc = vec![start_elt.to_accum(); self.dst_shape.elem_count()];
                 for (unstr_index, &src) in src.iter().enumerate() {
                     let mut dst_index = unstr_index;
                     // Set the reduce_dims indexes to 0.
@@ -279,10 +285,12 @@ impl ReduceSum<'_> {
                         let (pre, post) = (dst_index / stride, dst_index % stride);
                         dst_index = (pre / dim) * stride + post;
                     }
-                    dst[dst_index] += src;
+                    T::accum_add(&mut acc[dst_index], src);
                 }
+                Ok(acc.into_iter().map(T::from_accum).collect())
             }
             None => {
+                let mut acc = vec![start_elt.to_accum(); self.dst_shape.elem_count()];
                 for (unstr_index, src_index) in src_l.strided_index().enumerate() {
                     let mut dst_index = unstr_index;
                     // Set the reduce_dims indexes to 0.
@@ -291,11 +299,11 @@ impl ReduceSum<'_> {
                         let (pre, post) = (dst_index / stride, dst_index % stride);
                         dst_index = (pre / dim) * stride + post;
                     }
-                    dst[dst_index] += src[src_index];
+                    T::accum_add(&mut acc[dst_index], src[src_index]);
                 }
+                Ok(acc.into_iter().map(T::from_accum).collect())
             }
         }
-        Ok(dst)
     }
 }
 

--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -330,8 +330,14 @@ impl Map1 for AvgPool2D {
         let w_out = (w - k_w) / s_w + 1;
         let src_index = layout.start_offset();
         let mut dst = vec![T::zero(); b_sz * c * h_out * w_out];
-        let scale = 1f64 / (k_h * k_w) as f64;
-        let scale = T::from_f64(scale);
+        let count = (k_h * k_w) as f64;
+        let scale = T::from_f64(1f64 / count);
+        // Narrow floats saturate when a large window (e.g. global average
+        // pooling) is summed in their own dtype, so the average comes out far
+        // too small; accumulate those in f64 instead (the Metal backend already
+        // accumulates in f32). f32/f64/integer dtypes keep the native
+        // accumulation so results stay bit-identical (e.g. PyTorch parity).
+        let wide = matches!(T::DTYPE, DType::F16 | DType::BF16);
         for b_idx in 0..b_sz {
             let dst = &mut dst[b_idx * c * h_out * w_out..];
             let src_index = src_index + b_idx * stride[0];
@@ -340,15 +346,28 @@ impl Map1 for AvgPool2D {
                 let src_index = src_index + c_idx * stride[1];
                 for h_idx in 0..h_out {
                     for w_idx in 0..w_out {
-                        let mut sum = T::zero();
-                        for m in 0..k_h {
-                            for n in 0..k_w {
-                                let m = s_h * h_idx + m;
-                                let n = s_w * w_idx + n;
-                                sum += src[src_index + m * stride_h + n * stride_w]
+                        let dst_val = if wide {
+                            let mut sum = 0f64;
+                            for m in 0..k_h {
+                                for n in 0..k_w {
+                                    let m = s_h * h_idx + m;
+                                    let n = s_w * w_idx + n;
+                                    sum += src[src_index + m * stride_h + n * stride_w].to_f64();
+                                }
                             }
-                        }
-                        dst[h_idx * w_out + w_idx] = sum * scale;
+                            T::from_f64(sum / count)
+                        } else {
+                            let mut sum = T::zero();
+                            for m in 0..k_h {
+                                for n in 0..k_w {
+                                    let m = s_h * h_idx + m;
+                                    let n = s_w * w_idx + n;
+                                    sum += src[src_index + m * stride_h + n * stride_w];
+                                }
+                            }
+                            sum * scale
+                        };
+                        dst[h_idx * w_out + w_idx] = dst_val;
                     }
                 }
             }

--- a/candle-core/src/dummy_dtype.rs
+++ b/candle-core/src/dummy_dtype.rs
@@ -233,6 +233,29 @@ macro_rules! dummy_num_assign {
                     stringify!($ty)
                 )
             }
+
+            type Accum = Self;
+
+            fn to_accum(self) -> Self::Accum {
+                panic!(
+                    "{} is a dummy type and does not support operations",
+                    stringify!($ty)
+                )
+            }
+
+            fn accum_add(_acc: &mut Self::Accum, _val: Self) {
+                panic!(
+                    "{} is a dummy type and does not support operations",
+                    stringify!($ty)
+                )
+            }
+
+            fn from_accum(_acc: Self::Accum) -> Self {
+                panic!(
+                    "{} is a dummy type and does not support operations",
+                    stringify!($ty)
+                )
+            }
         }
     };
 }

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -1051,7 +1051,17 @@ impl Tensor {
         let mean_dims = mean_dims.to_indexes(self.shape(), "mean-keepdim")?;
         let reduced_dim: usize = mean_dims.iter().map(|i| self.dims()[*i]).product();
         let scale = 1f64 / (reduced_dim as f64);
-        self.sum_impl(mean_dims, true)? * scale
+        // A f16 sum can overflow to infinity well before the mean itself would (e.g.
+        // summing 65520 ones overflows f16's ~65504 max, even though the true mean, 1.0,
+        // is trivially representable). Do the sum and scaling in f32 and narrow back down
+        // once at the end, instead of dividing an already-narrowed, possibly-infinite sum.
+        match self.dtype() {
+            DType::F16 | DType::BF16 => {
+                let dtype = self.dtype();
+                (self.to_dtype(DType::F32)?.sum_impl(mean_dims, true)? * scale)?.to_dtype(dtype)
+            }
+            _ => self.sum_impl(mean_dims, true)? * scale,
+        }
     }
 
     /// Returns the mean of all elements in the input tensor. The mean is performed over all the
@@ -1061,7 +1071,15 @@ impl Tensor {
         let mean_dims = mean_dims.to_indexes(self.shape(), "mean")?;
         let reduced_dim: usize = mean_dims.iter().map(|i| self.dims()[*i]).product();
         let scale = 1f64 / (reduced_dim as f64);
-        self.sum_impl(mean_dims, false)? * scale
+        // See the comment in `mean_keepdim`: narrow-down-then-scale can overflow f16 even
+        // when the true mean is in range, so scale in f32 and narrow back down at the end.
+        match self.dtype() {
+            DType::F16 | DType::BF16 => {
+                let dtype = self.dtype();
+                (self.to_dtype(DType::F32)?.sum_impl(mean_dims, false)? * scale)?.to_dtype(dtype)
+            }
+            _ => self.sum_impl(mean_dims, false)? * scale,
+        }
     }
 
     /// Returns the unbiased variance over the selected dimension.
@@ -2136,7 +2154,11 @@ impl Tensor {
     }
 
     pub fn mean_all(&self) -> Result<Tensor> {
-        self.sum_all()? / self.elem_count() as f64
+        // Route through `mean` rather than `sum_all()? / count` so f16 tensors get the
+        // overflow-safe f32 scaling from `mean`/`mean_keepdim` instead of dividing an
+        // already-narrowed (possibly infinite) f16 sum.
+        let dims: Vec<_> = (0..self.rank()).collect();
+        self.mean(dims)
     }
 
     fn flatten_<D1: Dim, D2: Dim>(

--- a/candle-core/tests/f16_avgpool_check.rs
+++ b/candle-core/tests/f16_avgpool_check.rs
@@ -1,0 +1,33 @@
+use candle_core::{DType, Device, Tensor};
+
+// Global average pooling sums a large window; a narrow-dtype accumulator
+// saturates, so the average of an all-ones map comes out far too small.
+fn check(dtype: DType) {
+    let dev = Device::Cpu;
+    let (h, w) = (64usize, 64usize); // 4096-element window
+    let t = Tensor::ones((1, 1, h, w), dtype, &dev).unwrap();
+    let pooled = t.avg_pool2d((h, w)).unwrap();
+    let v = pooled
+        .to_dtype(DType::F32)
+        .unwrap()
+        .flatten_all()
+        .unwrap()
+        .get(0)
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+    assert!(
+        (v - 1.0).abs() < 1e-2,
+        "{dtype:?} global avg_pool of ones = {v}"
+    );
+}
+
+#[test]
+fn f16_global_avg_pool_no_saturation() {
+    check(DType::F16);
+}
+
+#[test]
+fn bf16_global_avg_pool_no_saturation() {
+    check(DType::BF16);
+}

--- a/candle-core/tests/f16_sum_check.rs
+++ b/candle-core/tests/f16_sum_check.rs
@@ -32,3 +32,46 @@ fn f16_sum_mean_no_saturation() {
 fn bf16_sum_mean_no_saturation() {
     check(DType::BF16);
 }
+
+// Summing over a non-trailing axis (or a strided view) can't use the contiguous
+// vec_reduce_sum fast path, so it used to fall back to a plain in-dtype `+=` chain
+// that still saturates for f16/bf16 even though the trailing-axis case above was fixed.
+fn check_non_last_dim(dtype: DType) {
+    let n = 4096usize;
+    let t = Tensor::ones((n, 2), dtype, &Device::Cpu).unwrap();
+    let s = t
+        .sum(0)
+        .unwrap()
+        .to_dtype(DType::F32)
+        .unwrap()
+        .to_vec1::<f32>()
+        .unwrap();
+    assert_eq!(s, vec![n as f32, n as f32], "{dtype:?} column sum = {s:?}");
+}
+
+#[test]
+fn f16_sum_non_last_dim_no_saturation() {
+    check_non_last_dim(DType::F16);
+}
+
+#[test]
+fn bf16_sum_non_last_dim_no_saturation() {
+    check_non_last_dim(DType::BF16);
+}
+
+// A f16 sum can overflow to +inf well before the true mean would (f16's max finite
+// value is 65504), so mean must scale down in f32 rather than dividing an
+// already-narrowed, possibly-infinite f16 sum.
+#[test]
+fn f16_mean_all_overflowing_sum() {
+    let n = 65520usize;
+    let t = Tensor::ones((n,), DType::F16, &Device::Cpu).unwrap();
+    let m = t
+        .mean_all()
+        .unwrap()
+        .to_dtype(DType::F32)
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+    assert!((m - 1.0).abs() < 1e-3, "f16 mean of {n} ones = {m}");
+}

--- a/candle-core/tests/f16_sum_check.rs
+++ b/candle-core/tests/f16_sum_check.rs
@@ -1,0 +1,34 @@
+use candle_core::{DType, Device, Tensor};
+
+// A sequential in-dtype sum of f16/bf16 saturates on a long axis; sum/mean must
+// accumulate in f32 so the result stays correct (and matches the Metal backend).
+fn check(dtype: DType) {
+    let n = 4096usize;
+    let t = Tensor::ones((n,), dtype, &Device::Cpu).unwrap();
+    let s = t
+        .sum_all()
+        .unwrap()
+        .to_dtype(DType::F32)
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+    assert_eq!(s, n as f32, "{dtype:?} sum of {n} ones = {s}");
+    let m = t
+        .mean_all()
+        .unwrap()
+        .to_dtype(DType::F32)
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+    assert!((m - 1.0).abs() < 1e-3, "{dtype:?} mean of ones = {m}");
+}
+
+#[test]
+fn f16_sum_mean_no_saturation() {
+    check(DType::F16);
+}
+
+#[test]
+fn bf16_sum_mean_no_saturation() {
+    check(DType::BF16);
+}

--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -320,9 +320,49 @@ impl candle::CustomOp1 for SoftmaxLastDim {
             Ok((storage, Shape::from_dims(dims)))
         }
 
+        // Narrow floats (f16/bf16) must not accumulate the exp denominator in
+        // their own dtype: a sequential in-dtype sum saturates on long axes
+        // (e.g. an f16 sum of 4096 ones stalls at 2048), so the row fails to
+        // normalize to 1. Compute those in f32, matching the Metal kernel which
+        // keeps the softmax denominator in f32.
+        fn softmax_via_f32<T: candle::WithDType + num_traits::Float>(
+            src: &[T],
+            layout: &Layout,
+        ) -> Result<(CpuStorage, Shape)> {
+            let src = match layout.contiguous_offsets() {
+                None => candle::bail!("input has to be contiguous"),
+                Some((o1, o2)) => &src[o1..o2],
+            };
+            let el_count = layout.shape().elem_count();
+            let dims = layout.shape().dims();
+            let dim_m1 = dims[dims.len() - 1];
+            let mut dst = vec![T::zero(); el_count];
+            src.par_chunks(dim_m1)
+                .zip(dst.par_chunks_mut(dim_m1))
+                .for_each(|(src, dst)| {
+                    let to_f32 = |x: &T| num_traits::ToPrimitive::to_f32(x).unwrap();
+                    let mut max = f32::NEG_INFINITY;
+                    for s in src.iter() {
+                        max = max.max(to_f32(s));
+                    }
+                    let mut sum_exp = 0f32;
+                    for (s, d) in src.iter().zip(dst.iter_mut()) {
+                        let e = (to_f32(s) - max).exp();
+                        *d = num_traits::NumCast::from(e).unwrap();
+                        sum_exp += e;
+                    }
+                    let inv = 1f32 / sum_exp;
+                    for d in dst.iter_mut() {
+                        *d = num_traits::NumCast::from(to_f32(d) * inv).unwrap();
+                    }
+                });
+            let storage = candle::WithDType::to_cpu_storage_owned(dst);
+            Ok((storage, Shape::from_dims(dims)))
+        }
+
         match storage {
-            CpuStorage::BF16(slice) => softmax::<half::bf16>(slice, layout),
-            CpuStorage::F16(slice) => softmax::<half::f16>(slice, layout),
+            CpuStorage::BF16(slice) => softmax_via_f32::<half::bf16>(slice, layout),
+            CpuStorage::F16(slice) => softmax_via_f32::<half::f16>(slice, layout),
             CpuStorage::F32(slice) => softmax::<f32>(slice, layout),
             CpuStorage::F64(slice) => softmax::<f64>(slice, layout),
             _ => candle::bail!("unsupported dtype for softmax {:?}", storage),

--- a/candle-nn/tests/softmax_f16_check.rs
+++ b/candle-nn/tests/softmax_f16_check.rs
@@ -1,0 +1,33 @@
+use candle::{DType, Device, Tensor};
+use candle_nn::ops::softmax_last_dim;
+
+// f16/bf16 softmax must accumulate the denominator in f32; otherwise the
+// in-dtype sum saturates on a long axis and the row fails to normalize.
+fn check_row_sums_to_one(dtype: DType) {
+    let dev = Device::Cpu;
+    let n = 4096usize;
+    let t = Tensor::zeros((1, n), dtype, &dev).unwrap();
+    let sm = softmax_last_dim(&t).unwrap();
+    // Measure in f32 so the check itself does not saturate.
+    let row_sum = sm
+        .to_dtype(DType::F32)
+        .unwrap()
+        .sum_all()
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+    assert!(
+        (row_sum - 1.0).abs() < 1e-2,
+        "{dtype:?} softmax row sum {row_sum} != 1.0"
+    );
+}
+
+#[test]
+fn f16_softmax_row_sums_to_one() {
+    check_row_sums_to_one(DType::F16);
+}
+
+#[test]
+fn bf16_softmax_row_sums_to_one() {
+    check_row_sums_to_one(DType::BF16);
+}


### PR DESCRIPTION
Fixes #3727.

## What

candle's CPU backend accumulates several f16/bf16 reductions **in the narrow dtype**, which saturates on long axes / large windows and silently produces wrong results — and disagrees with the Metal backend, which accumulates in f32. This PR fixes the three instances (same root cause), each verified:

| Op | Before (f16) | After |
|----|-------------|-------|
| `softmax_last_dim` over len-4096 | row sums to **2.0**, probs = 1/2048 | sums to 1.0, matches Metal to 1.2e-7 |
| `sum`/`mean` of 4096 ones | **2048** / 0.5 | 4096 / 1.0 (matches Metal) |
| global `avg_pool2d` of ones | **0.5** | 1.0 (matches Metal) |

softmax is on the attention hot path; `avg_pool2d` saturation hits global average pooling before classifier heads — so this silently corrupts real f16/bf16 inference.

## Fix

- **softmax** (`candle-nn/src/ops.rs`): compute the f16/bf16 path in f32 (max, exp, denominator, normalization), cast back. Matches the Metal kernel (`MD::d` is already f32).
- **sum/mean** (`candle-core/src/cpu/kernels.rs`): override `vec_reduce_sum` for f16/bf16 to accumulate in f32 — exactly as `vec_dot` already does for these types in the same file.
- **avg_pool2d** (`candle-core/src/cpu_backend/mod.rs`): accumulate the window in f64 for f16/bf16; branch on `T::DTYPE` so f32/f64/integer stay bit-identical (PyTorch-parity test unaffected).

f32/f64 paths are unchanged throughout.

## Tests

Regression tests for each (`softmax_f16_check`, `f16_sum_check`, `f16_avgpool_check`), f16 + bf16. Full `candle-core`/`candle-nn` suites green; `cargo fmt --all` and `cargo clippy --workspace --tests -- -D warnings` clean.

_(Consolidates the three same-root-cause fixes previously split across #3717/#3718/#3719 into one review, per @LaurentMazare's preference for reviewing them together.)_

cc @LaurentMazare @ivarflakstad @EricLBuehler