### PR TITLE
Accumulate f16/bf16 sum reductions in f32 (fix saturation on long axes)

### DIFF
--- a/candle-core/src/cpu/kernels.rs
+++ b/candle-core/src/cpu/kernels.rs
@@ -134,6 +134,19 @@ impl VecOps for half::f16 {
         super::vec_dot_f16(lhs, rhs, &mut res_f32, len);
         *res = half::f16::from_f32(res_f32);
     }
+
+    // Accumulate in f32: a sequential sum in f16 saturates on long axes (e.g. an
+    // f16 sum of 4096 ones stalls at 2048 once the running ULP exceeds 1),
+    // giving wrong `sum`/`mean` results that also disagree with the Metal
+    // backend. This mirrors the f32 accumulation already used by `vec_dot`.
+    #[inline(always)]
+    unsafe fn vec_reduce_sum(xs: *const Self, res: *mut Self, len: usize) {
+        let mut sum = 0f32;
+        for i in 0..len {
+            sum += (*xs.add(i)).to_f32();
+        }
+        *res = half::f16::from_f32(sum);
+    }
 }
 
 impl VecOps for f64 {
@@ -186,6 +199,19 @@ impl VecOps for half::bf16 {
         let mut res_f32 = 0f32;
         super::vec_dot_bf16(lhs, rhs, &mut res_f32, len);
         *res = half::bf16::from_f32(res_f32);
+    }
+
+    // Accumulate in f32: a sequential sum in bf16 saturates on long axes (bf16
+    // has only 8 mantissa bits, so the running sum stalls even sooner than
+    // f16), giving wrong `sum`/`mean` results that also disagree with the Metal
+    // backend. This mirrors the f32 accumulation already used by `vec_dot`.
+    #[inline(always)]
+    unsafe fn vec_reduce_sum(xs: *const Self, res: *mut Self, len: usize) {
+        let mut sum = 0f32;
+        for i in 0..len {
+            sum += (*xs.add(i)).to_f32();
+        }
+        *res = half::bf16::from_f32(sum);
     }
 }
 impl VecOps for u8 {

--- a/candle-core/tests/f16_sum_check.rs
+++ b/candle-core/tests/f16_sum_check.rs
@@ -1,0 +1,34 @@
+use candle_core::{DType, Device, Tensor};
+
+// A sequential in-dtype sum of f16/bf16 saturates on a long axis; sum/mean must
+// accumulate in f32 so the result stays correct (and matches the Metal backend).
+fn check(dtype: DType) {
+    let n = 4096usize;
+    let t = Tensor::ones((n,), dtype, &Device::Cpu).unwrap();
+    let s = t
+        .sum_all()
+        .unwrap()
+        .to_dtype(DType::F32)
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+    assert_eq!(s, n as f32, "{dtype:?} sum of {n} ones = {s}");
+    let m = t
+        .mean_all()
+        .unwrap()
+        .to_dtype(DType::F32)
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+    assert!((m - 1.0).abs() < 1e-3, "{dtype:?} mean of ones = {m}");
+}
+
+#[test]
+fn f16_sum_mean_no_saturation() {
+    check(DType::F16);
+}
+
+#[test]
+fn bf16_sum_mean_no_saturation() {
+    check(DType::BF16);
+}


### PR DESCRIPTION
## What

`vec_reduce_sum` for `f16`/`bf16` uses the default sequential accumulator, which sums in the narrow dtype:

```rust
unsafe fn vec_reduce_sum(xs: *const Self, res: *mut Self, len: usize) {
    *res = Self::zero();
    for i in 0..len { *res += *xs.add(i) }   // accumulates in f16/bf16
}
```

On a long axis this **saturates**: an f16 running sum of ones stalls at 2048 (once the sum's ULP exceeds 1, each `+1` rounds back), and bf16 (8 mantissa bits) stalls even sooner. So `Tensor::sum`/`mean` over an f16 tensor return roughly half the true value, and disagree with the Metal backend, whose reduction stays accurate:

```
CPU:   sum of 4096 f16 ones = 2048,  mean = 0.5
Metal: sum of 4096 f16 ones = 4096,  mean = 1.0
```

## Fix

Override `vec_reduce_sum` for `f16` and `bf16` to accumulate in `f32` and round back — exactly the pattern `vec_dot` already uses for these types a few lines above:

```rust
unsafe fn vec_reduce_sum(xs: *const Self, res: *mut Self, len: usize) {
    let mut sum = 0f32;
    for i in 0..len { sum += (*xs.add(i)).to_f32(); }
    *res = half::f16::from_f32(sum);
}
```

Now CPU `sum` of 4096 f16 ones is 4096 and `mean` is 1.0, matching Metal.

## Tests

Adds `f16_sum_mean_no_saturation` and `bf16_sum_mean_no_saturation`. Existing `candle-core` lib/tensor/conv/pool/quantized suites stay green; `cargo fmt`/`clippy` clean.

cc @ivarflakstad @EricLBuehler