### PR TITLE
Add CUDA graph capture/replay and a graph-replay-safe decode position seam for Llama

### DIFF
--- a/candle-core/src/cuda_backend/device.rs
+++ b/candle-core/src/cuda_backend/device.rs
@@ -51,6 +51,24 @@ impl Drop for CudaGraphHtodCacheGuard {
     }
 }
 
+/// Restores cudarc's event-tracking setting when dropped.
+/// Created by [`CudaDevice::pause_event_tracking`].
+#[must_use]
+pub(crate) struct EventTrackingGuard {
+    context: Arc<cudarc::driver::CudaContext>,
+    restore_to_enabled: bool,
+}
+
+impl Drop for EventTrackingGuard {
+    fn drop(&mut self) {
+        if self.restore_to_enabled {
+            // SAFETY: re-enabling the tracking that `pause_event_tracking` disabled,
+            // restoring the context to the state it was in before the guard.
+            unsafe { self.context.enable_event_tracking() };
+        }
+    }
+}
+
 pub struct ModuleStore {
     mdls: [Option<Arc<cudarc::driver::CudaModule>>; kernels::ALL_IDS.len()],
 }
@@ -305,6 +323,36 @@ impl CudaDevice {
 
     pub fn is_event_tracking(&self) -> bool {
         self.context.is_event_tracking()
+    }
+
+    /// Disables cudarc's per-tensor CUDA-event dependency tracking for as long as
+    /// the returned guard is alive, restoring the previous setting on drop.
+    ///
+    /// candle runs cudarc in multi-stream mode, so by default every kernel launch
+    /// issues `cuStreamWaitEvent`/`cuEventRecord` against each tensor's read/write
+    /// events to order work across streams. Those event waits are illegal during
+    /// CUDA graph capture (they reference events recorded outside the capture
+    /// region) and make capture fail with `CUDA_ERROR_INVALID_VALUE`. Since a
+    /// captured graph encodes its own ordering and is replayed on a single stream,
+    /// the tracking is unnecessary while capturing.
+    ///
+    /// # Safety
+    ///
+    /// While tracking is paused the caller must not rely on event-based
+    /// cross-stream synchronization for tensors used in this scope (see
+    /// [`CudaDevice::disable_event_tracking`]). [`CudaGraph::capture`] only ever
+    /// uses this around a single-stream capture, where ordering is guaranteed by
+    /// the stream itself, so this holds.
+    pub(crate) fn pause_event_tracking(&self) -> EventTrackingGuard {
+        let was_enabled = self.context.is_event_tracking();
+        if was_enabled {
+            // SAFETY: restored to `was_enabled` when the guard is dropped.
+            unsafe { self.context.disable_event_tracking() };
+        }
+        EventTrackingGuard {
+            context: self.context.clone(),
+            restore_to_enabled: was_enabled,
+        }
     }
 
     #[cfg(all(feature = "ug", not(target_arch = "wasm32")))]

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use cudarc::driver::sys;
 
 use super::{CudaDevice, WrapErr};
-use crate::Result;
+use crate::{Context, Result};
 
 /// A captured, replayable sequence of CUDA operations.
 ///
@@ -53,7 +53,8 @@ impl CudaGraph {
             )
         }
         .result()
