### PR TITLE
Add MuScriptor audio-to-MIDI transcription (model + example)

### DIFF
--- a/candle-core/build.rs
+++ b/candle-core/build.rs
@@ -1,0 +1,17 @@
+fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rustc-check-cfg=cfg(candle_nightly)");
+    // The optimized aarch64 fp16 kernels rely on `float16x8_t`, which is
+    // still gated behind the unstable `stdarch_neon_f16` library feature.
+    // Detect a nightly compiler so those kernels can be enabled there while
+    // stable builds fall back to the widening implementation.
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+    let version = std::process::Command::new(rustc)
+        .arg("--version")
+        .output()
+        .map(|out| String::from_utf8_lossy(&out.stdout).into_owned())
+        .unwrap_or_default();
+    if version.contains("nightly") || version.contains("dev") {
+        println!("cargo::rustc-cfg=candle_nightly");
+    }
+}

--- a/candle-core/src/cpu/neon.rs
+++ b/candle-core/src/cpu/neon.rs
@@ -78,7 +78,9 @@ mod fp16 {
     use std::arch::asm;
 
     // Fallback: widen f16 to f32 on load using FCVTL, accumulate in f32.
-    #[cfg(not(target_feature = "fp16"))]
+    // Also used on stable toolchains: the optimized tier below needs the
+    // unstable stdarch_neon_f16 feature (see lib.rs).
+    #[cfg(not(all(target_feature = "fp16", candle_nightly)))]
     mod inner {
         use super::*;
 
@@ -150,7 +152,7 @@ mod fp16 {
     }
 
     // Optimized: accumulate in f16 using FMLA.8h, flush to f32 periodically.
-    #[cfg(target_feature = "fp16")]
+    #[cfg(all(target_feature = "fp16", candle_nightly))]
     mod inner {
         use super::*;
 

--- a/candle-core/src/lib.rs
+++ b/candle-core/src/lib.rs
@@ -47,6 +47,15 @@
 //! - [candle-transformers](https://docs.rs/candle-transformers/). Candle implementation of many published transformer models.
 //!
 
+// The optimized fp16 NEON kernels use `float16x8_t`, which is nightly-only
+// until stdarch_neon_f16 is stabilized. `candle_nightly` is set by build.rs
+// when compiling with a nightly toolchain; stable builds use the widening
+// fallback kernels instead (see cpu/neon.rs).
+#![cfg_attr(
+    all(target_arch = "aarch64", target_feature = "fp16", candle_nightly),
+    feature(stdarch_neon_f16)
+)]
+
 #[cfg(feature = "accelerate")]
 mod accelerate;
 pub mod backend;

--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -119,6 +119,10 @@ name = "onnx_basics"
 required-features = ["onnx"]
 
 [[example]]
+name = "muscriptor"
+required-features = ["symphonia"]
+
+[[example]]
 name = "whisper"
 required-features = ["symphonia"]
 

--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -38,7 +38,8 @@ rubato = { version = "2", optional = true }
 safetensors = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-symphonia = { version = "0.6.0", features = ["all"], optional = true }
+# 0.6 reworked the whole API surface; the examples still use the 0.5 API.
+symphonia = { version = "0.5.4", features = ["all"], optional = true }
 tokenizers = { workspace = true, features = ["onig"] }
 cpal = { version = "0.17.3", optional = true }
 pdf2image = { version = "0.1.2", optional = true }

--- a/candle-examples/examples/muscriptor/README.md
+++ b/candle-examples/examples/muscriptor/README.md
@@ -1,0 +1,43 @@
+# candle-muscriptor: audio-to-MIDI music transcription
+
+MuScriptor is a decoder-only causal transformer (audiocraft/MusicGen lineage)
+that transcribes audio to MIDI. Audio is processed in 5-second chunks: each
+chunk's log-mel spectrogram is projected and prepended as prefix tokens
+(together with instrument-group / dataset class embeddings), after which MIDI
+event tokens are generated autoregressively and decoded into notes.
+
+Three variants are published on the HuggingFace hub — note the weights are
+licensed CC BY-NC 4.0 (non-commercial):
+
+- `small` (768d / 14 layers)
+- `medium` (1024d / 24 layers, the default)
+- `large` (1536d / 48 layers)
+
+## Running an example
+
+```bash
+cargo run --example muscriptor --release --features symphonia -- audio.mp3
+```
+
+On Apple Silicon, add `--features metal,accelerate`; the transformer then runs
+in f16 on the GPU by default (use `--dtype f32` to force full precision).
+
+Useful flags:
+
+```bash
+# model size or a local safetensors path (config.json read from alongside)
+--model large
+# write somewhere specific instead of <audio>.mid
+-o out.mid
+# print note events as they stream
+--notes
+# condition the model on the instruments present in the recording
+--instruments acoustic_piano,drums
+# temperature sampling instead of greedy decoding
+--sampling -t 0.9 --top-p 0.95
+# chunks transcribed per batch (default: 4 on GPU, 1 on CPU)
+--batch-size 8
+```
+
+The tokenizer recovers onsets, offsets, pitch and instrument group — not
+velocity (all notes are written at velocity 100).

--- a/candle-examples/examples/muscriptor/audio.rs
+++ b/candle-examples/examples/muscriptor/audio.rs
@@ -1,0 +1,165 @@
+//! Audio decoding (any symphonia-supported format, downmixed to mono) and
+//! fractional sinc resampling.
+
+use anyhow::Result;
+
+/// Decode an audio file to mono f32 samples, averaging all channels.
+pub fn pcm_decode_mono<P: AsRef<std::path::Path>>(path: P) -> Result<(Vec<f32>, u32)> {
+    use symphonia::core::audio::{AudioBufferRef, Signal};
+    use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
+    use symphonia::core::conv::FromSample;
+
+    fn accumulate<T>(
+        samples: &mut Vec<f32>,
+        data: std::borrow::Cow<symphonia::core::audio::AudioBuffer<T>>,
+    ) where
+        T: symphonia::core::sample::Sample,
+        f32: FromSample<T>,
+    {
+        let n_channels = data.spec().channels.count().max(1);
+        let scale = 1. / n_channels as f32;
+        let base = samples.len();
+        samples.resize(base + data.frames(), 0.);
+        for ch in 0..n_channels {
+            for (out, v) in samples[base..].iter_mut().zip(data.chan(ch)) {
+                *out += f32::from_sample(*v) * scale;
+            }
+        }
+    }
+
+    let src = std::fs::File::open(path)?;
+    let mss = symphonia::core::io::MediaSourceStream::new(Box::new(src), Default::default());
+    let hint = symphonia::core::probe::Hint::new();
+    let probed = symphonia::default::get_probe().format(
+        &hint,
+        mss,
+        &Default::default(),
+        &Default::default(),
+    )?;
+    let mut format = probed.format;
+    let track = format
+        .tracks()
+        .iter()
+        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+        .ok_or_else(|| anyhow::anyhow!("no supported audio track"))?;
+    let mut decoder =
+        symphonia::default::get_codecs().make(&track.codec_params, &DecoderOptions::default())?;
+    let track_id = track.id;
+    let mut sample_rate = track.codec_params.sample_rate.unwrap_or(0);
+    let mut samples = Vec::new();
+    loop {
+        let packet = match format.next_packet() {
+            Ok(packet) => packet,
+            // Only the normal end of stream terminates the loop; a decode /
+            // container error mid-file must not be mistaken for EOF.
+            Err(symphonia::core::errors::Error::IoError(e))
+                if e.kind() == std::io::ErrorKind::UnexpectedEof =>
+            {
+                break;
+            }
+            Err(e) => return Err(e.into()),
+        };
+        while !format.metadata().is_latest() {
+            format.metadata().pop();
+        }
+        if packet.track_id() != track_id {
+            continue;
+        }
+        match decoder.decode(&packet)? {
+            AudioBufferRef::F32(buf) => accumulate(&mut samples, buf),
+            AudioBufferRef::F64(buf) => accumulate(&mut samples, buf),
+            AudioBufferRef::U8(buf) => accumulate(&mut samples, buf),
+            AudioBufferRef::U16(buf) => accumulate(&mut samples, buf),
+            AudioBufferRef::U24(buf) => accumulate(&mut samples, buf),
+            AudioBufferRef::U32(buf) => accumulate(&mut samples, buf),
+            AudioBufferRef::S8(buf) => accumulate(&mut samples, buf),
+            AudioBufferRef::S16(buf) => accumulate(&mut samples, buf),
+            AudioBufferRef::S24(buf) => accumulate(&mut samples, buf),
+            AudioBufferRef::S32(buf) => accumulate(&mut samples, buf),
+        }
+    }
+    if sample_rate == 0 {
+        sample_rate = decoder
+            .codec_params()
+            .sample_rate
+            .ok_or_else(|| anyhow::anyhow!("unknown sample rate"))?;
+    }
+    Ok((samples, sample_rate))
+}
+
+fn sinc(x: f64) -> f64 {
+    if x == 0. {
+        1.
+    } else {
+        x.sin() / x
+    }
+}
+
+/// Fractional resampling with a windowed-sinc kernel bank (Julius O. Smith's
+/// algorithm, matching the `julius.resample_frac` implementation used by the
+/// reference: `zeros = 24`, `rolloff = 0.945`, replicate padding).
+pub fn resample(x: &[f32], old_sr: usize, new_sr: usize) -> Vec<f32> {
+    if old_sr == new_sr || x.is_empty() {
+        return x.to_vec();
+    }
+    let gcd = {
+        let (mut a, mut b) = (old_sr, new_sr);
+        while b != 0 {
+            (a, b) = (b, a % b);
+        }
+        a
+    };
+    let old_sr = old_sr / gcd;
+    let new_sr = new_sr / gcd;
+    const ZEROS: f64 = 24.;
+    const ROLLOFF: f64 = 0.945;
+    // The anti-aliasing lowpass sits at rolloff * min(sr) / 2.
+    let sr = old_sr.min(new_sr) as f64 * ROLLOFF;
+    let width = (ZEROS * old_sr as f64 / sr).ceil() as usize;
+    let kernel_len = 2 * width + old_sr;
+
+    // One kernel per output phase within a block of new_sr samples.
+    let mut kernels = vec![0f64; new_sr * kernel_len];
+    for i in 0..new_sr {
+        let kernel = &mut kernels[i * kernel_len..(i + 1) * kernel_len];
+        let mut sum = 0.;
+        for (k, v) in kernel.iter_mut().enumerate() {
+            let idx = k as f64 - width as f64;
+            let t = (-(i as f64) / new_sr as f64 + idx / old_sr as f64) * sr;
+            let t = t.clamp(-ZEROS, ZEROS) * std::f64::consts::PI;
+            let window = (t / ZEROS / 2.).cos().powi(2);
+            *v = sinc(t) * window;
+            sum += *v;
+        }
+        for v in kernel.iter_mut() {
+            *v /= sum;
+        }
+    }
+
+    // Replicate-pad by `width` left and `width + old_sr` right, then apply
+    // each kernel with a stride of old_sr.
+    let padded_len = x.len() + 2 * width + old_sr;
+    let mut padded = Vec::with_capacity(padded_len);
+    padded.extend(std::iter::repeat_n(x[0] as f64, width));
+    padded.extend(x.iter().map(|&v| v as f64));
+    padded.extend(std::iter::repeat_n(
+        *x.last().unwrap() as f64,
+        width + old_sr,
+    ));
+
+    let out_len = x.len() * new_sr / old_sr;
+    let n_blocks = (padded_len - kernel_len) / old_sr + 1;
+    let mut out = vec![0f32; out_len];
+    for block in 0..n_blocks {
+        let input = &padded[block * old_sr..block * old_sr + kernel_len];
+        for i in 0..new_sr {
+            let pos = block * new_sr + i;
+            if pos >= out_len {
+                break;
+            }
+            let kernel = &kernels[i * kernel_len..(i + 1) * kernel_len];
+            out[pos] = input.iter().zip(kernel).map(|(&a, &b)| a * b).sum::<f64>() as f32;
+        }
+    }
+    out
+}

--- a/candle-examples/examples/muscriptor/main.rs
+++ b/candle-examples/examples/muscriptor/main.rs
@@ -1,0 +1,346 @@
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+mod audio;
+mod midi;
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use anyhow::{bail, Result};
+use candle::DType;
+use candle_nn::VarBuilder;
+use candle_transformers::generation::Sampling;
+use candle_transformers::models::muscriptor::{
+    tokenizer, Config, GenerateOptions, Model, SAMPLE_RATE, SEGMENT_DURATION,
+};
+use clap::Parser;
+use hf_hub::api::sync::Api;
+
+const FRAME_RATE: usize = 100;
+const MODEL_SIZES: [&str; 3] = ["small", "medium", "large"];
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "muscriptor — audio-to-MIDI transcription", long_about = None)]
+struct Args {
+    /// Input audio file (wav, mp3, flac, ...).
+    audio_file: PathBuf,
+
+    /// Output MIDI file path. Default: <audio_file>.mid
+    #[arg(long, short)]
+    output: Option<PathBuf>,
+
+    /// Model size ('small', 'medium', 'large') or a local safetensors path.
+    #[arg(long, short, default_value = "medium")]
+    model: String,
+
+    /// Run on CPU rather than on GPU.
+    #[arg(long)]
+    cpu: bool,
+
+    /// Transformer dtype: f32, f16 or bf16. Defaults to f16 on Metal
+    /// (decoding is bandwidth-bound), f32 elsewhere. The conditioning
+    /// pipeline always runs in f32.
+    #[arg(long)]
+    dtype: Option<String>,
+
+    /// Use temperature sampling instead of greedy decoding.
+    #[arg(long)]
+    sampling: bool,
+
+    /// Sampling temperature (only with --sampling).
+    #[arg(long, short, default_value_t = 1.0)]
+    temperature: f64,
+
+    /// Top-p (nucleus) sampling (only with --sampling; takes precedence over
+    /// --top-k, matching the reference).
+    #[arg(long)]
+    top_p: Option<f64>,
+
+    /// Top-k sampling (only with --sampling).
+    #[arg(long)]
+    top_k: Option<usize>,
+
+    /// Seed for --sampling.
+    #[arg(long, default_value_t = 299792458)]
+    seed: u64,
+
+    /// Comma-separated instrument names to condition on (e.g. "acoustic_piano,drums").
+    #[arg(long)]
+    instruments: Option<String>,
+
+    /// Number of 5-second chunks transcribed per batch. Default: 4 on GPU, 1 on CPU.
+    #[arg(long)]
+    batch_size: Option<usize>,
+
+    /// Maximum generated tokens per chunk.
+    #[arg(long, default_value_t = 2000)]
+    max_gen_len: usize,
+
+    /// Print decoded note events as they stream.
+    #[arg(long)]
+    notes: bool,
+}
+
+fn resolve_model(model: &str) -> Result<(PathBuf, Config)> {
+    if MODEL_SIZES.contains(&model) {
+        let api = Api::new()?;
+        let repo = api.model(format!("MuScriptor/muscriptor-{model}"));
+        let config: Config =
+            serde_json::from_reader(std::fs::File::open(repo.get("config.json")?)?)?;
+        return Ok((repo.get("model.safetensors")?, config));
+    }
+    let weights = PathBuf::from(model);
+    if !weights.is_file() {
+        bail!("--model must be 'small', 'medium', 'large' or a safetensors file path")
+    }
+    let config_path = weights.parent().map(|p| p.join("config.json"));
+    if let Some(config_path) = config_path.filter(|p| p.is_file()) {
+        let config = serde_json::from_reader(std::fs::File::open(config_path)?)?;
+        return Ok((weights, config));
+    }
+    // No config.json next to the weights: identify a known variant from the
+    // embedding shape (which determines dim and card) and the layer count.
+    let st = unsafe { candle::safetensors::MmapedSafetensors::new(&weights)? };
+    let mut dim = None;
+    let mut num_layers = 0;
+    for (name, view) in st.tensors() {
+        if name == "emb.0.weight" || name == "emb.weight" {
+            let shape = view.shape();
+            dim = Some((shape[1], shape[0] - 1));
+        }
+        if name.starts_with("transformer.layers.") {
+            if let Some(n) = name
+                .strip_prefix("transformer.layers.")
+                .and_then(|s| s.split('.').next())
+                .and_then(|s| s.parse::<usize>().ok())
+            {
+                num_layers = num_layers.max(n + 1);
+            }
+        }
+    }
+    let Some((dim, card)) = dim else {
+        bail!("no token embedding found in {}", weights.display())
+    };
+    for config in [Config::small(), Config::medium(), Config::large()] {
+        if config.dim == dim && config.card == card && config.num_layers == num_layers {
+            return Ok((weights, config));
+        }
+    }
+    bail!(
+        "cannot infer the model architecture (dim={dim}, card={card}, layers={num_layers}); \
+         put a config.json next to the weights"
+    )
+}
+
+fn print_event(ev: &tokenizer::NoteEvent) {
+    match ev {
+        tokenizer::NoteEvent::Start(s) => println!(
+            "NoteStartEvent(pitch={}, start_time={:.2}, index={}, instrument={})",
+            s.pitch, s.start_time, s.index, s.instrument
+        ),
+        tokenizer::NoteEvent::End {
+            end_time,
+            start_index,
+        } => println!("NoteEndEvent(end_time={end_time:.2}, start_event_index={start_index})",),
+    }
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let device = candle_examples::device(args.cpu)?;
+    let dtype = match args.dtype.as_deref() {
+        Some("f32") | Some("float32") => DType::F32,
+        Some("f16") | Some("float16") => DType::F16,
+        Some("bf16") | Some("bfloat16") => DType::BF16,
+        Some(other) => bail!("unsupported dtype {other}"),
+        None if device.is_metal() => DType::F16,
+        None => DType::F32,
+    };
+
+    let start = std::time::Instant::now();
+    let (weights, config) = resolve_model(&args.model)?;
+    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[&weights], dtype, &device)? };
+    let vb_f32 = unsafe { VarBuilder::from_mmaped_safetensors(&[&weights], DType::F32, &device)? };
+    let mut model = Model::new(&config, vb, vb_f32)?;
+    eprintln!(
+        "[muscriptor] loaded {} ({:?}, {:?}): {:.2}s",
+        weights.display(),
+        dtype,
+        device.location(),
+        start.elapsed().as_secs_f64()
+    );
+
+    let start = std::time::Instant::now();
+    let (pcm, sample_rate) = audio::pcm_decode_mono(&args.audio_file)?;
+    let pcm = if sample_rate as usize != SAMPLE_RATE {
+        audio::resample(&pcm, sample_rate as usize, SAMPLE_RATE)
+    } else {
+        pcm
+    };
+    eprintln!(
+        "[muscriptor] load audio: {:.2}s",
+        start.elapsed().as_secs_f64()
+    );
+
+    let instrument_ids = match &args.instruments {
+        None => None,
+        Some(names) => {
+            let names: Vec<&str> = names.split(',').filter(|s| !s.is_empty()).collect();
+            Some(tokenizer::instrument_class_ids(&names).map_err(anyhow::Error::msg)?)
+        }
+    };
+
+    // Split into fixed 5-second segments, zero-padding the last one.
+    let segment_samples = (SEGMENT_DURATION * SAMPLE_RATE as f64) as usize;
+    let num_chunks = pcm.len().div_ceil(segment_samples).max(1);
+    let chunks: Vec<Vec<f32>> = (0..num_chunks)
+        .map(|i| {
+            let start = i * segment_samples;
+            let mut chunk = pcm[start..(start + segment_samples).min(pcm.len())].to_vec();
+            chunk.resize(segment_samples, 0.);
+            chunk
+        })
+        .collect();
+    eprintln!(
+        "[muscriptor] audio: {:.1}s → {num_chunks} chunk(s) of {SEGMENT_DURATION}s",
+        pcm.len() as f64 / SAMPLE_RATE as f64
+    );
+
+    let batch_size = args
+        .batch_size
+        .unwrap_or(if device.is_cpu() { 1 } else { 4 })
+        .max(1);
+    let opts = GenerateOptions {
+        max_gen_len: args.max_gen_len,
+        sampling: match (args.sampling, args.temperature) {
+            (false, _) => None,
+            (true, t) if t <= 0. => None,
+            // As in the reference: top-p wins over top-k, and a
+            // non-positive value disables the filter.
+            (true, temperature) => Some(
+                match (
+                    args.top_p.filter(|&p| p > 0.),
+                    args.top_k.filter(|&k| k > 0),
+                ) {
+                    (Some(p), _) => Sampling::TopP { p, temperature },
+                    (None, Some(k)) => Sampling::TopK { k, temperature },
+                    (None, None) => Sampling::All { temperature },
+                },
+            ),
+        },
+        seed: args.seed,
+    };
+
+    let seek_time = |chunk_idx: usize| chunk_idx as f64 * SEGMENT_DURATION;
+    let mut decoder = tokenizer::TokenDecoder::new(FRAME_RATE);
+    let mut all_events: Vec<tokenizer::NoteEvent> = Vec::new();
+    let emit = |events: &mut Vec<tokenizer::NoteEvent>, all: &mut Vec<tokenizer::NoteEvent>| {
+        if args.notes {
+            for ev in events.iter() {
+                print_event(ev);
+            }
+        }
+        all.append(events);
+    };
+    let start_chunk = |decoder: &mut tokenizer::TokenDecoder,
+                       out: &mut Vec<tokenizer::NoteEvent>,
+                       chunk_idx: usize| {
+        let next = (chunk_idx + 1 < num_chunks).then(|| seek_time(chunk_idx + 1));
+        decoder.start_chunk(seek_time(chunk_idx), next, out);
+    };
+
+    let gen_start = std::time::Instant::now();
+    for batch_start in (0..num_chunks).step_by(batch_size) {
+        let batch = &chunks[batch_start..(batch_start + batch_size).min(num_chunks)];
+        let n = batch.len();
+        let prefix = model.build_prefix(batch, instrument_ids.as_deref())?;
+
+        // The model emits one token per chunk per step, but the decoder
+        // consumes whole chunks in order: the first chunk streams live, the
+        // others buffer until every earlier chunk has hit EOS.
+        let mut buffers: Vec<Vec<u32>> = vec![Vec::new(); n];
+        let mut done = vec![false; n];
+        let mut active = 0usize;
+        let mut events = Vec::new();
+        start_chunk(&mut decoder, &mut events, batch_start);
+        emit(&mut events, &mut all_events);
+
+        model.generate(&prefix, &opts, |tokens| {
+            let mut events = Vec::new();
+            for (j, &tok) in tokens.iter().enumerate() {
+                if done[j] {
+                    continue;
+                }
+                if tok == tokenizer::EOS_ID {
+                    done[j] = true;
+                } else if j == active {
+                    decoder.push(tok, &mut events);
+                } else {
+                    buffers[j].push(tok);
+                }
+            }
+            while active < n && done[active] {
+                active += 1;
+                if active < n {
+                    start_chunk(&mut decoder, &mut events, batch_start + active);
+                    for tok in buffers[active].drain(..) {
+                        decoder.push(tok, &mut events);
+                    }
+                }
+            }
+            emit(&mut events, &mut all_events);
+            Ok(())
+        })?;
+
+        // Chunks that never emitted EOS within max_gen_len.
+        for j in active..n {
+            if !done[j] {
+                eprintln!(
+                    "[muscriptor] warning: chunk {} (seek={:.1}s) did not emit EOS within {} tokens",
+                    batch_start + j,
+                    seek_time(batch_start + j),
+                    args.max_gen_len
+                );
+            }
+            if j != active {
+                let mut events = Vec::new();
+                start_chunk(&mut decoder, &mut events, batch_start + j);
+                for tok in buffers[j].drain(..) {
+                    decoder.push(tok, &mut events);
+                }
+                emit(&mut events, &mut all_events);
+            }
+        }
+        eprintln!(
+            "[muscriptor] chunks {}/{}: {:.2}s",
+            batch_start + n,
+            num_chunks,
+            gen_start.elapsed().as_secs_f64()
+        );
+    }
+    let mut events = Vec::new();
+    decoder.finish(&mut events);
+    emit(&mut events, &mut all_events);
+    eprintln!(
+        "[muscriptor] generate total: {:.2}s",
+        gen_start.elapsed().as_secs_f64()
+    );
+
+    let notes = tokenizer::events_to_notes(&all_events);
+    let midi_bytes = midi::notes_to_midi_bytes(&notes);
+    let output = args
+        .output
+        .unwrap_or_else(|| args.audio_file.with_extension("mid"));
+    let mut file = std::fs::File::create(&output)?;
+    file.write_all(&midi_bytes)?;
+    eprintln!(
+        "[muscriptor] wrote {} note(s) to {}",
+        notes.len(),
+        output.display()
+    );
+    Ok(())
+}

