### PR TITLE
feat(generation): min-p sampling and OpenAI-style frequency/presence penalties

### DIFF
--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! Functionality for modeling sampling strategies and logits processing in text generation
 //! with support for temperature-based sampling, top-k filtering, nucleus sampling (top-p),
-//! and combinations thereof.
+//! min-p sampling, and combinations thereof, as well as OpenAI-style frequency and presence
+//! penalties.
 use candle::{DType, Error, Result, Tensor};
 use rand::{distr::Distribution, SeedableRng};
 
@@ -13,8 +14,34 @@ pub enum Sampling {
     TopK { k: usize, temperature: f64 },
     TopP { p: f64, temperature: f64 },
     TopKThenTopP { k: usize, p: f64, temperature: f64 },
+    MinP { p: f64, temperature: f64 },
     // Note that the rng is not used for the Gumbel-Softmax sampling.
     GumbelSoftmax { temperature: f64 },
+}
+
+pub fn apply_frequency_presence_penalty(
+    logits: &Tensor,
+    context: &[u32],
+    frequency_penalty: f32,
+    presence_penalty: f32,
+) -> Result<Tensor> {
+    if frequency_penalty == 0. && presence_penalty == 0. {
+        return Ok(logits.clone());
+    }
+    let device = logits.device();
+    let dtype = logits.dtype();
+    let mut logits_v = logits.to_dtype(DType::F32)?.to_vec1::<f32>()?;
+    let mut counts = std::collections::HashMap::new();
+    for token_id in context {
+        *counts.entry(*token_id).or_insert(0u32) += 1;
+    }
+    for (token_id, count) in counts {
+        if let Some(logit) = logits_v.get_mut(token_id as usize) {
+            *logit -= frequency_penalty * count as f32 + presence_penalty;
+        }
+    }
+    let logits_len = logits_v.len();
+    Tensor::from_vec(logits_v, logits_len, device)?.to_dtype(dtype)
 }
 
 pub struct LogitsProcessor {
@@ -91,6 +118,20 @@ impl LogitsProcessor {
         }
     }
 
