### PR TITLE
Add additive Cache::Paged seam to candle-transformers::models::llama

### DIFF
--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -142,11 +142,123 @@ impl Config {
     }
 }
 
+/// Physical KV storage and per-sequence block table for paged attention.
+///
+/// Constructed and owned by the caller (e.g. an external block allocator/eviction
+/// engine such as a vLLM-style scheduler). `key_cache`/`value_cache` must be
+/// contiguous: the model writes the newly computed K/V for the current forward
+/// pass into the slots designated by `block_table`, then reads the full paged
+/// history back through
+/// [`candle_flash_attn::flash_attn_varlen_paged_windowed`]. `block_table` and
+/// `seqlens_k` are read-only from the model's perspective — the caller owns
+/// block allocation, eviction, and keeping them in sync with what it wants
+/// written. One `PagedKvCache` covers a single transformer layer; attach one per
+/// layer via [`Cache::set_paged_kv`].
+#[derive(Debug, Clone)]
+pub struct PagedKvCache {
+    /// `(num_blocks, page_block_size, num_kv_heads, head_dim)`, contiguous.
+    pub key_cache: Tensor,
+    /// `(num_blocks, page_block_size, num_kv_heads, head_dim)`, contiguous.
+    pub value_cache: Tensor,
+    /// `(batch_size, max_blocks)`, physical block ids per sequence.
+    pub block_table: Tensor,
+    /// `(batch_size + 1,)`, cumulative sequence lengths (including the tokens
+    /// about to be written by this forward pass), used to drive the varlen kernel.
+    pub seqlens_k: Tensor,
+    pub page_block_size: usize,
+}
+
+impl PagedKvCache {
+    /// Scatters the newly computed K/V (shape `(b_sz, num_kv_heads, seq_len,
+    /// head_dim)`) into `key_cache`/`value_cache` at the physical slots that
+    /// `block_table` designates for absolute positions
+    /// `index_pos..index_pos+seq_len`.
+    fn write_new_kv(&self, k: &Tensor, v: &Tensor, index_pos: usize) -> Result<()> {
+        if !self.key_cache.is_contiguous() || !self.value_cache.is_contiguous() {
+            candle::bail!("PagedKvCache key_cache/value_cache must be contiguous")
+        }
+        let (b_sz, num_kv_heads, seq_len, head_dim) = k.dims4()?;
+        let (num_blocks, page_block_size, kv_heads_cache, head_dim_cache) =
+            self.key_cache.dims4()?;
+        if page_block_size != self.page_block_size {
+            candle::bail!(
+                "PagedKvCache.page_block_size ({}) does not match key_cache shape (block size {page_block_size})",
+                self.page_block_size
+            )
+        }
+        if kv_heads_cache != num_kv_heads || head_dim_cache != head_dim {
+            candle::bail!(
+                "PagedKvCache key/value cache shape {:?} is incompatible with new kv (heads={num_kv_heads}, head_dim={head_dim})",
+                self.key_cache.dims()
+            )
+        }
+        let block_table = self.block_table.to_dtype(DType::U32)?.to_vec2::<u32>()?;
+        if block_table.len() != b_sz {
+            candle::bail!(
+                "block_table batch dim ({}) does not match kv batch dim ({b_sz})",
+                block_table.len()
+            )
+        }
+        let last_pos = index_pos + seq_len - 1;
+        let mut slots = Vec::with_capacity(b_sz * seq_len);
+        for row in &block_table {
+            let max_logical_block = last_pos / self.page_block_size;
+            if max_logical_block >= row.len() {
+                candle::bail!(
+                    "block_table has {} blocks, but position {last_pos} needs logical block {max_logical_block}",
+                    row.len()
+                )
+            }
+            for t in 0..seq_len {
+                let pos = index_pos + t;
+                let logical_block = pos / self.page_block_size;
+                let offset = pos % self.page_block_size;
+                let physical_block = row[logical_block] as usize;
+                if physical_block >= num_blocks {
+                    candle::bail!(
+                        "block_table references physical block {physical_block}, but key_cache only has {num_blocks} blocks"
+                    )
+                }
+                slots.push((physical_block * self.page_block_size + offset) as u32);
+            }
+        }
+
+        let device = k.device();
+        let indices = Tensor::from_vec(slots, (b_sz * seq_len, 1, 1), device)?
+            .broadcast_as((b_sz * seq_len, num_kv_heads, head_dim))?
+            .contiguous()?;
+
+        let k_flat = k
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape((b_sz * seq_len, num_kv_heads, head_dim))?;
+        let v_flat = v
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape((b_sz * seq_len, num_kv_heads, head_dim))?;
+
+        let key_flat = self
+            .key_cache
+            .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?;
+        let value_flat = self
+            .value_cache
+            .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?;
+        key_flat.scatter_set(&indices, &k_flat, 0)?;
+        value_flat.scatter_set(&indices, &v_flat, 0)?;
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Cache {
     masks: HashMap<(usize, usize), Tensor>,
     pub use_kv_cache: bool,
     kvs: Vec<Option<(Tensor, Tensor)>>,
+    // Additive seam: caller-owned paged KV storage per transformer layer, indexed
+    // by `block_idx`. `None` (the default for every layer) preserves today's
+    // contiguous concat-and-narrow path byte-for-byte; existing callers that
+    // never touch this are entirely unaffected. See `PagedKvCache`.
+    paged_kvs: Vec<Option<PagedKvCache>>,
     cos: Tensor,
     sin: Tensor,
     device: Device,
@@ -209,10 +321,40 @@ impl Cache {
             masks: HashMap::new(),
             use_kv_cache,
             kvs: vec![None; config.num_hidden_layers],
+            paged_kvs: vec![None; config.num_hidden_layers],
             device: device.clone(),
             cos,
             sin,
         })
+    }
+
+    /// Attaches caller-owned paged KV storage for one transformer layer.
+    ///
+    /// Once set, that layer's attention routes through
+    /// `candle_flash_attn::flash_attn_varlen_paged_windowed` against the
+    /// caller-owned `key_cache`/`value_cache`/`block_table` instead of the
+    /// contiguous concat-and-narrow path. Existing callers that never call this
+    /// see no behavior change.
+    pub fn set_paged_kv(&mut self, block_idx: usize, paged: PagedKvCache) -> Result<()> {
+        let Some(slot) = self.paged_kvs.get_mut(block_idx) else {
+            candle::bail!(
+                "block_idx {block_idx} out of range for {} layers",
+                self.paged_kvs.len()
+            )
+        };
+        *slot = Some(paged);
+        Ok(())
+    }
+
+    /// Reverts a layer to the contiguous KV cache path.
+    pub fn clear_paged_kv(&mut self, block_idx: usize) {
+        if let Some(slot) = self.paged_kvs.get_mut(block_idx) {
+            *slot = None;
+        }
+    }
+
+    pub fn paged_kv(&self, block_idx: usize) -> Option<&PagedKvCache> {
+        self.paged_kvs.get(block_idx).and_then(|p| p.as_ref())
     }
 
     fn mask(&mut self, seq_len: usize, index_pos: usize) -> Result<Tensor> {
@@ -258,6 +400,55 @@ fn flash_attn(_: &Tensor, _: &Tensor, _: &Tensor, _: f32, _: bool) -> Result<Ten
     unimplemented!("compile with '--features flash-attn'")
 }
 
+#[cfg(feature = "flash-attn")]
+#[allow(clippy::too_many_arguments)]
+fn flash_attn_varlen_paged(
+    q: &Tensor,
+    key_cache: &Tensor,
+    value_cache: &Tensor,
+    seqlens_q: &Tensor,
+    seqlens_k: &Tensor,
+    block_table: &Tensor,
+    max_seqlen_q: usize,
+    max_seqlen_k: usize,
+    softmax_scale: f32,
+    page_block_size: usize,
+) -> Result<Tensor> {
+    candle_flash_attn::flash_attn_varlen_paged_windowed(
+        q,
+        key_cache,
+        value_cache,
+        seqlens_q,
+        seqlens_k,
+        block_table,
+        None,
+        max_seqlen_q,
+        max_seqlen_k,
+        softmax_scale,
+        None,
+        Some(0),
+        page_block_size,
+        None,
+    )
+}
+
+#[cfg(not(feature = "flash-attn"))]
+#[allow(clippy::too_many_arguments)]
+fn flash_attn_varlen_paged(
+    _: &Tensor,
+    _: &Tensor,
+    _: &Tensor,
+    _: &Tensor,
+    _: &Tensor,
+    _: &Tensor,
+    _: usize,
+    _: usize,
+    _: f32,
+    _: usize,
+) -> Result<Tensor> {
+    unimplemented!("compile with '--features flash-attn'")
+}
+
 impl CausalSelfAttention {
     fn apply_rotary_emb(&self, x: &Tensor, index_pos: usize, cache: &Cache) -> Result<Tensor> {
         let _enter = self.span_rot.enter();
@@ -294,6 +485,11 @@ impl CausalSelfAttention {
 
         let q = self.apply_rotary_emb(&q, index_pos, cache)?;
         let mut k = self.apply_rotary_emb(&k, index_pos, cache)?;
+
+        if let Some(paged) = cache.paged_kv(block_idx) {
+            let v = v.contiguous()?;
+            return self.forward_paged(&q, &k, &v, index_pos, b_sz, seq_len, hidden_size, paged);
+        }
 
         if cache.use_kv_cache {
             if let Some((cache_k, cache_v)) = &cache.kvs[block_idx] {
@@ -357,6 +553,53 @@ impl CausalSelfAttention {
 
     fn repeat_kv(&self, x: Tensor) -> Result<Tensor> {
         crate::utils::repeat_kv(x, self.num_attention_heads / self.num_key_value_heads)
+    }
+
+    /// Writes the current forward pass' K/V into the caller-owned paged cache,
+    /// then attends over the full paged history via
+    /// `candle_flash_attn::flash_attn_varlen_paged_windowed`. `q`, `k`, `v` are
+    /// `(b_sz, heads, seq_len, head_dim)`, post-RoPE for `q`/`k`.
+    #[allow(clippy::too_many_arguments)]
+    fn forward_paged(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        index_pos: usize,
+        b_sz: usize,
+        seq_len: usize,
+        hidden_size: usize,
+        paged: &PagedKvCache,
+    ) -> Result<Tensor> {
+        paged.write_new_kv(k, v, index_pos)?;
+
+        let q = q
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape((b_sz * seq_len, self.num_attention_heads, self.head_dim))?;
+        let seqlens_q = Tensor::new(
+            (0..=b_sz)
+                .map(|i| (i * seq_len) as u32)
+                .collect::<Vec<_>>(),
+            q.device(),
+        )?;
+        let max_seqlen_k = paged.block_table.dim(1)? * paged.page_block_size;
+        let softmax_scale = 1f32 / (self.head_dim as f32).sqrt();
+
+        let y = flash_attn_varlen_paged(
+            &q,
+            &paged.key_cache,
+            &paged.value_cache,
+            &seqlens_q,
+            &paged.seqlens_k,
+            &paged.block_table,
+            seq_len,
+            max_seqlen_k,
+            softmax_scale,
+            paged.page_block_size,
+        )?
+        .reshape((b_sz, seq_len, hidden_size))?;
+        self.o_proj.forward(&y)
     }
 
     fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
@@ -530,5 +773,198 @@ impl Llama {
             ln_f,
             lm_head,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tiny_config() -> Config {
+        Config {
+            hidden_size: 4,
+            intermediate_size: 8,
+            vocab_size: 16,
+            num_hidden_layers: 2,
+            num_attention_heads: 2,
+            num_key_value_heads: 2,
+            use_flash_attn: false,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10_000.0,
+            bos_token_id: None,
+            eos_token_id: None,
+            rope_scaling: None,
+            max_position_embeddings: DEFAULT_MAX_SEQ_LEN,
+            tie_word_embeddings: false,
+        }
+    }
+
+    #[test]
+    fn paged_kv_seam_is_additive_by_default() -> Result<()> {
+        let device = Device::Cpu;
+        let cfg = tiny_config();
+        let cache = Cache::new(true, DType::F32, &cfg, &device)?;
+        // Every layer defaults to the contiguous path: nothing to opt into paged
+        // attention unless a caller explicitly attaches a `PagedKvCache`.
+        for block_idx in 0..cfg.num_hidden_layers {
+            assert!(cache.paged_kv(block_idx).is_none());
+        }
+        assert!(cache.use_kv_cache);
+        Ok(())
+    }
+
+    #[test]
+    fn set_and_clear_paged_kv() -> Result<()> {
+        let device = Device::Cpu;
+        let cfg = tiny_config();
+        let mut cache = Cache::new(true, DType::F32, &cfg, &device)?;
+
+        let num_blocks = 2;
+        let page_block_size = 4;
+        let num_kv_heads = 1;
+        let head_dim = 2;
+        let paged = PagedKvCache {
+            key_cache: Tensor::zeros(
+                (num_blocks, page_block_size, num_kv_heads, head_dim),
+                DType::F32,
+                &device,
+            )?,
+            value_cache: Tensor::zeros(
+                (num_blocks, page_block_size, num_kv_heads, head_dim),
+                DType::F32,
+                &device,
+            )?,
+            block_table: Tensor::from_vec(vec![0u32, 1u32], (1, 2), &device)?,
+            seqlens_k: Tensor::new(&[0u32, 4u32], &device)?,
+            page_block_size,
+        };
+        cache.set_paged_kv(0, paged)?;
+        assert!(cache.paged_kv(0).is_some());
+        assert!(cache.paged_kv(1).is_none());
+
+        cache.clear_paged_kv(0);
+        assert!(cache.paged_kv(0).is_none());
+
+        // Out-of-range layers are rejected rather than silently ignored.
+        let paged = PagedKvCache {
+            key_cache: Tensor::zeros(
+                (num_blocks, page_block_size, num_kv_heads, head_dim),
+                DType::F32,
+                &device,
+            )?,
+            value_cache: Tensor::zeros(
+                (num_blocks, page_block_size, num_kv_heads, head_dim),
+                DType::F32,
+                &device,
+            )?,
+            block_table: Tensor::from_vec(vec![0u32, 1u32], (1, 2), &device)?,
+            seqlens_k: Tensor::new(&[0u32, 4u32], &device)?,
+            page_block_size,
+        };
+        assert!(cache.set_paged_kv(cfg.num_hidden_layers, paged).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn paged_kv_cache_writes_land_in_the_slots_the_block_table_designates() -> Result<()> {
+        let device = Device::Cpu;
+        // 2 physical blocks of 4 slots each, 1 kv head, head_dim 2.
+        let num_blocks = 2;
+        let page_block_size = 4;
+        let num_kv_heads = 1;
+        let head_dim = 2;
+        let key_cache = Tensor::zeros(
+            (num_blocks, page_block_size, num_kv_heads, head_dim),
+            DType::F32,
+            &device,
+        )?;
+        let value_cache = Tensor::zeros(
+            (num_blocks, page_block_size, num_kv_heads, head_dim),
+            DType::F32,
+            &device,
+        )?;
+        // Logical block 0 -> physical block 1, logical block 1 -> physical block 0.
+        let block_table = Tensor::from_vec(vec![1u32, 0u32], (1, 2), &device)?;
+        let paged = PagedKvCache {
+            key_cache: key_cache.clone(),
+            value_cache: value_cache.clone(),
+            block_table,
+            seqlens_k: Tensor::new(&[0u32, 5u32], &device)?,
+            page_block_size,
+        };
+
+        // 3 new tokens at absolute positions 2, 3, 4 (b_sz=1).
+        // pos 2 -> logical block 0, offset 2 -> physical slot 1*4+2 = 6
+        // pos 3 -> logical block 0, offset 3 -> physical slot 1*4+3 = 7
+        // pos 4 -> logical block 1, offset 0 -> physical slot 0*4+0 = 0
+        let index_pos = 2;
+        let seq_len = 3;
+        let k = Tensor::from_vec(
+            vec![10f32, 11., 20., 21., 30., 31.],
+            (1, num_kv_heads, seq_len, head_dim),
+            &device,
+        )?;
+        let v = Tensor::from_vec(
+            vec![-10f32, -11., -20., -21., -30., -31.],
+            (1, num_kv_heads, seq_len, head_dim),
+            &device,
+        )?;
+
+        paged.write_new_kv(&k, &v, index_pos)?;
+
+        let key_flat = paged
+            .key_cache
+            .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?
+            .i((.., 0, ..))?
+            .to_vec2::<f32>()?;
+        let value_flat = paged
+            .value_cache
+            .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?
+            .i((.., 0, ..))?
+            .to_vec2::<f32>()?;
+
+        assert_eq!(key_flat[6], [10., 11.]);
+        assert_eq!(key_flat[7], [20., 21.]);
+        assert_eq!(key_flat[0], [30., 31.]);
+        assert_eq!(value_flat[6], [-10., -11.]);
+        assert_eq!(value_flat[7], [-20., -21.]);
+        assert_eq!(value_flat[0], [-30., -31.]);
+
+        // Untouched slots stay zero.
+        for slot in [1, 2, 3, 4, 5] {
+            assert_eq!(key_flat[slot], [0., 0.]);
+            assert_eq!(value_flat[slot], [0., 0.]);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn paged_kv_cache_rejects_block_table_overflow() -> Result<()> {
+        let device = Device::Cpu;
+        let num_blocks = 1;
+        let page_block_size = 2;
+        let num_kv_heads = 1;
+        let head_dim = 2;
+        let paged = PagedKvCache {
+            key_cache: Tensor::zeros(
+                (num_blocks, page_block_size, num_kv_heads, head_dim),
+                DType::F32,
+                &device,
+            )?,
+            value_cache: Tensor::zeros(
+                (num_blocks, page_block_size, num_kv_heads, head_dim),
+                DType::F32,
+                &device,
+            )?,
+            // Only one logical block available.
+            block_table: Tensor::from_vec(vec![0u32], (1, 1), &device)?,
+            seqlens_k: Tensor::new(&[0u32, 2u32], &device)?,
+            page_block_size,
+        };
+        // Position 2 needs logical block 1, which doesn't exist in the table.
+        let k = Tensor::zeros((1, num_kv_heads, 1, head_dim), DType::F32, &device)?;
+        let v = Tensor::zeros((1, num_kv_heads, 1, head_dim), DType::F32, &device)?;
+        assert!(paged.write_new_kv(&k, &v, 2).is_err());
+        Ok(())
     }
 }

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -967,4 +967,87 @@ mod tests {
         assert!(paged.write_new_kv(&k, &v, 2).is_err());
         Ok(())
     }
+
+    // Requires a CUDA device and the `flash-attn` feature (which compiles the real
+    // `flash_attn_varlen_paged_windowed` kernel); not runnable on the CPU-only sandbox
+    // this crate is normally developed in. Exercises the actual GPU code path end to
+    // end: writes new K/V into a caller-owned paged cache and checks the attention
+    // output against the long-established dense (non-flash) causal path.
+    #[cfg(feature = "flash-attn")]
+    #[test]
+    fn paged_attention_matches_dense_causal_attention_on_gpu() -> Result<()> {
+        let device = Device::new_cuda(0)?;
+        let dtype = DType::BF16;
+
+        let num_attention_heads = 2;
+        let num_key_value_heads = 2;
+        let head_dim = 64;
+        let hidden_size = num_attention_heads * head_dim;
+        let kv_size = num_key_value_heads * head_dim;
+        let seq_len = 17;
+        let page_block_size = 32;
+
+        let new_linear = |out_dim: usize, in_dim: usize| -> Result<Linear> {
+            let w = Tensor::randn(0f32, 0.02, (out_dim, in_dim), &device)?.to_dtype(dtype)?;
+            Ok(Linear::from_weights(w, None))
+        };
+        let attn = CausalSelfAttention {
+            q_proj: new_linear(hidden_size, hidden_size)?,
+            k_proj: new_linear(kv_size, hidden_size)?,
+            v_proj: new_linear(kv_size, hidden_size)?,
+            o_proj: new_linear(hidden_size, hidden_size)?,
+            num_attention_heads,
+            num_key_value_heads,
+            head_dim,
+            use_flash_attn: false,
+            span: tracing::span!(tracing::Level::TRACE, "attn"),
+            span_rot: tracing::span!(tracing::Level::TRACE, "attn-rot"),
+            max_position_embeddings: DEFAULT_MAX_SEQ_LEN,
+        };
+
+        let mut cfg = tiny_config();
+        cfg.hidden_size = hidden_size;
+        cfg.num_attention_heads = num_attention_heads;
+        cfg.num_key_value_heads = num_key_value_heads;
+        cfg.num_hidden_layers = 1;
+
+        let x = Tensor::randn(0f32, 1., (1, seq_len, hidden_size), &device)?.to_dtype(dtype)?;
+
+        // Ground truth: the long-established dense (non-flash) causal softmax path.
+        let mut dense_cache = Cache::new(true, dtype, &cfg, &device)?;
+        let y_dense = attn.forward(&x, 0, 0, &mut dense_cache)?;
+
+        // Candidate: paged cache sized to hold the whole sequence in a single block,
+        // routed through `flash_attn_varlen_paged_windowed`.
+        let key_cache = Tensor::zeros(
+            (1, page_block_size, num_key_value_heads, head_dim),
+            dtype,
+            &device,
+        )?;
+        let value_cache = Tensor::zeros(
+            (1, page_block_size, num_key_value_heads, head_dim),
+            dtype,
+            &device,
+        )?;
+        let paged = PagedKvCache {
+            key_cache,
+            value_cache,
+            block_table: Tensor::from_vec(vec![0u32], (1, 1), &device)?,
+            seqlens_k: Tensor::new(&[0u32, seq_len as u32], &device)?,
+            page_block_size,
+        };
+        let mut paged_cache = Cache::new(true, dtype, &cfg, &device)?;
+        paged_cache.set_paged_kv(0, paged)?;
+        let y_paged = attn.forward(&x, 0, 0, &mut paged_cache)?;
+
+        let diff = y_dense
+            .to_dtype(DType::F32)?
+            .sub(&y_paged.to_dtype(DType::F32)?)?
+            .abs()?
+            .flatten_all()?
+            .max(0)?
+            .to_vec0::<f32>()?;
+        assert!(diff < 0.1, "paged vs dense max abs diff {diff}");
+        Ok(())
+    }
 }

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -7,7 +7,7 @@
 use super::with_tracing::{linear_no_bias as linear, Linear, RmsNorm};
 use candle::{DType, Device, IndexOp, Result, Tensor, D};
 use candle_nn::{embedding, Embedding, Module, VarBuilder};
-use std::{collections::HashMap, f32::consts::PI};
+use std::{collections::HashMap, f32::consts::PI, sync::Arc};
 
 pub const DEFAULT_MAX_SEQ_LEN: usize = 4096;
 
@@ -228,21 +228,21 @@ impl PagedKvCache {
             .broadcast_as((b_sz * seq_len, num_kv_heads, head_dim))?
             .contiguous()?;
 
-        let k_flat = k
-            .transpose(1, 2)?
-            .contiguous()?
-            .reshape((b_sz * seq_len, num_kv_heads, head_dim))?;
-        let v_flat = v
-            .transpose(1, 2)?
-            .contiguous()?
-            .reshape((b_sz * seq_len, num_kv_heads, head_dim))?;
+        let k_flat =
+            k.transpose(1, 2)?
+                .contiguous()?
+                .reshape((b_sz * seq_len, num_kv_heads, head_dim))?;
+        let v_flat =
+            v.transpose(1, 2)?
+                .contiguous()?
+                .reshape((b_sz * seq_len, num_kv_heads, head_dim))?;
 
-        let key_flat = self
-            .key_cache
-            .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?;
-        let value_flat = self
-            .value_cache
-            .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?;
+        let key_flat =
+            self.key_cache
+                .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?;
+        let value_flat =
+            self.value_cache
+                .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?;
         key_flat.scatter_set(&indices, &k_flat, 0)?;
         value_flat.scatter_set(&indices, &v_flat, 0)?;
         Ok(())
@@ -573,14 +573,13 @@ impl CausalSelfAttention {
     ) -> Result<Tensor> {
         paged.write_new_kv(k, v, index_pos)?;
 
-        let q = q
-            .transpose(1, 2)?
-            .contiguous()?
-            .reshape((b_sz * seq_len, self.num_attention_heads, self.head_dim))?;
+        let q = q.transpose(1, 2)?.contiguous()?.reshape((
+            b_sz * seq_len,
+            self.num_attention_heads,
+            self.head_dim,
+        ))?;
         let seqlens_q = Tensor::new(
-            (0..=b_sz)
-                .map(|i| (i * seq_len) as u32)
-                .collect::<Vec<_>>(),
+            (0..=b_sz).map(|i| (i * seq_len) as u32).collect::<Vec<_>>(),
             q.device(),
         )?;
         let max_seqlen_k = paged.block_table.dim(1)? * paged.page_block_size;
@@ -682,12 +681,25 @@ impl BlockMlp for Mlp {
     }
 }
 
+#[derive(Clone)]
 struct Block {
     rms_1: RmsNorm,
     attn: CausalSelfAttention,
     rms_2: RmsNorm,
-    mlp: Box<dyn BlockMlp>,
+    mlp: Arc<dyn BlockMlp>,
     span: tracing::Span,
+}
+
+impl std::fmt::Debug for Block {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Block")
+            .field("rms_1", &self.rms_1)
+            .field("attn", &self.attn)
+            .field("rms_2", &self.rms_2)
+            .field("mlp", &"dyn BlockMlp")
+            .field("span", &self.span)
+            .finish()
+    }
 }
 
 impl Block {
@@ -720,12 +732,13 @@ impl Block {
             rms_1,
             attn,
             rms_2,
-            mlp,
+            mlp: Arc::from(mlp),
             span,
         })
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Llama {
     wte: Embedding,
     blocks: Vec<Block>,
@@ -782,11 +795,7 @@ impl Llama {
     /// index and a [`VarBuilder`] rooted at `model.layers.{index}.mlp`. The
     /// supplied MLP may own weights on devices other than the rest of the model.
     /// All non-MLP computation remains Candle's normal Llama implementation.
-    pub fn load_with_mlp_factory<F>(
-        vb: VarBuilder,
-        cfg: &Config,
-        mlp_factory: F,
-    ) -> Result<Self>
+    pub fn load_with_mlp_factory<F>(vb: VarBuilder, cfg: &Config, mlp_factory: F) -> Result<Self>
     where
         F: for<'a> Fn(usize, VarBuilder<'a>) -> Result<Box<dyn BlockMlp>>,
     {

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -173,12 +173,7 @@ impl PagedKvCache {
     /// head_dim)`) into `key_cache`/`value_cache` at the physical slots that
     /// `block_table` designates for absolute positions
     /// `index_pos..index_pos+seq_len`.
-    fn validate_uniform_sequence_lengths(
-        &self,
-        b_sz: usize,
-        index_pos: usize,
-        seq_len: usize,
-    ) -> Result<()> {
+    fn validate_uniform_sequence_lengths(&self, b_sz: usize) -> Result<()> {
         if b_sz <= 1 {
             return Ok(());
         }
@@ -190,7 +185,7 @@ impl PagedKvCache {
                 b_sz + 1
             )
         }
-        let expected = (index_pos + seq_len) as u32;
+        let expected = seqlens[1].saturating_sub(seqlens[0]);
         if seqlens
             .windows(2)
             .any(|pair| pair[1].checked_sub(pair[0]) != Some(expected))
@@ -396,7 +391,10 @@ impl Cache {
     /// `candle_flash_attn::flash_attn_varlen_paged_windowed` against the
     /// caller-owned `key_cache`/`value_cache`/`block_table` instead of the
     /// contiguous concat-and-narrow path. Existing callers that never call this
-    /// see no behavior change.
+    /// see no behavior change. This validates the current `seqlens_k` metadata
+    /// before entering the forward path (and CUDA graph capture). If callers
+    /// update that metadata in place, call [`Cache::validate_paged_kv_metadata`]
+    /// at the same sequence boundary.
     pub fn set_paged_kv(&mut self, block_idx: usize, paged: PagedKvCache) -> Result<()> {
         let Some(slot) = self.paged_kvs.get_mut(block_idx) else {
             candle::bail!(
@@ -404,8 +402,17 @@ impl Cache {
                 self.paged_kvs.len()
             )
         };
+        paged.validate_uniform_sequence_lengths(paged.block_table.dim(0)?)?;
         *slot = Some(paged);
         Ok(())
+    }
+
+    /// Validates changed paged-cache metadata outside the model forward path.
+    pub fn validate_paged_kv_metadata(&self, block_idx: usize) -> Result<()> {
+        let Some(paged) = self.paged_kv(block_idx) else {
+            candle::bail!("no paged KV cache is attached for layer {block_idx}")
+        };
+        paged.validate_uniform_sequence_lengths(paged.block_table.dim(0)?)
     }
 
     /// Reverts a layer to the contiguous KV cache path.
@@ -603,9 +610,6 @@ impl CausalSelfAttention {
             .reshape((b_sz, seq_len, self.num_key_value_heads, self.head_dim))?
             .transpose(1, 2)?;
 
-        if let Some(paged) = cache.paged_kv(block_idx) {
-            paged.validate_uniform_sequence_lengths(b_sz, index_pos, seq_len)?;
-        }
         cache.ensure_paged_kv_sequence_boundary(block_idx, index_pos)?;
 
         let q = self.apply_rotary_emb(&q, index_pos, cache)?;
@@ -1164,15 +1168,13 @@ mod tests {
             seqlens_k: Tensor::new(&[0u32, 3, 6], &device)?,
             page_block_size: 4,
         };
-        paged.validate_uniform_sequence_lengths(2, 2, 1)?;
+        paged.validate_uniform_sequence_lengths(2)?;
 
         let nonuniform = PagedKvCache {
             seqlens_k: Tensor::new(&[0u32, 3, 7], &device)?,
             ..paged
         };
-        assert!(nonuniform
-            .validate_uniform_sequence_lengths(2, 2, 1)
-            .is_err());
+        assert!(nonuniform.validate_uniform_sequence_lengths(2).is_err());
         Ok(())
     }
 

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -666,12 +666,27 @@ impl Mlp {
     }
 }
 
-#[derive(Debug, Clone)]
+/// A transformer's feed-forward computation within a Llama block.
+///
+/// Implement this trait to replace a block's dense MLP while retaining Candle's
+/// attention, RoPE, causal masking, KV cache, norms, and residual wiring. The
+/// factory passed to [`Llama::load_with_mlp_factory`] receives the layer index
+/// and a [`VarBuilder`] rooted at that layer's `mlp` prefix.
+pub trait BlockMlp: Send + Sync {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor>;
+}
+
+impl BlockMlp for Mlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        Self::forward(self, xs)
+    }
+}
+
 struct Block {
     rms_1: RmsNorm,
     attn: CausalSelfAttention,
     rms_2: RmsNorm,
-    mlp: Mlp,
+    mlp: Box<dyn BlockMlp>,
     span: tracing::Span,
 }
 
@@ -692,10 +707,9 @@ impl Block {
         Ok(x)
     }
 
-    fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+    fn load(vb: VarBuilder, cfg: &Config, mlp: Box<dyn BlockMlp>) -> Result<Self> {
         let span = tracing::span!(tracing::Level::TRACE, "block");
         let attn = CausalSelfAttention::load(vb.pp("self_attn"), cfg)?;
-        let mlp = Mlp::load(vb.pp("mlp"), cfg)?;
         let rms_1 = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
         let rms_2 = RmsNorm::new(
             cfg.hidden_size,
@@ -712,7 +726,6 @@ impl Block {
     }
 }
 
-#[derive(Debug, Clone)]
 pub struct Llama {
     wte: Embedding,
     blocks: Vec<Block>,
@@ -755,7 +768,28 @@ impl Llama {
         logits.to_dtype(DType::F32)
     }
 
+    /// Loads the standard dense Llama architecture.
+    ///
+    /// This is identical to [`Llama::load_with_mlp_factory`] with the built-in
+    /// dense MLP factory.
     pub fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+        Self::load_with_mlp_factory(vb, cfg, |_, vb| Ok(Box::new(Mlp::load(vb, cfg)?)))
+    }
+
+    /// Loads Llama while supplying the feed-forward computation for each block.
+    ///
+    /// `mlp_factory` is called once per transformer layer with its zero-based
+    /// index and a [`VarBuilder`] rooted at `model.layers.{index}.mlp`. The
+    /// supplied MLP may own weights on devices other than the rest of the model.
+    /// All non-MLP computation remains Candle's normal Llama implementation.
+    pub fn load_with_mlp_factory<F>(
+        vb: VarBuilder,
+        cfg: &Config,
+        mlp_factory: F,
+    ) -> Result<Self>
+    where
+        F: for<'a> Fn(usize, VarBuilder<'a>) -> Result<Box<dyn BlockMlp>>,
+    {
         let wte = embedding(cfg.vocab_size, cfg.hidden_size, vb.pp("model.embed_tokens"))?;
         let lm_head = if cfg.tie_word_embeddings {
             Linear::from_weights(wte.embeddings().clone(), None)
@@ -764,8 +798,12 @@ impl Llama {
         };
         let ln_f = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("model.norm"))?;
         let blocks: Vec<_> = (0..cfg.num_hidden_layers)
-            .map(|i| Block::load(vb.pp(format!("model.layers.{i}")), cfg).unwrap())
-            .collect();
+            .map(|i| {
+                let block_vb = vb.pp(format!("model.layers.{i}"));
+                let mlp = mlp_factory(i, block_vb.pp("mlp"))?;
+                Block::load(block_vb, cfg, mlp)
+            })
+            .collect::<Result<_>>()?;
 
         Ok(Self {
             wte,
@@ -779,6 +817,7 @@ impl Llama {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Mutex};
 
     fn tiny_config() -> Config {
         Config {
@@ -965,6 +1004,43 @@ mod tests {
         let k = Tensor::zeros((1, num_kv_heads, 1, head_dim), DType::F32, &device)?;
         let v = Tensor::zeros((1, num_kv_heads, 1, head_dim), DType::F32, &device)?;
         assert!(paged.write_new_kv(&k, &v, 2).is_err());
+        Ok(())
+    }
+
+    #[derive(Debug)]
+    struct ZeroMlp {
+        forward_calls: Arc<Mutex<usize>>,
+    }
+
+    impl BlockMlp for ZeroMlp {
+        fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+            *self.forward_calls.lock().unwrap() += 1;
+            Tensor::zeros(xs.dims(), xs.dtype(), xs.device())
+        }
+    }
+
+    #[test]
+    fn load_with_mlp_factory_builds_one_mlp_per_block() -> Result<()> {
+        let device = Device::Cpu;
+        let cfg = tiny_config();
+        let layers = Arc::new(Mutex::new(Vec::new()));
+        let factory_layers = Arc::clone(&layers);
+        let forward_calls = Arc::new(Mutex::new(0));
+        let factory_forward_calls = Arc::clone(&forward_calls);
+        let vb = VarBuilder::zeros(DType::F32, &device);
+
+        let model = Llama::load_with_mlp_factory(vb, &cfg, move |layer, _mlp_vb| {
+            factory_layers.lock().unwrap().push(layer);
+            Ok(Box::new(ZeroMlp {
+                forward_calls: Arc::clone(&factory_forward_calls),
+            }))
+        })?;
+
+        assert_eq!(*layers.lock().unwrap(), vec![0, 1]);
+        let mut cache = Cache::new(true, DType::F32, &cfg, &device)?;
+        let tokens = Tensor::zeros((1, 1), DType::U32, &device)?;
+        model.forward(&tokens, 0, &mut cache)?;
+        assert_eq!(*forward_calls.lock().unwrap(), cfg.num_hidden_layers);
         Ok(())
     }
 

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -1053,6 +1053,30 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn custom_dense_mlp_matches_standard_llama_bit_for_bit() -> Result<()> {
+        let device = Device::Cpu;
+        let cfg = tiny_config();
+        // Both models read the same initialized weights, mirroring a checkpoint
+        // load while exercising the public factory path for every MLP.
+        let varmap = candle_nn::VarMap::new();
+        let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+        let dense = Llama::load(vb.clone(), &cfg)?;
+        let custom =
+            Llama::load_with_mlp_factory(vb, &cfg, |_, vb| Ok(Box::new(Mlp::load(vb, &cfg)?)))?;
+        let tokens = Tensor::from_vec(vec![1u32, 2, 3], (1, 3), &device)?;
+        let mut dense_cache = Cache::new(true, DType::F32, &cfg, &device)?;
+        let mut custom_cache = Cache::new(true, DType::F32, &cfg, &device)?;
+
+        let dense_logits = dense.forward(&tokens, 0, &mut dense_cache)?;
+        let custom_logits = custom.forward(&tokens, 0, &mut custom_cache)?;
+        assert_eq!(
+            dense_logits.to_vec2::<f32>()?,
+            custom_logits.to_vec2::<f32>()?
+        );
+        Ok(())
+    }
+
     // Requires a CUDA device and the `flash-attn` feature (which compiles the real
     // `flash_attn_varlen_paged_windowed` kernel); not runnable on the CPU-only sandbox
     // this crate is normally developed in. Exercises the actual GPU code path end to

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -173,7 +173,42 @@ impl PagedKvCache {
     /// head_dim)`) into `key_cache`/`value_cache` at the physical slots that
     /// `block_table` designates for absolute positions
     /// `index_pos..index_pos+seq_len`.
-    fn write_new_kv(&self, k: &Tensor, v: &Tensor, index_pos: usize) -> Result<()> {
+    fn validate_uniform_sequence_lengths(
+        &self,
+        b_sz: usize,
+        index_pos: usize,
+        seq_len: usize,
+    ) -> Result<()> {
+        if b_sz <= 1 {
+            return Ok(());
+        }
+        let seqlens = self.seqlens_k.to_dtype(DType::U32)?.to_vec1::<u32>()?;
+        if seqlens.len() != b_sz + 1 {
+            candle::bail!(
+                "seqlens_k has {} entries, expected {} for batch size {b_sz}",
+                seqlens.len(),
+                b_sz + 1
+            )
+        }
+        let expected = (index_pos + seq_len) as u32;
+        if seqlens
+            .windows(2)
+            .any(|pair| pair[1].checked_sub(pair[0]) != Some(expected))
+        {
+            candle::bail!(
+                "paged KV cache requires equal history lengths across a batch; per-sequence positions are unsupported"
+            )
+        }
+        Ok(())
+    }
+
+    fn write_new_kv(
+        &self,
+        k: &Tensor,
+        v: &Tensor,
+        index_pos: usize,
+        decode_slot: Option<&Tensor>,
+    ) -> Result<()> {
         if !self.key_cache.is_contiguous() || !self.value_cache.is_contiguous() {
             candle::bail!("PagedKvCache key_cache/value_cache must be contiguous")
         }
@@ -192,42 +227,65 @@ impl PagedKvCache {
                 self.key_cache.dims()
             )
         }
-        let block_table = self.block_table.to_dtype(DType::U32)?.to_vec2::<u32>()?;
-        if block_table.len() != b_sz {
-            candle::bail!(
-                "block_table batch dim ({}) does not match kv batch dim ({b_sz})",
-                block_table.len()
-            )
-        }
-        let last_pos = index_pos + seq_len - 1;
-        let mut slots = Vec::with_capacity(b_sz * seq_len);
-        for row in &block_table {
-            let max_logical_block = last_pos / self.page_block_size;
-            if max_logical_block >= row.len() {
+        let device = k.device();
+        let indices = if let Some(decode_slot) = decode_slot {
+            if seq_len != 1 {
+                candle::bail!("paged KV decode slots are only valid for single-token decode")
+            }
+            if !decode_slot.device().same_device(device) {
+                candle::bail!("paged KV decode slots must reside on the K/V device")
+            }
+            if decode_slot.dims1()? != b_sz {
                 candle::bail!(
-                    "block_table has {} blocks, but position {last_pos} needs logical block {max_logical_block}",
-                    row.len()
+                    "paged KV decode slot count ({}) does not match kv batch size ({b_sz})",
+                    decode_slot.dims1()?
                 )
             }
-            for t in 0..seq_len {
-                let pos = index_pos + t;
-                let logical_block = pos / self.page_block_size;
-                let offset = pos % self.page_block_size;
-                let physical_block = row[logical_block] as usize;
-                if physical_block >= num_blocks {
+            decode_slot
+                .to_dtype(DType::U32)?
+                .reshape((b_sz, 1, 1))?
+                .broadcast_as((b_sz, num_kv_heads, head_dim))?
+                .contiguous()?
+        } else {
+            if device.is_cuda() && seq_len == 1 {
+                candle::bail!(
+                    "paged KV CUDA decode requires caller-provided device slots; call Cache::set_paged_kv_decode_slot"
+                )
+            }
+            let block_table = self.block_table.to_dtype(DType::U32)?.to_vec2::<u32>()?;
+            if block_table.len() != b_sz {
+                candle::bail!(
+                    "block_table batch dim ({}) does not match kv batch dim ({b_sz})",
+                    block_table.len()
+                )
+            }
+            let last_pos = index_pos + seq_len - 1;
+            let mut slots = Vec::with_capacity(b_sz * seq_len);
+            for row in &block_table {
+                let max_logical_block = last_pos / self.page_block_size;
+                if max_logical_block >= row.len() {
                     candle::bail!(
-                        "block_table references physical block {physical_block}, but key_cache only has {num_blocks} blocks"
+                        "block_table has {} blocks, but position {last_pos} needs logical block {max_logical_block}",
+                        row.len()
                     )
                 }
-                slots.push((physical_block * self.page_block_size + offset) as u32);
+                for t in 0..seq_len {
+                    let pos = index_pos + t;
+                    let logical_block = pos / self.page_block_size;
+                    let offset = pos % self.page_block_size;
+                    let physical_block = row[logical_block] as usize;
+                    if physical_block >= num_blocks {
+                        candle::bail!(
+                            "block_table references physical block {physical_block}, but key_cache only has {num_blocks} blocks"
+                        )
+                    }
+                    slots.push((physical_block * self.page_block_size + offset) as u32);
+                }
             }
-        }
-
-        let device = k.device();
-        let indices = Tensor::from_vec(slots, (b_sz * seq_len, 1, 1), device)?
-            .broadcast_as((b_sz * seq_len, num_kv_heads, head_dim))?
-            .contiguous()?;
-
+            Tensor::from_vec(slots, (b_sz * seq_len, 1, 1), device)?
+                .broadcast_as((b_sz * seq_len, num_kv_heads, head_dim))?
+                .contiguous()?
+        };
         let k_flat =
             k.transpose(1, 2)?
                 .contiguous()?
@@ -259,6 +317,8 @@ pub struct Cache {
     // contiguous concat-and-narrow path byte-for-byte; existing callers that
     // never touch this are entirely unaffected. See `PagedKvCache`.
     paged_kvs: Vec<Option<PagedKvCache>>,
+    paged_kv_decode_slots: Vec<Option<Tensor>>,
+    paged_kv_reset_required: Vec<bool>,
     cos: Tensor,
     sin: Tensor,
     device: Device,
@@ -322,6 +382,8 @@ impl Cache {
             use_kv_cache,
             kvs: vec![None; config.num_hidden_layers],
             paged_kvs: vec![None; config.num_hidden_layers],
+            paged_kv_decode_slots: vec![None; config.num_hidden_layers],
+            paged_kv_reset_required: vec![false; config.num_hidden_layers],
             device: device.clone(),
             cos,
             sin,
@@ -350,7 +412,55 @@ impl Cache {
     pub fn clear_paged_kv(&mut self, block_idx: usize) {
         if let Some(slot) = self.paged_kvs.get_mut(block_idx) {
             *slot = None;
+            self.kvs[block_idx] = None;
+            self.paged_kv_decode_slots[block_idx] = None;
+            self.paged_kv_reset_required[block_idx] = true;
         }
+    }
+
+    /// Supplies physical cache slots on the target device for CUDA single-token decode.
+    pub fn set_paged_kv_decode_slot(&mut self, block_idx: usize, slots: Tensor) -> Result<()> {
+        let Some(slot) = self.paged_kv_decode_slots.get_mut(block_idx) else {
+            candle::bail!(
+                "block_idx {block_idx} out of range for {} layers",
+                self.paged_kvs.len()
+            )
+        };
+        *slot = Some(slots);
+        Ok(())
+    }
+
+    pub fn clear_paged_kv_decode_slot(&mut self, block_idx: usize) {
+        if let Some(slot) = self.paged_kv_decode_slots.get_mut(block_idx) {
+            *slot = None;
+        }
+    }
+
+    fn paged_kv_decode_slot(&self, block_idx: usize) -> Option<&Tensor> {
+        self.paged_kv_decode_slots
+            .get(block_idx)
+            .and_then(Option::as_ref)
+    }
+
+    fn ensure_paged_kv_sequence_boundary(
+        &mut self,
+        block_idx: usize,
+        index_pos: usize,
+    ) -> Result<()> {
+        if self
+            .paged_kv_reset_required
+            .get(block_idx)
+            .copied()
+            .unwrap_or(false)
+        {
+            if index_pos != 0 {
+                candle::bail!(
+                    "paged KV cache was cleared; the next forward pass must start at index_pos 0"
+                )
+            }
+            self.paged_kv_reset_required[block_idx] = false;
+        }
+        Ok(())
     }
 
     pub fn paged_kv(&self, block_idx: usize) -> Option<&PagedKvCache> {
@@ -446,7 +556,17 @@ fn flash_attn_varlen_paged(
     _: f32,
     _: usize,
 ) -> Result<Tensor> {
-    unimplemented!("compile with '--features flash-attn'")
+    candle::bail!("paged attention requires the `flash-attn` feature")
+}
+
+#[cfg(feature = "flash-attn")]
+fn ensure_paged_attention_available() -> Result<()> {
+    Ok(())
+}
+
+#[cfg(not(feature = "flash-attn"))]
+fn ensure_paged_attention_available() -> Result<()> {
+    candle::bail!("paged attention requires the `flash-attn` feature")
 }
 
 impl CausalSelfAttention {
@@ -483,12 +603,28 @@ impl CausalSelfAttention {
             .reshape((b_sz, seq_len, self.num_key_value_heads, self.head_dim))?
             .transpose(1, 2)?;
 
+        if let Some(paged) = cache.paged_kv(block_idx) {
+            paged.validate_uniform_sequence_lengths(b_sz, index_pos, seq_len)?;
+        }
+        cache.ensure_paged_kv_sequence_boundary(block_idx, index_pos)?;
+
         let q = self.apply_rotary_emb(&q, index_pos, cache)?;
         let mut k = self.apply_rotary_emb(&k, index_pos, cache)?;
 
         if let Some(paged) = cache.paged_kv(block_idx) {
             let v = v.contiguous()?;
-            return self.forward_paged(&q, &k, &v, index_pos, b_sz, seq_len, hidden_size, paged);
+            let decode_slot = cache.paged_kv_decode_slot(block_idx);
+            return self.forward_paged(
+                &q,
+                &k,
+                &v,
+                index_pos,
+                b_sz,
+                seq_len,
+                hidden_size,
+                paged,
+                decode_slot,
+            );
         }
 
         if cache.use_kv_cache {
@@ -570,8 +706,10 @@ impl CausalSelfAttention {
         seq_len: usize,
         hidden_size: usize,
         paged: &PagedKvCache,
+        decode_slot: Option<&Tensor>,
     ) -> Result<Tensor> {
-        paged.write_new_kv(k, v, index_pos)?;
+        ensure_paged_attention_available()?;
+        paged.write_new_kv(k, v, index_pos, decode_slot)?;
 
         let q = q.transpose(1, 2)?.contiguous()?.reshape((
             b_sz * seq_len,
@@ -958,7 +1096,7 @@ mod tests {
             &device,
         )?;
 
-        paged.write_new_kv(&k, &v, index_pos)?;
+        paged.write_new_kv(&k, &v, index_pos, None)?;
 
         let key_flat = paged
             .key_cache
@@ -1012,8 +1150,47 @@ mod tests {
         // Position 2 needs logical block 1, which doesn't exist in the table.
         let k = Tensor::zeros((1, num_kv_heads, 1, head_dim), DType::F32, &device)?;
         let v = Tensor::zeros((1, num_kv_heads, 1, head_dim), DType::F32, &device)?;
-        assert!(paged.write_new_kv(&k, &v, 2).is_err());
+        assert!(paged.write_new_kv(&k, &v, 2, None).is_err());
         Ok(())
+    }
+
+    #[test]
+    fn paged_kv_rejects_nonuniform_batch_history() -> Result<()> {
+        let device = Device::Cpu;
+        let paged = PagedKvCache {
+            key_cache: Tensor::zeros((1, 4, 1, 2), DType::F32, &device)?,
+            value_cache: Tensor::zeros((1, 4, 1, 2), DType::F32, &device)?,
+            block_table: Tensor::zeros((2, 1), DType::U32, &device)?,
+            seqlens_k: Tensor::new(&[0u32, 3, 6], &device)?,
+            page_block_size: 4,
+        };
+        paged.validate_uniform_sequence_lengths(2, 2, 1)?;
+
+        let nonuniform = PagedKvCache {
+            seqlens_k: Tensor::new(&[0u32, 3, 7], &device)?,
+            ..paged
+        };
+        assert!(nonuniform
+            .validate_uniform_sequence_lengths(2, 2, 1)
+            .is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn clearing_paged_kv_requires_a_sequence_boundary() -> Result<()> {
+        let device = Device::Cpu;
+        let cfg = tiny_config();
+        let mut cache = Cache::new(true, DType::F32, &cfg, &device)?;
+        cache.clear_paged_kv(0);
+        assert!(cache.ensure_paged_kv_sequence_boundary(0, 1).is_err());
+        cache.ensure_paged_kv_sequence_boundary(0, 0)?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "flash-attn"))]
+    #[test]
+    fn paged_attention_without_flash_attn_returns_an_error() {
+        assert!(ensure_paged_attention_available().is_err());
     }
 
     #[derive(Debug)]

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -242,11 +242,9 @@ impl PagedKvCache {
                 .broadcast_as((b_sz, num_kv_heads, head_dim))?
                 .contiguous()?
         } else {
-            if device.is_cuda() && seq_len == 1 {
-                candle::bail!(
-                    "paged KV CUDA decode requires caller-provided device slots; call Cache::set_paged_kv_decode_slot"
-                )
-            }
+            // The host-derived path remains valid for ordinary CUDA decode.
+            // During CUDA graph capture its device-to-host readback returns a
+            // normal capture error; graph callers should attach a decode slot.
             let block_table = self.block_table.to_dtype(DType::U32)?.to_vec2::<u32>()?;
             if block_table.len() != b_sz {
                 candle::bail!(


### PR DESCRIPTION
## Summary

Adds an additive `Cache::Paged` seam to `candle-transformers::models::llama` so a downstream crate can drive block-paged KV storage through `Llama::forward` without forking the model or reimplementing RoPE/GQA/norm placement to reach the attention call site (#3720).

- `PagedKvCache`: caller-owned paged KV storage (`key_cache`/`value_cache` shaped `(num_blocks, page_block_size, num_kv_heads, head_dim)`, `block_table`, `seqlens_k`, `page_block_size`).
- `Cache::set_paged_kv(block_idx, PagedKvCache)` / `clear_paged_kv(block_idx)` / `paged_kv(block_idx)`: attach/detach paged storage per transformer layer. Every layer defaults to `None`.
- `CausalSelfAttention::forward` checks the per-layer paged slot first: if set, it writes the new K/V into the caller's `key_cache`/`value_cache` at the slots `block_table` designates, then attends via `candle_flash_attn::flash_attn_varlen_paged_windowed`. If unset, it falls through to today's contiguous concat-and-narrow path, unchanged.

`Cache` stays a struct rather than becoming an enum, so every existing field (`use_kv_cache`, etc.) and every existing call site (`Cache::new`, `candle-examples/examples/llama`, `candle-examples/examples/llava`) is unaffected. The paged path is purely opt-in.

## Why not an enum

An earlier sketch proposed turning `Cache` into `enum Cache { Contiguous(..), Paged(..) }`. That breaks direct field access (`cache.use_kv_cache`) at existing call sites and would require `CausalSelfAttention`/`Block`/`Mlp` to become `pub`. The additive-field version gets the same functional seam — attention already routes through `Llama::forward`, callers never need those internals to be public — with zero behavior change for anyone who doesn't opt in.

## Test plan

- [x] `cargo test -p candle-transformers --lib models::llama::` — 4 new CPU-only unit tests covering: paged storage defaults to `None` (no behavior change), `set_paged_kv`/`clear_paged_kv` lifecycle including out-of-range rejection, slot-index math writing new K/V into the exact physical block/offset the block table designates, and rejecting a block table that doesn't cover the requested position.
- [x] `cargo build -p candle-transformers` / `cargo clippy -p candle-transformers --lib` — clean.
- [x] `cargo build -p candle-examples --example llama --example llava` — confirms zero breakage at the two call sites that use `llama::Cache` directly.
- [x] `cargo test -p candle-transformers --release --features flash-attn --lib models::llama::` on a CUDA GPU — 1 additional test (`paged_attention_matches_dense_causal_attention_on_gpu`, gated behind the `flash-attn` feature since it needs real CUDA hardware) builds a `CausalSelfAttention` by hand and checks that attention through a single-block `PagedKvCache` + `flash_attn_varlen_paged_windowed` matches the existing dense causal path within tolerance.

Fixes #3720