--- a/candle-examples/examples/muscriptor/midi.rs
+++ b/candle-examples/examples/muscriptor/midi.rs
@@ -1,0 +1,144 @@
+//! Standard MIDI File (format 0) serialization of decoded notes, matching the
+//! reference `note_event2midi` (mido-based) byte for byte: same event
+//! ordering, channel assignment, running status and end-of-track handling.
+
+use candle_transformers::models::muscriptor::tokenizer::{Note, DRUM_PROGRAM};
+
+const TICKS_PER_BEAT: u32 = 480;
+const TEMPO_US: f64 = 500_000.; // 120 bpm
+const VELOCITY: u8 = 100;
+
+#[derive(Debug, Clone)]
+struct MidiEvent {
+    is_drum: bool,
+    program: i32,
+    time: f64,
+    /// 1 for onset, 0 for offset.
+    velocity: u8,
+    pitch: u8,
+}
+
+fn second2tick(second: f64) -> i64 {
+    (second * TICKS_PER_BEAT as f64 * 1e6 / TEMPO_US).round_ties_even() as i64
+}
+
+fn push_varlen(out: &mut Vec<u8>, mut value: u64) {
+    let mut bytes = vec![(value & 0x7f) as u8];
+    value >>= 7;
+    while value > 0 {
+        bytes.push((value & 0x7f) as u8 | 0x80);
+        value >>= 7;
+    }
+    bytes.reverse();
+    out.extend(bytes);
+}
+
+/// Serialize notes to a single-track (format 0) MIDI file.
+pub fn notes_to_midi_bytes(notes: &[Note]) -> Vec<u8> {
+    // Notes to on/off events; drums get only an onset here...
+    let mut events = Vec::with_capacity(notes.len() * 2);
+    for note in notes {
+        events.push(MidiEvent {
+            is_drum: note.is_drum,
+            program: note.program,
+            time: note.onset,
+            velocity: 1,
+            pitch: note.pitch,
+        });
+        if !note.is_drum {
+            events.push(MidiEvent {
+                is_drum: false,
+                program: note.program,
+                time: note.offset,
+                velocity: 0,
+                pitch: note.pitch,
+            });
+        }
+    }
+    // ...and a synthetic offset 10ms after each drum hit.
+    let drum_offsets: Vec<MidiEvent> = events
+        .iter()
+        .filter(|ev| ev.is_drum)
+        .map(|ev| MidiEvent {
+            time: ev.time + 0.01,
+            velocity: 0,
+            ..ev.clone()
+        })
+        .collect();
+    events.extend(drum_offsets);
+    events.sort_by(|a, b| {
+        a.time
+            .total_cmp(&b.time)
+            .then(a.is_drum.cmp(&b.is_drum))
+            .then(a.program.cmp(&b.program))
+            .then(a.velocity.cmp(&b.velocity))
+            .then(a.pitch.cmp(&b.pitch))
+    });
+
+    let mut track: Vec<u8> = Vec::new();
+    let mut running_status: Option<u8> = None;
+    let mut push_message = |track: &mut Vec<u8>, delta: u64, status: u8, data: &[u8]| {
+        push_varlen(track, delta);
+        if running_status != Some(status) {
+            track.push(status);
+            running_status = Some(status);
+        }
+        track.extend_from_slice(data);
+    };
+
+    // Programs are assigned channels 0-8, 10-15 in order of first appearance;
+    // drums always use channel 9. Overflow falls back to channel 15.
+    let mut program_to_channel: std::collections::HashMap<i32, u8> = Default::default();
+    let mut available_channels: std::collections::VecDeque<u8> = (0..9).chain(10..16).collect();
+    let mut drums_initialized = false;
+    let mut current_tick = 0i64;
+    for ev in &events {
+        let absolute_tick = second2tick(ev.time);
+        let mut delta_tick = (absolute_tick - current_tick).max(0) as u64;
+        current_tick = current_tick.max(absolute_tick);
+
+        let channel = match program_to_channel.get(&ev.program) {
+            Some(&ch) => ch,
+            None if ev.program == DRUM_PROGRAM || ev.is_drum => {
+                if !drums_initialized {
+                    push_message(&mut track, delta_tick, 0xc9, &[0]);
+                    delta_tick = 0;
+                    drums_initialized = true;
+                }
+                9
+            }
+            None => {
+                let ch = available_channels.pop_front().unwrap_or(15);
+                program_to_channel.insert(ev.program, ch);
+                push_message(&mut track, delta_tick, 0xc0 | ch, &[ev.program as u8]);
+                delta_tick = 0;
+                ch
+            }
+        };
+
+        let (status_nibble, velocity) = if ev.velocity > 0 {
+            (0x90u8, VELOCITY)
+        } else {
+            (0x80u8, 0)
+        };
+        push_message(
+            &mut track,
+            delta_tick,
+            status_nibble | channel,
+            &[ev.pitch, velocity],
+        );
+    }
+    // End of track meta event.
+    track.extend_from_slice(&[0x00, 0xff, 0x2f, 0x00]);
+
+    let mut out = Vec::with_capacity(track.len() + 22);
+    out.extend_from_slice(b"MThd");
+    out.extend_from_slice(&6u32.to_be_bytes());
+    out.extend_from_slice(&0u16.to_be_bytes()); // format 0
+    out.extend_from_slice(&1u16.to_be_bytes()); // one track
+    out.extend_from_slice(&(TICKS_PER_BEAT as u16).to_be_bytes());
+    out.extend_from_slice(b"MTrk");
+    out.extend_from_slice(&(track.len() as u32).to_be_bytes());
+    out.extend_from_slice(&track);
+    out
+}

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -73,6 +73,7 @@ pub mod mobileone;
 pub mod modernbert;
 pub mod moondream;
 pub mod mpt;
