### PR TITLE
Add backward pass for softmax_last_dim

### DIFF
--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -432,10 +432,19 @@ impl candle::CustomOp1 for SoftmaxLastDim {
             candle::MetalStorage::new(output, device.clone(), elem_count, storage.dtype());
         Ok((newstorage, layout.shape().clone()))
     }
+
+    fn bwd(&self, _arg: &Tensor, res: &Tensor, grad_res: &Tensor) -> Result<Option<Tensor>> {
+        // Backward pass for the softmax over the last dimension.
+        // With `y = softmax(x)` (`res`) and `g = dL/dy` (`grad_res`), the Jacobian-vector
+        // product is `dL/dx = y * (g - sum(g * y, dim=-1, keepdim=true))`.
+        let sum = grad_res.mul(res)?.sum_keepdim(D::Minus1)?;
+        let grad_arg = grad_res.broadcast_sub(&sum)?.mul(res)?;
+        Ok(Some(grad_arg))
+    }
 }
 
 pub fn softmax_last_dim(xs: &Tensor) -> Result<Tensor> {
-    xs.apply_op1_no_bwd(&SoftmaxLastDim)
+    xs.apply_op1(SoftmaxLastDim)
 }
 
 #[derive(Debug, Clone)]

--- a/candle-nn/tests/ops.rs
+++ b/candle-nn/tests/ops.rs
@@ -4,7 +4,7 @@ extern crate intel_mkl_src;
 #[cfg(feature = "accelerate")]
 extern crate accelerate_src;
 
-use candle::{test_device, test_utils::to_vec3_round, Device, IndexOp, Result, Tensor};
+use candle::{test_device, test_utils::to_vec3_round, Device, IndexOp, Result, Tensor, Var, D};
 
 fn softmax(device: &Device) -> Result<()> {
     let data = &[[[3f32, 1., 4.], [1., 5., 9.]], [[2., 1., 7.], [8., 2., 8.]]];
@@ -365,6 +365,41 @@ fn sigmoid(device: &Device) -> Result<()> {
     Ok(())
 }
 
+fn softmax_last_dim_grad(device: &Device) -> Result<()> {
+    // `softmax_last_dim` is a fused custom op. Check that its backward pass propagates a
+    // gradient to its input and that the gradient matches the reference `softmax(_, D::Minus1)`
+    // path, which is built from already-differentiable primitives.
+    let data = &[[3f32, 1., 4., 1.], [5., 9., 2., 6.]];
+
+    let x = Var::new(data, device)?;
+    let x = x.as_tensor();
+    let y = candle_nn::ops::softmax_last_dim(x)?;
+    let loss = y.sqr()?.sum_all()?;
+    let grads = loss.backward()?;
+    let grad_fused = grads
+        .get(x)
+        .expect("softmax_last_dim did not propagate a gradient to its input");
+
+    let xr = Var::new(data, device)?;
+    let xr = xr.as_tensor();
+    let yr = candle_nn::ops::softmax(xr, D::Minus1)?;
+    let loss_ref = yr.sqr()?.sum_all()?;
+    let grads_ref = loss_ref.backward()?;
+    let grad_ref = grads_ref
+        .get(xr)
+        .expect("no reference gradient for softmax");
+
+    let diff = (grad_fused - grad_ref)?
+        .abs()?
+        .sum_all()?
+        .to_vec0::<f32>()?;
+    assert!(
+        diff < 1e-5,
+        "softmax_last_dim backward mismatch vs reference softmax: {diff}"
+    );
+    Ok(())
+}
+
 test_device!(ropei, ropei_cpu, ropei_gpu, ropei_metal);
 test_device!(rope, rope_cpu, rope_gpu, rope_metal);
 test_device!(rope_thd, rope_thd_cpu, rope_thd_gpu, rope_thd_metal);
@@ -380,3 +415,9 @@ test_device!(
 test_device!(layer_norm, ln_cpu, ln_gpu, ln_metal);
 test_device!(layer_norml, lnl_cpu, lnl_gpu, lnl_metal);
 test_device!(sigmoid, sigmoid_cpu, sigmoid_gpu, sigmoid_metal);
+test_device!(
+    softmax_last_dim_grad,
+    softmax_last_dim_grad_cpu,
+    softmax_last_dim_grad_gpu,
+    softmax_last_dim_grad_metal
+);


### PR DESCRIPTION
`candle_nn::ops::softmax_last_dim` is implemented as a fused `CustomOp1`, but the wrapper uses `apply_op1_no_bwd`, so the op has no backward pass. Because the usual use site is attention weights inside a model's forward pass — with the loss computed downstream — `loss.backward()` returns `Ok`, but `grads.get(var)` is `None` for any `Var` upstream of the softmax. Gradients are silently dropped.

This adds the missing `bwd` to `SoftmaxLastDim` and switches the wrapper to `apply_op1`, following how `Sigmoid` is already set up in the same file.

The gradient is the standard softmax Jacobian-vector product: with `y = softmax(x)` and `g = dL/dy`,

```
dL/dx = y * (g - sum(g * y, dim=-1, keepdim=true))
```

### Test

Added `softmax_last_dim_grad` to `candle-nn/tests/ops.rs`. It checks that (1) a gradient actually reaches the input and (2) it matches the gradient from the reference `softmax(_, D::Minus1)` path, which is built from already-differentiable primitives. On `main` the test panics (no gradient in the store); with this change it passes.

```
cargo test -p candle-nn --test ops softmax_last_dim_grad
```

Closes #3569.
