### PR TITLE
cpu-optimize: aarch64 packed Q8_0 SDOT gemm/gemv (prefill up to 1.9x, decode up to 1.65x)

### DIFF
--- a/candle-core/src/quantized/k_quants.rs
+++ b/candle-core/src/quantized/k_quants.rs
@@ -2840,11 +2840,8 @@ verify_block_sizes!(
     BlockQ5K, BlockQ6K, BlockQ8K, f32, f16, bf16
 );
 
-// ---- Packed Q8_0 (llama block_q8_0x4), the q8_0 sibling of BlockQ4Kx8: 4 rows
-// interleaved in 4-byte chunks so the NEON kernels broadcast one activation
-// load across 4 output columns via SDOT lane selection. Built once per weight
-// tensor (cached on the QTensor, see mod.rs) and used for BOTH the m>=4 GEMM
-// and the decode GEMV.
+// Packed Q8_0 (llama block_q8_0x4): 4 rows interleaved in 4-byte chunks so one
+// SDOT covers 4 output columns via lane broadcast. Repacked once per tensor.
 
 #[derive(
     Debug,
@@ -2875,8 +2872,7 @@ impl BlockQ8_0x4 {
     }
 }
 
-/// Repack plain Q8_0 weight rows (n rows of nb blocks) into the x4 interleaved
-/// layout: out[g*nb + b] holds block b of rows 4g..4g+4. Requires n % 4 == 0.
+/// Repack n (n % 4 == 0) rows of Q8_0 blocks into the x4 interleaved layout.
 #[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
 pub(crate) fn repack_q8_0_weight(blocks: &[BlockQ8_0], n: usize) -> Vec<BlockQ8_0x4> {
     assert!(n.is_multiple_of(4), "q8_0 x4 repack needs n % 4 == 0");
@@ -2899,8 +2895,7 @@ pub(crate) fn repack_q8_0_weight(blocks: &[BlockQ8_0], n: usize) -> Vec<BlockQ8_
     out
 }
 
-/// Scalar reference twin of `neon::quantize_mat_q8_0x4_neon`: from_float per
-/// row + interleave. Kept for the bit-exactness test of the NEON pack.
+/// Scalar twin of `neon::quantize_mat_q8_0x4_neon`, kept for its bit-exactness test.
 #[cfg(all(test, target_arch = "aarch64", target_feature = "dotprod"))]
 pub(crate) fn quantize_q8_0_x4_into(rows: &[&[f32]; 4], out: &mut [BlockQ8_0x4]) {
     let nb = out.len();
@@ -2920,9 +2915,8 @@ pub(crate) fn quantize_q8_0_x4_into(rows: &[&[f32]; 4], out: &mut [BlockQ8_0x4])
     }
 }
 
-/// dst(m,n) = lhs(m,k) x W^T over x4-packed Q8_0 weights. m >= 4 runs 4-row
-/// GEMM tiles (last tile zero-padded); m < 4 runs the GEMV per row. Column
-/// groups are partitioned contiguously across the barrier pool.
+/// dst(m,n) = lhs(m,k) x W^T: 4-row GEMM tiles for m >= 4 (zero-padded tail),
+/// per-row GEMV below; column groups split across the barrier pool.
 #[cfg(all(
     target_arch = "aarch64",
     target_feature = "neon",

--- a/candle-core/src/quantized/k_quants.rs
+++ b/candle-core/src/quantized/k_quants.rs
@@ -2839,3 +2839,254 @@ verify_block_sizes!(
     BlockQ4_0, BlockQ4_1, BlockQ5_0, BlockQ5_1, BlockQ8_0, BlockQ8_1, BlockQ2K, BlockQ3K, BlockQ4K,
     BlockQ5K, BlockQ6K, BlockQ8K, f32, f16, bf16
 );
