### PR TITLE
[CPU] Fix wrong offset for non-contiguous conv2d im2col kernels

### DIFF
--- a/candle-core/src/cpu_backend/conv2d.rs
+++ b/candle-core/src/cpu_backend/conv2d.rs
@@ -401,10 +401,11 @@ fn conv2d_im2col_gemm<T: WithDType + num_traits::Num + Copy + 'static>(
             .broadcast_as((b, k, n))?;
         MatMul((b, m, n, k)).f(&col, &col_l, kernel, &kernel_l)?
     } else {
-        // Make the kernel contiguous if not already the case.
+        // copy_strided_src_ materializes the kernel into kernel_c starting at index 0, so the
+        // matmul layout must use offset 0, not the original (strided) kernel's start offset.
         let mut kernel_c = alloc_uninit_vec(kernel_l.shape().elem_count());
         copy_strided_src_(kernel, &mut kernel_c, 0, kernel_l);
-        let kernel_l = Layout::contiguous_with_offset((1, n, k), kernel_l.start_offset())
+        let kernel_l = Layout::contiguous_with_offset((1, n, k), 0)
             .transpose(1, 2)?
             .broadcast_as((b, k, n))?;
         MatMul((b, m, n, k)).f(&col, &col_l, &kernel_c, &kernel_l)?

--- a/candle-core/tests/conv_tests.rs
+++ b/candle-core/tests/conv_tests.rs
@@ -932,6 +932,49 @@ fn conv2d_c_eq_h_eq_w(dev: &Device) -> Result<()> {
     Ok(())
 }
 
+// Regression test for https://github.com/huggingface/candle/issues/3735: a non-contiguous
+// kernel and its contiguous copy must produce identical forward results and gradients.
+fn conv2d_grad_noncontiguous_kernel(dev: &Device) -> Result<()> {
+    use candle_core::Var;
+    let input_data: Vec<f32> = (1..=32).map(|v| v as f32 * 0.1).collect();
+    let weight_data: Vec<f32> = (1..=12).map(|v| v as f32 * 0.1).collect();
+
+    // Non-contiguous kernel: a channel slice of a larger weight, so it has a non-zero offset.
+    let input = Var::from_slice(&input_data, (1, 2, 4, 4), dev)?;
+    let weight = Var::from_slice(&weight_data, (3, 4, 1, 1), dev)?;
+    let kernel = weight.i((.., 1..3, .., ..))?;
+    let loss = input.conv2d(&kernel, 0, 2, 1, 1)?.sqr()?.sum_all()?;
+    let grads = loss.backward()?;
+    let grad_input = grads.get(&input).unwrap();
+    let grad_weight = grads.get(&weight).unwrap();
+
+    // Reference: the same logical kernel forced contiguous.
+    let input_ref = Var::from_slice(&input_data, (1, 2, 4, 4), dev)?;
+    let weight_ref = Var::from_slice(&weight_data, (3, 4, 1, 1), dev)?;
+    let kernel_ref = weight_ref.i((.., 1..3, .., ..))?.contiguous()?;
+    let loss_ref = input_ref
+        .conv2d(&kernel_ref, 0, 2, 1, 1)?
+        .sqr()?
+        .sum_all()?;
+    let grads_ref = loss_ref.backward()?;
+    let grad_input_ref = grads_ref.get(&input_ref).unwrap();
+    let grad_weight_ref = grads_ref.get(&weight_ref).unwrap();
+
+    assert_eq!(
+        test_utils::to_vec0_round(&loss, 4)?,
+        test_utils::to_vec0_round(&loss_ref, 4)?,
+    );
+    assert_eq!(
+        test_utils::to_vec1_round(&grad_input.flatten_all()?, 4)?,
+        test_utils::to_vec1_round(&grad_input_ref.flatten_all()?, 4)?,
+    );
+    assert_eq!(
+        test_utils::to_vec1_round(&grad_weight.flatten_all()?, 4)?,
+        test_utils::to_vec1_round(&grad_weight_ref.flatten_all()?, 4)?,
+    );
+    Ok(())
+}
+
 test_device!(conv1d, conv1d_cpu, conv1d_gpu, conv1d_metal);
 test_device!(
     conv1d_small,
@@ -969,4 +1012,10 @@ test_device!(
     conv2d_c_eq_h_eq_w_cpu,
     conv2d_c_eq_h_eq_w_gpu,
     conv2d_c_eq_h_eq_w_metal
+);
+test_device!(
+    conv2d_grad_noncontiguous_kernel,
+    conv2d_grad_noncontiguous_kernel_cpu,
+    conv2d_grad_noncontiguous_kernel_gpu,
+    conv2d_grad_noncontiguous_kernel_metal
 );


### PR DESCRIPTION
I ran into this while looking at #3735. In conv2d_im2col_gemm, a non-contiguous kernel gets copied into a fresh buffer (kernel_c) that starts at index 0, but the matmul layout was still built with the original kernel's start offset. If that kernel has a non zero offset, a channel slice of a larger pointwise weight, the matmul reads past kernel_c and the forward output and gradients come out wrong. Offset 0 lines the layout up with the buffer.

The test in conv_tests.rs runs a sliced 1x1 kernel and checks its forward result and both gradients against the same kernel made contiguous. It fails before the change and passes after.

The transposed-kernel repro in #3735 already passes on current main, probably from #3136 and #3405, so this is a different non-contiguous path, not that same case. This is a distinct case from the #3735 repro, so I did not link it to close the issue. 