### PR TITLE
Accumulate f16/bf16 avg_pool2d windows in f32 (fix global-average-pool saturation)

### DIFF
--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -330,8 +330,14 @@ impl Map1 for AvgPool2D {
         let w_out = (w - k_w) / s_w + 1;
         let src_index = layout.start_offset();
         let mut dst = vec![T::zero(); b_sz * c * h_out * w_out];
-        let scale = 1f64 / (k_h * k_w) as f64;
-        let scale = T::from_f64(scale);
+        let count = (k_h * k_w) as f64;
+        let scale = T::from_f64(1f64 / count);
+        // Narrow floats saturate when a large window (e.g. global average
+        // pooling) is summed in their own dtype, so the average comes out far
+        // too small; accumulate those in f64 instead (the Metal backend already
+        // accumulates in f32). f32/f64/integer dtypes keep the native
+        // accumulation so results stay bit-identical (e.g. PyTorch parity).
+        let wide = matches!(T::DTYPE, DType::F16 | DType::BF16);
         for b_idx in 0..b_sz {
             let dst = &mut dst[b_idx * c * h_out * w_out..];
             let src_index = src_index + b_idx * stride[0];
@@ -340,15 +346,28 @@ impl Map1 for AvgPool2D {
                 let src_index = src_index + c_idx * stride[1];
                 for h_idx in 0..h_out {
                     for w_idx in 0..w_out {
-                        let mut sum = T::zero();
-                        for m in 0..k_h {
-                            for n in 0..k_w {
-                                let m = s_h * h_idx + m;
-                                let n = s_w * w_idx + n;
-                                sum += src[src_index + m * stride_h + n * stride_w]
+                        let dst_val = if wide {
+                            let mut sum = 0f64;
+                            for m in 0..k_h {
+                                for n in 0..k_w {
+                                    let m = s_h * h_idx + m;
+                                    let n = s_w * w_idx + n;
+                                    sum += src[src_index + m * stride_h + n * stride_w].to_f64();
+                                }
                             }
-                        }
-                        dst[h_idx * w_out + w_idx] = sum * scale;
+                            T::from_f64(sum / count)
+                        } else {
+                            let mut sum = T::zero();
+                            for m in 0..k_h {
+                                for n in 0..k_w {
+                                    let m = s_h * h_idx + m;
+                                    let n = s_w * w_idx + n;
+                                    sum += src[src_index + m * stride_h + n * stride_w];
+                                }
+                            }
+                            sum * scale
+                        };
+                        dst[h_idx * w_out + w_idx] = dst_val;
                     }
                 }
             }

--- a/candle-core/tests/f16_avgpool_check.rs
+++ b/candle-core/tests/f16_avgpool_check.rs
@@ -1,0 +1,33 @@
+use candle_core::{DType, Device, Tensor};
+
+// Global average pooling sums a large window; a narrow-dtype accumulator
+// saturates, so the average of an all-ones map comes out far too small.
+fn check(dtype: DType) {
+    let dev = Device::Cpu;
+    let (h, w) = (64usize, 64usize); // 4096-element window
+    let t = Tensor::ones((1, 1, h, w), dtype, &dev).unwrap();
+    let pooled = t.avg_pool2d((h, w)).unwrap();
+    let v = pooled
+        .to_dtype(DType::F32)
+        .unwrap()
+        .flatten_all()
+        .unwrap()
+        .get(0)
+        .unwrap()
+        .to_scalar::<f32>()
+        .unwrap();
+    assert!(
+        (v - 1.0).abs() < 1e-2,
+        "{dtype:?} global avg_pool of ones = {v}"
+    );
+}
+
+#[test]
+fn f16_global_avg_pool_no_saturation() {
+    check(DType::F16);
+}
+
+#[test]
+fn bf16_global_avg_pool_no_saturation() {
+    check(DType::BF16);
+}


### PR DESCRIPTION
## What

`AvgPool2D` (CPU) sums each pooling window in the tensor's own dtype:

```rust
let mut sum = T::zero();
for m in 0..k_h { for n in 0..k_w { sum += src[...] } }
dst[...] = sum * scale;
```

For f16/bf16 this **saturates** on a large window. Global average pooling over a 64×64 feature map sums 4096 values, and an f16 running sum stalls at 2048, so the average of an all-ones map comes out as **0.5 instead of 1.0**:

```
f16 global avg_pool of ones = 0.5   (ideal 1.0)
```

Global average pooling is standard right before a classifier head, so f16/bf16 vision inference is silently corrupted — and the result disagrees with the Metal backend, which accumulates in f32.

## Fix

Accumulate the window in f64 for f16/bf16 and divide by the count there. `f32`/`f64`/integer dtypes keep the native accumulation, so their results are **bit-identical** — in particular the existing `avg_pool2d_pytorch` parity test is unaffected (PyTorch also accumulates in f32).

```rust
let wide = matches!(T::DTYPE, DType::F16 | DType::BF16);
// wide: sum in f64, `T::from_f64(sum / count)`
// else: original `sum: T`, `sum * scale`
```

## Tests

Adds `f16_global_avg_pool_no_saturation` and `bf16_…`. Existing `pool_tests` (4, incl. PyTorch parity), `conv_tests` (8) stay green; `cargo fmt`/`clippy` clean.

cc @ivarflakstad @EricLBuehler