+
+// ---- Packed Q8_0 (llama block_q8_0x4), the q8_0 sibling of BlockQ4Kx8: 4 rows
+// interleaved in 4-byte chunks so the NEON kernels broadcast one activation
+// load across 4 output columns via SDOT lane selection. Built once per weight
+// tensor (cached on the QTensor, see mod.rs) and used for BOTH the m>=4 GEMM
+// and the decode GEMV.
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    zerocopy::FromBytes,
+    zerocopy::IntoBytes,
+    zerocopy::KnownLayout,
+    zerocopy::Immutable,
+)]
+#[repr(C)]
+#[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
+pub struct BlockQ8_0x4 {
+    pub(crate) d: [f16; 4],
+    // qs[16*j + 4*r + l] = element 4*j + l of row r (j in 0..8, l in 0..4).
+    pub(crate) qs: [i8; 4 * QK8_0],
+}
+#[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
+const _: () = assert!(std::mem::size_of::<BlockQ8_0x4>() == 136);
+
+#[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
+impl BlockQ8_0x4 {
+    fn zeroed() -> Self {
+        Self {
+            d: [f16::ZERO; 4],
+            qs: [0i8; 4 * QK8_0],
+        }
+    }
+}
+
+/// Repack plain Q8_0 weight rows (n rows of nb blocks) into the x4 interleaved
+/// layout: out[g*nb + b] holds block b of rows 4g..4g+4. Requires n % 4 == 0.
+#[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
+pub(crate) fn repack_q8_0_weight(blocks: &[BlockQ8_0], n: usize) -> Vec<BlockQ8_0x4> {
+    assert!(n.is_multiple_of(4), "q8_0 x4 repack needs n % 4 == 0");
+    let nb = blocks.len() / n;
+    let mut out = vec![BlockQ8_0x4::zeroed(); blocks.len() / 4];
+    for g in 0..n / 4 {
+        for b in 0..nb {
+            let dst = &mut out[g * nb + b];
+            for r in 0..4 {
+                let src = &blocks[(g * 4 + r) * nb + b];
+                dst.d[r] = src.d;
+                for j in 0..QK8_0 / 4 {
+                    for l in 0..4 {
+                        dst.qs[16 * j + 4 * r + l] = src.qs[4 * j + l];
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Scalar reference twin of `neon::quantize_mat_q8_0x4_neon`: from_float per
+/// row + interleave. Kept for the bit-exactness test of the NEON pack.
+#[cfg(all(test, target_arch = "aarch64", target_feature = "dotprod"))]
+pub(crate) fn quantize_q8_0_x4_into(rows: &[&[f32]; 4], out: &mut [BlockQ8_0x4]) {
+    let nb = out.len();
+    let mut tmp = vec![BlockQ8_0::zeros(); nb];
+    for (r, row) in rows.iter().enumerate() {
+        debug_assert_eq!(row.len(), nb * QK8_0);
+        BlockQ8_0::from_float(row, &mut tmp);
+        for (b, blk) in tmp.iter().enumerate() {
+            let dst = &mut out[b];
+            dst.d[r] = blk.d;
+            for j in 0..QK8_0 / 4 {
+                for l in 0..4 {
+                    dst.qs[16 * j + 4 * r + l] = blk.qs[4 * j + l];
+                }
+            }
+        }
+    }
+}
+
+/// dst(m,n) = lhs(m,k) x W^T over x4-packed Q8_0 weights. m >= 4 runs 4-row
+/// GEMM tiles (last tile zero-padded); m < 4 runs the GEMV per row. Column
+/// groups are partitioned contiguously across the barrier pool.
+#[cfg(all(
+    target_arch = "aarch64",
+    target_feature = "neon",
+    target_feature = "dotprod"
+))]
+#[allow(clippy::needless_range_loop)]
+pub(crate) fn matmul_q8_0x4(
+    (m, k, n): (usize, usize, usize),
+    lhs: &[f32],
+    packed: &[BlockQ8_0x4],
+    dst: &mut [f32],
+) {
+    use super::neon::{gemm_q8_0x4, gemv_q8_0x4};
+    let nb = k / QK8_0;
+    let groups = n / 4;
+
+    struct DstPtr(*mut f32);
+    unsafe impl Sync for DstPtr {}
+    let dptr = DstPtr(dst.as_mut_ptr());
+
+    if m >= 4 {
+        let row_tiles = m.div_ceil(4);
+        let zeros = vec![0f32; k];
+        let mut q8: Vec<BlockQ8_0x4> = vec![BlockQ8_0x4::zeroed(); row_tiles * nb];
+        let tile_rows = |rt: usize| -> [&[f32]; 4] {
+            std::array::from_fn(|a| {
+                let r = rt * 4 + a;
+                if r < m {
+                    &lhs[r * k..(r + 1) * k]
+                } else {
+                    zeros.as_slice()
+                }
+            })
+        };
+        crate::utils::par_chunks_mut(&mut q8, nb, |rt, chunk| {
+            crate::quantized::neon::quantize_mat_q8_0x4_neon(&tile_rows(rt), chunk);
+        });
+
+        let process = |g: usize| {
+            let w = &packed[g * nb..(g + 1) * nb];
+            let p = &dptr;
+            for rt in 0..row_tiles {
+                let mut t = [0f32; 16];
+                gemm_q8_0x4(w, &q8[rt * nb..(rt + 1) * nb], &mut t);
+                for a in 0..4 {
+                    let r = rt * 4 + a;
+                    if r >= m {
+                        break;
+                    }
+                    for c in 0..4 {
+                        unsafe { *p.0.add(r * n + g * 4 + c) = t[a * 4 + c] };
+                    }
+                }
+            }
+        };
+        let pool = crate::utils::barrier_pool();
+        let n_total = pool.n_workers() + 1;
+        let gpt = groups.div_ceil(n_total);
+        pool.execute(|tid| {
+            let start = tid * gpt;
+            if start < groups {
+                let end = groups.min((tid + 1) * gpt);
+                for g in start..end {
+                    process(g);
+                }
+            }
+        });
+    } else {
+        // Decode / tiny m: plain Q8_0 activation rows + lane-broadcast GEMV.
+        let mut q8 = vec![BlockQ8_0::zeros(); m * nb];
+        for r in 0..m {
+            BlockQ8_0::from_float(&lhs[r * k..(r + 1) * k], &mut q8[r * nb..(r + 1) * nb]);
+        }
+        let process = |g: usize| {
+            let w = &packed[g * nb..(g + 1) * nb];
+            let p = &dptr;
+            for r in 0..m {
+                let mut t = [0f32; 4];
+                gemv_q8_0x4(w, &q8[r * nb..(r + 1) * nb], &mut t);
+                for c in 0..4 {
+                    unsafe { *p.0.add(r * n + g * 4 + c) = t[c] };
+                }
+            }
+        };
+        let pool = crate::utils::barrier_pool();
+        let n_total = pool.n_workers() + 1;
+        if n_total <= 1 {
+            for g in 0..groups {
+                process(g);
+            }
+        } else {
+            let gpt = groups.div_ceil(n_total);
+            pool.execute(|tid| {
+                let start = tid * gpt;
+                if start < groups {
+                    let end = groups.min((tid + 1) * gpt);
+                    for g in start..end {
+                        process(g);
+                    }
+                }
+            });
+        }
+    }
+}
+
+#[cfg(all(test, target_feature = "neon", target_feature = "dotprod"))]
+mod q8_0_packed_tests {
+    use super::*;
+
+    fn rand_f32(seed: u32, len: usize) -> Vec<f32> {
+        // Simple LCG, deterministic across runs.
+        let mut s = seed as u64;
+        (0..len)
+            .map(|_| {
+                s = s
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                ((s >> 33) as u32 as f32 / u32::MAX as f32) * 2.0 - 1.0
+            })
+            .collect()
+    }
+
+    #[test]
+    fn neon_activation_pack_matches_scalar() {
+        let k = 96;
+        let nb = k / QK8_0;
+        let rows_data: Vec<Vec<f32>> = (0..4).map(|r| rand_f32(50 + r, k)).collect();
+        let rows: [&[f32]; 4] = std::array::from_fn(|r| rows_data[r].as_slice());
+        let mut scalar = vec![BlockQ8_0x4::zeroed(); nb];
+        quantize_q8_0_x4_into(&rows, &mut scalar);
+        let mut neon = vec![BlockQ8_0x4::zeroed(); nb];
+        crate::quantized::neon::quantize_mat_q8_0x4_neon(&rows, &mut neon);
+        for b in 0..nb {
+            for r in 0..4 {
+                assert_eq!(
+                    scalar[b].d[r].to_bits(),
+                    neon[b].d[r].to_bits(),
+                    "d b={b} r={r}"
+                );
+            }
+            assert_eq!(scalar[b].qs, neon[b].qs, "qs b={b}");
+        }
+    }
+
+    #[test]
+    fn packed_q8_0_matmul_matches_baseline() {
+        let (k, n) = (96, 12); // 3 blocks per row, 3 column groups
+        let nb = k / QK8_0;
+        let wf = rand_f32(7, n * k);
+        let mut wq = vec![BlockQ8_0::zeros(); n * nb];
+        BlockQ8_0::from_float(&wf, &mut wq);
+        let packed = repack_q8_0_weight(&wq, n);
+
+        for m in [1usize, 3, 4, 7, 16] {
+            let lhs = rand_f32(100 + m as u32, m * k);
+            let mut want = vec![0f32; m * n];
+            matmul((m, k, n), &lhs, &wq, &mut want).unwrap();
+            let mut got = vec![0f32; m * n];
+            matmul_q8_0x4((m, k, n), &lhs, &packed, &mut got);
+            for i in 0..m * n {
+                let (a, b) = (want[i], got[i]);
+                let rel = (a - b).abs() / a.abs().max(1e-3);
+                assert!(rel < 1e-4, "m={m} i={i}: baseline {a} packed {b}");
+            }
+        }
+    }
+}

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -63,6 +63,10 @@ pub struct QTensor {
     /// Not always used.
     #[allow(dead_code)]
     repacked_qs: OnceLock<Option<Vec<u8>>>,
+    /// Lazily repacked Q8_0 weight (`k_quants::BlockQ8_0x4` bytes) for the
+    /// aarch64 GEMM/GEMV paths; same lifetime/caching scheme as `repacked_qs`.
+    #[allow(dead_code)]
+    repacked_q8_0: OnceLock<Option<Vec<u8>>>,
 }
 
 impl Device {
@@ -537,6 +541,7 @@ impl QTensor {
             storage,
             shape,
             repacked_qs: OnceLock::new(),
+            repacked_q8_0: OnceLock::new(),
         })
     }
 
@@ -558,6 +563,7 @@ impl QTensor {
             storage,
             shape: shape.clone(),
             repacked_qs: OnceLock::new(),
+            repacked_q8_0: OnceLock::new(),
         })
     }
 