+pub mod muscriptor;
 pub mod nomic_bert;
 pub mod nvembed_v2;
 pub mod olmo;

--- a/candle-transformers/src/models/muscriptor/mel.rs
+++ b/candle-transformers/src/models/muscriptor/mel.rs
@@ -1,0 +1,149 @@
+//! Mel-spectrogram front-end, equivalent to `torchaudio.transforms.MelSpectrogram`
+//! with `power=1.0`, `center=true`, reflect padding and `win_length == n_fft`.
+//!
+//! The Hann window and the (HTK, un-normalized) mel filterbank are not computed
+//! here: MuScriptor checkpoints ship both as buffers, and they are loaded from
+//! the weights so the numerics match the reference exactly. The FFT and the
+//! filterbank application accumulate in f64 (the cost is negligible and it
+//! keeps the roundoff well below the reference implementation's own f32
+//! noise floor).
+
+/// In-place iterative radix-2 Cooley-Tukey FFT.
+fn fft_inplace(re: &mut [f64], im: &mut [f64], twiddle_re: &[f64], twiddle_im: &[f64]) {
+    let n = re.len();
+    // Bit-reversal permutation.
+    let mut j = 0usize;
+    for i in 0..n {
+        if i < j {
+            re.swap(i, j);
+            im.swap(i, j);
+        }
+        let mut bit = n >> 1;
+        while j & bit != 0 {
+            j ^= bit;
+            bit >>= 1;
+        }
+        j |= bit;
+    }
+    let mut len = 2;
+    while len <= n {
+        let step = n / len;
+        for start in (0..n).step_by(len) {
+            for k in 0..len / 2 {
+                let w_re = twiddle_re[k * step];
+                let w_im = twiddle_im[k * step];
+                let a = start + k;
+                let b = start + k + len / 2;
+                let t_re = re[b] * w_re - im[b] * w_im;
+                let t_im = re[b] * w_im + im[b] * w_re;
+                re[b] = re[a] - t_re;
+                im[b] = im[a] - t_im;
+                re[a] += t_re;
+                im[a] += t_im;
+            }
+        }
+        len <<= 1;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MelSpectrogram {
+    n_fft: usize,
+    hop_length: usize,
+    n_mels: usize,
+    window: Vec<f64>,
+    /// Mel filterbank, transposed to `[n_mels, n_fft / 2 + 1]` row-major so
+    /// each mel bin reduces over a contiguous frequency slice.
+    fb_t: Vec<f64>,
+    twiddle_re: Vec<f64>,
+    twiddle_im: Vec<f64>,
+}
+
+impl MelSpectrogram {
+    /// `fb` is the `[n_fft / 2 + 1, n_mels]` row-major filterbank as stored
+    /// in the checkpoint.
+    pub fn new(
+        n_fft: usize,
+        hop_length: usize,
+        n_mels: usize,
+        window: Vec<f32>,
+        fb: Vec<f32>,
+    ) -> Self {
+        assert!(n_fft.is_power_of_two(), "n_fft must be a power of two");
+        assert_eq!(window.len(), n_fft);
+        let n_freqs = n_fft / 2 + 1;
+        assert_eq!(fb.len(), n_freqs * n_mels);
+        let mut fb_t = vec![0f64; fb.len()];
+        for f in 0..n_freqs {
+            for m in 0..n_mels {
+                fb_t[m * n_freqs + f] = fb[f * n_mels + m] as f64;
+            }
+        }
+        let (twiddle_re, twiddle_im) = (0..n_fft / 2)
+            .map(|k| {
+                let angle = -2. * std::f64::consts::PI * k as f64 / n_fft as f64;
+                (angle.cos(), angle.sin())
+            })
+            .unzip();
+        Self {
+            n_fft,
+            hop_length,
+            n_mels,
+            window: window.into_iter().map(|w| w as f64).collect(),
+            fb_t,
+            twiddle_re,
+            twiddle_im,
+        }
+    }
+
+    pub fn hop_length(&self) -> usize {
+        self.hop_length
+    }
+
+    /// Magnitude mel spectrogram of `samples`; returns `(mel, n_frames)` with
+    /// `mel` in `[n_frames, n_mels]` row-major order (natural log is applied
+    /// by the caller).
+    pub fn compute(&self, samples: &[f32]) -> (Vec<f32>, usize) {
+        let pad = self.n_fft / 2;
+        assert!(
+            samples.len() > pad,
+            "audio segment too short for reflect padding"
+        );
+        // Center the frames: reflect-pad by n_fft / 2 on both sides.
+        let padded_len = samples.len() + 2 * pad;
+        let mut padded = Vec::with_capacity(padded_len);
+        padded.extend((0..pad).map(|i| samples[pad - i] as f64));
+        padded.extend(samples.iter().map(|&v| v as f64));
+        padded.extend((0..pad).map(|i| samples[samples.len() - 2 - i] as f64));
+
+        let n_frames = 1 + (padded_len - self.n_fft) / self.hop_length;
+        let n_freqs = self.n_fft / 2 + 1;
+        let mut mel = vec![0f32; n_frames * self.n_mels];
+        let mut re = vec![0f64; self.n_fft];
+        let mut im = vec![0f64; self.n_fft];
+        let mut mag = vec![0f64; n_freqs];
+        for frame in 0..n_frames {
+            let start = frame * self.hop_length;
+            for i in 0..self.n_fft {
+                re[i] = padded[start + i] * self.window[i];
+                im[i] = 0.;
+            }
+            fft_inplace(&mut re, &mut im, &self.twiddle_re, &self.twiddle_im);
+            for f in 0..n_freqs {
+                mag[f] = (re[f] * re[f] + im[f] * im[f]).sqrt();
+            }
+            let out = &mut mel[frame * self.n_mels..(frame + 1) * self.n_mels];
+            for (m, o) in out.iter_mut().enumerate() {
+                let fb_row = &self.fb_t[m * n_freqs..(m + 1) * n_freqs];
+                // The filters are triangular: only a contiguous band is
+                // non-zero, but the full dot product is cheap enough.
+                *o = fb_row
+                    .iter()
+                    .zip(mag.iter())
+                    .map(|(&w, &v)| w * v)
+                    .sum::<f64>() as f32;
+            }
+        }
+        (mel, n_frames)
+    }
+}

--- a/candle-transformers/src/models/muscriptor/mod.rs
+++ b/candle-transformers/src/models/muscriptor/mod.rs
@@ -80,6 +80,34 @@ fn sin_embedding(offset: usize, t: usize, dim: usize, device: &Device) -> Result
     Tensor::from_vec(data, (t, dim), device)
 }
 
+/// LayerNorm that dispatches to the fused kernel on Metal (a single launch
+/// instead of the decomposed mean/variance op chain, which dominates decode
+/// time at batch 1-4) and to the standard module elsewhere.
+#[derive(Debug, Clone)]
+struct Norm {
+    inner: LayerNorm,
+    fused: bool,
+}
+
+impl Norm {
+    fn new(dim: usize, vb: VarBuilder) -> Result<Self> {
+        let fused = vb.device().is_metal();
+        Ok(Self {
+            inner: layer_norm(dim, LN_EPS, vb)?,
+            fused,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        match (self.fused, self.inner.bias()) {
+            (true, Some(bias)) => {
+                candle_nn::ops::layer_norm(xs, self.inner.weight(), bias, LN_EPS as f32)
+            }
+            _ => self.inner.forward(xs),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct StreamingMultiheadAttention {
     in_proj: Linear,
@@ -119,21 +147,29 @@ impl StreamingMultiheadAttention {
         let (k, v) = self.kv_cache.append(&k.contiguous()?, &v.contiguous()?)?;
 
         let scale = 1f64 / (self.head_dim as f64).sqrt();
-        let attn = (q.contiguous()?.matmul(&k.transpose(2, 3)?)? * scale)?;
-        let attn = match mask {
-            None => attn,
-            Some(mask) => attn.broadcast_add(mask)?,
-        };
-        // Softmax in f32 as torch's SDPA does for half-precision inputs.
-        let dtype = attn.dtype();
-        let attn = if dtype == DType::F32 {
-            candle_nn::ops::softmax_last_dim(&attn)?
+        let attn = if xs.device().is_metal() {
+            // Fused kernels; they read the KV cache's narrowed views through
+            // their strides directly. Prefill always starts from an empty
+            // cache (q_len == k_len), so plain causal alignment is correct;
+            // a single decode step attends to the whole cache.
+            candle_nn::ops::sdpa(&q.contiguous()?, &k, &v, None, t > 1, scale as f32, 1.0)?
         } else {
-            let attn = attn.to_dtype(DType::F32)?;
-            candle_nn::ops::softmax_last_dim(&attn)?.to_dtype(dtype)?
+            let attn = (q.contiguous()?.matmul(&k.transpose(2, 3)?)? * scale)?;
+            let attn = match mask {
+                None => attn,
+                Some(mask) => attn.broadcast_add(mask)?,
+            };
+            // Softmax in f32 as torch's SDPA does for half-precision inputs.
+            let dtype = attn.dtype();
+            let attn = if dtype == DType::F32 {
+                candle_nn::ops::softmax_last_dim(&attn)?
+            } else {
+                let attn = attn.to_dtype(DType::F32)?;
+                candle_nn::ops::softmax_last_dim(&attn)?.to_dtype(dtype)?
+            };
+            attn.matmul(&v.contiguous()?)?
         };
-        attn.matmul(&v.contiguous()?)?
-            .transpose(1, 2)?
+        attn.transpose(1, 2)?
             .reshape((b, t, dim))?
             .apply(&self.out_proj)
     }
@@ -142,8 +178,8 @@ impl StreamingMultiheadAttention {
 #[derive(Debug, Clone)]
 struct StreamingTransformerLayer {
     self_attn: StreamingMultiheadAttention,
-    norm1: LayerNorm,
-    norm2: LayerNorm,
+    norm1: Norm,
+    norm2: Norm,
     linear1: Linear,
     linear2: Linear,
 }
@@ -152,17 +188,18 @@ impl StreamingTransformerLayer {
     fn new(dim: usize, num_heads: usize, hidden: usize, vb: VarBuilder) -> Result<Self> {
         Ok(Self {
             self_attn: StreamingMultiheadAttention::new(dim, num_heads, vb.pp("self_attn"))?,
-            norm1: layer_norm(dim, LN_EPS, vb.pp("norm1"))?,
-            norm2: layer_norm(dim, LN_EPS, vb.pp("norm2"))?,
+            norm1: Norm::new(dim, vb.pp("norm1"))?,
+            norm2: Norm::new(dim, vb.pp("norm2"))?,
             linear1: linear_no_bias(dim, hidden, vb.pp("linear1"))?,
             linear2: linear_no_bias(hidden, dim, vb.pp("linear2"))?,
         })
     }
 
     fn forward(&mut self, xs: &Tensor, mask: Option<&Tensor>) -> Result<Tensor> {
-        let xs = (xs + self.self_attn.forward(&xs.apply(&self.norm1)?, mask)?)?;
-        let ff = xs
-            .apply(&self.norm2)?
+        let xs = (xs + self.self_attn.forward(&self.norm1.forward(xs)?, mask)?)?;
+        let ff = self
+            .norm2
+            .forward(&xs)?
             .apply(&self.linear1)?
             // torch's F.gelu defaults to the exact erf formulation.
             .gelu_erf()?
@@ -203,8 +240,9 @@ impl StreamingTransformer {
         let (_b, t, dim) = xs.dims3()?;
         let pos_emb = sin_embedding(self.offset, t, dim, xs.device())?.to_dtype(xs.dtype())?;
         let mut xs = xs.broadcast_add(&pos_emb)?;
-        let mask = if t <= 1 {
-            // A single decode step attends to the whole cache: no mask needed.
+        let mask = if t <= 1 || xs.device().is_metal() {
+            // A single decode step attends to the whole cache, and the fused
+            // Metal attention applies causality itself: no mask needed.
             None
         } else {
             let offset = self.offset;
@@ -353,7 +391,7 @@ pub struct Model {
     pub dataset_conditioner: ClassConditioner,
     emb: Embedding,
     transformer: StreamingTransformer,
-    out_norm: LayerNorm,
+    out_norm: Norm,
     linear: Linear,
     card: usize,
     dtype: DType,
@@ -384,7 +422,7 @@ impl Model {
             dataset_conditioner,
             emb: Embedding::new(emb_weight, cfg.dim),
             transformer: StreamingTransformer::new(cfg, vb.pp("transformer"))?,
-            out_norm: layer_norm(cfg.dim, LN_EPS, vb.pp("out_norm"))?,
+            out_norm: Norm::new(cfg.dim, vb.pp("out_norm"))?,
             linear: Linear::new(linear_weight, None),
             card: cfg.card,
             dtype: vb.dtype(),
@@ -428,8 +466,10 @@ impl Model {
     fn forward_embeds(&mut self, xs: &Tensor) -> Result<Tensor> {
         let t = xs.dim(1)?;
         let out = self.transformer.forward(xs)?;
-        let out = out.narrow(1, t - 1, 1)?;
-        let logits = out.apply(&self.out_norm)?.apply(&self.linear)?;
+        // contiguous: the fused layer-norm kernel requires it, and narrowing
+        // the time axis leaves a strided view when b > 1.
+        let out = out.narrow(1, t - 1, 1)?.contiguous()?;
+        let logits = self.out_norm.forward(&out)?.apply(&self.linear)?;
         // The reference sets logits at indices >= 1393 (reserved rows) to
         // -inf; restricting the head to the usable vocabulary is equivalent.
         let vocab = self.card.min(tokenizer::VOCAB_SIZE);
@@ -466,15 +506,16 @@ impl Model {
                 break;
             }
             let logits = self.forward_embeds(&input)?;
-            let mut tokens = Vec::with_capacity(b);
-            for row in 0..b {
-                let row_logits = logits.narrow(0, row, 1)?.squeeze(0)?;
-                let token = match logits_processor.as_mut() {
-                    None => row_logits.argmax(D::Minus1)?.to_scalar::<u32>()?,
-                    Some(lp) => lp.sample(&row_logits)?,
-                };
-                tokens.push(token);
-            }
+            // One device→host transfer per step, not one per batch row.
+            let tokens = match logits_processor.as_mut() {
+                None => logits.argmax(D::Minus1)?.to_vec1::<u32>()?,
+                Some(lp) => {
+                    let logits = logits.to_device(&Device::Cpu)?;
+                    (0..b)
+                        .map(|row| lp.sample(&logits.narrow(0, row, 1)?.squeeze(0)?))
+                        .collect::<Result<Vec<_>>>()?
+                }
+            };
             on_step(&tokens)?;
             for row in 0..b {
                 if !done[row] {

--- a/candle-transformers/src/models/muscriptor/mod.rs
+++ b/candle-transformers/src/models/muscriptor/mod.rs
@@ -1,0 +1,493 @@
+//! MuScriptor: audio-to-MIDI music transcription.
+//!
+//! A decoder-only causal transformer (audiocraft/MusicGen lineage): the audio is
+//! encoded as a log-mel spectrogram, projected to the model dimension and
+//! prepended as prefix tokens together with two class-conditioning embeddings
+//! (instrument group, dataset), after which MIDI event tokens are generated
+//! autoregressively over a single stream.
+//!
+//! Weights: hf.co/MuScriptor/muscriptor-{small,medium,large} (CC BY-NC 4.0).
+
+pub mod mel;
+pub mod tokenizer;
+
+use crate::generation::{LogitsProcessor, Sampling};
+use candle::{DType, Device, Module, Result, Tensor, D};
+use candle_nn::kv_cache::KvCache;
+use candle_nn::{layer_norm, linear, linear_no_bias, Embedding, LayerNorm, Linear, VarBuilder};
+
+pub const SAMPLE_RATE: usize = 16000;
+pub const SEGMENT_DURATION: f64 = 5.0;
+pub const FRAME_RATE: usize = 100;
+const N_FFT: usize = 2048;
+const N_MELS: usize = 512;
+const MEL_EPS: f32 = 1e-6;
+const MAX_PERIOD: f32 = 10000.;
+const LN_EPS: f64 = 1e-5;
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct Config {
+    pub dim: usize,
+    pub num_heads: usize,
+    pub num_layers: usize,
+    pub card: usize,
+}
+
+impl Config {
+    pub fn small() -> Self {
+        Self {
+            dim: 768,
+            num_heads: 12,
+            num_layers: 14,
+            card: 1393,
+        }
+    }
+
+    pub fn medium() -> Self {
+        Self {
+            dim: 1024,
+            num_heads: 16,
+            num_layers: 24,
+            card: 1395,
+        }
+    }
+
+    pub fn large() -> Self {
+        Self {
+            dim: 1536,
+            num_heads: 24,
+            num_layers: 48,
+            card: 1395,
+        }
+    }
+}
+
+/// `positions.cos() ++ positions.sin()` sinusoidal embedding, computed in f32.
+/// Matches the reference `create_sin_embedding`: the exponent denominator is
+/// `half_dim - 1` (not the usual `half_dim`).
+fn sin_embedding(offset: usize, t: usize, dim: usize, device: &Device) -> Result<Tensor> {
+    let half = dim / 2;
+    let mut data = vec![0f32; t * dim];
+    for pos_idx in 0..t {
+        let pos = (offset + pos_idx) as f32;
+        for i in 0..half {
+            let period = MAX_PERIOD.powf(i as f32 / (half - 1) as f32);
+            let phase = pos / period;
+            data[pos_idx * dim + i] = phase.cos();
+            data[pos_idx * dim + half + i] = phase.sin();
+        }
+    }
+    Tensor::from_vec(data, (t, dim), device)
+}
+
+#[derive(Debug, Clone)]
+struct StreamingMultiheadAttention {
+    in_proj: Linear,
+    out_proj: Linear,
+    kv_cache: KvCache,
+    num_heads: usize,
+    head_dim: usize,
+}
+
+impl StreamingMultiheadAttention {
+    fn new(dim: usize, num_heads: usize, vb: VarBuilder) -> Result<Self> {
+        let in_proj_weight = vb.get((3 * dim, dim), "in_proj_weight")?;
+        let in_proj = Linear::new(in_proj_weight, None);
+        let out_proj = linear_no_bias(dim, dim, vb.pp("out_proj"))?;
+        Ok(Self {
+            in_proj,
+            out_proj,
+            kv_cache: KvCache::new(2, 128),
+            num_heads,
+            head_dim: dim / num_heads,
+        })
+    }
+
+    fn reset_state(&mut self, max_seq_len: usize) {
+        self.kv_cache = KvCache::new(2, max_seq_len);
+    }
+
+    fn forward(&mut self, xs: &Tensor, mask: Option<&Tensor>) -> Result<Tensor> {
+        let (b, t, dim) = xs.dims3()?;
+        // The fused projection packs (q, k, v) along the outer dimension.
+        let qkv = xs
+            .apply(&self.in_proj)?
+            .reshape((b, t, 3, self.num_heads, self.head_dim))?;
+        let q = qkv.narrow(2, 0, 1)?.squeeze(2)?.transpose(1, 2)?;
+        let k = qkv.narrow(2, 1, 1)?.squeeze(2)?.transpose(1, 2)?;
+        let v = qkv.narrow(2, 2, 1)?.squeeze(2)?.transpose(1, 2)?;
+        let (k, v) = self.kv_cache.append(&k.contiguous()?, &v.contiguous()?)?;
+
+        let scale = 1f64 / (self.head_dim as f64).sqrt();
+        let attn = (q.contiguous()?.matmul(&k.transpose(2, 3)?)? * scale)?;
+        let attn = match mask {
+            None => attn,
+            Some(mask) => attn.broadcast_add(mask)?,
+        };
+        // Softmax in f32 as torch's SDPA does for half-precision inputs.
+        let dtype = attn.dtype();
+        let attn = if dtype == DType::F32 {
+            candle_nn::ops::softmax_last_dim(&attn)?
+        } else {
+            let attn = attn.to_dtype(DType::F32)?;
+            candle_nn::ops::softmax_last_dim(&attn)?.to_dtype(dtype)?
+        };
+        attn.matmul(&v.contiguous()?)?
+            .transpose(1, 2)?
+            .reshape((b, t, dim))?
+            .apply(&self.out_proj)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StreamingTransformerLayer {
+    self_attn: StreamingMultiheadAttention,
+    norm1: LayerNorm,
+    norm2: LayerNorm,
+    linear1: Linear,
+    linear2: Linear,
+}
+
+impl StreamingTransformerLayer {
+    fn new(dim: usize, num_heads: usize, hidden: usize, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            self_attn: StreamingMultiheadAttention::new(dim, num_heads, vb.pp("self_attn"))?,
+            norm1: layer_norm(dim, LN_EPS, vb.pp("norm1"))?,
+            norm2: layer_norm(dim, LN_EPS, vb.pp("norm2"))?,
+            linear1: linear_no_bias(dim, hidden, vb.pp("linear1"))?,
+            linear2: linear_no_bias(hidden, dim, vb.pp("linear2"))?,
+        })
+    }
+
+    fn forward(&mut self, xs: &Tensor, mask: Option<&Tensor>) -> Result<Tensor> {
+        let xs = (xs + self.self_attn.forward(&xs.apply(&self.norm1)?, mask)?)?;
+        let ff = xs
+            .apply(&self.norm2)?
+            .apply(&self.linear1)?
+            // torch's F.gelu defaults to the exact erf formulation.
+            .gelu_erf()?
+            .apply(&self.linear2)?;
+        xs + ff
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StreamingTransformer {
+    layers: Vec<StreamingTransformerLayer>,
+    offset: usize,
+}
+
+impl StreamingTransformer {
+    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let vb_l = vb.pp("layers");
+        let mut layers = Vec::with_capacity(cfg.num_layers);
+        for i in 0..cfg.num_layers {
+            layers.push(StreamingTransformerLayer::new(
+                cfg.dim,
+                cfg.num_heads,
+                4 * cfg.dim,
+                vb_l.pp(i),
+            )?)
+        }
+        Ok(Self { layers, offset: 0 })
+    }
+
+    fn reset_state(&mut self, max_seq_len: usize) {
+        self.offset = 0;
+        for layer in self.layers.iter_mut() {
+            layer.self_attn.reset_state(max_seq_len)
+        }
+    }
+
+    fn forward(&mut self, xs: &Tensor) -> Result<Tensor> {
+        let (_b, t, dim) = xs.dims3()?;
+        let pos_emb = sin_embedding(self.offset, t, dim, xs.device())?.to_dtype(xs.dtype())?;
+        let mut xs = xs.broadcast_add(&pos_emb)?;
+        let mask = if t <= 1 {
+            // A single decode step attends to the whole cache: no mask needed.
+            None
+        } else {
+            let offset = self.offset;
+            let s = offset + t;
+            let mask: Vec<f32> = (0..t)
+                .flat_map(|i| {
+                    (0..s).map(move |j| {
+                        if j <= offset + i {
+                            0.
+                        } else {
+                            f32::NEG_INFINITY
+                        }
+                    })
+                })
+                .collect();
+            Some(Tensor::from_vec(mask, (t, s), xs.device())?.to_dtype(xs.dtype())?)
+        };
+        for layer in self.layers.iter_mut() {
+            xs = layer.forward(&xs, mask.as_ref())?
+        }
+        self.offset += t;
+        Ok(xs)
+    }
+}
+
+/// Log-mel-spectrogram conditioner: mel bins are computed on the host in f32
+/// and projected to the transformer dimension.
+#[derive(Debug, Clone)]
+pub struct MelConditioner {
+    mel: mel::MelSpectrogram,
+    output_proj: Linear,
+    device: Device,
+}
+
+impl MelConditioner {
+    fn new(dim: usize, vb: VarBuilder) -> Result<Self> {
+        let vb_t = vb.pp("mel_spec_transform");
+        let window = vb_t
+            .get(N_FFT, "spectrogram.window")?
+            .to_device(&Device::Cpu)?
+            .to_vec1::<f32>()?;
+        let fb = vb_t
+            .get((N_FFT / 2 + 1, N_MELS), "mel_scale.fb")?
+            .to_device(&Device::Cpu)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        let hop = SAMPLE_RATE / FRAME_RATE;
+        Ok(Self {
+            mel: mel::MelSpectrogram::new(N_FFT, hop, N_MELS, window, fb),
+            output_proj: linear(N_MELS, dim, vb.pp("output_proj"))?,
+            device: vb.device().clone(),
+        })
+    }
+
+    /// Encode one fixed-size audio segment into `[1, n_frames, dim]` (f32).
+    pub fn encode(&self, samples: &[f32]) -> Result<Tensor> {
+        let (mel, n_frames) = self.mel.compute(samples);
+        let mel = mel.iter().map(|&v| (v + MEL_EPS).ln()).collect::<Vec<_>>();
+        let mel = Tensor::from_vec(mel, (1, n_frames, N_MELS), &self.device)?;
+        let embeds = mel.apply(&self.output_proj)?;
+        // The reference masks frames at index >= len(samples) / hop; with
+        // center-padded STFT there are len/hop + 1 frames, so the final frame
+        // is always zeroed.
+        let valid = samples.len() / self.mel.hop_length();
+        if valid < n_frames {
+            let zeros = Tensor::zeros(
+                (1, n_frames - valid, embeds.dim(2)?),
+                embeds.dtype(),
+                embeds.device(),
+            )?;
+            Tensor::cat(&[embeds.narrow(1, 0, valid)?, zeros], 1)
+        } else {
+            Ok(embeds)
+        }
+    }
+}
+
+/// Class-index conditioner (instrument group / dataset name).
+#[derive(Debug, Clone)]
+pub struct ClassConditioner {
+    embed: Embedding,
+    device: Device,
+}
+
+impl ClassConditioner {
+    fn new(num_classes: usize, dim: usize, vb: VarBuilder) -> Result<Self> {
+        let embed = candle_nn::embedding(num_classes + 1, dim, vb.pp("embed"))?;
+        Ok(Self {
+            embed,
+            device: vb.device().clone(),
+        })
+    }
+
+    /// Encode a class-id sequence into `[1, len, dim]` (f32). `None` is the
+    /// null (unconditional) condition. The reference tokenizer adds 1 to the
+    /// raw ids (null = -1) and its forward pass adds 1 again, so class `c`
+    /// lands on embedding row `c + 2` and null on row 1.
+    pub fn encode(&self, classes: Option<&[u32]>) -> Result<Tensor> {
+        let ids = match classes {
+            None => vec![1u32],
+            Some(cs) => cs.iter().map(|c| c + 2).collect(),
+        };
+        let len = ids.len();
+        let ids = Tensor::from_vec(ids, (1, len), &self.device)?;
+        self.embed.forward(&ids)
+    }
+}
+
+fn get_with_legacy_prefix(
+    vb: &VarBuilder,
+    shape: (usize, usize),
+    name: &str,
+    legacy: &str,
+) -> Result<Tensor> {
+    // Published checkpoints keep the audiocraft multi-codebook naming for the
+    // token embedding and output head (`emb.0.*` / `linears.0.*`).
+    if vb.contains_tensor(legacy) {
+        vb.get(shape, legacy)
+    } else {
+        vb.get(shape, name)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GenerateOptions {
+    /// Maximum number of generated tokens per segment.
+    pub max_gen_len: usize,
+    /// `None` decodes greedily (the reference default).
+    pub sampling: Option<Sampling>,
+    pub seed: u64,
+}
+
+impl Default for GenerateOptions {
+    fn default() -> Self {
+        Self {
+            max_gen_len: 2000,
+            sampling: None,
+            seed: 299792458,
+        }
+    }
+}
+
+pub struct Model {
+    pub mel_conditioner: MelConditioner,
+    pub instrument_conditioner: ClassConditioner,
+    pub dataset_conditioner: ClassConditioner,
+    emb: Embedding,
+    transformer: StreamingTransformer,
+    out_norm: LayerNorm,
+    linear: Linear,
+    card: usize,
+    dtype: DType,
+    device: Device,
+}
+
+impl Model {
+    /// Build the model. `vb` carries the transformer compute dtype; the
+    /// conditioners always run in f32 (`vb_f32`), matching the reference
+    /// which keeps the conditioning pipeline in full precision.
+    pub fn new(cfg: &Config, vb: VarBuilder, vb_f32: VarBuilder) -> Result<Self> {
+        let conds = vb_f32.pp("condition_provider").pp("conditioners");
+        let mel_conditioner = MelConditioner::new(cfg.dim, conds.pp("self_wav"))?;
+        let instrument_conditioner =
+            ClassConditioner::new(1000, cfg.dim, conds.pp("instrument_group"))?;
+        let dataset_conditioner = ClassConditioner::new(4, cfg.dim, conds.pp("dataset_name"))?;
+        let emb_weight =
+            get_with_legacy_prefix(&vb, (cfg.card + 1, cfg.dim), "emb.weight", "emb.0.weight")?;
+        let linear_weight = get_with_legacy_prefix(
+            &vb,
+            (cfg.card, cfg.dim),
+            "linear.weight",
+            "linears.0.weight",
+        )?;
+        Ok(Self {
+            mel_conditioner,
+            instrument_conditioner,
+            dataset_conditioner,
+            emb: Embedding::new(emb_weight, cfg.dim),
+            transformer: StreamingTransformer::new(cfg, vb.pp("transformer"))?,
+            out_norm: layer_norm(cfg.dim, LN_EPS, vb.pp("out_norm"))?,
+            linear: Linear::new(linear_weight, None),
+            card: cfg.card,
+            dtype: vb.dtype(),
+            device: vb.device().clone(),
+        })
+    }
+
+    /// The BOS token prepended to every generated sequence.
+    pub fn initial_token_id(&self) -> u32 {
+        self.card as u32
+    }
+
+    /// Build the conditioning prefix for a batch of equally-sized audio
+    /// segments: `[mel frames, dataset, instrument group(s)]`, in the
+    /// transformer dtype, shape `[b, prefix_len, dim]`.
+    pub fn build_prefix(
+        &self,
+        segments: &[impl AsRef<[f32]>],
+        instrument_classes: Option<&[u32]>,
+    ) -> Result<Tensor> {
+        let mels = segments
+            .iter()
+            .map(|s| self.mel_conditioner.encode(s.as_ref()))
+            .collect::<Result<Vec<_>>>()?;
+        let mel = Tensor::cat(&mels, 0)?;
+        let b = segments.len();
+        // Datasets are always conditioned on the null class at inference.
+        let dataset = self
+            .dataset_conditioner
+            .encode(None)?
+            .expand((b, 1, mel.dim(2)?))?;
+        let instrument = self.instrument_conditioner.encode(instrument_classes)?;
+        let instrument = instrument.expand((b, instrument.dim(1)?, mel.dim(2)?))?;
+        // The reference prepends conditions in front of the tokens one at a
+        // time (instrument, then dataset, then mel), which yields this order.
+        Tensor::cat(&[mel, dataset, instrument], 1)?.to_dtype(self.dtype)
+    }
+
+    /// One forward pass over embedded inputs; returns the last position's
+    /// logits over the usable vocabulary, in f32, shape `[b, vocab]`.
+    fn forward_embeds(&mut self, xs: &Tensor) -> Result<Tensor> {
+        let t = xs.dim(1)?;
+        let out = self.transformer.forward(xs)?;
+        let out = out.narrow(1, t - 1, 1)?;
+        let logits = out.apply(&self.out_norm)?.apply(&self.linear)?;
+        // The reference sets logits at indices >= 1393 (reserved rows) to
+        // -inf; restricting the head to the usable vocabulary is equivalent.
+        let vocab = self.card.min(tokenizer::VOCAB_SIZE);
+        logits.squeeze(1)?.narrow(1, 0, vocab)?.to_dtype(DType::F32)
+    }
+
+    /// Autoregressively generate MIDI tokens for a batch of conditioning
+    /// prefixes. `on_step` receives the batch's tokens after every step
+    /// (including EOS and post-EOS filler, exactly like the reference
+    /// streaming loop). Returns each row's tokens truncated at EOS.
+    pub fn generate(
+        &mut self,
+        prefix: &Tensor,
+        opts: &GenerateOptions,
+        mut on_step: impl FnMut(&[u32]) -> Result<()>,
+    ) -> Result<Vec<Vec<u32>>> {
+        let (b, prefix_len, _dim) = prefix.dims3()?;
+        self.transformer
+            .reset_state(prefix_len + opts.max_gen_len + 1);
+
+        let mut logits_processor = opts
+            .sampling
+            .as_ref()
+            .map(|sampling| LogitsProcessor::from_sampling(opts.seed, sampling.clone()));
+
+        let bos = Tensor::full(self.initial_token_id(), (b, 1), &self.device)?;
+        let bos = self.emb.forward(&bos)?;
+        let mut input = Tensor::cat(&[prefix.clone(), bos], 1)?;
+
+        let mut rows: Vec<Vec<u32>> = vec![Vec::new(); b];
+        let mut done = vec![false; b];
+        for _step in 0..opts.max_gen_len {
+            if done.iter().all(|&d| d) {
+                break;
+            }
+            let logits = self.forward_embeds(&input)?;
+            let mut tokens = Vec::with_capacity(b);
+            for row in 0..b {
+                let row_logits = logits.narrow(0, row, 1)?.squeeze(0)?;
+                let token = match logits_processor.as_mut() {
+                    None => row_logits.argmax(D::Minus1)?.to_scalar::<u32>()?,
+                    Some(lp) => lp.sample(&row_logits)?,
+                };
+                tokens.push(token);
+            }
+            on_step(&tokens)?;
+            for row in 0..b {
+                if !done[row] {
+                    if tokens[row] == tokenizer::EOS_ID {
+                        done[row] = true;
+                    } else {
+                        rows[row].push(tokens[row]);
+                    }
+                }
+            }
+            let next = Tensor::from_vec(tokens, (b, 1), &self.device)?;
+            input = self.emb.forward(&next)?;
+        }
+        Ok(rows)
+    }
+}

--- a/candle-transformers/src/models/muscriptor/tokenizer.rs
+++ b/candle-transformers/src/models/muscriptor/tokenizer.rs
@@ -1,0 +1,741 @@
+//! MT3-style MIDI token vocabulary and the streaming token → note-event decoder.
+//!
+//! The vocabulary layout is fixed: `PAD`, `EOS`, `UNK`, then `shift`
+//! (`max_shift_steps` values), `pitch` (128), `velocity` (2), `tie`,
+//! `program` (130) and `drum` (128) ranges.
+
+use std::collections::HashMap;
+
+pub const MAX_SHIFT_STEPS: u32 = 1001;
+/// 3 special tokens + 1001 shift + 128 pitch + 2 velocity + 1 tie + 130
+/// program + 128 drum.
+pub const VOCAB_SIZE: usize = 1393;
+pub const EOS_ID: u32 = 1;
+pub const DRUM_PROGRAM: i32 = 128;
+pub const MINIMUM_NOTE_DURATION_SEC: f64 = 0.01;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Event {
+    Pad,
+    Eos,
+    Unk,
+    Shift(u32),
+    Pitch(u8),
+    Velocity(u8),
+    Tie,
+    Program(i32),
+    Drum(u8),
+}
+
+pub fn decode_token(token: u32) -> Option<Event> {
+    let mut t = token;
+    match t {
+        0 => return Some(Event::Pad),
+        1 => return Some(Event::Eos),
+        2 => return Some(Event::Unk),
+        _ => t -= 3,
+    }
+    if t < MAX_SHIFT_STEPS {
+        return Some(Event::Shift(t));
+    }
+    t -= MAX_SHIFT_STEPS;
+    if t < 128 {
+        return Some(Event::Pitch(t as u8));
+    }
+    t -= 128;
+    if t < 2 {
+        return Some(Event::Velocity(t as u8));
+    }
+    t -= 2;
+    if t < 1 {
+        return Some(Event::Tie);
+    }
+    t -= 1;
+    if t < 130 {
+        return Some(Event::Program(t as i32));
+    }
+    t -= 130;
+    if t < 128 {
+        return Some(Event::Drum(t as u8));
+    }
+    None
+}
+
+/// The `MT3_FULL_PLUS` grouping of General MIDI programs, as `(group_id,
+/// programs)` pairs, followed by singleton groups for every unassigned
+/// program in `0..128` (matching the reference tokenizer's
+/// `misc_programs="SINGLETON_GROUPS"`, `is_mt3=True` construction).
+pub fn group_program_map() -> Vec<Vec<i32>> {
+    let mut groups: Vec<Vec<i32>> = vec![
+        vec![0, 1, 3, 6, 7],
+        vec![2, 4, 5],
+        (8..16).collect(),
+        (16..24).collect(),
+        vec![24, 25],
+        vec![26, 27, 28],
+        vec![29, 30, 31],
+        vec![32, 35],
+        vec![33, 34, 36, 37, 38, 39],
+        vec![40],
+        vec![41],
+        vec![42],
+        vec![43],
+        vec![46],
+        vec![47],
+        vec![48, 49, 44, 45],
+        vec![50, 51],
+        vec![52, 53, 54],
+        vec![55],
+        vec![56, 59],
+        vec![57],
+        vec![58],
+        vec![60],
+        vec![61, 62, 63],
+        vec![64, 65],
+        vec![66],
+        vec![67],
+        vec![68],
+        vec![69],
+        vec![70],
+        vec![71],
+        (72..80).collect(),
+        (80..88).collect(),
+        (88..96).collect(),
+        vec![100],
+        vec![101],
+    ];
+    let assigned: std::collections::HashSet<i32> = groups.iter().flatten().copied().collect();
+    for p in 0..128 {
+        if !assigned.contains(&p) {
+            groups.push(vec![p]);
+        }
+    }
+    groups
+}
+
+/// Human-readable names of the `MT3_FULL_PLUS` instrument groups, in group-id
+/// order. `("drums", 36)` names the first misc singleton group; the group ids
+/// index the model's learned conditioning classes and must not change.
+pub const GROUP_NAMES: [(&str, u32); 35] = [
+    ("acoustic_piano", 0),
+    ("electric_piano", 1),
+    ("chromatic_percussion", 2),
+    ("organ", 3),
+    ("acoustic_guitar", 4),
+    ("clean_electric_guitar", 5),
+    ("distorted_electric_guitar", 6),
+    ("acoustic_bass", 7),
+    ("electric_bass", 8),
+    ("violin", 9),
+    ("viola", 10),
+    ("cello", 11),
+    ("contrabass", 12),
+    ("orchestral_harp", 13),
+    ("timpani", 14),
+    ("string_ensemble", 15),
+    ("synth_strings", 16),
+    ("voice", 17),
+    ("orchestra_hit", 18),
+    ("trumpet", 19),
+    ("trombone", 20),
+    ("tuba", 21),
+    ("french_horn", 22),
+    ("brass_section", 23),
+    ("soprano_and_alto_sax", 24),
+    ("tenor_sax", 25),
+    ("baritone_sax", 26),
+    ("oboe", 27),
+    ("english_horn", 28),
+    ("bassoon", 29),
+    ("clarinet", 30),
+    ("flutes", 31),
+    ("synth_lead", 32),
+    ("synth_pad", 33),
+    ("drums", 36),
+];
+
+/// Map a decoded program number to a readable instrument name. The decoded
+/// program is always the first program of its group; unassigned programs
+/// surface as `program_<n>`.
+pub fn instrument_for_program(program: i32) -> String {
+    if program == DRUM_PROGRAM {
+        return "drums".to_string();
+    }
+    let groups = group_program_map();
+    for (name, gid) in GROUP_NAMES.iter() {
+        if let Some(programs) = groups.get(*gid as usize) {
+            if programs.first() == Some(&program) {
+                return name.to_string();
+            }
+        }
+    }
+    format!("program_{program}")
+}
+
+/// Inverse of [`instrument_for_program`] for MIDI assembly.
+pub fn program_for_instrument(instrument: &str) -> Option<i32> {
+    if instrument == "drums" {
+        return Some(DRUM_PROGRAM);
+    }
+    if let Some(n) = instrument.strip_prefix("program_") {
+        return n.parse().ok();
+    }
+    let groups = group_program_map();
+    GROUP_NAMES
+        .iter()
+        .find(|(name, _)| *name == instrument)
+        .and_then(|(_, gid)| groups.get(*gid as usize))
+        .and_then(|programs| programs.first().copied())
+}
+
+/// Resolve loosely-typed instrument tokens to conditioning class ids.
+/// Matching is case-insensitive; a non-exact token may be a substring that
+/// matches exactly one group name.
+pub fn instrument_class_ids(names: &[impl AsRef<str>]) -> std::result::Result<Vec<u32>, String> {
+    let mut ids = Vec::with_capacity(names.len());
+    for name in names {
+        let t = name.as_ref().trim().to_lowercase();
+        if let Some((_, gid)) = GROUP_NAMES.iter().find(|(n, _)| *n == t) {
+            ids.push(*gid);
+            continue;
+        }
+        let hits: Vec<&(&str, u32)> = GROUP_NAMES.iter().filter(|(n, _)| n.contains(&t)).collect();
+        match hits.as_slice() {
+            [(_, gid)] => ids.push(*gid),
+            [] => {
+                let valid: Vec<&str> = GROUP_NAMES.iter().map(|(n, _)| *n).collect();
+                return Err(format!(
+                    "unknown instrument name {t:?}; valid names: {}",
+                    valid.join(", ")
+                ));
+            }
+            _ => {
+                let matches: Vec<&str> = hits.iter().map(|(n, _)| *n).collect();
+                return Err(format!(
+                    "ambiguous instrument name {t:?}: matches {}",
+                    matches.join(", ")
+                ));
+            }
+        }
+    }
+    Ok(ids)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NoteStart {
+    pub pitch: u8,
+    pub start_time: f64,
+    pub index: usize,
+    pub instrument: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum NoteEvent {
+    Start(NoteStart),
+    End { end_time: f64, start_index: usize },
+}
+
+/// Streaming decoder from model tokens to [`NoteEvent`]s.
+///
+/// Feed each segment with [`TokenDecoder::start_chunk`] followed by its tokens
+/// (EOS already stripped) through [`TokenDecoder::push`], then call
+/// [`TokenDecoder::finish`] once at the end of the stream. Every emitted
+/// `Start` is matched by exactly one later `End` with the same index.
+///
+/// Each chunk begins with a *tie prologue* — `(program, pitch)` pairs for
+/// notes sustained from the previous chunk, terminated by a `tie` token —
+/// after which open notes not in the tie set are closed at the boundary.
+#[derive(Debug, Clone, Default)]
+pub struct TokenDecoder {
+    open_notes: HashMap<(i32, u8), NoteStart>,
+    next_index: usize,
+    seek_time: f64,
+    next_seek_time: Option<f64>,
+    start_tick: i64,
+    tick_state: i64,
+    program_state: Option<i32>,
+    velocity_state: Option<u8>,
+    in_prologue: bool,
+    skip_rest: bool,
+    tie_set: std::collections::HashSet<(i32, u8)>,
+    chunk_started: bool,
+    frame_rate: f64,
+}
+
+impl TokenDecoder {
+    pub fn new(frame_rate: usize) -> Self {
+        Self {
+            frame_rate: frame_rate as f64,
+            ..Default::default()
+        }
+    }
+
+    fn mint(&mut self, pitch: u8, start_time: f64, instrument: String) -> NoteStart {
+        let ev = NoteStart {
+            pitch,
+            start_time,
+            index: self.next_index,
+            instrument,
+        };
+        self.next_index += 1;
+        ev
+    }
+
+    fn close_all_at_boundary(&mut self, out: &mut Vec<NoteEvent>) {
+        let mut open: Vec<_> = self.open_notes.drain().map(|(_, v)| v).collect();
+        open.sort_by_key(|ev| ev.index);
+        for ev in open {
+            out.push(NoteEvent::End {
+                end_time: self.seek_time,
+                start_index: ev.index,
+            });
+        }
+    }
+
+    pub fn start_chunk(
+        &mut self,
+        seek_time: f64,
+        next_seek_time: Option<f64>,
+        out: &mut Vec<NoteEvent>,
+    ) {
+        // A previous chunk that never closed its tie prologue is malformed:
+        // every still-open note ends at that chunk's boundary.
+        if self.chunk_started && self.in_prologue {
+            self.close_all_at_boundary(out);
+        }
+        self.seek_time = seek_time;
+        self.next_seek_time = next_seek_time;
+        self.start_tick = (seek_time * self.frame_rate).round_ties_even() as i64;
+        self.tick_state = self.start_tick;
+        self.program_state = None;
+        self.velocity_state = None;
+        self.in_prologue = true;
+        self.skip_rest = false;
+        self.tie_set.clear();
+        self.chunk_started = true;
+    }
+
+    pub fn push(&mut self, token: u32, out: &mut Vec<NoteEvent>) {
+        let event = match decode_token(token) {
+            Some(event) => event,
+            None => return,
+        };
+
+        if self.in_prologue {
+            match event {
+                Event::Tie => {
+                    // End of the tie section: close prior notes not sustained here.
+                    self.in_prologue = false;
+                    self.velocity_state = None;
+                    let mut to_close: Vec<_> = self
+                        .open_notes
+                        .iter()
+                        .filter(|(key, _)| !self.tie_set.contains(key))
+                        .map(|(key, ev)| (*key, ev.index))
+                        .collect();
+                    to_close.sort_by_key(|&(_, index)| index);
+                    for (key, index) in to_close {
+                        self.open_notes.remove(&key);
+                        out.push(NoteEvent::End {
+                            end_time: self.seek_time,
+                            start_index: index,
+                        });
+                    }
+                }
+                Event::Shift(_) => {
+                    // No tie token: the chunk is malformed. Close all open
+                    // notes at the boundary and drop the rest of the chunk.
+                    self.in_prologue = false;
+                    self.skip_rest = true;
+                    let seek_time = self.seek_time;
+                    let mut open: Vec<_> = self.open_notes.drain().map(|(_, v)| v.index).collect();
+                    open.sort_unstable();
+                    for index in open {
+                        out.push(NoteEvent::End {
+                            end_time: seek_time,
+                            start_index: index,
+                        });
+                    }
+                }
+                Event::Program(p) => self.program_state = Some(p),
+                Event::Pitch(pitch) => {
+                    if let Some(program) = self.program_state {
+                        self.tie_set.insert((program, pitch));
+                    }
+                }
+                _ => {}
+            }
+            return;
+        }
+
+        if self.skip_rest {
+            return;
+        }
+
+        match event {
+            Event::Shift(v) => {
+                if v > 0 {
+                    self.tick_state = self.start_tick + v as i64;
+                }
+            }
+            Event::Program(p) => self.program_state = Some(p),
+            Event::Velocity(v) => self.velocity_state = Some(v),
+            Event::Drum(pitch) => {
+                let time = self.tick_state as f64 / self.frame_rate;
+                if self.next_seek_time.is_none_or(|next| time < next) {
+                    let start = self.mint(pitch, time, "drums".to_string());
+                    let index = start.index;
+                    out.push(NoteEvent::Start(start));
+                    out.push(NoteEvent::End {
+                        end_time: time + MINIMUM_NOTE_DURATION_SEC,
+                        start_index: index,
+                    });
+                }
+            }
+            Event::Pitch(pitch) => {
+                let (Some(program), Some(velocity)) = (self.program_state, self.velocity_state)
+                else {
+                    return;
+                };
+                let time = self.tick_state as f64 / self.frame_rate;
+                if self.next_seek_time.is_some_and(|next| time >= next) {
+                    return;
+                }
+                let key = (program, pitch);
+                if let Some(open) = self.open_notes.remove(&key) {
+                    out.push(NoteEvent::End {
+                        end_time: time,
+                        start_index: open.index,
+                    });
+                }
+                if velocity > 0 {
+                    let start = self.mint(pitch, time, instrument_for_program(program));
+                    self.open_notes.insert(key, start.clone());
+                    out.push(NoteEvent::Start(start));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// End of stream: close anything still open. A well-formed final chunk
+    /// uses the minimum-duration fallback; a chunk that ended mid-prologue
+    /// closes at its boundary.
+    pub fn finish(&mut self, out: &mut Vec<NoteEvent>) {
+        if self.chunk_started && self.in_prologue {
+            self.close_all_at_boundary(out);
+        } else {
+            let mut open: Vec<_> = self.open_notes.drain().map(|(_, v)| v).collect();
+            open.sort_by_key(|ev| ev.index);
+            for ev in open {
+                out.push(NoteEvent::End {
+                    end_time: ev.start_time + MINIMUM_NOTE_DURATION_SEC,
+                    start_index: ev.index,
+                });
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Note {
+    pub is_drum: bool,
+    /// MIDI program number (0-127); 128 for drums.
+    pub program: i32,
+    pub onset: f64,
+    pub offset: f64,
+    pub pitch: u8,
+}
+
+fn sort_notes(notes: &mut [Note]) {
+    notes.sort_by(|a, b| {
+        a.onset
+            .total_cmp(&b.onset)
+            .then(a.is_drum.cmp(&b.is_drum))
+            .then(a.program.cmp(&b.program))
+            .then(a.pitch.cmp(&b.pitch))
+            .then(a.offset.total_cmp(&b.offset))
+    });
+}
+
+/// Reassemble [`Note`]s from a `NoteEvent` stream and apply the reference
+/// note-cleanup pass (minimum durations, per-channel overlap trimming, final
+/// sort).
+pub fn events_to_notes(events: &[NoteEvent]) -> Vec<Note> {
+    let mut notes = Vec::new();
+    let mut open: HashMap<usize, Note> = HashMap::new();
+    for ev in events {
+        match ev {
+            NoteEvent::Start(start) => {
+                let is_drum = start.instrument == "drums";
+                let program = if is_drum {
+                    DRUM_PROGRAM
+                } else {
+                    program_for_instrument(&start.instrument).unwrap_or(0)
+                };
+                open.insert(
+                    start.index,
+                    Note {
+                        is_drum,
+                        program,
+                        onset: start.start_time,
+                        offset: start.start_time, // patched by the matching End
+                        pitch: start.pitch,
+                    },
+                );
+            }
+            NoteEvent::End {
+                end_time,
+                start_index,
+            } => {
+                if let Some(mut note) = open.remove(start_index) {
+                    note.offset = *end_time;
+                    notes.push(note);
+                }
+            }
+        }
+    }
+    validate_notes(&mut notes);
+    trim_overlapping_notes(notes)
+}
+
+/// Enforce a minimum note duration (`validate_notes(fix=True)`).
+fn validate_notes(notes: &mut [Note]) {
+    for note in notes.iter_mut() {
+        if note.onset > note.offset {
+            note.offset = note.offset.max(note.onset + MINIMUM_NOTE_DURATION_SEC);
+        } else if !note.is_drum && note.offset - note.onset < MINIMUM_NOTE_DURATION_SEC {
+            note.offset = note.onset + MINIMUM_NOTE_DURATION_SEC;
+        }
+    }
+}
+
+/// Truncate overlapping same-(program, pitch, drum) notes at the next onset
+/// and drop the ones that end up empty; sorts the result.
+fn trim_overlapping_notes(notes: Vec<Note>) -> Vec<Note> {
+    if notes.len() <= 1 {
+        return notes;
+    }
+    let mut channels: HashMap<(i32, u8, bool), Vec<Note>> = HashMap::new();
+    for note in notes {
+        channels
+            .entry((note.program, note.pitch, note.is_drum))
+            .or_default()
+            .push(note);
+    }
+    let mut trimmed = Vec::new();
+    for (_, mut channel_notes) in channels {
+        channel_notes.sort_by(|a, b| a.onset.total_cmp(&b.onset));
+        for i in 1..channel_notes.len() {
+            if channel_notes[i - 1].offset > channel_notes[i].onset {
+                channel_notes[i - 1].offset = channel_notes[i].onset;
+            }
+        }
+        trimmed.extend(channel_notes.into_iter().filter(|n| n.onset < n.offset));
+    }
+    sort_notes(&mut trimmed);
+    trimmed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vocab_ranges() {
+        assert_eq!(decode_token(0), Some(Event::Pad));
+        assert_eq!(decode_token(EOS_ID), Some(Event::Eos));
+        assert_eq!(decode_token(2), Some(Event::Unk));
+        assert_eq!(decode_token(3), Some(Event::Shift(0)));
+        assert_eq!(decode_token(3 + MAX_SHIFT_STEPS - 1), Some(Event::Shift(1000)));
+        assert_eq!(decode_token(1004), Some(Event::Pitch(0)));
+        assert_eq!(decode_token(1131), Some(Event::Pitch(127)));
+        assert_eq!(decode_token(1132), Some(Event::Velocity(0)));
+        assert_eq!(decode_token(1133), Some(Event::Velocity(1)));
+        assert_eq!(decode_token(1134), Some(Event::Tie));
+        assert_eq!(decode_token(1135), Some(Event::Program(0)));
+        assert_eq!(decode_token(1264), Some(Event::Program(129)));
+        assert_eq!(decode_token(1265), Some(Event::Drum(0)));
+        assert_eq!(decode_token(1392), Some(Event::Drum(127)));
+        assert_eq!(decode_token(VOCAB_SIZE as u32), None);
+    }
+
+    fn token(event: Event) -> u32 {
+        (0..VOCAB_SIZE as u32)
+            .find(|&t| decode_token(t) == Some(event))
+            .unwrap()
+    }
+
+    #[test]
+    fn instrument_group_round_trip() {
+        for (name, _) in GROUP_NAMES.iter() {
+            let program = program_for_instrument(name).unwrap();
+            assert_eq!(instrument_for_program(program), *name, "{name}");
+        }
+        assert_eq!(instrument_for_program(DRUM_PROGRAM), "drums");
+        assert_eq!(program_for_instrument("program_97"), Some(97));
+        assert_eq!(instrument_class_ids(&["ACOUSTIC_PIANO"]), Ok(vec![0]));
+        assert_eq!(instrument_class_ids(&["timp"]), Ok(vec![14]));
+        assert!(instrument_class_ids(&["piano"]).is_err()); // ambiguous
+        assert!(instrument_class_ids(&["theremin"]).is_err());
+    }
+
+    /// A well-formed chunk: empty tie prologue, one note opened and closed.
+    #[test]
+    fn decode_simple_note() {
+        let mut decoder = TokenDecoder::new(100);
+        let mut out = Vec::new();
+        decoder.start_chunk(0.0, Some(5.0), &mut out);
+        for t in [
+            token(Event::Tie),
+            token(Event::Shift(50)),
+            token(Event::Program(0)),
+            token(Event::Velocity(1)),
+            token(Event::Pitch(60)),
+            token(Event::Shift(150)),
+            token(Event::Velocity(0)),
+            token(Event::Pitch(60)),
+        ] {
+            decoder.push(t, &mut out);
+        }
+        decoder.finish(&mut out);
+        assert_eq!(
+            out,
+            vec![
+                NoteEvent::Start(NoteStart {
+                    pitch: 60,
+                    start_time: 0.5,
+                    index: 0,
+                    instrument: "acoustic_piano".to_string(),
+                }),
+                NoteEvent::End {
+                    end_time: 1.5,
+                    start_index: 0,
+                },
+            ]
+        );
+    }
+
+    /// A note sustained through the tie prologue survives into the next
+    /// chunk; one not in the tie set is closed at the boundary.
+    #[test]
+    fn decode_tie_prologue() {
+        let mut decoder = TokenDecoder::new(100);
+        let mut out = Vec::new();
+        decoder.start_chunk(0.0, Some(5.0), &mut out);
+        for t in [
+            token(Event::Tie),
+            token(Event::Program(0)),
+            token(Event::Velocity(1)),
+            token(Event::Pitch(60)),
+            token(Event::Pitch(64)),
+        ] {
+            decoder.push(t, &mut out);
+        }
+        assert_eq!(out.len(), 2); // both notes open
+        decoder.start_chunk(5.0, None, &mut out);
+        for t in [
+            token(Event::Program(0)),
+            token(Event::Pitch(60)), // only pitch 60 is tied over
+            token(Event::Tie),
+            token(Event::Shift(100)),
+            token(Event::Velocity(0)),
+            token(Event::Pitch(60)),
+        ] {
+            decoder.push(t, &mut out);
+        }
+        decoder.finish(&mut out);
+        assert_eq!(
+            &out[2..],
+            &[
+                // pitch 64 not tied: closed at the 5 s boundary.
+                NoteEvent::End {
+                    end_time: 5.0,
+                    start_index: 1,
+                },
+                NoteEvent::End {
+                    end_time: 6.0,
+                    start_index: 0,
+                },
+            ]
+        );
+    }
+
+    /// A chunk whose prologue never emits `tie` (first event is a shift) is
+    /// malformed: all open notes close at the boundary, the rest is dropped.
+    #[test]
+    fn decode_malformed_chunk() {
+        let mut decoder = TokenDecoder::new(100);
+        let mut out = Vec::new();
+        decoder.start_chunk(0.0, Some(5.0), &mut out);
+        for t in [
+            token(Event::Tie),
+            token(Event::Program(40)),
+            token(Event::Velocity(1)),
+            token(Event::Pitch(70)),
+        ] {
+            decoder.push(t, &mut out);
+        }
+        decoder.start_chunk(5.0, None, &mut out);
+        decoder.push(token(Event::Shift(10)), &mut out);
+        // Note events after the malformed prologue are dropped.
+        for t in [
+            token(Event::Program(0)),
+            token(Event::Velocity(1)),
+            token(Event::Pitch(50)),
+        ] {
+            decoder.push(t, &mut out);
+        }
+        decoder.finish(&mut out);
+        assert_eq!(
+            out,
+            vec![
+                NoteEvent::Start(NoteStart {
+                    pitch: 70,
+                    start_time: 0.0,
+                    index: 0,
+                    instrument: "violin".to_string(),
+                }),
+                NoteEvent::End {
+                    end_time: 5.0,
+                    start_index: 0,
+                },
+            ]
+        );
+    }
+
+    /// Overlapping same-pitch notes are trimmed at the next onset and the
+    /// minimum note duration is enforced.
+    #[test]
+    fn note_cleanup() {
+        let events = vec![
+            NoteEvent::Start(NoteStart {
+                pitch: 60,
+                start_time: 0.0,
+                index: 0,
+                instrument: "acoustic_piano".to_string(),
+            }),
+            NoteEvent::Start(NoteStart {
+                pitch: 60,
+                start_time: 1.0,
+                index: 1,
+                instrument: "acoustic_piano".to_string(),
+            }),
+            NoteEvent::End {
+                end_time: 2.0,
+                start_index: 0, // overlaps the second onset
+            },
+            NoteEvent::End {
+                end_time: 1.0, // zero length: extended to the minimum
+                start_index: 1,
+            },
+        ];
+        let notes = events_to_notes(&events);
+        assert_eq!(notes.len(), 2);
+        assert_eq!((notes[0].onset, notes[0].offset), (0.0, 1.0));
+        assert_eq!(
+            (notes[1].onset, notes[1].offset),
+            (1.0, 1.0 + MINIMUM_NOTE_DURATION_SEC)
+        );
+    }
+}

--- a/candle-transformers/src/models/muscriptor/tokenizer.rs
+++ b/candle-transformers/src/models/muscriptor/tokenizer.rs
@@ -547,7 +547,10 @@ mod tests {
         assert_eq!(decode_token(EOS_ID), Some(Event::Eos));
         assert_eq!(decode_token(2), Some(Event::Unk));
         assert_eq!(decode_token(3), Some(Event::Shift(0)));
-        assert_eq!(decode_token(3 + MAX_SHIFT_STEPS - 1), Some(Event::Shift(1000)));
+        assert_eq!(
+            decode_token(3 + MAX_SHIFT_STEPS - 1),
+            Some(Event::Shift(1000))
+        );
         assert_eq!(decode_token(1004), Some(Event::Pitch(0)));
         assert_eq!(decode_token(1131), Some(Event::Pitch(127)));
         assert_eq!(decode_token(1132), Some(Event::Velocity(0)));


### PR DESCRIPTION
This adds [MuScriptor](https://huggingface.co/MuScriptor) (Kyutai/Mirelo lineage), an audio→MIDI music transcription model, plus two small build fixes it surfaced.

## Model

A decoder-only prefix-LM in the audiocraft/MusicGen style: audio is processed in 5-second chunks, each chunk's log-mel spectrogram is projected and prepended as prefix tokens (together with instrument-group/dataset class embeddings), then MIDI event tokens are generated autoregressively over a single stream and decoded into notes via an MT3-style tokenizer.

- `candle-transformers/src/models/muscriptor/`: transformer + LM + conditioners; a pure-Rust STFT/mel front-end (the Hann window and HTK filterbank are loaded from checkpoint buffers, so they match the reference by construction); the token vocabulary and the streaming token→note-event decoder, with unit tests for the pure-logic parts.
- `candle-examples/examples/muscriptor/`: CLI — symphonia decode, a julius-style sinc resampler, chunked/batched generation with streaming note output, and a MIDI (SMF format 0) writer. No new dependencies.

Verified against the PyTorch reference implementation (large checkpoint, greedy decoding): MIDI output is **byte-identical** on CPU f32 and Metal f32, and event-identical on Metal f16, on both synthetic and real-music inputs.

Note the published weights are CC BY-NC 4.0 (small/medium/large variants; gated repos).

```bash
cargo run --example muscriptor --release --features symphonia -- song.mp3 --model large --notes
```

## Build fixes included

- **fix(cpu): gate the unstable neon fp16 kernel tier behind nightly toolchains** — `float16x8_t` requires the unstable `stdarch_neon_f16` feature (rust-lang/rust#136306) and `target_feature=fp16` is enabled by default on `aarch64-apple-darwin`, so `cargo check` on stable currently fails with E0658 on Apple Silicon. A small `build.rs` sets `cfg(candle_nightly)` on nightly compilers; stable builds fall back to the existing FCVTL-widening kernels.
- **fix(examples): pin symphonia to 0.5** — the bump to 0.6 (a full API rework) broke all examples behind the `symphonia`/`mimi`/`encodec`/`snac` features; CI doesn't build those features so it went unnoticed.

Happy to split the two fixes into separate PRs if preferred.