+    // min-p sampling keeps the tokens whose probability is at least min_p times the probability
+    // of the most likely token, then samples from the renormalized survivors.
+    fn sample_minp(&mut self, prs: &mut Vec<f32>, min_p: f32) -> Result<u32> {
+        let max_p = prs.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let threshold = min_p * max_p;
+        for p in prs.iter_mut() {
+            if *p < threshold {
+                *p = 0.0;
+            }
+        }
+        // WeightedIndex renormalizes, so there is no need to rescale the survivors.
+        self.sample_multinomial(prs)
+    }
+
     // top-k sampling samples from the k tokens with the largest probabilities.
     // then top-p sampling.
     fn sample_topk_topp(&mut self, prs: &mut Vec<f32>, top_k: usize, top_p: f32) -> Result<u32> {
@@ -151,6 +192,15 @@ impl LogitsProcessor {
             Sampling::TopKThenTopP { k, p, temperature } => {
                 let mut prs = prs(*temperature)?;
                 self.sample_topk_topp(&mut prs, *k, *p as f32)?
+            }
+            Sampling::MinP { p, temperature } => {
+                let mut prs = prs(*temperature)?;
+                if *p <= 0.0 {
+                    // A non-positive threshold keeps every token.
+                    self.sample_multinomial(&prs)?
+                } else {
+                    self.sample_minp(&mut prs, *p as f32)?
+                }
             }
         };
         Ok(next_token)

--- a/candle-transformers/tests/generation_tests.rs
+++ b/candle-transformers/tests/generation_tests.rs
@@ -1,5 +1,7 @@
 use candle::{Device, Result, Tensor};
-use candle_transformers::generation::LogitsProcessor;
+use candle_transformers::generation::{
+    apply_frequency_presence_penalty, LogitsProcessor, Sampling,
+};
 
 #[test]
 fn sample_with_zero_temperature() -> Result<()> {
@@ -52,6 +54,96 @@ fn sample_with_top_k() -> Result<()> {
     assert_eq!(token, 3);
     let token = logits_process.sample(&logits)?;
     assert_eq!(token, 2);
+    Ok(())
+}
+
+#[test]
+fn sample_with_min_p_dominant_token() -> Result<()> {
+    // Token 3 holds ~98% of the mass; with min_p = 0.5 every other token falls below
+    // 0.5 * max_prob, so sampling is deterministic whatever the seed.
+    let logits = Tensor::new(&[0.0, 0.0, 0.0, 5.0], &Device::Cpu)?;
+    for seed in [0, 42, 1337] {
+        let mut logits_process = LogitsProcessor::from_sampling(
+            seed,
+            Sampling::MinP {
+                p: 0.5,
+                temperature: 1.0,
+            },
+        );
+        assert_eq!(logits_process.sample(&logits)?, 3);
+    }
+    Ok(())
+}
+
+#[test]
+fn sample_with_min_p_filters_and_renormalizes() -> Result<()> {
+    // Probabilities are [1/7, 2/7, 4/7]. With min_p = 0.4 the threshold is 4/7 * 0.4 = 1.6/7:
+    // token 0 is filtered out, tokens 1 and 2 survive with renormalized odds 1:2.
+    let logits = Tensor::new(&[0.0, 2f32.ln(), 4f32.ln()], &Device::Cpu)?;
+    let mut logits_process = LogitsProcessor::from_sampling(
+        42,
+        Sampling::MinP {
+            p: 0.4,
+            temperature: 1.0,
+        },
+    );
+    let samples = 10000;
+    let mut counts = [0usize; 3];
+    for _ in 0..samples {
+        counts[logits_process.sample(&logits)? as usize] += 1;
+    }
+    assert_eq!(counts[0], 0, "token below the min-p threshold was sampled");
+    let ratio = counts[2] as f64 / counts[1] as f64;
+    assert!(
+        (ratio - 2.0).abs() < 0.2,
+        "renormalized odds off: {counts:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn sample_with_min_p_zero_keeps_all_tokens() -> Result<()> {
+    // p <= 0 keeps the whole distribution; every token must eventually be sampled.
+    let logits = Tensor::new(&[1.0, 1.0, 1.0, 1.0], &Device::Cpu)?;
+    let mut logits_process = LogitsProcessor::from_sampling(
+        42,
+        Sampling::MinP {
+            p: 0.0,
+            temperature: 1.0,
+        },
+    );
+    let mut seen = [false; 4];
+    for _ in 0..1000 {
+        seen[logits_process.sample(&logits)? as usize] = true;
+    }
+    assert_eq!(seen, [true; 4]);
+    Ok(())
+}
+
+#[test]
+fn frequency_presence_penalty_matches_openai_semantics() -> Result<()> {
+    let logits = Tensor::new(&[1.0f32, 1.0, 1.0, 1.0], &Device::Cpu)?;
+    // Token 2 appears twice, token 3 once.
+    let context = [2u32, 2, 3];
+    let penalized = apply_frequency_presence_penalty(&logits, &context, 0.5, 0.25)?;
+    let penalized = penalized.to_vec1::<f32>()?;
+    // logit -= frequency_penalty * count + presence_penalty
+    assert_eq!(
+        penalized,
+        [1.0, 1.0, 1.0 - (0.5 * 2.0 + 0.25), 1.0 - (0.5 + 0.25)]
+    );
+    Ok(())
+}
+
+#[test]
+fn frequency_presence_penalty_noop_and_out_of_range() -> Result<()> {
+    let logits = Tensor::new(&[0.5f32, -0.5, 2.0], &Device::Cpu)?;
+    // Zero penalties leave the logits untouched.
+    let same = apply_frequency_presence_penalty(&logits, &[0, 1, 2], 0.0, 0.0)?;
+    assert_eq!(same.to_vec1::<f32>()?, logits.to_vec1::<f32>()?);
+    // Context tokens outside the vocab are ignored rather than panicking.
+    let same = apply_frequency_presence_penalty(&logits, &[100], 1.0, 1.0)?;
+    assert_eq!(same.to_vec1::<f32>()?, logits.to_vec1::<f32>()?);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Implements #3654: `min_p` sampling and OpenAI-style frequency/presence penalties in `candle_transformers::generation` — both expected by anyone exposing an OpenAI-compatible API on top of candle.

### `Sampling::MinP { p, temperature }`

Min-p sampling ([arXiv:2407.01082](https://arxiv.org/abs/2407.01082)) keeps tokens whose probability is at least `p * max_prob`, then samples from the renormalized survivors. Wired through `LogitsProcessor::sample` like the existing TopK/TopP variants; `p <= 0` degrades gracefully to plain multinomial sampling.

```rust
let mut lp = LogitsProcessor::from_sampling(seed, Sampling::MinP { p: 0.05, temperature: 0.8 });
let next = lp.sample(&logits)?;
```

### `apply_frequency_presence_penalty`

OpenAI semantics, applied to logits before sampling:

```
logit[t] -= frequency_penalty * count(t) + presence_penalty   // for every t in context
```

Distinct from `utils::apply_repeat_penalty` (multiplicative, count-insensitive). Out-of-vocab context tokens are ignored; zero penalties are a no-op returning the input tensor. Input dtype is preserved.

```rust
let logits = apply_frequency_presence_penalty(&logits, &generated, 0.5, 0.3)?;
```

## Tests

```
cargo test -p candle-transformers --test generation_tests
```
- `sample_with_min_p_dominant_token` — deterministic across seeds when one token dominates
- `sample_with_min_p_filters_and_renormalizes` — sub-threshold token never sampled; survivor odds match the renormalized distribution over 10k draws
- `sample_with_min_p_zero_keeps_all_tokens` — `p = 0` keeps the full distribution
- `frequency_presence_penalty_matches_openai_semantics` — exact penalty arithmetic
- `frequency_presence_penalty_noop_and_out_of_range` — zero-penalty no-op, out-of-vocab ids ignored

All existing tests pass; `cargo clippy -p candle-transformers --tests -- -D warnings` and `cargo fmt --check` are clean.

Fixes #3654