-        .w()?;
+        .w()
+        .context("cuStreamBeginCapture_v2 failed")?;
 
         let value = match f() {
             Ok(value) => value,
@@ -70,7 +71,8 @@ impl CudaGraph {
         let mut cu_graph: sys::CUgraph = std::ptr::null_mut();
         unsafe { sys::cuStreamEndCapture(stream.cu_stream(), &mut cu_graph) }
             .result()
-            .w()?;
+            .w()
+            .context("cuStreamEndCapture failed")?;
         if cu_graph.is_null() {
             crate::bail!("cuda graph capture recorded no operations");
         }
@@ -78,7 +80,8 @@ impl CudaGraph {
         let mut cu_graph_exec: sys::CUgraphExec = std::ptr::null_mut();
         let instantiate = unsafe { sys::cuGraphInstantiateWithFlags(&mut cu_graph_exec, cu_graph, 0) }
             .result()
-            .w();
+            .w()
+            .context("cuGraphInstantiateWithFlags failed");
         if let Err(err) = instantiate {
             let _ = unsafe { sys::cuGraphDestroy(cu_graph) };
             return Err(err);
@@ -99,6 +102,7 @@ impl CudaGraph {
         unsafe { sys::cuGraphLaunch(self.cu_graph_exec, self.stream.cu_stream()) }
             .result()
             .w()
+            .context("cuGraphLaunch failed")
     }
 }
 

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -77,7 +77,7 @@ impl CudaGraph {
                 if !cu_graph.is_null() {
                     let _ = unsafe { sys::cuGraphDestroy(cu_graph) };
                 }
-                return Err(err);
+                return Err(err).context("operation inside cuda graph capture closure failed");
             }
         };
 
@@ -91,10 +91,11 @@ impl CudaGraph {
         }
 
         let mut cu_graph_exec: sys::CUgraphExec = std::ptr::null_mut();
-        let instantiate = unsafe { sys::cuGraphInstantiateWithFlags(&mut cu_graph_exec, cu_graph, 0) }
-            .result()
-            .w()
-            .context("cuGraphInstantiateWithFlags failed");
+        let instantiate =
+            unsafe { sys::cuGraphInstantiateWithFlags(&mut cu_graph_exec, cu_graph, 0) }
+                .result()
+                .w()
+                .context("cuGraphInstantiateWithFlags failed");
         if let Err(err) = instantiate {
             let _ = unsafe { sys::cuGraphDestroy(cu_graph) };
             return Err(err);

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -34,6 +34,14 @@ impl CudaGraph {
     /// constants are served from a cache (see
     /// [`CudaDevice::enable_cuda_graph_htod_cache`]) since a fresh upload
     /// cannot be recorded as a replayable graph node.
+    ///
+    /// Callers must run the same operations `f` will perform at least once,
+    /// outside of capture, before calling this function. That warm-up run
+    /// JIT-loads any CUDA modules the operations need and populates the
+    /// host-to-device upload cache; both module loading and uncached uploads
+    /// are disallowed once capture starts and invalidate the capture
+    /// (`CUDA_ERROR_STREAM_CAPTURE_INVALIDATED`) if attempted while it is
+    /// active.
     pub fn capture<T>(device: &CudaDevice, f: impl FnOnce() -> Result<T>) -> Result<(Self, T)> {
         let stream = device.cuda_stream();
         let _cache_guard = device.enable_cuda_graph_htod_cache();

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -45,6 +45,12 @@ impl CudaGraph {
     pub fn capture<T>(device: &CudaDevice, f: impl FnOnce() -> Result<T>) -> Result<(Self, T)> {
         let stream = device.cuda_stream();
         let _cache_guard = device.enable_cuda_graph_htod_cache();
+        // candle drives cudarc in multi-stream mode, so each kernel launch would
+        // otherwise emit cuStreamWaitEvent/cuEventRecord against the tensors'
+        // dependency-tracking events. Those event waits reference events recorded
+        // outside the capture region and make capture fail with
+        // CUDA_ERROR_INVALID_VALUE, so pause event tracking for the capture.
+        let _event_tracking_guard = device.pause_event_tracking();
 
         unsafe {
             sys::cuStreamBeginCapture_v2(

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -42,6 +42,13 @@ impl CudaGraph {
     /// are disallowed once capture starts and invalidate the capture
     /// (`CUDA_ERROR_STREAM_CAPTURE_INVALIDATED`) if attempted while it is
     /// active.
+    ///
+    /// Any buffer whose contents you need to read between replays must be
+    /// allocated *before* capture and written in place by `f` (e.g. via
+    /// `Tensor::slice_set`). A tensor allocated *inside* `f` becomes a
+    /// graph-owned allocation node whose device memory is only valid while the
+    /// graph is executing, so reading it outside of a replay fails with
+    /// `CUDA_ERROR_INVALID_VALUE`.
     pub fn capture<T>(device: &CudaDevice, f: impl FnOnce() -> Result<T>) -> Result<(Self, T)> {
         let stream = device.cuda_stream();
         let _cache_guard = device.enable_cuda_graph_htod_cache();

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -1,0 +1,111 @@
+//! CUDA Graph capture and replay.
+//!
+//! During autoregressive decoding the same fixed-shape sequence of kernels is
+//! launched once per generated token, and per-kernel launch overhead can
+//! dominate once the model is small relative to the GPU. [`CudaGraph`] lets
+//! that sequence be captured once and replayed with a single `cuGraphLaunch`
+//! call instead of relaunching every individual kernel.
+use std::sync::Arc;
+
+use cudarc::driver::sys;
+
+use super::{CudaDevice, WrapErr};
+use crate::Result;
+
+/// A captured, replayable sequence of CUDA operations.
+///
+/// Build one with [`CudaGraph::capture`], then call [`CudaGraph::replay`] as
+/// many times as needed. The shapes and buffer addresses touched by the
+/// captured closure must stay the same across replays: a CUDA graph records
+/// the exact kernel launches and memory addresses used during capture, it
+/// does not re-derive them.
+pub struct CudaGraph {
+    cu_graph: sys::CUgraph,
+    cu_graph_exec: sys::CUgraphExec,
+    stream: Arc<cudarc::driver::CudaStream>,
+}
+
+impl CudaGraph {
+    /// Captures the CUDA operations issued by `f` on `device`'s stream.
+    ///
+    /// `f` is run exactly once, with the stream in capture mode so that the
+    /// kernels it launches are recorded into a graph rather than executed
+    /// immediately. While capturing, host-to-device uploads of small
+    /// constants are served from a cache (see
+    /// [`CudaDevice::enable_cuda_graph_htod_cache`]) since a fresh upload
+    /// cannot be recorded as a replayable graph node.
+    pub fn capture<T>(device: &CudaDevice, f: impl FnOnce() -> Result<T>) -> Result<(Self, T)> {
+        let stream = device.cuda_stream();
+        let _cache_guard = device.enable_cuda_graph_htod_cache();
+
+        unsafe {
+            sys::cuStreamBeginCapture_v2(
+                stream.cu_stream(),
+                sys::CUstreamCaptureMode::CU_STREAM_CAPTURE_MODE_THREAD_LOCAL,
+            )
+        }
+        .result()
+        .w()?;
+
+        let value = match f() {
+            Ok(value) => value,
+            Err(err) => {
+                let mut cu_graph: sys::CUgraph = std::ptr::null_mut();
+                let _ = unsafe { sys::cuStreamEndCapture(stream.cu_stream(), &mut cu_graph) };
+                if !cu_graph.is_null() {
+                    let _ = unsafe { sys::cuGraphDestroy(cu_graph) };
+                }
+                return Err(err);
+            }
+        };
+
+        let mut cu_graph: sys::CUgraph = std::ptr::null_mut();
+        unsafe { sys::cuStreamEndCapture(stream.cu_stream(), &mut cu_graph) }
+            .result()
+            .w()?;
+        if cu_graph.is_null() {
+            crate::bail!("cuda graph capture recorded no operations");
+        }
+
+        let mut cu_graph_exec: sys::CUgraphExec = std::ptr::null_mut();
+        let instantiate = unsafe { sys::cuGraphInstantiateWithFlags(&mut cu_graph_exec, cu_graph, 0) }
+            .result()
+            .w();
+        if let Err(err) = instantiate {
+            let _ = unsafe { sys::cuGraphDestroy(cu_graph) };
+            return Err(err);
+        }
+
+        Ok((
+            Self {
+                cu_graph,
+                cu_graph_exec,
+                stream,
+            },
+            value,
+        ))
+    }
+
+    /// Replays the captured operations on the stream they were captured on.
+    pub fn replay(&self) -> Result<()> {
+        unsafe { sys::cuGraphLaunch(self.cu_graph_exec, self.stream.cu_stream()) }
+            .result()
+            .w()
+    }
+}
+
+impl Drop for CudaGraph {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = sys::cuGraphExecDestroy(self.cu_graph_exec);
+            let _ = sys::cuGraphDestroy(self.cu_graph);
+        }
+    }
+}
+
+// SAFETY: the underlying CUgraph/CUgraphExec handles are only ever
+// dereferenced through the CUDA driver API while holding `&self`/`&mut self`,
+// matching the thread-safety story of the other cudarc driver handles
+// (CudaStream, CudaModule, ...) that candle already shares across threads.
+unsafe impl Send for CudaGraph {}
+unsafe impl Sync for CudaGraph {}

--- a/candle-core/src/cuda_backend/graph.rs
+++ b/candle-core/src/cuda_backend/graph.rs
@@ -36,12 +36,19 @@ impl CudaGraph {
     /// cannot be recorded as a replayable graph node.
     ///
     /// Callers must run the same operations `f` will perform at least once,
-    /// outside of capture, before calling this function. That warm-up run
-    /// JIT-loads any CUDA modules the operations need and populates the
-    /// host-to-device upload cache; both module loading and uncached uploads
-    /// are disallowed once capture starts and invalidate the capture
+    /// outside of capture, before calling this function, with that warm-up
+    /// run itself wrapped in [`CudaDevice::enable_cuda_graph_htod_cache`]
+    /// (this function only holds that guard for its own call, not for
+    /// whatever warm-up the caller ran beforehand). The warm-up run JIT-loads
+    /// any CUDA modules the operations need and, under the guard, populates
+    /// the host-to-device upload cache; both module loading and uncached
+    /// uploads are disallowed once capture starts and invalidate the capture
     /// (`CUDA_ERROR_STREAM_CAPTURE_INVALIDATED`) if attempted while it is
-    /// active.
+    /// active. A warm-up run outside of the guard JIT-loads modules but
+    /// leaves the cache empty, so capture still fails on any operation that
+    /// needs an uncached host upload (e.g. a kernel launch's non-contiguous
+    /// layout parameters, or `Tensor::index_select` against a small index
+    /// tensor).
     ///
     /// Any buffer whose contents you need to read between replays must be
     /// allocated *before* capture and written in place by `f` (e.g. via

--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -17,9 +17,11 @@ use std::sync::{Arc, Mutex, OnceLock};
 pub mod cudnn;
 mod device;
 mod error;
+mod graph;
 mod utils;
 pub use device::{CudaDevice, DeviceId};
 pub use error::{CudaError, WrapErr};
+pub use graph::CudaGraph;
 pub use utils::{Map1, Map1Any, Map2, Map2Any, Map2InPlace, Map3, S};
 
 type ParamCache = HashMap<(DeviceId, Vec<usize>), Arc<CudaSlice<usize>>>;

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -315,3 +315,15 @@ pub fn gemm_reduced_precision_f32() -> bool {
 /// This bool controls whether reduced precision reductions (e.g., with tf32 accumulation type) are
 /// allowed with f32 GEMMs.
 pub fn set_gemm_reduced_precision_f32(_b: bool) {}
+
+pub struct CudaGraph;
+
+impl CudaGraph {
+    pub fn capture<T>(_device: &CudaDevice, _f: impl FnOnce() -> Result<T>) -> Result<(Self, T)> {
+        Err(Error::NotCompiledWithCudaSupport)
+    }
+
+    pub fn replay(&self) -> Result<()> {
+        Err(Error::NotCompiledWithCudaSupport)
+    }
+}

--- a/candle-core/src/lib.rs
+++ b/candle-core/src/lib.rs
@@ -116,7 +116,7 @@ pub use cuda_backend as cuda;
 #[cfg(not(feature = "cuda"))]
 pub use dummy_cuda_backend as cuda;
 
-pub use cuda::{CudaDevice, CudaStorage};
+pub use cuda::{CudaDevice, CudaGraph, CudaStorage};
 
 #[cfg(feature = "metal")]
 pub use metal_backend::{MetalDevice, MetalError, MetalStorage};

--- a/candle-core/tests/cuda_graph_tests.rs
+++ b/candle-core/tests/cuda_graph_tests.rs
@@ -15,6 +15,11 @@ fn capture_and_replay_decode_step() -> Result<()> {
     let rhs = Tensor::ones((4, 4), candle_core::DType::F32, &device)?;
     let mut out = Tensor::zeros((4, 4), candle_core::DType::F32, &device)?;
 
+    // Warm-up run outside of capture: JIT-loads the multiply kernel's module so that
+    // capture only ever records already-loaded kernel launches (see CudaGraph::capture).
+    out = (&lhs * &rhs)?;
+    device.synchronize()?;
+
     let (graph, ()) = CudaGraph::capture(cuda_device, || {
         out = (&lhs * &rhs)?;
         Ok(())

--- a/candle-core/tests/cuda_graph_tests.rs
+++ b/candle-core/tests/cuda_graph_tests.rs
@@ -1,6 +1,15 @@
 #![cfg(feature = "cuda")]
-use candle_core::{CudaGraph, Device, Result, Tensor};
+use candle_core::{CudaGraph, DType, Device, Result, Tensor};
 
+// Captures a small "decode step" (an elementwise multiply written into a
+// persistent output buffer) and checks that replaying the graph reproduces it.
+//
+// The output buffer `out` is allocated *before* capture and written in place
+// with `slice_set`, so the captured graph only records kernel launches and a
+// device-to-device copy into already-existing memory. Allocating the result
+// *inside* capture would instead make it a graph-owned allocation node whose
+// memory is only valid while the graph runs, which is not what a decode loop
+// wants (and cannot be read back between replays).
 #[test]
 fn capture_and_replay_decode_step() -> Result<()> {
     let device = match Device::new_cuda(0) {
@@ -12,23 +21,39 @@ fn capture_and_replay_decode_step() -> Result<()> {
     };
 
     let lhs = Tensor::arange(0f32, 16f32, &device)?.reshape((4, 4))?;
-    let rhs = Tensor::ones((4, 4), candle_core::DType::F32, &device)?;
-    let mut out = Tensor::zeros((4, 4), candle_core::DType::F32, &device)?;
+    let rhs = Tensor::ones((4, 4), DType::F32, &device)?;
+    let zeros = Tensor::zeros((4, 4), DType::F32, &device)?;
+    let out = Tensor::zeros((4, 4), DType::F32, &device)?;
 
-    // Warm-up run outside of capture: JIT-loads the multiply kernel's module so that
-    // capture only ever records already-loaded kernel launches (see CudaGraph::capture).
-    out = (&lhs * &rhs)?;
+    // Warm-up run outside of capture: JIT-loads the multiply and copy kernels so
+    // that capture only ever records already-loaded launches (see
+    // CudaGraph::capture), then reset `out` back to zeros.
+    let tmp = (&lhs * &rhs)?;
+    out.slice_set(&tmp, 0, 0)?;
+    out.slice_set(&zeros, 0, 0)?;
     device.synchronize()?;
 
+    // Before replay the captured work has not run, so `out` is still zeros.
+    let before = out.to_vec2::<f32>()?;
+    assert_eq!(before, vec![vec![0f32; 4]; 4]);
+
     let (graph, ()) = CudaGraph::capture(cuda_device, || {
-        out = (&lhs * &rhs)?;
+        let tmp = (&lhs * &rhs)?;
+        out.slice_set(&tmp, 0, 0)?;
         Ok(())
     })?;
 
-    let before = out.to_vec2::<f32>()?;
+    // Capture records but does not execute, so `out` is unchanged until replay.
+    assert_eq!(out.to_vec2::<f32>()?, vec![vec![0f32; 4]; 4]);
+
     graph.replay()?;
+    device.synchronize()?;
     let after = out.to_vec2::<f32>()?;
-    assert_eq!(before, after);
     assert_eq!(after, lhs.to_vec2::<f32>()?);
+
+    // Replaying again is idempotent for this graph.
+    graph.replay()?;
+    device.synchronize()?;
+    assert_eq!(out.to_vec2::<f32>()?, lhs.to_vec2::<f32>()?);
     Ok(())
 }

--- a/candle-core/tests/cuda_graph_tests.rs
+++ b/candle-core/tests/cuda_graph_tests.rs
@@ -1,0 +1,29 @@
+#![cfg(feature = "cuda")]
+use candle_core::{CudaGraph, Device, Result, Tensor};
+
+#[test]
+fn capture_and_replay_decode_step() -> Result<()> {
+    let device = match Device::new_cuda(0) {
+        Ok(device) => device,
+        Err(_) => return Ok(()),
+    };
+    let Device::Cuda(cuda_device) = &device else {
+        unreachable!()
+    };
+
+    let lhs = Tensor::arange(0f32, 16f32, &device)?.reshape((4, 4))?;
+    let rhs = Tensor::ones((4, 4), candle_core::DType::F32, &device)?;
+    let mut out = Tensor::zeros((4, 4), candle_core::DType::F32, &device)?;
+
+    let (graph, ()) = CudaGraph::capture(cuda_device, || {
+        out = (&lhs * &rhs)?;
+        Ok(())
+    })?;
+
+    let before = out.to_vec2::<f32>()?;
+    graph.replay()?;
+    let after = out.to_vec2::<f32>()?;
+    assert_eq!(before, after);
+    assert_eq!(after, lhs.to_vec2::<f32>()?);
+    Ok(())
+}

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -142,11 +142,123 @@ impl Config {
     }
 }
 
+/// Physical KV storage and per-sequence block table for paged attention.
+///
+/// Constructed and owned by the caller (e.g. an external block allocator/eviction
+/// engine such as a vLLM-style scheduler). `key_cache`/`value_cache` must be
+/// contiguous: the model writes the newly computed K/V for the current forward
+/// pass into the slots designated by `block_table`, then reads the full paged
+/// history back through
+/// [`candle_flash_attn::flash_attn_varlen_paged_windowed`]. `block_table` and
+/// `seqlens_k` are read-only from the model's perspective — the caller owns
+/// block allocation, eviction, and keeping them in sync with what it wants
+/// written. One `PagedKvCache` covers a single transformer layer; attach one per
+/// layer via [`Cache::set_paged_kv`].
+#[derive(Debug, Clone)]
+pub struct PagedKvCache {
+    /// `(num_blocks, page_block_size, num_kv_heads, head_dim)`, contiguous.
+    pub key_cache: Tensor,
+    /// `(num_blocks, page_block_size, num_kv_heads, head_dim)`, contiguous.
+    pub value_cache: Tensor,
+    /// `(batch_size, max_blocks)`, physical block ids per sequence.
+    pub block_table: Tensor,
+    /// `(batch_size + 1,)`, cumulative sequence lengths (including the tokens
+    /// about to be written by this forward pass), used to drive the varlen kernel.
+    pub seqlens_k: Tensor,
+    pub page_block_size: usize,
+}
+
+impl PagedKvCache {
+    /// Scatters the newly computed K/V (shape `(b_sz, num_kv_heads, seq_len,
+    /// head_dim)`) into `key_cache`/`value_cache` at the physical slots that
+    /// `block_table` designates for absolute positions
+    /// `index_pos..index_pos+seq_len`.
+    fn write_new_kv(&self, k: &Tensor, v: &Tensor, index_pos: usize) -> Result<()> {
+        if !self.key_cache.is_contiguous() || !self.value_cache.is_contiguous() {
+            candle::bail!("PagedKvCache key_cache/value_cache must be contiguous")
+        }
+        let (b_sz, num_kv_heads, seq_len, head_dim) = k.dims4()?;
+        let (num_blocks, page_block_size, kv_heads_cache, head_dim_cache) =
+            self.key_cache.dims4()?;
+        if page_block_size != self.page_block_size {
+            candle::bail!(
+                "PagedKvCache.page_block_size ({}) does not match key_cache shape (block size {page_block_size})",
+                self.page_block_size
+            )
+        }
+        if kv_heads_cache != num_kv_heads || head_dim_cache != head_dim {
+            candle::bail!(
+                "PagedKvCache key/value cache shape {:?} is incompatible with new kv (heads={num_kv_heads}, head_dim={head_dim})",
+                self.key_cache.dims()
+            )
+        }
+        let block_table = self.block_table.to_dtype(DType::U32)?.to_vec2::<u32>()?;
+        if block_table.len() != b_sz {
+            candle::bail!(
+                "block_table batch dim ({}) does not match kv batch dim ({b_sz})",
+                block_table.len()
+            )
+        }
+        let last_pos = index_pos + seq_len - 1;
+        let mut slots = Vec::with_capacity(b_sz * seq_len);
+        for row in &block_table {
+            let max_logical_block = last_pos / self.page_block_size;
+            if max_logical_block >= row.len() {
+                candle::bail!(
+                    "block_table has {} blocks, but position {last_pos} needs logical block {max_logical_block}",
+                    row.len()
+                )
+            }
+            for t in 0..seq_len {
+                let pos = index_pos + t;
+                let logical_block = pos / self.page_block_size;
+                let offset = pos % self.page_block_size;
+                let physical_block = row[logical_block] as usize;
+                if physical_block >= num_blocks {
+                    candle::bail!(
+                        "block_table references physical block {physical_block}, but key_cache only has {num_blocks} blocks"
+                    )
+                }
+                slots.push((physical_block * self.page_block_size + offset) as u32);
+            }
+        }
+
+        let device = k.device();
+        let indices = Tensor::from_vec(slots, (b_sz * seq_len, 1, 1), device)?
+            .broadcast_as((b_sz * seq_len, num_kv_heads, head_dim))?
+            .contiguous()?;
+
+        let k_flat = k
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape((b_sz * seq_len, num_kv_heads, head_dim))?;
+        let v_flat = v
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape((b_sz * seq_len, num_kv_heads, head_dim))?;
+
+        let key_flat = self
+            .key_cache
+            .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?;
+        let value_flat = self
+            .value_cache
+            .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?;
+        key_flat.scatter_set(&indices, &k_flat, 0)?;
+        value_flat.scatter_set(&indices, &v_flat, 0)?;
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Cache {
     masks: HashMap<(usize, usize), Tensor>,
     pub use_kv_cache: bool,
     kvs: Vec<Option<(Tensor, Tensor)>>,
+    // Additive seam: caller-owned paged KV storage per transformer layer, indexed
+    // by `block_idx`. `None` (the default for every layer) preserves today's
+    // contiguous concat-and-narrow path byte-for-byte; existing callers that
+    // never touch this are entirely unaffected. See `PagedKvCache`.
+    paged_kvs: Vec<Option<PagedKvCache>>,
     cos: Tensor,
     sin: Tensor,
     device: Device,
@@ -209,10 +321,40 @@ impl Cache {
             masks: HashMap::new(),
             use_kv_cache,
             kvs: vec![None; config.num_hidden_layers],
+            paged_kvs: vec![None; config.num_hidden_layers],
             device: device.clone(),
             cos,
             sin,
         })
+    }
+
+    /// Attaches caller-owned paged KV storage for one transformer layer.
+    ///
+    /// Once set, that layer's attention routes through
+    /// `candle_flash_attn::flash_attn_varlen_paged_windowed` against the
+    /// caller-owned `key_cache`/`value_cache`/`block_table` instead of the
+    /// contiguous concat-and-narrow path. Existing callers that never call this
+    /// see no behavior change.
+    pub fn set_paged_kv(&mut self, block_idx: usize, paged: PagedKvCache) -> Result<()> {
+        let Some(slot) = self.paged_kvs.get_mut(block_idx) else {
+            candle::bail!(
+                "block_idx {block_idx} out of range for {} layers",
+                self.paged_kvs.len()
+            )
+        };
+        *slot = Some(paged);
+        Ok(())
+    }
+
+    /// Reverts a layer to the contiguous KV cache path.
+    pub fn clear_paged_kv(&mut self, block_idx: usize) {
+        if let Some(slot) = self.paged_kvs.get_mut(block_idx) {
+            *slot = None;
+        }
+    }
+
+    pub fn paged_kv(&self, block_idx: usize) -> Option<&PagedKvCache> {
+        self.paged_kvs.get(block_idx).and_then(|p| p.as_ref())
     }
 
     fn mask(&mut self, seq_len: usize, index_pos: usize) -> Result<Tensor> {
@@ -258,6 +400,55 @@ fn flash_attn(_: &Tensor, _: &Tensor, _: &Tensor, _: f32, _: bool) -> Result<Ten
     unimplemented!("compile with '--features flash-attn'")
 }
 
+#[cfg(feature = "flash-attn")]
+#[allow(clippy::too_many_arguments)]
+fn flash_attn_varlen_paged(
+    q: &Tensor,
+    key_cache: &Tensor,
+    value_cache: &Tensor,
+    seqlens_q: &Tensor,
+    seqlens_k: &Tensor,
+    block_table: &Tensor,
+    max_seqlen_q: usize,
+    max_seqlen_k: usize,
+    softmax_scale: f32,
+    page_block_size: usize,
+) -> Result<Tensor> {
+    candle_flash_attn::flash_attn_varlen_paged_windowed(
+        q,
+        key_cache,
+        value_cache,
+        seqlens_q,
+        seqlens_k,
+        block_table,
+        None,
+        max_seqlen_q,
+        max_seqlen_k,
+        softmax_scale,
+        None,
+        Some(0),
+        page_block_size,
+        None,
+    )
+}
+
+#[cfg(not(feature = "flash-attn"))]
+#[allow(clippy::too_many_arguments)]
+fn flash_attn_varlen_paged(
+    _: &Tensor,
+    _: &Tensor,
+    _: &Tensor,
+    _: &Tensor,
+    _: &Tensor,
+    _: &Tensor,
+    _: usize,
+    _: usize,
+    _: f32,
+    _: usize,
+) -> Result<Tensor> {
+    unimplemented!("compile with '--features flash-attn'")
+}
+
 impl CausalSelfAttention {
     fn apply_rotary_emb(&self, x: &Tensor, index_pos: usize, cache: &Cache) -> Result<Tensor> {
         let _enter = self.span_rot.enter();
@@ -294,6 +485,11 @@ impl CausalSelfAttention {
 
         let q = self.apply_rotary_emb(&q, index_pos, cache)?;
         let mut k = self.apply_rotary_emb(&k, index_pos, cache)?;
+
+        if let Some(paged) = cache.paged_kv(block_idx) {
+            let v = v.contiguous()?;
+            return self.forward_paged(&q, &k, &v, index_pos, b_sz, seq_len, hidden_size, paged);
+        }
 
         if cache.use_kv_cache {
             if let Some((cache_k, cache_v)) = &cache.kvs[block_idx] {
@@ -357,6 +553,53 @@ impl CausalSelfAttention {
 
     fn repeat_kv(&self, x: Tensor) -> Result<Tensor> {
         crate::utils::repeat_kv(x, self.num_attention_heads / self.num_key_value_heads)
+    }
+
+    /// Writes the current forward pass' K/V into the caller-owned paged cache,
+    /// then attends over the full paged history via
+    /// `candle_flash_attn::flash_attn_varlen_paged_windowed`. `q`, `k`, `v` are
+    /// `(b_sz, heads, seq_len, head_dim)`, post-RoPE for `q`/`k`.
+    #[allow(clippy::too_many_arguments)]
+    fn forward_paged(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        index_pos: usize,
+        b_sz: usize,
+        seq_len: usize,
+        hidden_size: usize,
+        paged: &PagedKvCache,
+    ) -> Result<Tensor> {
+        paged.write_new_kv(k, v, index_pos)?;
+
+        let q = q
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape((b_sz * seq_len, self.num_attention_heads, self.head_dim))?;
+        let seqlens_q = Tensor::new(
+            (0..=b_sz)
+                .map(|i| (i * seq_len) as u32)
+                .collect::<Vec<_>>(),
+            q.device(),
+        )?;
+        let max_seqlen_k = paged.block_table.dim(1)? * paged.page_block_size;
+        let softmax_scale = 1f32 / (self.head_dim as f32).sqrt();
+
+        let y = flash_attn_varlen_paged(
+            &q,
+            &paged.key_cache,
+            &paged.value_cache,
+            &seqlens_q,
+            &paged.seqlens_k,
+            &paged.block_table,
+            seq_len,
+            max_seqlen_k,
+            softmax_scale,
+            paged.page_block_size,
+        )?
+        .reshape((b_sz, seq_len, hidden_size))?;
+        self.o_proj.forward(&y)
     }
 
     fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
@@ -530,5 +773,290 @@ impl Llama {
             ln_f,
             lm_head,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tiny_config() -> Config {
+        Config {
+            hidden_size: 4,
+            intermediate_size: 4,
+            vocab_size: 8,
+            num_hidden_layers: 1,
+            num_attention_heads: 2,
+            num_key_value_heads: 2,
+            use_flash_attn: false,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10_000.0,
+            bos_token_id: None,
+            eos_token_id: None,
+            rope_scaling: None,
+            max_position_embeddings: 16,
+            tie_word_embeddings: false,
+        }
+    }
+
+    // Distinct from `tiny_config()` above: uses 2 layers so paged-cache tests can
+    // exercise per-layer attach/detach independently.
+    fn paged_test_config() -> Config {
+        Config {
+            num_hidden_layers: 2,
+            ..tiny_config()
+        }
+    }
+
+    #[test]
+    fn paged_kv_seam_is_additive_by_default() -> Result<()> {
+        let device = Device::Cpu;
+        let cfg = paged_test_config();
+        let cache = Cache::new(true, DType::F32, &cfg, &device)?;
+        // Every layer defaults to the contiguous path: nothing to opt into paged
+        // attention unless a caller explicitly attaches a `PagedKvCache`.
+        for block_idx in 0..cfg.num_hidden_layers {
+            assert!(cache.paged_kv(block_idx).is_none());
+        }
+        assert!(cache.use_kv_cache);
+        Ok(())
+    }
+
+    #[test]
+    fn set_and_clear_paged_kv() -> Result<()> {
+        let device = Device::Cpu;
+        let cfg = paged_test_config();
+        let mut cache = Cache::new(true, DType::F32, &cfg, &device)?;
+
+        let num_blocks = 2;
+        let page_block_size = 4;
+        let num_kv_heads = 1;
+        let head_dim = 2;
+        let paged = PagedKvCache {
+            key_cache: Tensor::zeros(
+                (num_blocks, page_block_size, num_kv_heads, head_dim),
+                DType::F32,
+                &device,
+            )?,
+            value_cache: Tensor::zeros(
+                (num_blocks, page_block_size, num_kv_heads, head_dim),
+                DType::F32,
+                &device,
+            )?,
+            block_table: Tensor::from_vec(vec![0u32, 1u32], (1, 2), &device)?,
+            seqlens_k: Tensor::new(&[0u32, 4u32], &device)?,
+            page_block_size,
+        };
+        cache.set_paged_kv(0, paged)?;
+        assert!(cache.paged_kv(0).is_some());
+        assert!(cache.paged_kv(1).is_none());
+
+        cache.clear_paged_kv(0);
+        assert!(cache.paged_kv(0).is_none());
+
+        // Out-of-range layers are rejected rather than silently ignored.
+        let paged = PagedKvCache {
+            key_cache: Tensor::zeros(
+                (num_blocks, page_block_size, num_kv_heads, head_dim),
+                DType::F32,
+                &device,
+            )?,
+            value_cache: Tensor::zeros(
+                (num_blocks, page_block_size, num_kv_heads, head_dim),
+                DType::F32,
+                &device,
+            )?,
+            block_table: Tensor::from_vec(vec![0u32, 1u32], (1, 2), &device)?,
+            seqlens_k: Tensor::new(&[0u32, 4u32], &device)?,
+            page_block_size,
+        };
+        assert!(cache.set_paged_kv(cfg.num_hidden_layers, paged).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn paged_kv_cache_writes_land_in_the_slots_the_block_table_designates() -> Result<()> {
+        let device = Device::Cpu;
+        // 2 physical blocks of 4 slots each, 1 kv head, head_dim 2.
+        let num_blocks = 2;
+        let page_block_size = 4;
+        let num_kv_heads = 1;
+        let head_dim = 2;
+        let key_cache = Tensor::zeros(
+            (num_blocks, page_block_size, num_kv_heads, head_dim),
+            DType::F32,
+            &device,
+        )?;
+        let value_cache = Tensor::zeros(
+            (num_blocks, page_block_size, num_kv_heads, head_dim),
+            DType::F32,
+            &device,
+        )?;
+        // Logical block 0 -> physical block 1, logical block 1 -> physical block 0.
+        let block_table = Tensor::from_vec(vec![1u32, 0u32], (1, 2), &device)?;
+        let paged = PagedKvCache {
+            key_cache: key_cache.clone(),
+            value_cache: value_cache.clone(),
+            block_table,
+            seqlens_k: Tensor::new(&[0u32, 5u32], &device)?,
+            page_block_size,
+        };
+
+        // 3 new tokens at absolute positions 2, 3, 4 (b_sz=1).
+        // pos 2 -> logical block 0, offset 2 -> physical slot 1*4+2 = 6
+        // pos 3 -> logical block 0, offset 3 -> physical slot 1*4+3 = 7
+        // pos 4 -> logical block 1, offset 0 -> physical slot 0*4+0 = 0
+        let index_pos = 2;
+        let seq_len = 3;
+        let k = Tensor::from_vec(
+            vec![10f32, 11., 20., 21., 30., 31.],
+            (1, num_kv_heads, seq_len, head_dim),
+            &device,
+        )?;
+        let v = Tensor::from_vec(
+            vec![-10f32, -11., -20., -21., -30., -31.],
+            (1, num_kv_heads, seq_len, head_dim),
+            &device,
+        )?;
+
+        paged.write_new_kv(&k, &v, index_pos)?;
+
+        let key_flat = paged
+            .key_cache
+            .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?
+            .i((.., 0, ..))?
+            .to_vec2::<f32>()?;
+        let value_flat = paged
+            .value_cache
+            .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?
+            .i((.., 0, ..))?
+            .to_vec2::<f32>()?;
+
+        assert_eq!(key_flat[6], [10., 11.]);
+        assert_eq!(key_flat[7], [20., 21.]);
+        assert_eq!(key_flat[0], [30., 31.]);
+        assert_eq!(value_flat[6], [-10., -11.]);
+        assert_eq!(value_flat[7], [-20., -21.]);
+        assert_eq!(value_flat[0], [-30., -31.]);
+
+        // Untouched slots stay zero.
+        for slot in [1, 2, 3, 4, 5] {
+            assert_eq!(key_flat[slot], [0., 0.]);
+            assert_eq!(value_flat[slot], [0., 0.]);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn paged_kv_cache_rejects_block_table_overflow() -> Result<()> {
+        let device = Device::Cpu;
+        let num_blocks = 1;
+        let page_block_size = 2;
+        let num_kv_heads = 1;
+        let head_dim = 2;
+        let paged = PagedKvCache {
+            key_cache: Tensor::zeros(
+                (num_blocks, page_block_size, num_kv_heads, head_dim),
+                DType::F32,
+                &device,
+            )?,
+            value_cache: Tensor::zeros(
+                (num_blocks, page_block_size, num_kv_heads, head_dim),
+                DType::F32,
+                &device,
+            )?,
+            // Only one logical block available.
+            block_table: Tensor::from_vec(vec![0u32], (1, 1), &device)?,
+            seqlens_k: Tensor::new(&[0u32, 2u32], &device)?,
+            page_block_size,
+        };
+        // Position 2 needs logical block 1, which doesn't exist in the table.
+        let k = Tensor::zeros((1, num_kv_heads, 1, head_dim), DType::F32, &device)?;
+        let v = Tensor::zeros((1, num_kv_heads, 1, head_dim), DType::F32, &device)?;
+        assert!(paged.write_new_kv(&k, &v, 2).is_err());
+        Ok(())
+    }
+
+    // Requires a CUDA device and the `flash-attn` feature (which compiles the real
+    // `flash_attn_varlen_paged_windowed` kernel); not runnable on the CPU-only sandbox
+    // this crate is normally developed in. Exercises the actual GPU code path end to
+    // end: writes new K/V into a caller-owned paged cache and checks the attention
+    // output against the long-established dense (non-flash) causal path.
+    #[cfg(feature = "flash-attn")]
+    #[test]
+    fn paged_attention_matches_dense_causal_attention_on_gpu() -> Result<()> {
+        let device = Device::new_cuda(0)?;
+        let dtype = DType::BF16;
+
+        let num_attention_heads = 2;
+        let num_key_value_heads = 2;
+        let head_dim = 64;
+        let hidden_size = num_attention_heads * head_dim;
+        let kv_size = num_key_value_heads * head_dim;
+        let seq_len = 17;
+        let page_block_size = 32;
+
+        let new_linear = |out_dim: usize, in_dim: usize| -> Result<Linear> {
+            let w = Tensor::randn(0f32, 0.02, (out_dim, in_dim), &device)?.to_dtype(dtype)?;
+            Ok(Linear::from_weights(w, None))
+        };
+        let attn = CausalSelfAttention {
+            q_proj: new_linear(hidden_size, hidden_size)?,
+            k_proj: new_linear(kv_size, hidden_size)?,
+            v_proj: new_linear(kv_size, hidden_size)?,
+            o_proj: new_linear(hidden_size, hidden_size)?,
+            num_attention_heads,
+            num_key_value_heads,
+            head_dim,
+            use_flash_attn: false,
+            span: tracing::span!(tracing::Level::TRACE, "attn"),
+            span_rot: tracing::span!(tracing::Level::TRACE, "attn-rot"),
+            max_position_embeddings: DEFAULT_MAX_SEQ_LEN,
+        };
+
+        let mut cfg = paged_test_config();
+        cfg.hidden_size = hidden_size;
+        cfg.num_attention_heads = num_attention_heads;
+        cfg.num_key_value_heads = num_key_value_heads;
+        cfg.num_hidden_layers = 1;
+
+        let x = Tensor::randn(0f32, 1., (1, seq_len, hidden_size), &device)?.to_dtype(dtype)?;
+
+        // Ground truth: the long-established dense (non-flash) causal softmax path.
+        let mut dense_cache = Cache::new(true, dtype, &cfg, &device)?;
+        let y_dense = attn.forward(&x, 0, 0, &mut dense_cache)?;
+
+        // Candidate: paged cache sized to hold the whole sequence in a single block,
+        // routed through `flash_attn_varlen_paged_windowed`.
+        let key_cache = Tensor::zeros(
+            (1, page_block_size, num_key_value_heads, head_dim),
+            dtype,
+            &device,
+        )?;
+        let value_cache = Tensor::zeros(
+            (1, page_block_size, num_key_value_heads, head_dim),
+            dtype,
+            &device,
+        )?;
+        let paged = PagedKvCache {
+            key_cache,
+            value_cache,
+            block_table: Tensor::from_vec(vec![0u32], (1, 1), &device)?,
+            seqlens_k: Tensor::new(&[0u32, seq_len as u32], &device)?,
+            page_block_size,
+        };
+        let mut paged_cache = Cache::new(true, dtype, &cfg, &device)?;
+        paged_cache.set_paged_kv(0, paged)?;
+        let y_paged = attn.forward(&x, 0, 0, &mut paged_cache)?;
+
+        let diff = y_dense
+            .to_dtype(DType::F32)?
+            .sub(&y_paged.to_dtype(DType::F32)?)?
+            .abs()?
+            .flatten_all()?
+            .max(0)?
+            .to_vec0::<f32>()?;
+        assert!(diff < 0.1, "paged vs dense max abs diff {diff}");
+        Ok(())
     }
 }

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -1268,10 +1268,18 @@ mod tests {
         // `out` is allocated before capture and written in place via `slice_set`,
         // per `CudaGraph::capture`'s contract: a tensor allocated inside the
         // capture closure would be a graph-owned allocation, unreadable outside
-        // replay. Warm-up run outside of capture JIT-loads the kernels `f` uses.
+        // replay. The warm-up run must itself hold `enable_cuda_graph_htod_cache`:
+        // that guard is what makes the *first* upload of a given host constant
+        // (here, `index_select`'s non-contiguous-layout parameter vector) populate
+        // the cache instead of performing a plain upload; `CudaGraph::capture` only
+        // enables the guard for its own call, so a warm-up run outside of any guard
+        // never seeds the cache, and capture then fails with a cache-miss error.
         let out = Tensor::zeros((1, 1, cfg.hidden_size), dtype, &device)?;
-        let y = attn.forward(&x, 0, 0, &mut cache)?;
-        out.slice_set(&y, 0, 0)?;
+        {
+            let _warmup_cache_guard = cuda_device.enable_cuda_graph_htod_cache();
+            let y = attn.forward(&x, 0, 0, &mut cache)?;
+            out.slice_set(&y, 0, 0)?;
+        }
         device.synchronize()?;
 
         let (graph, ()) = CudaGraph::capture(cuda_device, || {

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -259,6 +259,11 @@ pub struct Cache {
     // contiguous concat-and-narrow path byte-for-byte; existing callers that
     // never touch this are entirely unaffected. See `PagedKvCache`.
     paged_kvs: Vec<Option<PagedKvCache>>,
+    // Additive seam: caller-owned, graph-replay-safe decode-position tensor per
+    // transformer layer, indexed by `block_idx`. `None` (the default for every
+    // layer) preserves today's host-side `narrow(0, index_pos, seq_len)` rotary
+    // lookup byte-for-byte. See `Cache::set_decode_position`.
+    decode_positions: Vec<Option<Tensor>>,
     cos: Tensor,
     sin: Tensor,
     device: Device,
@@ -322,6 +327,7 @@ impl Cache {
             use_kv_cache,
             kvs: vec![None; config.num_hidden_layers],
             paged_kvs: vec![None; config.num_hidden_layers],
+            decode_positions: vec![None; config.num_hidden_layers],
             device: device.clone(),
             cos,
             sin,
@@ -355,6 +361,59 @@ impl Cache {
 
     pub fn paged_kv(&self, block_idx: usize) -> Option<&PagedKvCache> {
         self.paged_kvs.get(block_idx).and_then(|p| p.as_ref())
+    }
+
+    /// Attaches a persistent, caller-owned decode-position tensor (shape `(1,)`,
+    /// an integer dtype accepted by [`Tensor::index_select`], e.g. `DType::U32`)
+    /// for one transformer layer.
+    ///
+    /// Once set, that layer's rotary embedding lookup reads `cos`/`sin` via
+    /// [`Tensor::index_select`] against this device tensor instead of
+    /// `narrow(0, index_pos, seq_len)`. `narrow`'s offset is computed on the
+    /// host from `index_pos` and baked into the exact device pointer a CUDA
+    /// graph capture (`candle_core::CudaGraph`) would record, so replaying a
+    /// graph captured at one decode step would silently reuse that step's
+    /// rotary embeddings forever. Reading the position from a device tensor
+    /// instead keeps the captured kernel launches identical across steps: the
+    /// caller updates `position`'s *contents* in place (e.g. via
+    /// `Tensor::slice_set`) before each replay, while the tensor's
+    /// identity/address stays fixed.
+    ///
+    /// Scoped to the decode step only (`seq_len == 1`, one query token) —
+    /// `CausalSelfAttention::forward` returns an error if a layer with a
+    /// decode position attached is called with `seq_len != 1`. Prefill always
+    /// uses the existing `narrow`-based path unconditionally, so callers must
+    /// not attach a decode position before the first decode step.
+    ///
+    /// Existing callers that never call this are entirely unaffected.
+    pub fn set_decode_position(&mut self, block_idx: usize, position: Tensor) -> Result<()> {
+        let Some(slot) = self.decode_positions.get_mut(block_idx) else {
+            candle::bail!(
+                "block_idx {block_idx} out of range for {} layers",
+                self.decode_positions.len()
+            )
+        };
+        if position.dims() != [1] {
+            candle::bail!(
+                "decode position tensor must have shape (1,), got {:?}",
+                position.dims()
+            )
+        }
+        *slot = Some(position);
+        Ok(())
+    }
+
+    /// Reverts a layer to the host-side `narrow`-based rotary lookup.
+    pub fn clear_decode_position(&mut self, block_idx: usize) {
+        if let Some(slot) = self.decode_positions.get_mut(block_idx) {
+            *slot = None;
+        }
+    }
+
+    pub fn decode_position(&self, block_idx: usize) -> Option<&Tensor> {
+        self.decode_positions
+            .get(block_idx)
+            .and_then(|p| p.as_ref())
     }
 
     fn mask(&mut self, seq_len: usize, index_pos: usize) -> Result<Tensor> {
@@ -450,11 +509,32 @@ fn flash_attn_varlen_paged(
 }
 
 impl CausalSelfAttention {
-    fn apply_rotary_emb(&self, x: &Tensor, index_pos: usize, cache: &Cache) -> Result<Tensor> {
+    fn apply_rotary_emb(
+        &self,
+        x: &Tensor,
+        index_pos: usize,
+        block_idx: usize,
+        cache: &Cache,
+    ) -> Result<Tensor> {
         let _enter = self.span_rot.enter();
         let (_b_sz, _, seq_len, _hidden_size) = x.dims4()?;
-        let cos = cache.cos.narrow(0, index_pos, seq_len)?;
-        let sin = cache.sin.narrow(0, index_pos, seq_len)?;
+        let (cos, sin) = match cache.decode_position(block_idx) {
+            Some(position) => {
+                if seq_len != 1 {
+                    candle::bail!(
+                        "Cache::set_decode_position is decode-only (seq_len must be 1), got seq_len {seq_len}"
+                    )
+                }
+                (
+                    cache.cos.index_select(position, 0)?,
+                    cache.sin.index_select(position, 0)?,
+                )
+            }
+            None => (
+                cache.cos.narrow(0, index_pos, seq_len)?,
+                cache.sin.narrow(0, index_pos, seq_len)?,
+            ),
+        };
         candle_nn::rotary_emb::rope(x, &cos, &sin)
     }
 
@@ -483,8 +563,8 @@ impl CausalSelfAttention {
             .reshape((b_sz, seq_len, self.num_key_value_heads, self.head_dim))?
             .transpose(1, 2)?;
 
-        let q = self.apply_rotary_emb(&q, index_pos, cache)?;
-        let mut k = self.apply_rotary_emb(&k, index_pos, cache)?;
+        let q = self.apply_rotary_emb(&q, index_pos, block_idx, cache)?;
+        let mut k = self.apply_rotary_emb(&k, index_pos, block_idx, cache)?;
 
         if let Some(paged) = cache.paged_kv(block_idx) {
             let v = v.contiguous()?;
@@ -1060,6 +1140,102 @@ mod tests {
             .max(0)?
             .to_vec0::<f32>()?;
         assert!(diff < 0.1, "paged vs dense max abs diff {diff}");
+        Ok(())
+    }
+
+    #[test]
+    fn decode_position_seam_is_additive_by_default() -> Result<()> {
+        let device = Device::Cpu;
+        let cfg = paged_test_config();
+        let cache = Cache::new(true, DType::F32, &cfg, &device)?;
+        // Every layer defaults to the host-side narrow path: nothing changes
+        // unless a caller explicitly attaches a decode-position tensor.
+        for block_idx in 0..cfg.num_hidden_layers {
+            assert!(cache.decode_position(block_idx).is_none());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn set_and_clear_decode_position() -> Result<()> {
+        let device = Device::Cpu;
+        let cfg = paged_test_config();
+        let mut cache = Cache::new(true, DType::F32, &cfg, &device)?;
+
+        cache.set_decode_position(0, Tensor::new(&[3u32], &device)?)?;
+        assert!(cache.decode_position(0).is_some());
+        assert!(cache.decode_position(1).is_none());
+
+        cache.clear_decode_position(0);
+        assert!(cache.decode_position(0).is_none());
+
+        // Out-of-range layers are rejected rather than silently ignored.
+        assert!(cache
+            .set_decode_position(cfg.num_hidden_layers, Tensor::new(&[3u32], &device)?)
+            .is_err());
+
+        // Anything other than a single-element tensor is rejected: the seam
+        // is decode-only (one query token per layer per step).
+        assert!(cache
+            .set_decode_position(0, Tensor::new(&[3u32, 4u32], &device)?)
+            .is_err());
+        Ok(())
+    }
+
+    fn tiny_causal_self_attention(cfg: &Config, device: &Device) -> Result<CausalSelfAttention> {
+        let hidden_size = cfg.hidden_size;
+        let kv_size = (hidden_size / cfg.num_attention_heads) * cfg.num_key_value_heads;
+        let new_linear = |out_dim: usize, in_dim: usize| -> Result<Linear> {
+            let w = Tensor::randn(0f32, 0.02, (out_dim, in_dim), device)?;
+            Ok(Linear::from_weights(w, None))
+        };
+        Ok(CausalSelfAttention {
+            q_proj: new_linear(hidden_size, hidden_size)?,
+            k_proj: new_linear(kv_size, hidden_size)?,
+            v_proj: new_linear(kv_size, hidden_size)?,
+            o_proj: new_linear(hidden_size, hidden_size)?,
+            num_attention_heads: cfg.num_attention_heads,
+            num_key_value_heads: cfg.num_key_value_heads,
+            head_dim: hidden_size / cfg.num_attention_heads,
+            use_flash_attn: false,
+            span: tracing::span!(tracing::Level::TRACE, "attn"),
+            span_rot: tracing::span!(tracing::Level::TRACE, "attn-rot"),
+            max_position_embeddings: cfg.max_position_embeddings,
+        })
+    }
+
+    #[test]
+    fn decode_position_matches_narrow_based_rotary_lookup() -> Result<()> {
+        let device = Device::Cpu;
+        let cfg = tiny_config();
+        let attn = tiny_causal_self_attention(&cfg, &device)?;
+        let x = Tensor::randn(0f32, 1., (1, 1, cfg.hidden_size), &device)?;
+        let index_pos = 3;
+
+        // Baseline: today's host-side narrow-based rotary lookup.
+        let mut narrow_cache = Cache::new(false, DType::F32, &cfg, &device)?;
+        let y_narrow = attn.forward(&x, index_pos, 0, &mut narrow_cache)?;
+
+        // Candidate: device-tensor decode-position gather, same absolute position.
+        let mut gather_cache = Cache::new(false, DType::F32, &cfg, &device)?;
+        gather_cache.set_decode_position(0, Tensor::new(&[index_pos as u32], &device)?)?;
+        let y_gather = attn.forward(&x, index_pos, 0, &mut gather_cache)?;
+
+        assert_eq!(y_narrow.to_vec3::<f32>()?, y_gather.to_vec3::<f32>()?);
+        Ok(())
+    }
+
+    #[test]
+    fn decode_position_rejects_multi_token_forward() -> Result<()> {
+        let device = Device::Cpu;
+        let cfg = tiny_config();
+        let attn = tiny_causal_self_attention(&cfg, &device)?;
+        // Prefill-shaped input (seq_len > 1) must not be routed through the
+        // decode-only gather path.
+        let x = Tensor::randn(0f32, 1., (1, 3, cfg.hidden_size), &device)?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &device)?;
+        cache.set_decode_position(0, Tensor::new(&[0u32], &device)?)?;
+        assert!(attn.forward(&x, 0, 0, &mut cache).is_err());
         Ok(())
     }
 }

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -1238,4 +1238,73 @@ mod tests {
         assert!(attn.forward(&x, 0, 0, &mut cache).is_err());
         Ok(())
     }
+
+    // Requires a CUDA device (feature-gated behind flash-attn, same as the paged-
+    // attention GPU test above, since that's the GPU feature this crate's CI
+    // compiles under); not runnable on the CPU-only sandbox this crate is
+    // normally developed in. Exercises the actual property issue #12 is about:
+    // a CudaGraph capturing a decode step must replay against the *current*
+    // contents of the attached decode-position tensor, not the position that
+    // was live at capture time.
+    #[cfg(feature = "flash-attn")]
+    #[test]
+    fn decode_position_stays_correct_across_cuda_graph_replay() -> Result<()> {
+        use candle::CudaGraph;
+
+        let device = Device::new_cuda(0)?;
+        let Device::Cuda(cuda_device) = &device else {
+            unreachable!()
+        };
+        let dtype = DType::F32;
+
+        let cfg = tiny_config();
+        let attn = tiny_causal_self_attention(&cfg, &device)?;
+        let x = Tensor::randn(0f32, 1., (1, 1, cfg.hidden_size), &device)?;
+
+        let position = Tensor::new(&[0u32], &device)?;
+        let mut cache = Cache::new(false, dtype, &cfg, &device)?;
+        cache.set_decode_position(0, position.clone())?;
+
+        // `out` is allocated before capture and written in place via `slice_set`,
+        // per `CudaGraph::capture`'s contract: a tensor allocated inside the
+        // capture closure would be a graph-owned allocation, unreadable outside
+        // replay. Warm-up run outside of capture JIT-loads the kernels `f` uses.
+        let out = Tensor::zeros((1, 1, cfg.hidden_size), dtype, &device)?;
+        let y = attn.forward(&x, 0, 0, &mut cache)?;
+        out.slice_set(&y, 0, 0)?;
+        device.synchronize()?;
+
+        let (graph, ()) = CudaGraph::capture(cuda_device, || {
+            let y = attn.forward(&x, 0, 0, &mut cache)?;
+            out.slice_set(&y, 0, 0)?;
+            Ok(())
+        })?;
+
+        // Replaying at the captured position (0) must match the dense narrow-based
+        // path at position 0.
+        graph.replay()?;
+        device.synchronize()?;
+        let mut narrow_cache_0 = Cache::new(false, dtype, &cfg, &device)?;
+        let y_expected_0 = attn.forward(&x, 0, 0, &mut narrow_cache_0)?;
+        assert_eq!(out.to_vec3::<f32>()?, y_expected_0.to_vec3::<f32>()?);
+
+        // Update the position tensor's *contents* in place (its identity/address
+        // is unchanged) and replay again: the graph must pick up position 5, not
+        // silently keep replaying position 0.
+        position.slice_set(&Tensor::new(&[5u32], &device)?, 0, 0)?;
+        graph.replay()?;
+        device.synchronize()?;
+        let mut narrow_cache_5 = Cache::new(false, dtype, &cfg, &device)?;
+        let y_expected_5 = attn.forward(&x, 5, 0, &mut narrow_cache_5)?;
+        assert_eq!(out.to_vec3::<f32>()?, y_expected_5.to_vec3::<f32>()?);
+
+        // Sanity check that positions 0 and 5 actually produce different rotary
+        // embeddings; otherwise the assertions above wouldn't distinguish a
+        // graph that's still stuck on the captured position from one that isn't.
+        assert_ne!(
+            y_expected_0.to_vec3::<f32>()?,
+            y_expected_5.to_vec3::<f32>()?
+        );
+        Ok(())
+    }
 }

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -1259,7 +1259,15 @@ mod tests {
 
         let cfg = tiny_config();
         let attn = tiny_causal_self_attention(&cfg, &device)?;
-        let x = Tensor::randn(0f32, 1., (1, 1, cfg.hidden_size), &device)?;
+        let head_dim = cfg.hidden_size / cfg.num_attention_heads;
+        // Shape (b_sz, heads, seq_len=1, head_dim): what `apply_rotary_emb` sees
+        // for a single decode step's query. Capture that call directly instead
+        // of routing through the full attention `forward`: with one query
+        // attending only to itself and no cached history, softmax over a
+        // single key is trivially 1.0 and the attention *output* is
+        // position-invariant regardless of rotary correctness, so it can't
+        // distinguish a graph stuck on a stale position from a correct one.
+        let q_in = Tensor::randn(0f32, 1., (1, cfg.num_attention_heads, 1, head_dim), &device)?;
 
         let position = Tensor::new(&[0u32], &device)?;
         let mut cache = Cache::new(false, dtype, &cfg, &device)?;
@@ -1274,17 +1282,17 @@ mod tests {
         // the cache instead of performing a plain upload; `CudaGraph::capture` only
         // enables the guard for its own call, so a warm-up run outside of any guard
         // never seeds the cache, and capture then fails with a cache-miss error.
-        let out = Tensor::zeros((1, 1, cfg.hidden_size), dtype, &device)?;
+        let out = Tensor::zeros((1, cfg.num_attention_heads, 1, head_dim), dtype, &device)?;
         {
             let _warmup_cache_guard = cuda_device.enable_cuda_graph_htod_cache();
-            let y = attn.forward(&x, 0, 0, &mut cache)?;
-            out.slice_set(&y, 0, 0)?;
+            let rotated = attn.apply_rotary_emb(&q_in, 0, 0, &cache)?;
+            out.slice_set(&rotated, 0, 0)?;
         }
         device.synchronize()?;
 
         let (graph, ()) = CudaGraph::capture(cuda_device, || {
-            let y = attn.forward(&x, 0, 0, &mut cache)?;
-            out.slice_set(&y, 0, 0)?;
+            let rotated = attn.apply_rotary_emb(&q_in, 0, 0, &cache)?;
+            out.slice_set(&rotated, 0, 0)?;
             Ok(())
         })?;
 
@@ -1292,9 +1300,12 @@ mod tests {
         // path at position 0.
         graph.replay()?;
         device.synchronize()?;
-        let mut narrow_cache_0 = Cache::new(false, dtype, &cfg, &device)?;
-        let y_expected_0 = attn.forward(&x, 0, 0, &mut narrow_cache_0)?;
-        assert_eq!(out.to_vec3::<f32>()?, y_expected_0.to_vec3::<f32>()?);
+        let narrow_cache_0 = Cache::new(false, dtype, &cfg, &device)?;
+        let expected_0 = attn.apply_rotary_emb(&q_in, 0, 0, &narrow_cache_0)?;
+        assert_eq!(
+            out.flatten_all()?.to_vec1::<f32>()?,
+            expected_0.flatten_all()?.to_vec1::<f32>()?
+        );
 
         // Update the position tensor's *contents* in place (its identity/address
         // is unchanged) and replay again: the graph must pick up position 5, not
@@ -1302,16 +1313,19 @@ mod tests {
         position.slice_set(&Tensor::new(&[5u32], &device)?, 0, 0)?;
         graph.replay()?;
         device.synchronize()?;
-        let mut narrow_cache_5 = Cache::new(false, dtype, &cfg, &device)?;
-        let y_expected_5 = attn.forward(&x, 5, 0, &mut narrow_cache_5)?;
-        assert_eq!(out.to_vec3::<f32>()?, y_expected_5.to_vec3::<f32>()?);
+        let narrow_cache_5 = Cache::new(false, dtype, &cfg, &device)?;
+        let expected_5 = attn.apply_rotary_emb(&q_in, 5, 0, &narrow_cache_5)?;
+        assert_eq!(
+            out.flatten_all()?.to_vec1::<f32>()?,
+            expected_5.flatten_all()?.to_vec1::<f32>()?
+        );
 
         // Sanity check that positions 0 and 5 actually produce different rotary
         // embeddings; otherwise the assertions above wouldn't distinguish a
         // graph that's still stuck on the captured position from one that isn't.
         assert_ne!(
-            y_expected_0.to_vec3::<f32>()?,
-            y_expected_5.to_vec3::<f32>()?
+            expected_0.flatten_all()?.to_vec1::<f32>()?,
+            expected_5.flatten_all()?.to_vec1::<f32>()?
         );
         Ok(())
     }

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -228,21 +228,21 @@ impl PagedKvCache {
             .broadcast_as((b_sz * seq_len, num_kv_heads, head_dim))?
             .contiguous()?;
 
-        let k_flat = k
-            .transpose(1, 2)?
-            .contiguous()?
-            .reshape((b_sz * seq_len, num_kv_heads, head_dim))?;
-        let v_flat = v
-            .transpose(1, 2)?
-            .contiguous()?
-            .reshape((b_sz * seq_len, num_kv_heads, head_dim))?;
+        let k_flat =
+            k.transpose(1, 2)?
+                .contiguous()?
+                .reshape((b_sz * seq_len, num_kv_heads, head_dim))?;
+        let v_flat =
+            v.transpose(1, 2)?
+                .contiguous()?
+                .reshape((b_sz * seq_len, num_kv_heads, head_dim))?;
 
-        let key_flat = self
-            .key_cache
-            .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?;
-        let value_flat = self
-            .value_cache
-            .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?;
+        let key_flat =
+            self.key_cache
+                .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?;
+        let value_flat =
+            self.value_cache
+                .reshape((num_blocks * page_block_size, num_kv_heads, head_dim))?;
         key_flat.scatter_set(&indices, &k_flat, 0)?;
         value_flat.scatter_set(&indices, &v_flat, 0)?;
         Ok(())
@@ -573,14 +573,13 @@ impl CausalSelfAttention {
     ) -> Result<Tensor> {
         paged.write_new_kv(k, v, index_pos)?;
 
-        let q = q
-            .transpose(1, 2)?
-            .contiguous()?
-            .reshape((b_sz * seq_len, self.num_attention_heads, self.head_dim))?;
+        let q = q.transpose(1, 2)?.contiguous()?.reshape((
+            b_sz * seq_len,
+            self.num_attention_heads,
+            self.head_dim,
+        ))?;
         let seqlens_q = Tensor::new(
-            (0..=b_sz)
-                .map(|i| (i * seq_len) as u32)
-                .collect::<Vec<_>>(),
+            (0..=b_sz).map(|i| (i * seq_len) as u32).collect::<Vec<_>>(),
             q.device(),
         )?;
         let max_seqlen_k = paged.block_table.dim(1)? * paged.page_block_size;
@@ -1019,6 +1018,10 @@ mod tests {
         cfg.num_attention_heads = num_attention_heads;
         cfg.num_key_value_heads = num_key_value_heads;
         cfg.num_hidden_layers = 1;
+        // `paged_test_config()`'s base `max_position_embeddings` (16) is too small
+        // for this test's `seq_len` (17); the dense reference path narrows the
+        // RoPE cos/sin cache to `max_position_embeddings` rows.
+        cfg.max_position_embeddings = DEFAULT_MAX_SEQ_LEN;
 
         let x = Tensor::randn(0f32, 1., (1, seq_len, hidden_size), &device)?.to_dtype(dtype)?;
 


### PR DESCRIPTION
## Summary

Addresses #3728.

Adds two related pieces:

1. **`CudaGraph`** (`candle-core/src/cuda_backend/graph.rs`): a thin wrapper around `cuStreamBeginCapture`/`cuStreamEndCapture`/`cuGraphInstantiateWithFlags`/`cuGraphLaunch` that lets a fixed sequence of CUDA operations be captured once and replayed with a single `cuGraphLaunch` instead of relaunching every individual kernel — useful for autoregressive decoding, where the same kernel sequence runs once per generated token and per-launch overhead can dominate for small models. Host-to-device uploads of small constants during capture are served from a cache (`CudaDevice::enable_cuda_graph_htod_cache`), since a fresh upload cannot be recorded as a replayable graph node; the same guard also covers the kernel-launch parameter vectors used for non-contiguous tensor layouts. The warm-up run callers must perform before capturing (to JIT-load kernels and seed that cache) needs to be wrapped in the same guard, which is documented on `CudaGraph::capture`.

2. **`Cache::set_decode_position`** (`candle-transformers/src/models/llama.rs`): an additive seam so a decode step captured with `CudaGraph` doesn't silently go stale. Today, `CausalSelfAttention`'s rotary embedding lookup computes `cache.cos.narrow(0, index_pos, seq_len)` — a host-derived offset baked into the exact device pointer a graph capture would record. Since `index_pos` increments every decode step, replaying a graph captured at step *N* at step *N+1* would silently reuse step *N*'s rotary embeddings, a correctness bug rather than a missed optimization. `Cache::set_decode_position(block_idx, position: Tensor)` attaches a persistent, caller-owned position tensor (shape `(1,)`) per transformer layer; when attached, the rotary lookup uses `Tensor::index_select` against that device tensor instead of `narrow`. The caller updates the tensor's *contents* in place (e.g. via `Tensor::slice_set`) before each `CudaGraph::replay()`; its identity/address stays fixed, so the same captured kernel launches pick up the new position on the next replay.

Both changes are purely additive:
- `CudaGraph` is a new, independent type; nothing existing calls into it.
- `Cache::set_decode_position` defaults every layer to `None`, which preserves the existing `narrow`-based path byte-for-byte. `Cache::new` and every existing caller of `Llama::forward`/`forward_input_embed` are unaffected.

The seam is scoped to the decode step only (`seq_len == 1`, one query token); `CausalSelfAttention::forward` returns an error if a layer with a decode position attached is called with `seq_len != 1`, rather than silently doing something wrong on a misuse. Prefill (`seq_len > 1`) always uses the existing `narrow`-based path, whether or not a decode position happens to be attached.

## Test plan

- [ ] `cargo test -p candle-core --features cuda` — includes a `CudaGraph` capture/replay round-trip test (`candle-core/tests/cuda_graph_tests.rs`): captures an elementwise multiply into a persistent output buffer, checks the buffer is unchanged immediately after capture (before any replay), then that replaying it reproduces the expected result, twice.
- [ ] `cargo test -p candle-transformers` (CPU, no feature flags) — new `Cache::set_decode_position` unit tests: the seam is additive by default, `set_decode_position`/`clear_decode_position` round-trip and reject an out-of-range layer or a wrong-shaped position tensor, the `index_select`-based rotary lookup matches the existing `narrow`-based one for the same position, and a multi-token (`seq_len != 1`) call is rejected once a decode position is attached.
- [ ] `cargo test -p candle-transformers --release --features flash-attn --lib models::llama::` on a CUDA device — a dedicated GPU test captures a decode step's rotary lookup inside an actual `CudaGraph`, replays it once at the captured position, updates the attached position tensor's *contents* in place, replays again, and asserts the output tracks the new position rather than the one live at capture time (i.e. it isn't stuck on the captured value). Verified passing on real GPU hardware.