@@ -594,6 +600,7 @@ impl QTensor {
             storage,
             shape: shape.clone(),
             repacked_qs: OnceLock::new(),
+            repacked_q8_0: OnceLock::new(),
         })
     }
 
@@ -638,6 +645,7 @@ impl QTensor {
             storage,
             shape: shape.clone(),
             repacked_qs: OnceLock::new(),
+            repacked_q8_0: OnceLock::new(),
         })
     }
 
@@ -667,6 +675,7 @@ impl QTensor {
             storage,
             shape: shape.clone(),
             repacked_qs: OnceLock::new(),
+            repacked_q8_0: OnceLock::new(),
         })
     }
 
@@ -965,6 +974,40 @@ impl crate::CustomOp1 for QTensor {
                             block_x8,
                             &mut dst_storage,
                         )?;
+                        return Ok((crate::CpuStorage::F32(dst_storage), dst_shape));
+                    }
+                }
+
+                // Packed Q8_0 (block_q8_0x4): lane-broadcast SDOT GEMM/GEMV, the
+                // llama.cpp aarch64 online-repack equivalent. Serves all m.
+                #[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
+                if self_storage.dtype() == GgmlDType::Q8_0 && n.is_multiple_of(4) {
+                    use zerocopy::{FromBytes, IntoBytes};
+
+                    let total_blocks =
+                        self_storage.storage_size_in_bytes() / std::mem::size_of::<BlockQ8_0>();
+                    let repacked = self.repacked_q8_0.get_or_init(|| {
+                        let blocks = unsafe {
+                            std::slice::from_raw_parts(
+                                self_storage.as_ptr() as *const BlockQ8_0,
+                                total_blocks,
+                            )
+                        };
+                        Some(k_quants::repack_q8_0_weight(blocks, n).as_bytes().to_vec())
+                    });
+                    if let Some(bytes) = repacked {
+                        let packed: &[BlockQ8_0x4] = <[BlockQ8_0x4]>::ref_from_bytes(bytes)
+                            .map_err(|_| {
+                                crate::Error::Msg(
+                                    "repacked_q8_0 alignment invariant violated".to_string(),
+                                )
+                            })?;
+                        k_quants::matmul_q8_0x4(
+                            (dst_shape.elem_count() / n, k, n),
+                            slice,
+                            packed,
+                            &mut dst_storage,
+                        );
                         return Ok((crate::CpuStorage::F32(dst_storage), dst_shape));
                     }
                 }

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -63,8 +63,8 @@ pub struct QTensor {
     /// Not always used.
     #[allow(dead_code)]
     repacked_qs: OnceLock<Option<Vec<u8>>>,
-    /// Lazily repacked Q8_0 weight (`k_quants::BlockQ8_0x4` bytes) for the
-    /// aarch64 GEMM/GEMV paths; same lifetime/caching scheme as `repacked_qs`.
+    /// Lazily repacked Q8_0 weight (`k_quants::BlockQ8_0x4` bytes); same scheme
+    /// as `repacked_qs`.
     #[allow(dead_code)]
     repacked_q8_0: OnceLock<Option<Vec<u8>>>,
 }
@@ -978,8 +978,7 @@ impl crate::CustomOp1 for QTensor {
                     }
                 }
 
-                // Packed Q8_0 (block_q8_0x4): lane-broadcast SDOT GEMM/GEMV, the
-                // llama.cpp aarch64 online-repack equivalent. Serves all m.
+                // Packed Q8_0: lane-broadcast SDOT GEMM/GEMV (all m).
                 #[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
                 if self_storage.dtype() == GgmlDType::Q8_0 && n.is_multiple_of(4) {
                     use zerocopy::{FromBytes, IntoBytes};

--- a/candle-core/src/quantized/neon.rs
+++ b/candle-core/src/quantized/neon.rs
@@ -1328,8 +1328,7 @@ pub(crate) fn vec_dot_8_q4k_q8k(n: usize, xs: &[BlockQ4Kx8], ys: &[BlockQ8K]) ->
     out
 }
 
-// Lane-indexed SDOT (emits `sdot ... .4b[LANE]`; the std vdotq_laneq_s32 is unstable).
-// LANE selects the activation row, so one weight load feeds all 4 rows of the tile.
+// Lane-indexed SDOT (std vdotq_laneq_s32 is unstable); LANE picks the activation row.
 #[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
 #[inline(always)]
 unsafe fn vdot_laneq<const LANE: i32>(mut acc: int32x4_t, a: int8x16_t, b: int8x16_t) -> int32x4_t {
@@ -1344,13 +1343,10 @@ unsafe fn vdot_laneq<const LANE: i32>(mut acc: int32x4_t, a: int8x16_t, b: int8x
     acc
 }
 
-// ---- Packed Q8_0 (block_q8_0x4) kernels, ports of llama.cpp's
-// ggml_gemm_q8_0_4x4_q8_0 / ggml_gemv_q8_0_4x4_q8_0 (arch/arm/repack.cpp).
-// The x4 layout interleaves 4 rows in 4-byte chunks so one SDOT covers 4
-// output columns via lane broadcast; see repack::BlockQ8_0x4.
+// Packed Q8_0 kernels: ports of llama.cpp ggml_gemm/gemv_q8_0_4x4_q8_0
+// (arch/arm/repack.cpp) over the BlockQ8_0x4 layout.
 
-/// One 4-col x 4-row tile: w = 4 interleaved weight rows, a = 4 interleaved
-/// activation rows, both `nb` blocks long. out[r * 4 + c] = row r x col c.
+/// One 4x4 tile over `nb` blocks; out[r * 4 + c] = activation row r x weight col c.
 #[cfg(all(target_feature = "neon", target_feature = "dotprod"))]
 #[allow(clippy::needless_range_loop)]
 pub(crate) fn gemm_q8_0x4(w: &[BlockQ8_0x4], a: &[BlockQ8_0x4], out: &mut [f32; 16]) {
@@ -1386,8 +1382,7 @@ pub(crate) fn gemm_q8_0x4(w: &[BlockQ8_0x4], a: &[BlockQ8_0x4], out: &mut [f32; 
     }
 }
 
-/// GEMV against one 4-col weight group: a is a plain Q8_0 activation row.
-/// out[c] = a x col c.
+/// GEMV against one 4-col weight group; out[c] = plain Q8_0 row a x col c.
 #[cfg(all(target_feature = "neon", target_feature = "dotprod"))]
 #[allow(clippy::needless_range_loop)]
 pub(crate) fn gemv_q8_0x4(w: &[BlockQ8_0x4], a: &[BlockQ8_0], out: &mut [f32; 4]) {
@@ -1423,10 +1418,9 @@ pub(crate) fn gemv_q8_0x4(w: &[BlockQ8_0x4], a: &[BlockQ8_0], out: &mut [f32; 4]
     }
 }
 
-/// NEON activation pack for the Q8_0x4 GEMM: quantize 4 rows and write the
-/// 4-byte-interleaved layout directly (port of llama ggml_quantize_mat_q8_0_4x4).
-/// Bit-identical to the scalar `BlockQ8_0::from_float` + interleave: vcvtaq
-/// rounds ties away from zero exactly like Rust `f32::round`.
+/// Quantize 4 activation rows into the interleaved layout (port of llama
+/// ggml_quantize_mat_q8_0_4x4). Bit-identical to scalar `BlockQ8_0::from_float`
+/// + interleave: vcvtaq rounds ties away from zero like `f32::round`.
 #[cfg(all(target_feature = "neon", target_feature = "dotprod"))]
 #[allow(clippy::needless_range_loop)]
 pub(crate) fn quantize_mat_q8_0x4_neon(rows: &[&[f32]; 4], out: &mut [BlockQ8_0x4]) {

--- a/candle-core/src/quantized/neon.rs
+++ b/candle-core/src/quantized/neon.rs
@@ -1,5 +1,7 @@
 #[cfg(target_feature = "dotprod")]
 use super::k_quants::BlockQ4Kx8;
+#[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
+use super::k_quants::BlockQ8_0x4;
 use super::k_quants::{
     BlockQ2K, BlockQ3K, BlockQ4K, BlockQ4_0, BlockQ5K, BlockQ6K, BlockQ8K, BlockQ8_0, QK8_0, QK_K,
 };
@@ -1324,4 +1326,137 @@ pub(crate) fn vec_dot_8_q4k_q8k(n: usize, xs: &[BlockQ4Kx8], ys: &[BlockQ8K]) ->
         vst1q_f32(out.as_mut_ptr().add(4), vacc_1);
     }
     out
+}
+
+// Lane-indexed SDOT (emits `sdot ... .4b[LANE]`; the std vdotq_laneq_s32 is unstable).
+// LANE selects the activation row, so one weight load feeds all 4 rows of the tile.
+#[cfg(all(target_arch = "aarch64", target_feature = "dotprod"))]
+#[inline(always)]
+unsafe fn vdot_laneq<const LANE: i32>(mut acc: int32x4_t, a: int8x16_t, b: int8x16_t) -> int32x4_t {
+    core::arch::asm!(
+        "sdot {acc:v}.4s, {a:v}.16b, {b:v}.4b[{lane}]",
+        acc = inout(vreg) acc,
+        a = in(vreg) a,
+        b = in(vreg) b,
+        lane = const LANE,
+        options(pure, nomem, nostack, preserves_flags),
+    );
+    acc
+}
+
+// ---- Packed Q8_0 (block_q8_0x4) kernels, ports of llama.cpp's
+// ggml_gemm_q8_0_4x4_q8_0 / ggml_gemv_q8_0_4x4_q8_0 (arch/arm/repack.cpp).
+// The x4 layout interleaves 4 rows in 4-byte chunks so one SDOT covers 4
+// output columns via lane broadcast; see repack::BlockQ8_0x4.
+
+/// One 4-col x 4-row tile: w = 4 interleaved weight rows, a = 4 interleaved
+/// activation rows, both `nb` blocks long. out[r * 4 + c] = row r x col c.
+#[cfg(all(target_feature = "neon", target_feature = "dotprod"))]
+#[allow(clippy::needless_range_loop)]
+pub(crate) fn gemm_q8_0x4(w: &[BlockQ8_0x4], a: &[BlockQ8_0x4], out: &mut [f32; 16]) {
+    use core::arch::aarch64::*;
+    debug_assert_eq!(w.len(), a.len());
+    unsafe {
+        let mut sumf: [float32x4_t; 4] = [vdupq_n_f32(0.0); 4];
+        for (wb, ab) in w.iter().zip(a.iter()) {
+            let mut sumi: [int32x4_t; 4] = [vdupq_n_s32(0); 4];
+            for j in 0..8 {
+                let bv = vld1q_s8(wb.qs.as_ptr().add(16 * j));
+                let av = vld1q_s8(ab.qs.as_ptr().add(16 * j));
+                sumi[0] = vdot_laneq::<0>(sumi[0], bv, av);
+                sumi[1] = vdot_laneq::<1>(sumi[1], bv, av);
+                sumi[2] = vdot_laneq::<2>(sumi[2], bv, av);
+                sumi[3] = vdot_laneq::<3>(sumi[3], bv, av);
+            }
+            let bd = [
+                wb.d[0].to_f32(),
+                wb.d[1].to_f32(),
+                wb.d[2].to_f32(),
+                wb.d[3].to_f32(),
+            ];
+            let bdv = vld1q_f32(bd.as_ptr());
+            for r in 0..4 {
+                let ad = ab.d[r].to_f32();
+                sumf[r] = vfmaq_f32(sumf[r], vmulq_n_f32(bdv, ad), vcvtq_f32_s32(sumi[r]));
+            }
+        }
+        for r in 0..4 {
+            vst1q_f32(out.as_mut_ptr().add(r * 4), sumf[r]);
+        }
+    }
+}
+
+/// GEMV against one 4-col weight group: a is a plain Q8_0 activation row.
+/// out[c] = a x col c.
+#[cfg(all(target_feature = "neon", target_feature = "dotprod"))]
+#[allow(clippy::needless_range_loop)]
+pub(crate) fn gemv_q8_0x4(w: &[BlockQ8_0x4], a: &[BlockQ8_0], out: &mut [f32; 4]) {
+    use core::arch::aarch64::*;
+    debug_assert_eq!(w.len(), a.len());
+    unsafe {
+        let mut acc = vdupq_n_f32(0.0);
+        for (wb, ab) in w.iter().zip(a.iter()) {
+            let a_lo = vld1q_s8(ab.qs.as_ptr());
+            let a_hi = vld1q_s8(ab.qs.as_ptr().add(16));
+
+            let mut ret = vdupq_n_s32(0);
+            ret = vdot_laneq::<0>(ret, vld1q_s8(wb.qs.as_ptr()), a_lo);
+            ret = vdot_laneq::<1>(ret, vld1q_s8(wb.qs.as_ptr().add(16)), a_lo);
+            ret = vdot_laneq::<2>(ret, vld1q_s8(wb.qs.as_ptr().add(32)), a_lo);
+            ret = vdot_laneq::<3>(ret, vld1q_s8(wb.qs.as_ptr().add(48)), a_lo);
+            ret = vdot_laneq::<0>(ret, vld1q_s8(wb.qs.as_ptr().add(64)), a_hi);
+            ret = vdot_laneq::<1>(ret, vld1q_s8(wb.qs.as_ptr().add(80)), a_hi);
+            ret = vdot_laneq::<2>(ret, vld1q_s8(wb.qs.as_ptr().add(96)), a_hi);
+            ret = vdot_laneq::<3>(ret, vld1q_s8(wb.qs.as_ptr().add(112)), a_hi);
+
+            let bd = [
+                wb.d[0].to_f32(),
+                wb.d[1].to_f32(),
+                wb.d[2].to_f32(),
+                wb.d[3].to_f32(),
+            ];
+            let bdv = vld1q_f32(bd.as_ptr());
+            let ad = ab.d.to_f32();
+            acc = vfmaq_f32(acc, vcvtq_f32_s32(ret), vmulq_n_f32(bdv, ad));
+        }
+        vst1q_f32(out.as_mut_ptr(), acc);
+    }
+}
+
+/// NEON activation pack for the Q8_0x4 GEMM: quantize 4 rows and write the
+/// 4-byte-interleaved layout directly (port of llama ggml_quantize_mat_q8_0_4x4).
+/// Bit-identical to the scalar `BlockQ8_0::from_float` + interleave: vcvtaq
+/// rounds ties away from zero exactly like Rust `f32::round`.
+#[cfg(all(target_feature = "neon", target_feature = "dotprod"))]
+#[allow(clippy::needless_range_loop)]
+pub(crate) fn quantize_mat_q8_0x4_neon(rows: &[&[f32]; 4], out: &mut [BlockQ8_0x4]) {
+    use core::arch::aarch64::*;
+    let nb = out.len();
+    unsafe {
+        for (i, dst) in out.iter_mut().enumerate() {
+            let mut srcv = [[vdupq_n_f32(0.0); 8]; 4];
+            for (r, row) in rows.iter().enumerate() {
+                debug_assert_eq!(row.len(), nb * 32);
+                let base = row.as_ptr().add(i * 32);
+                let mut amaxv = vdupq_n_f32(0.0);
+                for j in 0..8 {
+                    let v = vld1q_f32(base.add(4 * j));
+                    srcv[r][j] = v;
+                    amaxv = vmaxq_f32(amaxv, vabsq_f32(v));
+                }
+                let amax = vmaxvq_f32(amaxv);
+                let d = amax / 127.0;
+                let id = if d != 0.0 { 1.0 / d } else { 0.0 };
+                dst.d[r] = half::f16::from_f32(d);
+                for j in 0..8 {
+                    let vi = vcvtaq_s32_f32(vmulq_n_f32(srcv[r][j], id));
+                    let p = dst.qs.as_mut_ptr().add(16 * j + 4 * r);
+                    *p = vgetq_lane_s32::<0>(vi) as i8;
+                    *p.add(1) = vgetq_lane_s32::<1>(vi) as i8;
+                    *p.add(2) = vgetq_lane_s32::<2>(vi) as i8;
+                    *p.add(3) = vgetq_lane_s32::<3>(vi) as i8;
+                }
+            }
+        }
+    }
 }

--- a/candle-core/src/utils.rs
+++ b/candle-core/src/utils.rs
@@ -422,3 +422,26 @@ pub fn with_simd128() -> bool {
 pub fn with_f16c() -> bool {
     cfg!(target_feature = "f16c")
 }
+
+// Apply `f` to each `chunk`-sized disjoint sub-slice of `dst` in parallel across the
+// barrier pool. `dst.len()` must be a multiple of `chunk`.
+pub fn par_chunks_mut<U: Send>(dst: &mut [U], chunk: usize, f: impl Fn(usize, &mut [U]) + Sync) {
+    let n = dst.len() / chunk;
+    struct DstP<U>(*mut U);
+    unsafe impl<U> Sync for DstP<U> {}
+    let dp = DstP(dst.as_mut_ptr());
+    let pool = barrier_pool();
+    let n_total = pool.n_workers() + 1;
+    let cpt = n.div_ceil(n_total);
+    pool.execute(|tid| {
+        let p = &dp;
+        let start = tid * cpt;
+        if start < n {
+            let end = n.min((tid + 1) * cpt);
+            for ci in start..end {
+                let d = unsafe { std::slice::from_raw_parts_mut(p.0.add(ci * chunk), chunk) };
+                f(ci, d);
+            }
+        }
+    });
+}


### PR DESCRIPTION
Q8_0 sibling of the BlockQ4Kx8 repack from #3643, same scheme: weights are repacked once per tensor (cached on the QTensor) into llama.cpp's block_q8_0x4 layout - 4 rows interleaved in 4-byte chunks - so one SDOT consumes one activation load for 4 output columns via lane selection. The gemm (m >= 4, 4x4 tiles) and gemv kernels are ports of ggml_gemm_q8_0_4x4_q8_0 / ggml_gemv_q8_0_4x4_q8_0, plus a NEON activation pack that stays bit-identical to the scalar BlockQ8_0::from_float path.

Measured on Granite-Docling-258M (Q8_0 text + mmproj): Graviton2 (c6g): prefill pp512 1.7-1.9x (6t: 303 -> 538 t/s), decode tg128 1.3-1.65x (1t: 33 -> 54 t/s), vision encoder 1.4-1.7x; Apple M1 (4t): prefill 600 -> 938 t/s (1.56x), vision encoder step 1289 -> 880 ms, decode neutral