### PR TITLE
Upgrade hf-hub to 1.0 and use the new client API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ cudarc = { version = "0.19.8", features = [
 ], default-features = false }
 fancy-regex = "0.18.0"
 gemm = { version = "0.19.0", features = ["wasm-simd128-enable"] }
-hf-hub = "0.5.0"
+hf-hub = "1.0"
 half = { version = "2.5.0", features = [
     "num-traits",
     "use-intrinsics",

--- a/candle-book/Cargo.toml
+++ b/candle-book/Cargo.toml
@@ -29,7 +29,7 @@ tokio = "1.48.0"
 
 [dev-dependencies]
 byteorder = { workspace = true }
-hf-hub = { workspace = true, features=["tokio"]}
+hf-hub = { workspace = true, features=["blocking"]}
 clap = { workspace = true }
 memmap2 = { workspace = true }
 rand = { workspace = true }

--- a/candle-book/src/lib.rs
+++ b/candle-book/src/lib.rs
@@ -13,12 +13,12 @@ mod tests {
     async fn book_hub_1() {
 // ANCHOR: book_hub_1
 use candle::Device;
-use hf_hub::api::tokio::Api;
+use hf_hub::HFClient;
 
-let api = Api::new().unwrap();
-let repo = api.model("bert-base-uncased".to_string());
+let client = HFClient::new().unwrap();
+let repo = client.model("google-bert", "bert-base-uncased");
 
-let weights_filename = repo.get("model.safetensors").await.unwrap();
+let weights_filename = repo.download_file().filename("model.safetensors").send().await.unwrap();
 
 let weights = candle::safetensors::load(weights_filename, &Device::Cpu).unwrap();
 // ANCHOR_END: book_hub_1
@@ -31,13 +31,13 @@ let weights = candle::safetensors::load(weights_filename, &Device::Cpu).unwrap()
         {
 // ANCHOR: book_hub_2
 use candle::Device;
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use memmap2::Mmap;
 use std::fs;
 
-let api = Api::new().unwrap();
-let repo = api.model("bert-base-uncased".to_string());
-let weights_filename = repo.get("model.safetensors").unwrap();
+let client = HFClientSync::new().unwrap();
+let repo = client.model("google-bert", "bert-base-uncased");
+let weights_filename = repo.download_file().filename("model.safetensors").send().unwrap();
 
 let file = fs::File::open(weights_filename).unwrap();
 let mmap = unsafe { Mmap::map(&file).unwrap() };
@@ -52,15 +52,15 @@ let weights = candle::safetensors::load_buffer(&mmap[..], &Device::Cpu).unwrap()
     {
 // ANCHOR: book_hub_3
 use candle::{DType, Device, Tensor};
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use memmap2::Mmap;
 use safetensors::slice::IndexOp;
 use safetensors::SafeTensors;
 use std::fs;
 
-let api = Api::new().unwrap();
-let repo = api.model("bert-base-uncased".to_string());
-let weights_filename = repo.get("model.safetensors").unwrap();
+let client = HFClientSync::new().unwrap();
+let repo = client.model("google-bert", "bert-base-uncased");
+let weights_filename = repo.download_file().filename("model.safetensors").send().unwrap();
 
 let file = fs::File::open(weights_filename).unwrap();
 let mmap = unsafe { Mmap::map(&file).unwrap() };
@@ -110,19 +110,15 @@ let tp_tensor = Tensor::from_raw_buffer(&raw, dtype, &tp_shape, &Device::Cpu).un
     #[rustfmt::skip]
     fn book_training_1() -> Result<()>{
 // ANCHOR: book_training_1
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 
-let dataset_id = "mnist".to_string();
+let dataset_id = "ylecun/mnist".to_string();
 
-let api = Api::new()?;
-let repo = Repo::with_revision(
-    dataset_id,
-    RepoType::Dataset,
-    "refs/convert/parquet".to_string(),
-);
-let repo = api.repo(repo);
-let test_parquet_filename = repo.get("mnist/test/0000.parquet")?;
-let train_parquet_filename = repo.get("mnist/train/0000.parquet")?;
+let client = HFClientSync::new()?;
+let (owner, name) = hf_hub::split_id(&dataset_id);
+let repo = client.dataset(owner, name);
+let test_parquet_filename = repo.download_file().filename("mnist/test/0000.parquet").revision("refs/convert/parquet").send()?;
+let train_parquet_filename = repo.download_file().filename("mnist/train/0000.parquet").revision("refs/convert/parquet").send()?;
 let test_parquet =
     SerializedFileReader::new(std::fs::File::open(test_parquet_filename)?)?;
 let train_parquet =
@@ -137,8 +133,8 @@ for row in test_parquet {
     }
 }
 // ANCHOR_END: book_training_2
-let test_parquet_filename = repo.get("mnist/test/0000.parquet")?;
-let train_parquet_filename = repo.get("mnist/train/0000.parquet")?;
+let test_parquet_filename = repo.download_file().filename("mnist/test/0000.parquet").revision("refs/convert/parquet").send()?;
+let train_parquet_filename = repo.download_file().filename("mnist/train/0000.parquet").revision("refs/convert/parquet").send()?;
 let test_parquet = SerializedFileReader::new(std::fs::File::open(test_parquet_filename)?)?;
 let train_parquet = SerializedFileReader::new(std::fs::File::open(train_parquet_filename)?)?;
 // ANCHOR: book_training_3

--- a/candle-datasets/Cargo.toml
+++ b/candle-datasets/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 byteorder = { workspace = true }
 candle = { workspace = true }
 candle-nn = { workspace = true }
-hf-hub = { workspace = true}
+hf-hub = { workspace = true, features = ["blocking"]}
 intel-mkl-src = { workspace = true, optional = true }
 memmap2 = { workspace = true }
 tokenizers = { workspace = true, features = ["onig"] }

--- a/candle-datasets/src/hub.rs
+++ b/candle-datasets/src/hub.rs
@@ -1,7 +1,4 @@
-use hf_hub::{
-    api::sync::{Api, ApiRepo},
-    Repo, RepoType,
-};
+use hf_hub::{HFClientSync, HFRepositorySync, RepoTypeDataset};
 use parquet::file::reader::SerializedFileReader;
 use std::fs::File;
 
@@ -19,8 +16,8 @@ use std::fs::File;
 /// # Example
 /// ```
 /// use candle_datasets::hub::{from_hub, FileReader};  // Re-exported trait
-/// let api = hf_hub::api::sync::Api::new().unwrap();
-/// let files = from_hub(&api, "hf-internal-testing/dummy_image_text_data".to_string()).unwrap();
+/// let client = hf_hub::HFClientSync::new().unwrap();
+/// let files = from_hub(&client, "hf-internal-testing/dummy_image_text_data".to_string()).unwrap();
 /// let num_rows = files[0].metadata().file_metadata().num_rows();
 /// ```
 pub use parquet::file::reader::FileReader;
@@ -28,7 +25,7 @@ pub use parquet::file::reader::FileReader;
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("ApiError : {0}")]
-    ApiError(#[from] hf_hub::api::sync::ApiError),
+    ApiError(#[from] hf_hub::HFError),
 
     #[error("IoError : {0}")]
     IoError(#[from] std::io::Error),
@@ -39,9 +36,14 @@ pub enum Error {
 
 fn sibling_to_parquet(
     rfilename: &str,
-    repo: &ApiRepo,
+    repo: &HFRepositorySync<RepoTypeDataset>,
+    revision: &str,
 ) -> Result<SerializedFileReader<File>, Error> {
-    let local = repo.get(rfilename)?;
+    let local = repo
+        .download_file()
+        .filename(rfilename)
+        .revision(revision)
+        .send()?;
     let file = File::open(local)?;
     Ok(SerializedFileReader::new(file)?)
 }
@@ -53,24 +55,25 @@ fn sibling_to_parquet(
 /// # Example
 /// ```
 /// use candle_datasets::hub::{from_hub, FileReader};
-/// let api = hf_hub::api::sync::Api::new().unwrap();
-/// let readers = from_hub(&api, "hf-internal-testing/dummy_image_text_data".to_string()).unwrap();
+/// let client = hf_hub::HFClientSync::new().unwrap();
+/// let readers = from_hub(&client, "hf-internal-testing/dummy_image_text_data".to_string()).unwrap();
 /// let metadata = readers[0].metadata();
 /// assert_eq!(metadata.file_metadata().num_rows(), 20);
 /// ```
-pub fn from_hub(api: &Api, dataset_id: String) -> Result<Vec<SerializedFileReader<File>>, Error> {
-    let repo = Repo::with_revision(
-        dataset_id,
-        RepoType::Dataset,
-        "refs/convert/parquet".to_string(),
-    );
-    let repo = api.repo(repo);
-    let info = repo.info()?;
+pub fn from_hub(
+    client: &HFClientSync,
+    dataset_id: String,
+) -> Result<Vec<SerializedFileReader<File>>, Error> {
+    let revision = "refs/convert/parquet";
+    let (owner, name) = hf_hub::split_id(&dataset_id);
+    let repo = client.dataset(owner, name);
+    let info = repo.info().revision(revision).send()?;
 
     info.siblings
+        .unwrap_or_default()
         .into_iter()
         .filter(|s| s.rfilename.ends_with(".parquet"))
-        .map(|s| sibling_to_parquet(&s.rfilename, &repo))
+        .map(|s| sibling_to_parquet(&s.rfilename, &repo, revision))
         .collect()
 }
 
@@ -80,9 +83,9 @@ mod tests {
 
     #[test]
     fn test_dataset() {
-        let api = Api::new().unwrap();
+        let client = HFClientSync::new().unwrap();
         let files = from_hub(
-            &api,
+            &client,
             "hf-internal-testing/dummy_image_text_data".to_string(),
         )
         .unwrap();

--- a/candle-datasets/src/vision/cifar.rs
+++ b/candle-datasets/src/vision/cifar.rs
@@ -5,7 +5,7 @@
 //! The binary version of the dataset is used.
 use crate::vision::Dataset;
 use candle::{DType, Device, Error, Result, Tensor};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use std::fs::File;
 use std::io::{BufReader, Read};
@@ -93,19 +93,19 @@ fn load_parquet(parquet: SerializedFileReader<std::fs::File>) -> Result<(Tensor,
 }
 
 pub fn load() -> Result<Dataset> {
-    let api = Api::new().map_err(|e| Error::Msg(format!("Api error: {e}")))?;
-    let dataset_id = "cifar10".to_string();
-    let repo = Repo::with_revision(
-        dataset_id,
-        RepoType::Dataset,
-        "refs/convert/parquet".to_string(),
-    );
-    let repo = api.repo(repo);
+    let client = HFClientSync::new().map_err(|e| Error::Msg(format!("Api error: {e}")))?;
+    let repo = client.dataset("", "cifar10");
     let test_parquet_filename = repo
-        .get("plain_text/test/0000.parquet")
+        .download_file()
+        .filename("plain_text/test/0000.parquet")
+        .revision("refs/convert/parquet")
+        .send()
         .map_err(|e| Error::Msg(format!("Api error: {e}")))?;
     let train_parquet_filename = repo
-        .get("plain_text/train/0000.parquet")
+        .download_file()
+        .filename("plain_text/train/0000.parquet")
+        .revision("refs/convert/parquet")
+        .send()
         .map_err(|e| Error::Msg(format!("Api error: {e}")))?;
     let test_parquet = SerializedFileReader::new(std::fs::File::open(test_parquet_filename)?)
         .map_err(|e| Error::Msg(format!("Parquet error: {e}")))?;

--- a/candle-datasets/src/vision/mnist.rs
+++ b/candle-datasets/src/vision/mnist.rs
@@ -3,7 +3,7 @@
 //! The files can be obtained from the following link:
 //! <http://yann.lecun.com/exdb/mnist/>
 use candle::{DType, Device, Error, Result, Tensor};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use std::fs::File;
 use std::io::{self, BufReader, Read};
@@ -92,18 +92,20 @@ pub(crate) fn load_mnist_like(
     test_filename: &str,
     train_filename: &str,
 ) -> Result<crate::vision::Dataset> {
-    let api = Api::new().map_err(|e| Error::Msg(format!("Api error: {e}")))?;
-    let repo = Repo::with_revision(
-        dataset_id.to_string(),
-        RepoType::Dataset,
-        revision.to_string(),
-    );
-    let repo = api.repo(repo);
+    let client = HFClientSync::new().map_err(|e| Error::Msg(format!("Api error: {e}")))?;
+    let (owner, name) = hf_hub::split_id(dataset_id);
+    let repo = client.dataset(owner, name);
     let test_parquet_filename = repo
-        .get(test_filename)
+        .download_file()
+        .filename(test_filename)
+        .revision(revision)
+        .send()
         .map_err(|e| Error::Msg(format!("Api error: {e}")))?;
     let train_parquet_filename = repo
-        .get(train_filename)
+        .download_file()
+        .filename(train_filename)
+        .revision(revision)
+        .send()
         .map_err(|e| Error::Msg(format!("Api error: {e}")))?;
     let test_parquet = SerializedFileReader::new(std::fs::File::open(test_parquet_filename)?)
         .map_err(|e| Error::Msg(format!("Parquet error: {e}")))?;

--- a/candle-examples/Cargo.toml
+++ b/candle-examples/Cargo.toml
@@ -22,7 +22,7 @@ chrono = "0.4"
 csv = "1.3.0"
 cudarc = { workspace = true, optional = true }
 half = { workspace = true, optional = true }
-hf-hub = { workspace = true, features = ["tokio"] }
+hf-hub = { workspace = true, features = ["blocking"] }
 image = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
 num-traits = { workspace = true }
@@ -61,7 +61,7 @@ tokio = "1.48.0"
 [build-dependencies]
 anyhow = { workspace = true }
 cudaforge = { version = "0.1.2", optional = true }
-hf-hub = { workspace = true, features = ["tokio"] }
+hf-hub = { workspace = true, features = ["blocking"] }
 
 [features]
 default = []

--- a/candle-examples/buildtime_downloader.rs
+++ b/candle-examples/buildtime_downloader.rs
@@ -1,18 +1,36 @@
 use anyhow::Result;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 
 pub fn download_model(model_and_revision: &str) -> Result<()> {
     let (model_id, revision) = match model_and_revision.split_once(":") {
         Some((model_id, revision)) => (model_id, revision),
         None => (model_and_revision, "main"),
     };
-    let repo = Repo::with_revision(model_id.to_string(), RepoType::Model, revision.to_string());
     let (config_filename, tokenizer_filename, weights_filename) = {
-        let api = Api::new()?;
-        let api = api.repo(repo);
-        let config = api.get("config.json")?.to_string_lossy().to_string();
-        let tokenizer = api.get("tokenizer.json")?.to_string_lossy().to_string();
-        let weights = api.get("model.safetensors")?.to_string_lossy().to_string();
+        let client = HFClientSync::new()?;
+        let (owner, name) = hf_hub::split_id(model_id);
+        let repo = client.model(owner, name);
+        let config = repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision)
+            .send()?
+            .to_string_lossy()
+            .to_string();
+        let tokenizer = repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision)
+            .send()?
+            .to_string_lossy()
+            .to_string();
+        let weights = repo
+            .download_file()
+            .filename("model.safetensors")
+            .revision(revision)
+            .send()?
+            .to_string_lossy()
+            .to_string();
         (config, tokenizer, weights)
     };
     println!("cargo::rustc-env=CANDLE_BUILDTIME_MODEL_CONFIG={config_filename}");

--- a/candle-examples/examples/based/main.rs
+++ b/candle-examples/examples/based/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -207,7 +207,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => match args.which {
@@ -216,27 +216,33 @@ fn main() -> Result<()> {
             Which::W1b50b => "hazyresearch/based-1b-50b".to_string(),
         },
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let config_file = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => vec![repo.get("model.safetensors")?],
+        None => vec![repo
+            .download_file()
+            .filename("model.safetensors")
+            .revision(args.revision.as_str())
+            .send()?],
     };
 
-    let repo = api.model("openai-community/gpt2".to_string());
+    let (owner, name) = hf_hub::split_id("openai-community/gpt2");
+    let repo = client.model(owner, name);
     let tokenizer_file = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").send()?,
     };
 
     println!("retrieved the files in {:?}", start.elapsed());

--- a/candle-examples/examples/beit/main.rs
+++ b/candle-examples/examples/beit/main.rs
@@ -53,9 +53,11 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("vincent-espitalier/candle-beit".into());
-            api.get("beit_base_patch16_384.in22k_ft_in22k_in1k.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let repo = client.model("vincent-espitalier", "candle-beit");
+            repo.download_file()
+                .filename("beit_base_patch16_384.in22k_ft_in22k_in1k.safetensors")
+                .send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/bert/main.rs
+++ b/candle-examples/examples/bert/main.rs
@@ -9,7 +9,7 @@ use anyhow::{Error as E, Result};
 use candle::Tensor;
 use candle_nn::VarBuilder;
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingParams, Tokenizer};
 
 #[derive(Parser, Debug)]
@@ -67,16 +67,30 @@ impl Args {
             (None, None) => (default_model, default_revision),
         };
 
-        let repo = Repo::with_revision(model_id, RepoType::Model, revision);
         let (config_filename, tokenizer_filename, weights_filename) = {
-            let api = Api::new()?;
-            let api = api.repo(repo);
-            let config = api.get("config.json")?;
-            let tokenizer = api.get("tokenizer.json")?;
+            let client = HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id(&model_id);
+            let repo = client.model(owner, name);
+            let config = repo
+                .download_file()
+                .filename("config.json")
+                .revision(revision.as_str())
+                .send()?;
+            let tokenizer = repo
+                .download_file()
+                .filename("tokenizer.json")
+                .revision(revision.as_str())
+                .send()?;
             let weights = if self.use_pth {
-                api.get("pytorch_model.bin")?
+                repo.download_file()
+                    .filename("pytorch_model.bin")
+                    .revision(revision.as_str())
+                    .send()?
             } else {
-                api.get("model.safetensors")?
+                repo.download_file()
+                    .filename("model.safetensors")
+                    .revision(revision.as_str())
+                    .send()?
             };
             (config, tokenizer, weights)
         };

--- a/candle-examples/examples/bigcode/main.rs
+++ b/candle-examples/examples/bigcode/main.rs
@@ -12,7 +12,7 @@ use candle_transformers::models::bigcode::{Config, GPTBigCode};
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -121,18 +121,24 @@ fn main() -> Result<()> {
     let args = Args::parse();
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id,
-        RepoType::Model,
-        args.revision,
-    ));
-    let tokenizer_filename = repo.get("tokenizer.json")?;
+    let client = HFClientSync::new()?;
+    let (owner, name) = hf_hub::split_id(&args.model_id);
+    let repo = client.model(owner, name);
+    let tokenizer_filename = repo
+        .download_file()
+        .filename("tokenizer.json")
+        .revision(args.revision.as_str())
+        .send()?;
     let filenames = match args.weight_file {
         Some(weight_file) => vec![std::path::PathBuf::from(weight_file)],
         None => ["model.safetensors"]
             .iter()
-            .map(|f| repo.get(f))
+            .map(|f| {
+                repo.download_file()
+                    .filename(*f)
+                    .revision(args.revision.as_str())
+                    .send()
+            })
             .collect::<std::result::Result<Vec<_>, _>>()?,
     };
     println!("retrieved the files in {:?}", start.elapsed());

--- a/candle-examples/examples/blip/main.rs
+++ b/candle-examples/examples/blip/main.rs
@@ -76,26 +76,30 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
+            let client = hf_hub::HFClientSync::new()?;
             if args.quantized {
-                let api = api.model("lmz/candle-blip".to_string());
-                api.get("blip-image-captioning-large-q4k.gguf")?
+                let (owner, name) = hf_hub::split_id("lmz/candle-blip");
+                let repo = client.model(owner, name);
+                repo.download_file()
+                    .filename("blip-image-captioning-large-q4k.gguf")
+                    .send()?
             } else {
-                let api = api.repo(hf_hub::Repo::with_revision(
-                    "Salesforce/blip-image-captioning-large".to_string(),
-                    hf_hub::RepoType::Model,
-                    "refs/pr/18".to_string(),
-                ));
-                api.get("model.safetensors")?
+                let (owner, name) = hf_hub::split_id("Salesforce/blip-image-captioning-large");
+                let repo = client.model(owner, name);
+                repo.download_file()
+                    .filename("model.safetensors")
+                    .revision("refs/pr/18")
+                    .send()?
             }
         }
         Some(model) => model.into(),
     };
     let tokenizer = match args.tokenizer {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("Salesforce/blip-image-captioning-large".to_string());
-            api.get("tokenizer.json")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id("Salesforce/blip-image-captioning-large");
+            let repo = client.model(owner, name);
+            repo.download_file().filename("tokenizer.json").send()?
         }
         Some(file) => file.into(),
     };

--- a/candle-examples/examples/chatglm/main.rs
+++ b/candle-examples/examples/chatglm/main.rs
@@ -12,7 +12,7 @@ use candle_transformers::models::chatglm::{Config, Model};
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -190,7 +190,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id.to_string(),
         None => "THUDM/chatglm3-6b".to_string(),
@@ -199,16 +199,26 @@ fn main() -> Result<()> {
         Some(rev) => rev.to_string(),
         None => "main".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
-        None => api
-            .model("lmz/candle-chatglm".to_string())
-            .get("chatglm-tokenizer.json")?,
+        None => {
+            let (owner, name) = hf_hub::split_id("lmz/candle-chatglm");
+            client
+                .model(owner, name)
+                .download_file()
+                .filename("chatglm-tokenizer.json")
+                .send()?
+        }
     };
     let filenames = match args.weight_file {
         Some(weight_file) => vec![std::path::PathBuf::from(weight_file)],
-        None => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+        None => candle_examples::hub_load_safetensors(
+            &repo,
+            revision.as_str(),
+            "model.safetensors.index.json",
+        )?,
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;

--- a/candle-examples/examples/chinese_clip/main.rs
+++ b/candle-examples/examples/chinese_clip/main.rs
@@ -80,14 +80,13 @@ fn main() -> anyhow::Result<()> {
 pub fn load_weights(model: Option<String>, device: &Device) -> anyhow::Result<nn::VarBuilder<'_>> {
     let model_file = match model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let repo = hf_hub::Repo::with_revision(
-                "OFA-Sys/chinese-clip-vit-base-patch16".to_string(),
-                hf_hub::RepoType::Model,
-                "refs/pr/3".to_string(),
-            );
-            let api = api.repo(repo);
-            api.get("model.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id("OFA-Sys/chinese-clip-vit-base-patch16");
+            let repo = client.model(owner, name);
+            repo.download_file()
+                .filename("model.safetensors")
+                .revision("refs/pr/3")
+                .send()?
         }
         Some(model) => model.into(),
     };
@@ -97,14 +96,13 @@ pub fn load_weights(model: Option<String>, device: &Device) -> anyhow::Result<nn
 
 pub fn load_tokenizer() -> anyhow::Result<Tokenizer> {
     let tokenizer_file = {
-        let api = hf_hub::api::sync::Api::new()?;
-        let repo = hf_hub::Repo::with_revision(
-            "OFA-Sys/chinese-clip-vit-base-patch16".to_string(),
-            hf_hub::RepoType::Model,
-            "refs/pr/3".to_string(),
-        );
-        let api = api.repo(repo);
-        api.get("tokenizer.json")?
+        let client = hf_hub::HFClientSync::new()?;
+        let (owner, name) = hf_hub::split_id("OFA-Sys/chinese-clip-vit-base-patch16");
+        let repo = client.model(owner, name);
+        repo.download_file()
+            .filename("tokenizer.json")
+            .revision("refs/pr/3")
+            .send()?
     };
 
     Tokenizer::from_file(tokenizer_file).map_err(anyhow::Error::msg)

--- a/candle-examples/examples/clip/main.rs
+++ b/candle-examples/examples/clip/main.rs
@@ -65,15 +65,15 @@ pub fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
+            let client = hf_hub::HFClientSync::new()?;
 
-            let api = api.repo(hf_hub::Repo::with_revision(
-                "openai/clip-vit-base-patch32".to_string(),
-                hf_hub::RepoType::Model,
-                "refs/pr/15".to_string(),
-            ));
+            let (owner, name) = hf_hub::split_id("openai/clip-vit-base-patch32");
+            let repo = client.model(owner, name);
 
-            api.get("model.safetensors")?
+            repo.download_file()
+                .filename("model.safetensors")
+                .revision("refs/pr/15")
+                .send()?
         }
         Some(model) => model.into(),
     };
@@ -117,13 +117,13 @@ pub fn main() -> anyhow::Result<()> {
 pub fn get_tokenizer(tokenizer: Option<String>) -> anyhow::Result<Tokenizer> {
     let tokenizer = match tokenizer {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.repo(hf_hub::Repo::with_revision(
-                "openai/clip-vit-base-patch32".to_string(),
-                hf_hub::RepoType::Model,
-                "refs/pr/15".to_string(),
-            ));
-            api.get("tokenizer.json")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id("openai/clip-vit-base-patch32");
+            let repo = client.model(owner, name);
+            repo.download_file()
+                .filename("tokenizer.json")
+                .revision("refs/pr/15")
+                .send()?
         }
         Some(file) => file.into(),
     };

--- a/candle-examples/examples/codegeex4-9b/main.rs
+++ b/candle-examples/examples/codegeex4-9b/main.rs
@@ -3,7 +3,6 @@ use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
 use candle_transformers::models::codegeex4_9b::*;
 use clap::Parser;
-use hf_hub::{Repo, RepoType};
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -188,13 +187,12 @@ fn main() -> anyhow::Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = match args.cache_path.as_ref() {
-        None => hf_hub::api::sync::Api::new()?,
-        Some(path) => {
-            hf_hub::api::sync::ApiBuilder::from_cache(hf_hub::Cache::new(path.to_string().into()))
-                .build()
-                .map_err(anyhow::Error::msg)?
-        }
+    let client = match args.cache_path.as_ref() {
+        None => hf_hub::HFClientSync::new()?,
+        Some(path) => hf_hub::HFClient::builder()
+            .cache_dir(path.to_string())
+            .build_sync()
+            .map_err(anyhow::Error::msg)?,
     };
     let model_id = match args.model_id {
         Some(model_id) => model_id.to_string(),
@@ -204,24 +202,35 @@ fn main() -> anyhow::Result<()> {
         Some(rev) => rev.to_string(),
         None => "main".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
-        None => api
-            .model("THUDM/codegeex4-all-9b".to_string())
-            .get("tokenizer.json")
+        None => client
+            .model("THUDM", "codegeex4-all-9b")
+            .download_file()
+            .filename("tokenizer.json")
+            .send()
             .map_err(anyhow::Error::msg)?,
     };
     let config_filename = match &args.weight_path {
         Some(path) => std::path::Path::new(path).join("config.json"),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.as_str())
+            .send()?,
     };
 
     let filenames = match &args.weight_path {
         Some(path) => {
             candle_examples::hub_load_local_safetensors(path, "model.safetensors.index.json")?
         }
-        _ => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+        _ => candle_examples::hub_load_safetensors(
+            &repo,
+            revision.as_str(),
+            "model.safetensors.index.json",
+        )?,
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).expect("Tokenizer Error");

--- a/candle-examples/examples/colpali/main.rs
+++ b/candle-examples/examples/colpali/main.rs
@@ -4,7 +4,7 @@ use candle_nn::VarBuilder;
 use candle_transformers::models::colpali::Model;
 use candle_transformers::models::{colpali, paligemma};
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use image::DynamicImage;
 use pdf2image::{RenderOptionsBuilder, PDF};
 use tokenizers::Tokenizer;
@@ -195,26 +195,25 @@ fn main() -> Result<()> {
         candle::utils::with_f16c()
     );
 
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => "vidore/colpali-v1.2-merged".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
 
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => api
-            .repo(Repo::with_revision(
-                "vidore/colpali".to_string(),
-                RepoType::Model,
-                "main".to_string(),
-            ))
-            .get("tokenizer.json")?,
+        None => {
+            let (owner, name) = hf_hub::split_id("vidore/colpali");
+            client
+                .model(owner, name)
+                .download_file()
+                .filename("tokenizer.json")
+                .revision("main")
+                .send()?
+        }
     };
 
     let filenames = match args.weight_files {
@@ -222,7 +221,11 @@ fn main() -> Result<()> {
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+        None => candle_examples::hub_load_safetensors(
+            &repo,
+            args.revision.as_str(),
+            "model.safetensors.index.json",
+        )?,
     };
 
     let start = std::time::Instant::now();

--- a/candle-examples/examples/convmixer/main.rs
+++ b/candle-examples/examples/convmixer/main.rs
@@ -33,9 +33,12 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("lmz/candle-convmixer".into());
-            api.get("convmixer_1024_20_ks9_p14.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id("lmz/candle-convmixer");
+            let repo = client.model(owner, name);
+            repo.download_file()
+                .filename("convmixer_1024_20_ks9_p14.safetensors")
+                .send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/convnext/main.rs
+++ b/candle-examples/examples/convnext/main.rs
@@ -99,9 +99,10 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id(&model_name);
+            let repo = client.model(owner, name);
+            repo.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/csm/main.rs
+++ b/candle-examples/examples/csm/main.rs
@@ -11,7 +11,7 @@ use candle_transformers::models::csm::{Config, Model};
 
 use candle::{DType, IndexOp, Tensor};
 use candle_nn::VarBuilder;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -124,7 +124,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => {
@@ -134,29 +134,40 @@ fn main() -> Result<()> {
             name.to_string()
         }
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let filenames = match args.weights {
         Some(files) => files
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => vec![repo.get("model.safetensors")?],
+        None => vec![repo
+            .download_file()
+            .filename("model.safetensors")
+            .revision(args.revision.as_str())
+            .send()?],
     };
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
-        None => api
-            .model("meta-llama/Llama-3.2-1B".to_string())
-            .get("tokenizer.json")?,
+        None => {
+            let (owner, name) = hf_hub::split_id("meta-llama/Llama-3.2-1B");
+            client
+                .model(owner, name)
+                .download_file()
+                .filename("tokenizer.json")
+                .send()?
+        }
     };
     let mimi_filename = match args.mimi_weights {
         Some(model) => std::path::PathBuf::from(model),
-        None => Api::new()?
-            .model("kyutai/mimi".to_string())
-            .get("model.safetensors")?,
+        None => {
+            let (owner, name) = hf_hub::split_id("kyutai/mimi");
+            HFClientSync::new()?
+                .model(owner, name)
+                .download_file()
+                .filename("model.safetensors")
+                .send()?
+        }
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
@@ -165,7 +176,11 @@ fn main() -> Result<()> {
     let config: Config = match args.config {
         Some(config_file) => serde_json::from_slice(&std::fs::read(config_file)?)?,
         None => {
-            let config_file = repo.get("config.json")?;
+            let config_file = repo
+                .download_file()
+                .filename("config.json")
+                .revision(args.revision.as_str())
+                .send()?;
             serde_json::from_slice(&std::fs::read(config_file)?)?
         }
     };

--- a/candle-examples/examples/debertav2/main.rs
+++ b/candle-examples/examples/debertav2/main.rs
@@ -16,7 +16,7 @@ use candle_transformers::models::debertav2::{Config as DebertaV2Config, DebertaV
 use candle_transformers::models::debertav2::{DebertaV2SeqClassificationModel, Id2Label};
 use candle_transformers::models::debertav2::{NERItem, TextClassificationItem};
 use clap::{ArgGroup, Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{Encoding, PaddingParams, Tokenizer};
 
 enum TaskType {
@@ -114,19 +114,31 @@ impl Args {
                     (config, tokenizer, weights)
                 }
                 None => {
-                    let repo = Repo::with_revision(
-                        self.model_id.as_ref().unwrap().clone(),
-                        RepoType::Model,
-                        self.revision.clone(),
-                    );
-                    let api = Api::new()?;
-                    let api = api.repo(repo);
-                    let config = api.get("config.json")?;
-                    let tokenizer = api.get("tokenizer.json")?;
+                    let client = HFClientSync::new()?;
+                    let model_id = self.model_id.as_ref().unwrap().clone();
+                    let (owner, name) = hf_hub::split_id(&model_id);
+                    let repo = client.model(owner, name);
+                    let revision = self.revision.clone();
+                    let config = repo
+                        .download_file()
+                        .filename("config.json")
+                        .revision(revision.as_str())
+                        .send()?;
+                    let tokenizer = repo
+                        .download_file()
+                        .filename("tokenizer.json")
+                        .revision(revision.as_str())
+                        .send()?;
                     let weights = if self.use_pth {
-                        api.get("pytorch_model.bin")?
+                        repo.download_file()
+                            .filename("pytorch_model.bin")
+                            .revision(revision.as_str())
+                            .send()?
                     } else {
-                        api.get("model.safetensors")?
+                        repo.download_file()
+                            .filename("model.safetensors")
+                            .revision(revision.as_str())
+                            .send()?
                     };
                     (config, tokenizer, weights)
                 }

--- a/candle-examples/examples/deepseekv2/main.rs
+++ b/candle-examples/examples/deepseekv2/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -226,7 +226,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => match args.which {
@@ -237,19 +237,29 @@ fn main() -> Result<()> {
             Which::V2Chat => "deepseek-ai/DeepSeek-V2-Chat".to_string(),
         },
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
-    let tokenizer_filename = repo.get("tokenizer.json")?;
-    let filenames = candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?;
+    let revision = args.revision;
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
+    let tokenizer_filename = repo
+        .download_file()
+        .filename("tokenizer.json")
+        .revision(revision.as_str())
+        .send()?;
+    let filenames = candle_examples::hub_load_safetensors(
+        &repo,
+        revision.as_str(),
+        "model.safetensors.index.json",
+    )?;
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
 
     let start = std::time::Instant::now();
     let config: DeepSeekV2Config = {
-        let config_file = repo.get("config.json")?;
+        let config_file = repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.as_str())
+            .send()?;
         serde_json::from_slice(&std::fs::read(config_file)?)?
     };
     let device = candle_examples::device(args.cpu)?;

--- a/candle-examples/examples/depth_anything_v2/main.rs
+++ b/candle-examples/examples/depth_anything_v2/main.rs
@@ -53,9 +53,12 @@ pub fn main() -> anyhow::Result<()> {
 
     let dinov2_model_file = match args.dinov2_model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("lmz/candle-dino-v2".into());
-            api.get("dinov2_vits14.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id("lmz/candle-dino-v2");
+            let repo = client.model(owner, name);
+            repo.download_file()
+                .filename("dinov2_vits14.safetensors")
+                .send()?
         }
         Some(dinov2_model) => dinov2_model,
     };
@@ -67,9 +70,12 @@ pub fn main() -> anyhow::Result<()> {
 
     let depth_anything_model_file = match args.depth_anything_v2_model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("jeroenvlek/depth-anything-v2-safetensors".into());
-            api.get("depth_anything_v2_vits.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id("jeroenvlek/depth-anything-v2-safetensors");
+            let repo = client.model(owner, name);
+            repo.download_file()
+                .filename("depth_anything_v2_vits.safetensors")
+                .send()?
         }
         Some(depth_anything_model) => depth_anything_model,
     };

--- a/candle-examples/examples/dinov2/main.rs
+++ b/candle-examples/examples/dinov2/main.rs
@@ -36,9 +36,12 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("lmz/candle-dino-v2".into());
-            api.get("dinov2_vits14.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id("lmz/candle-dino-v2");
+            let repo = client.model(owner, name);
+            repo.download_file()
+                .filename("dinov2_vits14.safetensors")
+                .send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/dinov2reg4/main.rs
+++ b/candle-examples/examples/dinov2reg4/main.rs
@@ -45,12 +45,15 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api =
-                api.model("vincent-espitalier/dino-v2-reg4-with-plantclef2024-weights".into());
-            api.get(
-                "vit_base_patch14_reg4_dinov2_lvd142m_pc24_onlyclassifier_then_all.safetensors",
-            )?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) =
+                hf_hub::split_id("vincent-espitalier/dino-v2-reg4-with-plantclef2024-weights");
+            let repo = client.model(owner, name);
+            repo.download_file()
+                .filename(
+                    "vit_base_patch14_reg4_dinov2_lvd142m_pc24_onlyclassifier_then_all.safetensors",
+                )
+                .send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/distilbert/main.rs
+++ b/candle-examples/examples/distilbert/main.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Error as E, Result};
 use candle::{Device, Tensor};
 use candle_nn::VarBuilder;
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use std::path::PathBuf;
 use tokenizers::Tokenizer;
 
@@ -119,16 +119,30 @@ impl Args {
         model_id: &str,
         revision: &str,
     ) -> Result<(PathBuf, PathBuf, PathBuf)> {
-        let repo = Repo::with_revision(model_id.to_string(), RepoType::Model, revision.to_string());
-        let api = Api::new()?;
-        let api = api.repo(repo);
+        let client = HFClientSync::new()?;
+        let (owner, name) = hf_hub::split_id(model_id);
+        let repo = client.model(owner, name);
 
-        let config = api.get("config.json")?;
-        let tokenizer = api.get("tokenizer.json")?;
+        let config = repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision)
+            .send()?;
+        let tokenizer = repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision)
+            .send()?;
         let weights = if self.use_pth {
-            api.get("pytorch_model.bin")?
+            repo.download_file()
+                .filename("pytorch_model.bin")
+                .revision(revision)
+                .send()?
         } else {
-            api.get("model.safetensors")?
+            repo.download_file()
+                .filename("model.safetensors")
+                .revision(revision)
+                .send()?
         };
 
         Ok((config, tokenizer, weights))

--- a/candle-examples/examples/efficientnet/main.rs
+++ b/candle-examples/examples/efficientnet/main.rs
@@ -52,8 +52,8 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("lmz/candle-efficientnet".into());
+            let client = hf_hub::HFClientSync::new()?;
+            let repo = client.model("lmz", "candle-efficientnet");
             let filename = match args.which {
                 Which::B0 => "efficientnet-b0.safetensors",
                 Which::B1 => "efficientnet-b1.safetensors",
@@ -64,7 +64,7 @@ pub fn main() -> anyhow::Result<()> {
                 Which::B6 => "efficientnet-b6.safetensors",
                 Which::B7 => "efficientnet-b7.safetensors",
             };
-            api.get(filename)?
+            repo.download_file().filename(filename).send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/efficientvit/main.rs
+++ b/candle-examples/examples/efficientvit/main.rs
@@ -72,9 +72,10 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id(&model_name);
+            let repo = client.model(owner, name);
+            repo.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/encodec/main.rs
+++ b/candle-examples/examples/encodec/main.rs
@@ -9,7 +9,7 @@ use candle::{DType, IndexOp, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::encodec::{Config, Model};
 use clap::{Parser, ValueEnum};
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 
 mod audio_io;
 
@@ -46,9 +46,12 @@ fn main() -> Result<()> {
     let device = candle_examples::device(args.cpu)?;
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
-        None => Api::new()?
-            .model("facebook/encodec_24khz".to_string())
-            .get("model.safetensors")?,
+        None => {
+            let client = HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id("facebook/encodec_24khz");
+            let repo = client.model(owner, name);
+            repo.download_file().filename("model.safetensors").send()?
+        }
     };
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DType::F32, &device)? };
     let config = Config::default();

--- a/candle-examples/examples/eva2/main.rs
+++ b/candle-examples/examples/eva2/main.rs
@@ -55,9 +55,12 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("vincent-espitalier/candle-eva2".into());
-            api.get("eva02_base_patch14_448.mim_in22k_ft_in22k_in1k_adapted.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id("vincent-espitalier/candle-eva2");
+            let repo = client.model(owner, name);
+            repo.download_file()
+                .filename("eva02_base_patch14_448.mim_in22k_ft_in22k_in1k_adapted.safetensors")
+                .send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/falcon/main.rs
+++ b/candle-examples/examples/falcon/main.rs
@@ -11,7 +11,7 @@ use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 use candle_transformers::models::falcon::{Config, Falcon};
@@ -158,14 +158,20 @@ fn main() -> Result<()> {
 
     let device = candle_examples::device(args.cpu)?;
     let start = std::time::Instant::now();
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id,
-        RepoType::Model,
-        args.revision,
-    ));
-    let tokenizer_filename = repo.get("tokenizer.json")?;
-    let filenames = candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?;
+    let client = HFClientSync::new()?;
+    let revision = args.revision;
+    let (owner, name) = hf_hub::split_id(&args.model_id);
+    let repo = client.model(owner, name);
+    let tokenizer_filename = repo
+        .download_file()
+        .filename("tokenizer.json")
+        .revision(revision.as_str())
+        .send()?;
+    let filenames = candle_examples::hub_load_safetensors(
+        &repo,
+        revision.as_str(),
+        "model.safetensors.index.json",
+    )?;
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
 

--- a/candle-examples/examples/fastvit/main.rs
+++ b/candle-examples/examples/fastvit/main.rs
@@ -75,9 +75,10 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id(&model_name);
+            let repo = client.model(owner, name);
+            repo.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/flux/main.rs
+++ b/candle-examples/examples/flux/main.rs
@@ -86,13 +86,14 @@ fn run(args: Args) -> Result<()> {
         None
     };
 
-    let api = hf_hub::api::sync::Api::new()?;
+    let client = hf_hub::HFClientSync::new()?;
     let bf_repo = {
         let name = match model {
             Model::Dev => "black-forest-labs/FLUX.1-dev",
             Model::Schnell => "black-forest-labs/FLUX.1-schnell",
         };
-        api.repo(hf_hub::Repo::model(name.to_string()))
+        let (owner, name) = hf_hub::split_id(name);
+        client.model(owner, name)
     };
     let device = candle_examples::device(cpu)?;
     if let Some(seed) = args.seed {
@@ -102,21 +103,30 @@ fn run(args: Args) -> Result<()> {
     let img = match decode_only {
         None => {
             let t5_emb = {
-                let repo = api.repo(hf_hub::Repo::with_revision(
-                    "google/t5-v1_1-xxl".to_string(),
-                    hf_hub::RepoType::Model,
-                    "refs/pr/2".to_string(),
-                ));
-                let model_file = repo.get("model.safetensors")?;
+                let (owner, name) = hf_hub::split_id("google/t5-v1_1-xxl");
+                let repo = client.model(owner, name);
+                let revision = "refs/pr/2";
+                let model_file = repo
+                    .download_file()
+                    .filename("model.safetensors")
+                    .revision(revision)
+                    .send()?;
                 let vb =
                     unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], dtype, &device)? };
-                let config_filename = repo.get("config.json")?;
+                let config_filename = repo
+                    .download_file()
+                    .filename("config.json")
+                    .revision(revision)
+                    .send()?;
                 let config = std::fs::read_to_string(config_filename)?;
                 let config: t5::Config = serde_json::from_str(&config)?;
                 let mut model = t5::T5EncoderModel::load(vb, &config)?;
-                let tokenizer_filename = api
-                    .model("lmz/mt5-tokenizers".to_string())
-                    .get("t5-v1_1-xxl.tokenizer.json")?;
+                let (owner, name) = hf_hub::split_id("lmz/mt5-tokenizers");
+                let tokenizer_filename = client
+                    .model(owner, name)
+                    .download_file()
+                    .filename("t5-v1_1-xxl.tokenizer.json")
+                    .send()?;
                 let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
                 let mut tokens = tokenizer
                     .encode(prompt.as_str(), true)
@@ -130,10 +140,9 @@ fn run(args: Args) -> Result<()> {
             };
             println!("T5\n{t5_emb}");
             let clip_emb = {
-                let repo = api.repo(hf_hub::Repo::model(
-                    "openai/clip-vit-large-patch14".to_string(),
-                ));
-                let model_file = repo.get("model.safetensors")?;
+                let (owner, name) = hf_hub::split_id("openai/clip-vit-large-patch14");
+                let repo = client.model(owner, name);
+                let model_file = repo.download_file().filename("model.safetensors").send()?;
                 let vb =
                     unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], dtype, &device)? };
                 // https://huggingface.co/openai/clip-vit-large-patch14/blob/main/config.json
@@ -150,7 +159,7 @@ fn run(args: Args) -> Result<()> {
                 };
                 let model =
                     clip::text_model::ClipTextTransformer::new(vb.pp("text_model"), &config)?;
-                let tokenizer_filename = repo.get("tokenizer.json")?;
+                let tokenizer_filename = repo.download_file().filename("tokenizer.json").send()?;
                 let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
                 let tokens = tokenizer
                     .encode(prompt.as_str(), true)
@@ -187,9 +196,14 @@ fn run(args: Args) -> Result<()> {
                 println!("{timesteps:?}");
                 if quantized {
                     let model_file = match model {
-                        Model::Schnell => api
-                            .repo(hf_hub::Repo::model("lmz/candle-flux".to_string()))
-                            .get("flux1-schnell.gguf")?,
+                        Model::Schnell => {
+                            let (owner, name) = hf_hub::split_id("lmz/candle-flux");
+                            client
+                                .model(owner, name)
+                                .download_file()
+                                .filename("flux1-schnell.gguf")
+                                .send()?
+                        }
                         Model::Dev => todo!(),
                     };
                     let vb = candle_transformers::quantized_var_builder::VarBuilder::from_gguf(
@@ -210,8 +224,14 @@ fn run(args: Args) -> Result<()> {
                     .to_dtype(dtype)?
                 } else {
                     let model_file = match model {
-                        Model::Schnell => bf_repo.get("flux1-schnell.safetensors")?,
-                        Model::Dev => bf_repo.get("flux1-dev.safetensors")?,
+                        Model::Schnell => bf_repo
+                            .download_file()
+                            .filename("flux1-schnell.safetensors")
+                            .send()?,
+                        Model::Dev => bf_repo
+                            .download_file()
+                            .filename("flux1-dev.safetensors")
+                            .send()?,
                     };
                     let vb = unsafe {
                         VarBuilder::from_mmaped_safetensors(&[model_file], dtype, &device)?
@@ -239,7 +259,7 @@ fn run(args: Args) -> Result<()> {
     println!("latent img\n{img}");
 
     let img = {
-        let model_file = bf_repo.get("ae.safetensors")?;
+        let model_file = bf_repo.download_file().filename("ae.safetensors").send()?;
         let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], dtype, &device)? };
         let cfg = match model {
             Model::Dev => flux::autoencoder::Config::dev(),

--- a/candle-examples/examples/gemma/main.rs
+++ b/candle-examples/examples/gemma/main.rs
@@ -15,7 +15,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -266,7 +266,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => match args.which {
@@ -288,18 +288,23 @@ fn main() -> Result<()> {
             Which::InstructV3_1B => "google/gemma-3-1b-it".to_string(),
         },
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -307,8 +312,16 @@ fn main() -> Result<()> {
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
         None => match args.which {
-            Which::BaseV3_1B | Which::InstructV3_1B => vec![repo.get("model.safetensors")?],
-            _ => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+            Which::BaseV3_1B | Which::InstructV3_1B => vec![repo
+                .download_file()
+                .filename("model.safetensors")
+                .revision(args.revision.as_str())
+                .send()?],
+            _ => candle_examples::hub_load_safetensors(
+                &repo,
+                args.revision.as_str(),
+                "model.safetensors.index.json",
+            )?,
         },
     };
     println!("retrieved the files in {:?}", start.elapsed());

--- a/candle-examples/examples/gemma4/main.rs
+++ b/candle-examples/examples/gemma4/main.rs
@@ -17,7 +17,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 #[allow(clippy::large_enum_variant)]
@@ -240,19 +240,20 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = args
         .model_id
         .clone()
         .unwrap_or_else(|| "google/gemma-4-E4B-it".to_string());
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -260,9 +261,17 @@ fn main() -> Result<()> {
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
         None => {
-            match candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json") {
+            match candle_examples::hub_load_safetensors(
+                &repo,
+                args.revision.as_str(),
+                "model.safetensors.index.json",
+            ) {
                 Ok(files) => files,
-                Err(_) => vec![repo.get("model.safetensors")?],
+                Err(_) => vec![repo
+                    .download_file()
+                    .filename("model.safetensors")
+                    .revision(args.revision.as_str())
+                    .send()?],
             }
         }
     };
@@ -282,7 +291,11 @@ fn main() -> Result<()> {
         let config: Gemma4Config = match args.config_file {
             Some(config_file) => serde_json::from_slice(&std::fs::read(config_file)?)?,
             None => {
-                let config_file = repo.get("config.json")?;
+                let config_file = repo
+                    .download_file()
+                    .filename("config.json")
+                    .revision(args.revision.as_str())
+                    .send()?;
                 serde_json::from_slice(&std::fs::read(config_file)?)?
             }
         };
@@ -292,7 +305,11 @@ fn main() -> Result<()> {
         let mut config: Gemma4TextConfig = match args.config_file {
             Some(config_file) => serde_json::from_slice(&std::fs::read(config_file)?)?,
             None => {
-                let config_file = repo.get("config.json")?;
+                let config_file = repo
+                    .download_file()
+                    .filename("config.json")
+                    .revision(args.revision.as_str())
+                    .send()?;
                 // For text-only, try to parse the text_config sub-object
                 let raw: serde_json::Value = serde_json::from_slice(&std::fs::read(config_file)?)?;
                 if let Some(text_cfg) = raw.get("text_config") {

--- a/candle-examples/examples/gguf-tokenizer.rs
+++ b/candle-examples/examples/gguf-tokenizer.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use candle::quantized::gguf_file;
 use candle::quantized::tokenizer::TokenizerFromGguf;
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 #[derive(Parser, Debug)]
@@ -85,13 +85,15 @@ fn resolve_model_path(model: &str, revision: Option<String>) -> Result<PathBuf> 
 
     let repo_id = format!("{}/{}", parts[0], parts[1]);
     let filename = parts[2..].join("/");
+    let revision = revision.unwrap_or_else(|| "main".to_string());
 
-    let api = Api::new()?;
-    let repo = Repo::with_revision(
-        repo_id,
-        RepoType::Model,
-        revision.unwrap_or_else(|| "main".to_string()),
-    );
-    let path = api.repo(repo).get(&filename)?;
+    let client = HFClientSync::new()?;
+    let (owner, name) = hf_hub::split_id(&repo_id);
+    let repo = client.model(owner, name);
+    let path = repo
+        .download_file()
+        .filename(filename.as_str())
+        .revision(revision.as_str())
+        .send()?;
     Ok(path)
 }

--- a/candle-examples/examples/glm4/main.rs
+++ b/candle-examples/examples/glm4/main.rs
@@ -5,7 +5,6 @@ use candle_transformers::models::glm4::{Config as ConfigOld, EosTokenId, Model a
 use candle_transformers::models::glm4_new::{Config as ConfigNew, ModelForCausalLM as ModelNew};
 
 use clap::Parser;
-use hf_hub::{Repo, RepoType};
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -213,13 +212,12 @@ fn main() -> anyhow::Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = match args.cache_path.as_ref() {
-        None => hf_hub::api::sync::Api::new()?,
-        Some(path) => {
-            hf_hub::api::sync::ApiBuilder::from_cache(hf_hub::Cache::new(path.to_string().into()))
-                .build()
-                .map_err(anyhow::Error::msg)?
-        }
+    let client = match args.cache_path.as_ref() {
+        None => hf_hub::HFClientSync::new()?,
+        Some(path) => hf_hub::HFClient::builder()
+            .cache_dir(path.to_string())
+            .build_sync()
+            .map_err(anyhow::Error::msg)?,
     };
 
     let model_id = match args.model_id.as_ref() {
@@ -233,23 +231,36 @@ fn main() -> anyhow::Result<()> {
         Some(rev) => rev.to_string(),
         None => "main".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match (args.weight_path.as_ref(), args.tokenizer.as_ref()) {
         (Some(_), Some(file)) => std::path::PathBuf::from(file),
         (None, Some(file)) => std::path::PathBuf::from(file),
         (Some(path), None) => std::path::Path::new(path).join("tokenizer.json"),
-        (None, None) => repo.get("tokenizer.json")?,
+        (None, None) => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let config_filename = match &args.weight_path {
         Some(path) => std::path::Path::new(path).join("config.json"),
-        _ => repo.get("config.json")?,
+        _ => repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.as_str())
+            .send()?,
     };
 
     let filenames = match &args.weight_path {
         Some(path) => {
             candle_examples::hub_load_local_safetensors(path, "model.safetensors.index.json")?
         }
-        _ => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+        _ => candle_examples::hub_load_safetensors(
+            &repo,
+            revision.as_str(),
+            "model.safetensors.index.json",
+        )?,
     };
 
     println!("retrieved the files in {:?}", start.elapsed());

--- a/candle-examples/examples/granite/main.rs
+++ b/candle-examples/examples/granite/main.rs
@@ -12,7 +12,7 @@ use clap::{Parser, ValueEnum};
 use candle::{DType, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use std::io::Write;
 
 use candle_transformers::models::granite as model;
@@ -115,23 +115,34 @@ fn main() -> Result<()> {
         None => DType::F16,
     };
     let (granite, tokenizer_filename, mut cache, config) = {
-        let api = Api::new()?;
+        let client = HFClientSync::new()?;
         let model_id = args.model_id.unwrap_or_else(|| match args.model_type {
             GraniteModel::Granite7bInstruct => "ibm-granite/granite-7b-instruct".to_string(),
         });
         println!("loading the model weights from {model_id}");
         let revision = args.revision.unwrap_or("main".to_string());
-        let api = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+        let (owner, name) = hf_hub::split_id(&model_id);
+        let repo = client.model(owner, name);
 
-        let tokenizer_filename = api.get("tokenizer.json")?;
-        let config_filename = api.get("config.json")?;
+        let tokenizer_filename = repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?;
+        let config_filename = repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.as_str())
+            .send()?;
         let config: GraniteConfig = serde_json::from_slice(&std::fs::read(config_filename)?)?;
         let config = config.into_config(args.use_flash_attn);
 
         let filenames = match args.model_type {
-            GraniteModel::Granite7bInstruct => {
-                candle_examples::hub_load_safetensors(&api, "model.safetensors.index.json")?
-            }
+            GraniteModel::Granite7bInstruct => candle_examples::hub_load_safetensors(
+                &repo,
+                revision.as_str(),
+                "model.safetensors.index.json",
+            )?,
         };
         let cache = model::Cache::new(!args.no_kv_cache, dtype, &config, &device)?;
 

--- a/candle-examples/examples/granitemoehybrid/main.rs
+++ b/candle-examples/examples/granitemoehybrid/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
 use candle_transformers::models::granitemoehybrid as model;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use model::{GraniteMoeHybrid, GraniteMoeHybridCache, GraniteMoeHybridConfig};
 
 use std::{io::Write, path::Path};
@@ -151,17 +151,29 @@ fn main() -> Result<()> {
                 config,
             )
         } else {
-            let api = Api::new()?;
+            let client = HFClientSync::new()?;
             let revision = args.revision.clone().unwrap_or_else(|| "main".to_string());
-            let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+            let (owner, name) = hf_hub::split_id(&model_id);
+            let repo = client.model(owner, name);
 
-            let tokenizer_filename = repo.get("tokenizer.json")?;
-            let config_filename = repo.get("config.json")?;
+            let tokenizer_filename = repo
+                .download_file()
+                .filename("tokenizer.json")
+                .revision(revision.as_str())
+                .send()?;
+            let config_filename = repo
+                .download_file()
+                .filename("config.json")
+                .revision(revision.as_str())
+                .send()?;
             let config: GraniteMoeHybridConfig =
                 serde_json::from_slice(&std::fs::read(config_filename)?)?;
             let config = config.into_config(args.use_flash_attn);
-            let filenames =
-                candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?;
+            let filenames = candle_examples::hub_load_safetensors(
+                &repo,
+                revision.as_str(),
+                "model.safetensors.index.json",
+            )?;
             let cache = GraniteMoeHybridCache::new(!args.no_kv_cache, dtype, &config, &device)?;
             let vb = unsafe { VarBuilder::from_mmaped_safetensors(&filenames, dtype, &device)? };
             (

--- a/candle-examples/examples/gte-qwen/main.rs
+++ b/candle-examples/examples/gte-qwen/main.rs
@@ -11,7 +11,7 @@ use candle_transformers::models::qwen2::{Config, Model};
 
 use candle::{DType, Tensor};
 use candle_nn::VarBuilder;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{
     utils::padding::{PaddingDirection, PaddingParams, PaddingStrategy},
     Tokenizer,
@@ -51,16 +51,25 @@ struct ConfigFiles {
 
 // Loading the model from the HuggingFace Hub. Network access is required.
 fn load_from_hub(model_id: &str, revision: &str) -> Result<ConfigFiles> {
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        model_id.to_string(),
-        RepoType::Model,
-        revision.to_string(),
-    ));
+    let client = HFClientSync::new()?;
+    let (owner, name) = hf_hub::split_id(model_id);
+    let repo = client.model(owner, name);
     Ok(ConfigFiles {
-        config: repo.get("config.json")?,
-        tokenizer: repo.get("tokenizer.json")?,
-        weights: candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+        config: repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision)
+            .send()?,
+        tokenizer: repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision)
+            .send()?,
+        weights: candle_examples::hub_load_safetensors(
+            &repo,
+            revision,
+            "model.safetensors.index.json",
+        )?,
     })
 }
 

--- a/candle-examples/examples/helium/main.rs
+++ b/candle-examples/examples/helium/main.rs
@@ -16,7 +16,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 #[derive(Debug, Clone)]
@@ -272,7 +272,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => {
@@ -283,21 +283,26 @@ fn main() -> Result<()> {
             name.to_string()
         }
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
     let filenames = match args.weights {
         Some(files) => files
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => vec![repo.get("model.safetensors")?],
+        None => vec![repo
+            .download_file()
+            .filename("model.safetensors")
+            .revision(args.revision.as_str())
+            .send()?],
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
@@ -305,7 +310,11 @@ fn main() -> Result<()> {
     let start = std::time::Instant::now();
     let config_file = match args.config {
         Some(config_file) => std::path::PathBuf::from(config_file),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
     let config = match args.which {
         Which::V1Preview => Config::Preview(serde_json::from_slice(&std::fs::read(config_file)?)?),

--- a/candle-examples/examples/hiera/main.rs
+++ b/candle-examples/examples/hiera/main.rs
@@ -72,9 +72,10 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id(&model_name);
+            let repo = client.model(owner, name);
+            repo.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/jina-bert/main.rs
+++ b/candle-examples/examples/jina-bert/main.rs
@@ -46,7 +46,7 @@ struct Args {
 
 impl Args {
     fn build_model_and_tokenizer(&self) -> anyhow::Result<(BertModel, tokenizers::Tokenizer)> {
-        use hf_hub::{api::sync::Api, Repo, RepoType};
+        use hf_hub::HFClientSync;
         let model_name = match self.model.as_ref() {
             Some(model) => model.to_string(),
             None => "jinaai/jina-embeddings-v2-base-en".to_string(),
@@ -54,15 +54,21 @@ impl Args {
 
         let model = match &self.model_file {
             Some(model_file) => std::path::PathBuf::from(model_file),
-            None => Api::new()?
-                .repo(Repo::new(model_name.to_string(), RepoType::Model))
-                .get("model.safetensors")?,
+            None => {
+                let client = HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id(&model_name);
+                let repo = client.model(owner, name);
+                repo.download_file().filename("model.safetensors").send()?
+            }
         };
         let tokenizer = match &self.tokenizer {
             Some(file) => std::path::PathBuf::from(file),
-            None => Api::new()?
-                .repo(Repo::new(model_name.to_string(), RepoType::Model))
-                .get("tokenizer.json")?,
+            None => {
+                let client = HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id(&model_name);
+                let repo = client.model(owner, name);
+                repo.download_file().filename("tokenizer.json").send()?
+            }
         };
         let device = candle_examples::device(self.cpu)?;
         let tokenizer = tokenizers::Tokenizer::from_file(tokenizer).map_err(E::msg)?;

--- a/candle-examples/examples/lfm2/main.rs
+++ b/candle-examples/examples/lfm2/main.rs
@@ -25,7 +25,7 @@ use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
 use candle_transformers::models::lfm2::{Cache, LayerType, Lfm2Config, Model};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -271,19 +271,20 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = args
         .model_id
         .unwrap_or_else(|| args.which.model_id().to_string());
-    let repo = api.repo(Repo::with_revision(
-        model_id.clone(),
-        RepoType::Model,
-        args.revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
 
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
 
     let filenames = match args.weight_files {
@@ -293,9 +294,17 @@ fn main() -> Result<()> {
             .collect::<Vec<_>>(),
         None => {
             // Try sharded first, fall back to single file
-            match candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json") {
+            match candle_examples::hub_load_safetensors(
+                &repo,
+                args.revision.as_str(),
+                "model.safetensors.index.json",
+            ) {
                 Ok(files) => files,
-                Err(_) => vec![repo.get("model.safetensors")?],
+                Err(_) => vec![repo
+                    .download_file()
+                    .filename("model.safetensors")
+                    .revision(args.revision.as_str())
+                    .send()?],
             }
         }
     };
@@ -307,7 +316,11 @@ fn main() -> Result<()> {
     let config: Lfm2Config = match args.config_file {
         Some(config_file) => serde_json::from_slice(&std::fs::read(config_file)?)?,
         None => {
-            let config_file = repo.get("config.json")?;
+            let config_file = repo
+                .download_file()
+                .filename("config.json")
+                .revision(args.revision.as_str())
+                .send()?;
             serde_json::from_slice(&std::fs::read(config_file)?)?
         }
     };

--- a/candle-examples/examples/llama/main.rs
+++ b/candle-examples/examples/llama/main.rs
@@ -18,7 +18,7 @@ use clap::{Parser, ValueEnum};
 use candle::{DType, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use std::io::Write;
 
 use candle_transformers::models::llama as model;
@@ -145,7 +145,7 @@ fn main() -> Result<()> {
         None => DType::F16,
     };
     let (llama, tokenizer_filename, mut cache, config) = {
-        let api = Api::new()?;
+        let client = HFClientSync::new()?;
         let model_id = args.model_id.unwrap_or_else(|| {
             let str = match args.which {
                 Which::V1 => "Narsil/amall-7b",
@@ -171,10 +171,19 @@ fn main() -> Result<()> {
         });
         println!("loading the model weights from {model_id}");
         let revision = args.revision.unwrap_or("main".to_string());
-        let api = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+        let (owner, name) = hf_hub::split_id(&model_id);
+        let repo = client.model(owner, name);
 
-        let tokenizer_filename = api.get("tokenizer.json")?;
-        let config_filename = api.get("config.json")?;
+        let tokenizer_filename = repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?;
+        let config_filename = repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.as_str())
+            .send()?;
         let config: LlamaConfig = serde_json::from_slice(&std::fs::read(config_filename)?)?;
         let config = config.into_config(args.use_flash_attn);
 
@@ -187,9 +196,11 @@ fn main() -> Result<()> {
             | Which::V31Instruct
             | Which::V32_3b
             | Which::V32_3bInstruct
-            | Which::Solar10_7B => {
-                candle_examples::hub_load_safetensors(&api, "model.safetensors.index.json")?
-            }
+            | Which::Solar10_7B => candle_examples::hub_load_safetensors(
+                &repo,
+                revision.as_str(),
+                "model.safetensors.index.json",
+            )?,
             Which::SmolLM2_360M
             | Which::SmolLM2_360MInstruct
             | Which::SmolLM2_135M
@@ -199,7 +210,11 @@ fn main() -> Result<()> {
             | Which::V32_1b
             | Which::V32_1bInstruct
             | Which::TinyLlama1_1BChat => {
-                vec![api.get("model.safetensors")?]
+                vec![repo
+                    .download_file()
+                    .filename("model.safetensors")
+                    .revision(revision.as_str())
+                    .send()?]
             }
         };
         let cache = model::Cache::new(!args.no_kv_cache, dtype, &config, &device)?;

--- a/candle-examples/examples/llama2-c/main.rs
+++ b/candle-examples/examples/llama2-c/main.rs
@@ -124,9 +124,10 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
-                let api = api.model("hf-internal-testing/llama-tokenizer".to_string());
-                api.get("tokenizer.json")?
+                let client = hf_hub::HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id("hf-internal-testing/llama-tokenizer");
+                let repo = client.model(owner, name);
+                repo.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(E::msg)
@@ -174,10 +175,13 @@ fn run_eval(args: &EvaluationCmd, common_args: &Args) -> Result<()> {
     let config_path = match &args.config {
         Some(config) => std::path::PathBuf::from(config),
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
+            let client = hf_hub::HFClientSync::new()?;
             println!("loading the model weights from {}", args.model_id);
-            let api = api.model(args.model_id.clone());
-            api.get(&args.which_model)?
+            let (owner, name) = hf_hub::split_id(&args.model_id);
+            let repo = client.model(owner, name);
+            repo.download_file()
+                .filename(args.which_model.as_str())
+                .send()?
         }
     };
 
@@ -193,11 +197,15 @@ fn run_eval(args: &EvaluationCmd, common_args: &Args) -> Result<()> {
 
     let tokens = match &args.pretokenized_dir {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
+            let client = hf_hub::HFClientSync::new()?;
             let model_id = "roneneldan/TinyStories"; // TODO: Make this configurable.
             println!("loading the evaluation dataset from {}", model_id);
-            let api = api.dataset(model_id.to_string());
-            let dataset_path = api.get("TinyStories-valid.txt")?;
+            let (owner, name) = hf_hub::split_id(model_id);
+            let repo = client.dataset(owner, name);
+            let dataset_path = repo
+                .download_file()
+                .filename("TinyStories-valid.txt")
+                .send()?;
             let file = std::fs::File::open(dataset_path)?;
             let file = std::io::BufReader::new(file);
             let mut tokens = vec![];
@@ -246,10 +254,13 @@ fn run_inference(args: &InferenceCmd, common_args: &Args) -> Result<()> {
     let config_path = match &args.config {
         Some(config) => std::path::PathBuf::from(config),
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
+            let client = hf_hub::HFClientSync::new()?;
             println!("loading the model weights from {}", args.model_id);
-            let api = api.model(args.model_id.clone());
-            api.get(&args.which_model)?
+            let (owner, name) = hf_hub::split_id(&args.model_id);
+            let repo = client.model(owner, name);
+            repo.download_file()
+                .filename(args.which_model.as_str())
+                .send()?
         }
     };
 

--- a/candle-examples/examples/llama_multiprocess/main.rs
+++ b/candle-examples/examples/llama_multiprocess/main.rs
@@ -17,7 +17,7 @@ use candle_transformers::generation::LogitsProcessor;
 use candle_transformers::models::llama::LlamaEosToks;
 use cudarc::driver::safe::CudaDevice;
 use cudarc::nccl::safe::{Comm, Id};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use std::io::Write;
 use std::rc::Rc;
 
@@ -105,7 +105,7 @@ fn main() -> Result<()> {
         bail!("comm file {comm_file:?} already exists, please remove it first")
     }
 
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model) => model,
         None => match args.which {
@@ -117,11 +117,24 @@ fn main() -> Result<()> {
     };
     println!("loading the model weights from {model_id}");
     let revision = args.revision.unwrap_or("main".to_string());
-    let api = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
-    let config_filename = api.get("config.json")?;
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
+    let config_filename = repo
+        .download_file()
+        .filename("config.json")
+        .revision(revision.as_str())
+        .send()?;
     let config: Config = serde_json::from_slice(&std::fs::read(config_filename)?)?;
-    let tokenizer_filename = api.get("tokenizer.json")?;
-    let filenames = candle_examples::hub_load_safetensors(&api, "model.safetensors.index.json")?;
+    let tokenizer_filename = repo
+        .download_file()
+        .filename("tokenizer.json")
+        .revision(revision.as_str())
+        .send()?;
+    let filenames = candle_examples::hub_load_safetensors(
+        &repo,
+        revision.as_str(),
+        "model.safetensors.index.json",
+    )?;
 
     let rank = match args.rank {
         None => {

--- a/candle-examples/examples/llava/image_processor.rs
+++ b/candle-examples/examples/llava/image_processor.rs
@@ -5,7 +5,7 @@ use candle_transformers::models::llava::{
     config::{HFPreProcessorConfig, LLaVAConfig},
     utils::select_best_resolution,
 };
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use image::{imageops::overlay, DynamicImage, GenericImageView, Rgb, RgbImage};
 use serde::{Deserialize, Serialize};
 
@@ -73,10 +73,13 @@ fn default_image_std() -> Vec<f32> {
 
 impl ImageProcessor {
     pub fn from_pretrained(clip_id: &str) -> Result<Self> {
-        let api = Api::new().map_err(|e| candle::Error::Msg(e.to_string()))?;
-        let api = api.model(clip_id.to_string());
-        let config_filename = api
-            .get("preprocessor_config.json")
+        let client = HFClientSync::new().map_err(|e| candle::Error::Msg(e.to_string()))?;
+        let (owner, name) = hf_hub::split_id(clip_id);
+        let repo = client.model(owner, name);
+        let config_filename = repo
+            .download_file()
+            .filename("preprocessor_config.json")
+            .send()
             .map_err(|e| candle::Error::Msg(e.to_string()))?;
         let image_processor =
             serde_json::from_slice(&std::fs::read(config_filename).map_err(candle::Error::Io)?)

--- a/candle-examples/examples/llava/main.rs
+++ b/candle-examples/examples/llava/main.rs
@@ -15,7 +15,7 @@ use candle_transformers::models::llava::{config::LLaVAConfig, LLaVA};
 use clap::Parser;
 use constants::*;
 use conversation::Conversation;
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use image_processor::{process_image, ImageProcessor};
 use std::io::Write;
 use tokenizers::Tokenizer;
@@ -150,21 +150,28 @@ fn main() -> Result<()> {
     let mut args = Args::parse();
     let device = candle_examples::device(args.cpu)?;
     println!("Start loading model");
-    let api = Api::new()?;
-    let api = api.model(args.model_path.clone());
+    let client = HFClientSync::new()?;
+    let (owner, name) = hf_hub::split_id(&args.model_path);
+    let repo = client.model(owner, name);
     let (llava_config, tokenizer, clip_vision_config, image_processor) = if args.hf {
-        let config_filename = api.get("config.json")?;
+        let config_filename = repo.download_file().filename("config.json").send()?;
         let hf_llava_config: HFLLaVAConfig =
             serde_json::from_slice(&std::fs::read(config_filename)?)?;
-        let generation_config_filename = api.get("generation_config.json")?;
+        let generation_config_filename = repo
+            .download_file()
+            .filename("generation_config.json")
+            .send()?;
         let generation_config: HFGenerationConfig =
             serde_json::from_slice(&std::fs::read(generation_config_filename)?)?;
-        let preprocessor_config_filename = api.get("preprocessor_config.json")?;
+        let preprocessor_config_filename = repo
+            .download_file()
+            .filename("preprocessor_config.json")
+            .send()?;
         let preprocessor_config: HFPreProcessorConfig =
             serde_json::from_slice(&std::fs::read(preprocessor_config_filename)?)?;
         let llava_config =
             hf_llava_config.to_llava_config(&generation_config, &preprocessor_config);
-        let tokenizer_filename = api.get("tokenizer.json")?;
+        let tokenizer_filename = repo.download_file().filename("tokenizer.json").send()?;
         let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
         let clip_vision_config = hf_llava_config.to_clip_vision_config();
         (
@@ -174,7 +181,7 @@ fn main() -> Result<()> {
             ImageProcessor::from_hf_preprocessor_config(&preprocessor_config),
         )
     } else {
-        let config_filename = api.get("config.json")?;
+        let config_filename = repo.download_file().filename("config.json").send()?;
         let llava_config: LLaVAConfig = serde_json::from_slice(&std::fs::read(config_filename)?)?;
         let tokenizer = Tokenizer::from_file(&args.tokenizer_path)
             .map_err(|e| E::msg(format!("Error loading {}: {}", &args.tokenizer_path, e)))?;
@@ -201,7 +208,7 @@ fn main() -> Result<()> {
     println!("loading model weights");
 
     let weight_filenames =
-        candle_examples::hub_load_safetensors(&api, "model.safetensors.index.json")?;
+        candle_examples::hub_load_safetensors(&repo, "main", "model.safetensors.index.json")?;
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&weight_filenames, dtype, &device)? };
     let llava: LLaVA = LLaVA::load(vb, &llava_config, clip_vision_config)?;
 

--- a/candle-examples/examples/mamba-minimal/main.rs
+++ b/candle-examples/examples/mamba-minimal/main.rs
@@ -14,7 +14,7 @@ use candle::{DType, Device, Module, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -235,23 +235,33 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id
-            .unwrap_or_else(|| args.which.model_id().to_string()),
-        RepoType::Model,
-        args.revision
-            .unwrap_or_else(|| args.which.revision().to_string()),
-    ));
+    let client = HFClientSync::new()?;
+    let model_id = args
+        .model_id
+        .unwrap_or_else(|| args.which.model_id().to_string());
+    let revision = args
+        .revision
+        .unwrap_or_else(|| args.which.revision().to_string());
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => api
-            .model("EleutherAI/gpt-neox-20b".to_string())
-            .get("tokenizer.json")?,
+        None => {
+            let (owner, name) = hf_hub::split_id("EleutherAI/gpt-neox-20b");
+            client
+                .model(owner, name)
+                .download_file()
+                .filename("tokenizer.json")
+                .send()?
+        }
     };
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -259,7 +269,11 @@ fn main() -> Result<()> {
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
         None => {
-            vec![repo.get("model.safetensors")?]
+            vec![repo
+                .download_file()
+                .filename("model.safetensors")
+                .revision(revision.as_str())
+                .send()?]
         }
     };
     println!("retrieved the files in {:?}", start.elapsed());

--- a/candle-examples/examples/mamba/main.rs
+++ b/candle-examples/examples/mamba/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -251,23 +251,33 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id
-            .unwrap_or_else(|| args.which.model_id().to_string()),
-        RepoType::Model,
-        args.revision
-            .unwrap_or_else(|| args.which.revision().to_string()),
-    ));
+    let client = HFClientSync::new()?;
+    let model_id = args
+        .model_id
+        .unwrap_or_else(|| args.which.model_id().to_string());
+    let revision = args
+        .revision
+        .unwrap_or_else(|| args.which.revision().to_string());
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => api
-            .model("EleutherAI/gpt-neox-20b".to_string())
-            .get("tokenizer.json")?,
+        None => {
+            let (owner, name) = hf_hub::split_id("EleutherAI/gpt-neox-20b");
+            client
+                .model(owner, name)
+                .download_file()
+                .filename("tokenizer.json")
+                .send()?
+        }
     };
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -275,7 +285,11 @@ fn main() -> Result<()> {
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
         None => {
-            vec![repo.get("model.safetensors")?]
+            vec![repo
+                .download_file()
+                .filename("model.safetensors")
+                .revision(revision.as_str())
+                .send()?]
         }
     };
     println!("retrieved the files in {:?}", start.elapsed());

--- a/candle-examples/examples/mamba2/main.rs
+++ b/candle-examples/examples/mamba2/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -272,18 +272,19 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = args
         .model_id
         .unwrap_or_else(|| args.which.model_id().to_string());
-    let repo = api.repo(Repo::new(model_id.clone(), RepoType::Model));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").send()?,
     };
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo.download_file().filename("config.json").send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -291,7 +292,7 @@ fn main() -> Result<()> {
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
         None => {
-            vec![repo.get("model.safetensors")?]
+            vec![repo.download_file().filename("model.safetensors").send()?]
         }
     };
     println!("retrieved the files in {:?}", start.elapsed());

--- a/candle-examples/examples/marian-mt/main.rs
+++ b/candle-examples/examples/marian-mt/main.rs
@@ -70,7 +70,7 @@ struct Args {
 }
 
 pub fn main() -> anyhow::Result<()> {
-    use hf_hub::api::sync::Api;
+    use hf_hub::HFClientSync;
     let args = Args::parse();
 
     let config = match (args.which, args.language_pair) {
@@ -107,9 +107,14 @@ pub fn main() -> anyhow::Result<()> {
                         anyhow::bail!("big is not supported for language pair {lp:?}")
                     }
                 };
-                Api::new()?
-                    .model(tokenizer_default_repo.to_string())
-                    .get(filename)?
+                {
+                    let (owner, name) = hf_hub::split_id(tokenizer_default_repo);
+                    HFClientSync::new()?
+                        .model(owner, name)
+                        .download_file()
+                        .filename(filename)
+                        .send()?
+                }
             }
         };
         Tokenizer::from_file(&tokenizer).map_err(E::msg)?
@@ -131,9 +136,14 @@ pub fn main() -> anyhow::Result<()> {
                         anyhow::bail!("big is not supported for language pair {lp:?}")
                     }
                 };
-                Api::new()?
-                    .model(tokenizer_default_repo.to_string())
-                    .get(filename)?
+                {
+                    let (owner, name) = hf_hub::split_id(tokenizer_default_repo);
+                    HFClientSync::new()?
+                        .model(owner, name)
+                        .download_file()
+                        .filename(filename)
+                        .send()?
+                }
             }
         };
         Tokenizer::from_file(&tokenizer).map_err(E::msg)?
@@ -145,46 +155,42 @@ pub fn main() -> anyhow::Result<()> {
         let model = match args.model {
             Some(model) => std::path::PathBuf::from(model),
             None => {
-                let api = Api::new()?;
-                let api = match (args.which, args.language_pair) {
-                    (Which::Base, LanguagePair::FrEn) => api.repo(hf_hub::Repo::with_revision(
-                        "Helsinki-NLP/opus-mt-fr-en".to_string(),
-                        hf_hub::RepoType::Model,
-                        "refs/pr/4".to_string(),
-                    )),
-                    (Which::Big, LanguagePair::FrEn) => {
-                        api.model("Helsinki-NLP/opus-mt-tc-big-fr-en".to_string())
+                let client = HFClientSync::new()?;
+                let (owner, name, revision) = match (args.which, args.language_pair) {
+                    (Which::Base, LanguagePair::FrEn) => {
+                        ("Helsinki-NLP", "opus-mt-fr-en", Some("refs/pr/4"))
                     }
-                    (Which::Base, LanguagePair::EnZh) => api.repo(hf_hub::Repo::with_revision(
-                        "Helsinki-NLP/opus-mt-en-zh".to_string(),
-                        hf_hub::RepoType::Model,
-                        "refs/pr/13".to_string(),
-                    )),
-                    (Which::Base, LanguagePair::EnHi) => api.repo(hf_hub::Repo::with_revision(
-                        "Helsinki-NLP/opus-mt-en-hi".to_string(),
-                        hf_hub::RepoType::Model,
-                        "refs/pr/3".to_string(),
-                    )),
-                    (Which::Base, LanguagePair::EnEs) => api.repo(hf_hub::Repo::with_revision(
-                        "Helsinki-NLP/opus-mt-en-es".to_string(),
-                        hf_hub::RepoType::Model,
-                        "refs/pr/4".to_string(),
-                    )),
-                    (Which::Base, LanguagePair::EnFr) => api.repo(hf_hub::Repo::with_revision(
-                        "Helsinki-NLP/opus-mt-en-fr".to_string(),
-                        hf_hub::RepoType::Model,
-                        "refs/pr/9".to_string(),
-                    )),
-                    (Which::Base, LanguagePair::EnRu) => api.repo(hf_hub::Repo::with_revision(
-                        "Helsinki-NLP/opus-mt-en-ru".to_string(),
-                        hf_hub::RepoType::Model,
-                        "refs/pr/7".to_string(),
-                    )),
+                    (Which::Big, LanguagePair::FrEn) => {
+                        ("Helsinki-NLP", "opus-mt-tc-big-fr-en", None)
+                    }
+                    (Which::Base, LanguagePair::EnZh) => {
+                        ("Helsinki-NLP", "opus-mt-en-zh", Some("refs/pr/13"))
+                    }
+                    (Which::Base, LanguagePair::EnHi) => {
+                        ("Helsinki-NLP", "opus-mt-en-hi", Some("refs/pr/3"))
+                    }
+                    (Which::Base, LanguagePair::EnEs) => {
+                        ("Helsinki-NLP", "opus-mt-en-es", Some("refs/pr/4"))
+                    }
+                    (Which::Base, LanguagePair::EnFr) => {
+                        ("Helsinki-NLP", "opus-mt-en-fr", Some("refs/pr/9"))
+                    }
+                    (Which::Base, LanguagePair::EnRu) => {
+                        ("Helsinki-NLP", "opus-mt-en-ru", Some("refs/pr/7"))
+                    }
                     (Which::Big, lp) => {
                         anyhow::bail!("big is not supported for language pair {lp:?}")
                     }
                 };
-                api.get("model.safetensors")?
+                let repo = client.model(owner, name);
+                match revision {
+                    Some(revision) => repo
+                        .download_file()
+                        .filename("model.safetensors")
+                        .revision(revision)
+                        .send()?,
+                    None => repo.download_file().filename("model.safetensors").send()?,
+                }
             }
         };
         unsafe { VarBuilder::from_mmaped_safetensors(&[&model], DType::F32, &device)? }

--- a/candle-examples/examples/metavoice/main.rs
+++ b/candle-examples/examples/metavoice/main.rs
@@ -15,7 +15,7 @@ use candle_transformers::models::quantized_metavoice::transformer as qtransforme
 
 use candle::{DType, IndexOp, Tensor};
 use candle_nn::VarBuilder;
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use rand::{distr::Distribution, SeedableRng};
 
 pub const ENCODEC_NTOKENS: u32 = 1024;
@@ -109,11 +109,15 @@ fn main() -> Result<()> {
         candle::utils::with_f16c()
     );
     let device = candle_examples::device(args.cpu)?;
-    let api = Api::new()?;
-    let repo = api.model("lmz/candle-metavoice".to_string());
+    let client = HFClientSync::new()?;
+    let (owner, name) = hf_hub::split_id("lmz/candle-metavoice");
+    let repo = client.model(owner, name);
     let first_stage_meta = match &args.first_stage_meta {
         Some(w) => std::path::PathBuf::from(w),
-        None => repo.get("first_stage.meta.json")?,
+        None => repo
+            .download_file()
+            .filename("first_stage.meta.json")
+            .send()?,
     };
     let first_stage_meta: serde_json::Value =
         serde_json::from_reader(&std::fs::File::open(first_stage_meta)?)?;
@@ -128,13 +132,21 @@ fn main() -> Result<()> {
 
     let second_stage_weights = match &args.second_stage_weights {
         Some(w) => std::path::PathBuf::from(w),
-        None => repo.get("second_stage.safetensors")?,
+        None => repo
+            .download_file()
+            .filename("second_stage.safetensors")
+            .send()?,
     };
     let encodec_weights = match args.encodec_weights {
         Some(w) => std::path::PathBuf::from(w),
-        None => Api::new()?
-            .model("facebook/encodec_24khz".to_string())
-            .get("model.safetensors")?,
+        None => {
+            let (owner, name) = hf_hub::split_id("facebook/encodec_24khz");
+            HFClientSync::new()?
+                .model(owner, name)
+                .download_file()
+                .filename("model.safetensors")
+                .send()?
+        }
     };
     let dtype = match args.dtype {
         ArgDType::F32 => DType::F32,
@@ -146,7 +158,10 @@ fn main() -> Result<()> {
     let mut first_stage_model = if args.quantized {
         let filename = match &args.first_stage_weights {
             Some(w) => std::path::PathBuf::from(w),
-            None => repo.get("first_stage_q4k.gguf")?,
+            None => repo
+                .download_file()
+                .filename("first_stage_q4k.gguf")
+                .send()?,
         };
         let vb =
             candle_transformers::quantized_var_builder::VarBuilder::from_gguf(filename, &device)?;
@@ -155,7 +170,10 @@ fn main() -> Result<()> {
     } else {
         let first_stage_weights = match &args.first_stage_weights {
             Some(w) => std::path::PathBuf::from(w),
-            None => repo.get("first_stage.safetensors")?,
+            None => repo
+                .download_file()
+                .filename("first_stage.safetensors")
+                .send()?,
         };
         let first_stage_vb =
             unsafe { VarBuilder::from_mmaped_safetensors(&[first_stage_weights], dtype, &device)? };
@@ -184,7 +202,10 @@ fn main() -> Result<()> {
     println!("{tokens:?}");
     let spk_emb_file = match &args.spk_emb {
         Some(w) => std::path::PathBuf::from(w),
-        None => repo.get("spk_emb.safetensors")?,
+        None => repo
+            .download_file()
+            .filename("spk_emb.safetensors")
+            .send()?,
     };
     let spk_emb = candle::safetensors::load(&spk_emb_file, &candle::Device::Cpu)?;
     let spk_emb = match spk_emb.get("spk_emb") {

--- a/candle-examples/examples/mimi/main.rs
+++ b/candle-examples/examples/mimi/main.rs
@@ -9,7 +9,7 @@ use candle::{DType, IndexOp, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::mimi::{Config, Model};
 use clap::{Parser, ValueEnum};
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 
 mod audio_io;
 
@@ -51,9 +51,12 @@ fn main() -> Result<()> {
     let device = candle_examples::device(args.cpu)?;
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
-        None => Api::new()?
-            .model("kyutai/mimi".to_string())
-            .get("model.safetensors")?,
+        None => {
+            let client = HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id("kyutai/mimi");
+            let repo = client.model(owner, name);
+            repo.download_file().filename("model.safetensors").send()?
+        }
     };
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DType::F32, &device)? };
     let config = Config::v0_1(None);

--- a/candle-examples/examples/mistral/main.rs
+++ b/candle-examples/examples/mistral/main.rs
@@ -14,7 +14,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -257,7 +257,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => {
@@ -280,14 +280,16 @@ fn main() -> Result<()> {
             }
         }
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision;
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -296,9 +298,17 @@ fn main() -> Result<()> {
             .collect::<Vec<_>>(),
         None => {
             if args.quantized {
-                vec![repo.get("model-q4k.gguf")?]
+                vec![repo
+                    .download_file()
+                    .filename("model-q4k.gguf")
+                    .revision(revision.as_str())
+                    .send()?]
             } else {
-                candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?
+                candle_examples::hub_load_safetensors(
+                    &repo,
+                    revision.as_str(),
+                    "model.safetensors.index.json",
+                )?
             }
         }
     };
@@ -312,7 +322,11 @@ fn main() -> Result<()> {
             if args.quantized {
                 Config::config_7b_v0_1(args.use_flash_attn)
             } else {
-                let config_file = repo.get("config.json")?;
+                let config_file = repo
+                    .download_file()
+                    .filename("config.json")
+                    .revision(revision.as_str())
+                    .send()?;
                 serde_json::from_slice(&std::fs::read(config_file)?)?
             }
         }

--- a/candle-examples/examples/mixtral/main.rs
+++ b/candle-examples/examples/mixtral/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -194,22 +194,28 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let client = HFClientSync::new()?;
+    let revision = args.revision;
+    let (owner, name) = hf_hub::split_id(&args.model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+        None => candle_examples::hub_load_safetensors(
+            &repo,
+            revision.as_str(),
+            "model.safetensors.index.json",
+        )?,
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;

--- a/candle-examples/examples/mobileclip/main.rs
+++ b/candle-examples/examples/mobileclip/main.rs
@@ -77,14 +77,19 @@ pub fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     let model_name = args.which.model_name();
-    let api = hf_hub::api::sync::Api::new()?;
-    let api = api.model(model_name);
+    let client = hf_hub::HFClientSync::new()?;
+    let (owner, name) = hf_hub::split_id(&model_name);
+    let repo = client.model(owner, name);
     let model_file = if args.use_pth {
-        api.get("open_clip_pytorch_model.bin")?
+        repo.download_file()
+            .filename("open_clip_pytorch_model.bin")
+            .send()?
     } else {
-        api.get("open_clip_model.safetensors")?
+        repo.download_file()
+            .filename("open_clip_model.safetensors")
+            .send()?
     };
-    let tokenizer = api.get("tokenizer.json")?;
+    let tokenizer = repo.download_file().filename("tokenizer.json").send()?;
     let tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;
     let config = &args.which.config();
     let device = candle_examples::device(args.cpu)?;

--- a/candle-examples/examples/mobilenetv4/main.rs
+++ b/candle-examples/examples/mobilenetv4/main.rs
@@ -80,9 +80,10 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id(&model_name);
+            let repo = client.model(owner, name);
+            repo.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/mobileone/main.rs
+++ b/candle-examples/examples/mobileone/main.rs
@@ -69,9 +69,10 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id(&model_name);
+            let repo = client.model(owner, name);
+            repo.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/modernbert/main.rs
+++ b/candle-examples/examples/modernbert/main.rs
@@ -5,7 +5,7 @@ use candle::{Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::modernbert;
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingParams, Tokenizer};
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -53,7 +53,7 @@ struct Args {
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => match args.model {
@@ -61,27 +61,42 @@ fn main() -> Result<()> {
             Model::ModernBertLarge => "answerdotai/ModernBERT-large".to_string(),
         },
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
 
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
 
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
 
     let weights_filename = match args.weight_files {
         Some(files) => PathBuf::from(files),
-        None => match repo.get("model.safetensors") {
+        None => match repo
+            .download_file()
+            .filename("model.safetensors")
+            .revision(args.revision.as_str())
+            .send()
+        {
             Ok(safetensors) => safetensors,
-            Err(_) => match repo.get("pytorch_model.bin") {
+            Err(_) => match repo
+                .download_file()
+                .filename("pytorch_model.bin")
+                .revision(args.revision.as_str())
+                .send()
+            {
                 Ok(pytorch_model) => pytorch_model,
                 Err(e) => {
                     anyhow::bail!("Model weights not found. The weights should either be a `model.safetensors` or `pytorch_model.bin` file.  Error: {e}")

--- a/candle-examples/examples/moondream/main.rs
+++ b/candle-examples/examples/moondream/main.rs
@@ -251,7 +251,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = hf_hub::api::tokio::Api::new()?;
+    let client = hf_hub::HFClient::new()?;
     let (model_id, revision) = match args.model_id {
         Some(model_id) => (model_id.to_string(), None),
         None => {
@@ -270,24 +270,35 @@ async fn main() -> anyhow::Result<()> {
         (None, Some(r)) => r.to_string(),
         (None, None) => "main".to_string(),
     };
-    let repo = api.repo(hf_hub::Repo::with_revision(
-        model_id,
-        hf_hub::RepoType::Model,
-        revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let model_file = match args.model_file {
         Some(m) => m.into(),
         None => {
             if args.quantized {
-                repo.get("model-q4_0.gguf").await?
+                repo.download_file()
+                    .filename("model-q4_0.gguf")
+                    .revision(revision.as_str())
+                    .send()
+                    .await?
             } else {
-                repo.get("model.safetensors").await?
+                repo.download_file()
+                    .filename("model.safetensors")
+                    .revision(revision.as_str())
+                    .send()
+                    .await?
             }
         }
     };
     let tokenizer = match args.tokenizer_file {
         Some(m) => m.into(),
-        None => repo.get("tokenizer.json").await?,
+        None => {
+            repo.download_file()
+                .filename("tokenizer.json")
+                .revision(revision.as_str())
+                .send()
+                .await?
+        }
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;

--- a/candle-examples/examples/musicgen/main.rs
+++ b/candle-examples/examples/musicgen/main.rs
@@ -18,7 +18,7 @@ use anyhow::{Error as E, Result};
 use candle::{DType, Tensor};
 use candle_nn::VarBuilder;
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 
 const DTYPE: DType = DType::F32;
 
@@ -51,9 +51,14 @@ fn main() -> Result<()> {
     let device = candle_examples::device(args.cpu)?;
     let tokenizer = match args.tokenizer {
         Some(tokenizer) => std::path::PathBuf::from(tokenizer),
-        None => Api::new()?
-            .model("facebook/musicgen-small".to_string())
-            .get("tokenizer.json")?,
+        None => {
+            let (owner, name) = hf_hub::split_id("facebook/musicgen-small");
+            HFClientSync::new()?
+                .model(owner, name)
+                .download_file()
+                .filename("tokenizer.json")
+                .send()?
+        }
     };
     let mut tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;
     let tokenizer = tokenizer
@@ -63,13 +68,15 @@ fn main() -> Result<()> {
 
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
-        None => Api::new()?
-            .repo(Repo::with_revision(
-                "facebook/musicgen-small".to_string(),
-                RepoType::Model,
-                "refs/pr/13".to_string(),
-            ))
-            .get("model.safetensors")?,
+        None => {
+            let (owner, name) = hf_hub::split_id("facebook/musicgen-small");
+            HFClientSync::new()?
+                .model(owner, name)
+                .download_file()
+                .filename("model.safetensors")
+                .revision("refs/pr/13")
+                .send()?
+        }
     };
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DTYPE, &device)? };
     let config = GenConfig::small();

--- a/candle-examples/examples/nomic-bert/main.rs
+++ b/candle-examples/examples/nomic-bert/main.rs
@@ -10,7 +10,7 @@ use anyhow::{bail, Error as E, Result};
 use candle::{DType, Tensor};
 use candle_nn::VarBuilder;
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingParams, Tokenizer};
 
 #[derive(Parser, Debug)]
@@ -58,13 +58,25 @@ fn main() -> Result<()> {
     };
 
     let device = candle_examples::device(args.cpu)?;
-    let repo = Repo::with_revision(args.model_id.clone(), RepoType::Model, args.revision);
     let (config_filename, tokenizer_filename, weights_filename) = {
-        let api = Api::new()?;
-        let api = api.repo(repo);
-        let config = api.get("config.json")?;
-        let tokenizer = api.get("tokenizer.json")?;
-        let weights = api.get("model.safetensors")?;
+        let client = HFClientSync::new()?;
+        let (owner, name) = hf_hub::split_id(&args.model_id);
+        let repo = client.model(owner, name);
+        let config = repo
+            .download_file()
+            .filename("config.json")
+            .revision(args.revision.as_str())
+            .send()?;
+        let tokenizer = repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(args.revision.as_str())
+            .send()?;
+        let weights = repo
+            .download_file()
+            .filename("model.safetensors")
+            .revision(args.revision.as_str())
+            .send()?;
         (config, tokenizer, weights)
     };
 

--- a/candle-examples/examples/nvembed_v2/main.rs
+++ b/candle-examples/examples/nvembed_v2/main.rs
@@ -9,7 +9,7 @@ use candle::{DType, IndexOp, Shape, Tensor, D};
 use candle_nn::VarBuilder;
 use candle_transformers::models::nvembed_v2::model::Model;
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingDirection, PaddingParams, Tokenizer, TruncationParams};
 
 #[derive(Parser, Debug)]
@@ -49,20 +49,25 @@ impl Args {
             None => "nvidia/NV-Embed-v2".to_string(),
         };
 
-        let api = Api::new()?;
-        let repo = api.repo(Repo::new(model_name.to_string(), RepoType::Model));
+        let client = HFClientSync::new()?;
+        let (owner, name) = hf_hub::split_id(&model_name);
+        let repo = client.model(owner, name);
 
         let model_files = match &self.model_files {
             Some(files) => files
                 .split(',')
                 .map(std::path::PathBuf::from)
                 .collect::<Vec<_>>(),
-            None => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+            None => candle_examples::hub_load_safetensors(
+                &repo,
+                "main",
+                "model.safetensors.index.json",
+            )?,
         };
 
         let tokenizer_file = match &self.tokenizer {
             Some(file) => std::path::PathBuf::from(file),
-            None => repo.get("tokenizer.json")?,
+            None => repo.download_file().filename("tokenizer.json").send()?,
         };
 
         let device = candle_examples::device(self.cpu)?;

--- a/candle-examples/examples/olmo/main.rs
+++ b/candle-examples/examples/olmo/main.rs
@@ -14,7 +14,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -217,7 +217,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => match args.model {
@@ -229,14 +229,16 @@ fn main() -> Result<()> {
         },
     };
 
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision;
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -245,13 +247,25 @@ fn main() -> Result<()> {
             .collect::<Vec<_>>(),
         None => match args.model {
             Which::W1b | Which::V2W1b => {
-                vec![repo.get("model.safetensors")?]
+                vec![repo
+                    .download_file()
+                    .filename("model.safetensors")
+                    .revision(revision.as_str())
+                    .send()?]
             }
-            _ => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+            _ => candle_examples::hub_load_safetensors(
+                &repo,
+                revision.as_str(),
+                "model.safetensors.index.json",
+            )?,
         },
     };
 
-    let config_filename = repo.get("config.json")?;
+    let config_filename = repo
+        .download_file()
+        .filename("config.json")
+        .revision(revision.as_str())
+        .send()?;
     println!("retrieved the files in {:?}", start.elapsed());
 
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;

--- a/candle-examples/examples/onnx-llm/main.rs
+++ b/candle-examples/examples/onnx-llm/main.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use candle::{DType, Tensor};
 use candle_transformers::generation::{LogitsProcessor, Sampling};
 use clap::{Parser, ValueEnum};
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use serde::Deserialize;
 use std::io::Write;
 use tokenizers::Tokenizer;
@@ -69,15 +69,23 @@ pub fn main() -> Result<()> {
         Which::SmolLM135M => ("HuggingFaceTB/SmolLM-135M", "HuggingFaceTB/SmolLM-135M"),
     };
 
-    let api = Api::new()?;
-    let model_repo = api.model(model_id.to_string());
-    let tokenizer_repo = api.model(tokenizer_id.to_string());
+    let client = HFClientSync::new()?;
+    let (model_owner, model_name) = hf_hub::split_id(model_id);
+    let model_repo = client.model(model_owner, model_name);
+    let (tokenizer_owner, tokenizer_name) = hf_hub::split_id(tokenizer_id);
+    let tokenizer_repo = client.model(tokenizer_owner, tokenizer_name);
 
-    let model_path = model_repo.get("onnx/model.onnx")?;
-    let config_file = model_repo.get("config.json")?;
+    let model_path = model_repo
+        .download_file()
+        .filename("onnx/model.onnx")
+        .send()?;
+    let config_file = model_repo.download_file().filename("config.json").send()?;
     let config: Config = serde_json::from_reader(std::fs::File::open(config_file)?)?;
 
-    let tokenizer_path = tokenizer_repo.get("tokenizer.json")?;
+    let tokenizer_path = tokenizer_repo
+        .download_file()
+        .filename("tokenizer.json")
+        .send()?;
     let tokenizer = Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)?;
 
     let tokens_u32 = tokenizer

--- a/candle-examples/examples/onnx/main.rs
+++ b/candle-examples/examples/onnx/main.rs
@@ -52,15 +52,30 @@ pub fn main() -> anyhow::Result<()> {
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
         None => match args.which {
-            Which::SqueezeNet => hf_hub::api::sync::Api::new()?
-                .model("lmz/candle-onnx".into())
-                .get("squeezenet1.1-7.onnx")?,
-            Which::EfficientNet => hf_hub::api::sync::Api::new()?
-                .model("onnx/EfficientNet-Lite4".into())
-                .get("efficientnet-lite4-11.onnx")?,
-            Which::EsrGan => hf_hub::api::sync::Api::new()?
-                .model("qualcomm/Real-ESRGAN-x4plus".into())
-                .get("Real-ESRGAN-x4plus.onnx")?,
+            Which::SqueezeNet => {
+                let (owner, name) = hf_hub::split_id("lmz/candle-onnx");
+                hf_hub::HFClientSync::new()?
+                    .model(owner, name)
+                    .download_file()
+                    .filename("squeezenet1.1-7.onnx")
+                    .send()?
+            }
+            Which::EfficientNet => {
+                let (owner, name) = hf_hub::split_id("onnx/EfficientNet-Lite4");
+                hf_hub::HFClientSync::new()?
+                    .model(owner, name)
+                    .download_file()
+                    .filename("efficientnet-lite4-11.onnx")
+                    .send()?
+            }
+            Which::EsrGan => {
+                let (owner, name) = hf_hub::split_id("qualcomm/Real-ESRGAN-x4plus");
+                hf_hub::HFClientSync::new()?
+                    .model(owner, name)
+                    .download_file()
+                    .filename("Real-ESRGAN-x4plus.onnx")
+                    .send()?
+            }
         },
     };
 

--- a/candle-examples/examples/orpheus/main.rs
+++ b/candle-examples/examples/orpheus/main.rs
@@ -158,12 +158,17 @@ struct Model {
 }
 
 fn load_snac(device: &Device) -> Result<SnacModel> {
-    let api = hf_hub::api::sync::Api::new()?;
-    let m = api.model("hubertsiuzdak/snac_24khz".to_string());
-    let config = m.get("config.json")?;
+    let client = hf_hub::HFClientSync::new()?;
+    let (owner, name) = hf_hub::split_id("hubertsiuzdak/snac_24khz");
+    let m = client.model(owner, name);
+    let config = m.download_file().filename("config.json").send()?;
     let config: SnacConfig = serde_json::from_reader(std::fs::File::open(config)?)?;
-    let m = api.model("lmz/candle-snac".to_string());
-    let model = m.get("snac_24khz.safetensors")?;
+    let (owner, name) = hf_hub::split_id("lmz/candle-snac");
+    let m = client.model(owner, name);
+    let model = m
+        .download_file()
+        .filename("snac_24khz.safetensors")
+        .send()?;
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DType::F32, device)? };
     let model = SnacModel::new(&config, vb)?;
     Ok(model)
@@ -172,7 +177,7 @@ fn load_snac(device: &Device) -> Result<SnacModel> {
 impl Model {
     fn load(args: Args) -> Result<Self> {
         let start = std::time::Instant::now();
-        let api = hf_hub::api::sync::Api::new()?;
+        let client = hf_hub::HFClientSync::new()?;
         let model_id = match args.model_id {
             Some(model_id) => model_id.to_string(),
             None => match args.which {
@@ -183,26 +188,33 @@ impl Model {
             Some(r) => r,
             None => "main".to_string(),
         };
-        let repo = api.repo(hf_hub::Repo::with_revision(
-            model_id,
-            hf_hub::RepoType::Model,
-            revision,
-        ));
+        let (owner, name) = hf_hub::split_id(&model_id);
+        let repo = client.model(owner, name);
         let model_files = match args.model_file {
             Some(m) => vec![m.into()],
             None => match args.which {
-                Which::ThreeB0_1Ft => {
-                    candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?
-                }
+                Which::ThreeB0_1Ft => candle_examples::hub_load_safetensors(
+                    &repo,
+                    revision.as_str(),
+                    "model.safetensors.index.json",
+                )?,
             },
         };
         let config = match args.config_file {
             Some(m) => m.into(),
-            None => repo.get("config.json")?,
+            None => repo
+                .download_file()
+                .filename("config.json")
+                .revision(revision.as_str())
+                .send()?,
         };
         let tokenizer = match args.tokenizer_file {
             Some(m) => m.into(),
-            None => repo.get("tokenizer.json")?,
+            None => repo
+                .download_file()
+                .filename("tokenizer.json")
+                .revision(revision.as_str())
+                .send()?,
         };
         println!("retrieved the files in {:?}", start.elapsed());
         let tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;

--- a/candle-examples/examples/paddleocr-vl/main.rs
+++ b/candle-examples/examples/paddleocr-vl/main.rs
@@ -596,15 +596,16 @@ fn main() -> Result<()> {
 
     // Load model from HuggingFace
     println!("Loading model from {}...", args.model_id);
-    let api = hf_hub::api::sync::Api::new()?;
-    let repo = api.repo(hf_hub::Repo::with_revision(
-        args.model_id.clone(),
-        hf_hub::RepoType::Model,
-        args.revision.clone(),
-    ));
+    let client = hf_hub::HFClientSync::new()?;
+    let (owner, name) = hf_hub::split_id(&args.model_id);
+    let repo = client.model(owner, name);
 
     // Load config
-    let config_file = repo.get("config.json")?;
+    let config_file = repo
+        .download_file()
+        .filename("config.json")
+        .revision(args.revision.as_str())
+        .send()?;
     let config: Config = serde_json::from_str(&std::fs::read_to_string(&config_file)?)?;
     println!(
         "Vision: {}L {}H, Text: {}L {}H (GQA: {}KV)",
@@ -616,13 +617,26 @@ fn main() -> Result<()> {
     );
 
     // Load tokenizer
-    let tokenizer_file = repo.get("tokenizer.json")?;
+    let tokenizer_file = repo
+        .download_file()
+        .filename("tokenizer.json")
+        .revision(args.revision.as_str())
+        .send()?;
     let tokenizer = Tokenizer::from_file(&tokenizer_file).map_err(E::msg)?;
 
     // Load model weights
-    let model_file = match repo.get("model.safetensors") {
+    let model_file = match repo
+        .download_file()
+        .filename("model.safetensors")
+        .revision(args.revision.as_str())
+        .send()
+    {
         Ok(f) => f,
-        Err(_) => repo.get("pytorch_model.bin")?,
+        Err(_) => repo
+            .download_file()
+            .filename("pytorch_model.bin")
+            .revision(args.revision.as_str())
+            .send()?,
     };
 
     println!("Loading weights from {:?}...", model_file);

--- a/candle-examples/examples/paligemma/main.rs
+++ b/candle-examples/examples/paligemma/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -218,26 +218,31 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => "google/paligemma-3b-mix-224".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+        None => candle_examples::hub_load_safetensors(
+            &repo,
+            args.revision.as_str(),
+            "model.safetensors.index.json",
+        )?,
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;

--- a/candle-examples/examples/parler-tts/main.rs
+++ b/candle-examples/examples/parler-tts/main.rs
@@ -125,7 +125,7 @@ fn main() -> anyhow::Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = hf_hub::api::sync::Api::new()?;
+    let client = hf_hub::HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id.to_string(),
         None => match args.which {
@@ -137,27 +137,38 @@ fn main() -> anyhow::Result<()> {
         Some(r) => r,
         None => "main".to_string(),
     };
-    let repo = api.repo(hf_hub::Repo::with_revision(
-        model_id,
-        hf_hub::RepoType::Model,
-        revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let model_files = match args.model_file {
         Some(m) => vec![m.into()],
         None => match args.which {
-            Which::MiniV1 => vec![repo.get("model.safetensors")?],
-            Which::LargeV1 => {
-                candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?
-            }
+            Which::MiniV1 => vec![repo
+                .download_file()
+                .filename("model.safetensors")
+                .revision(revision.as_str())
+                .send()?],
+            Which::LargeV1 => candle_examples::hub_load_safetensors(
+                &repo,
+                revision.as_str(),
+                "model.safetensors.index.json",
+            )?,
         },
     };
     let config = match args.config_file {
         Some(m) => m.into(),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let tokenizer = match args.tokenizer_file {
         Some(m) => m.into(),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer).map_err(E::msg)?;

--- a/candle-examples/examples/phi/main.rs
+++ b/candle-examples/examples/phi/main.rs
@@ -16,7 +16,7 @@ use candle_transformers::models::quantized_mixformer::MixFormerSequentialForCaus
 use candle::{DType, Device, IndexOp, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -250,7 +250,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id.to_string(),
         None => {
@@ -291,7 +291,8 @@ fn main() -> Result<()> {
             }
         }
     };
-    let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
         None => match args.model {
@@ -301,10 +302,16 @@ fn main() -> Result<()> {
             | WhichModel::V2Old
             | WhichModel::V3
             | WhichModel::V3Medium
-            | WhichModel::V4Mini => repo.get("tokenizer.json")?,
-            WhichModel::PuffinPhiV2 | WhichModel::PhiHermes => {
-                repo.get("tokenizer-puffin-phi-v2.json")?
-            }
+            | WhichModel::V4Mini => repo
+                .download_file()
+                .filename("tokenizer.json")
+                .revision(revision.as_str())
+                .send()?,
+            WhichModel::PuffinPhiV2 | WhichModel::PhiHermes => repo
+                .download_file()
+                .filename("tokenizer-puffin-phi-v2.json")
+                .revision(revision.as_str())
+                .send()?,
         },
     };
     let filenames = match args.weight_file {
@@ -312,28 +319,61 @@ fn main() -> Result<()> {
         None => {
             if args.quantized {
                 match args.model {
-                    WhichModel::V1 => vec![repo.get("model-v1-q4k.gguf")?],
-                    WhichModel::V1_5 => vec![repo.get("model-q4k.gguf")?],
-                    WhichModel::V2 | WhichModel::V2Old => vec![repo.get("model-v2-q4k.gguf")?],
-                    WhichModel::PuffinPhiV2 => vec![repo.get("model-puffin-phi-v2-q4k.gguf")?],
-                    WhichModel::PhiHermes => vec![repo.get("model-phi-hermes-1_3B-q4k.gguf")?],
+                    WhichModel::V1 => vec![repo
+                        .download_file()
+                        .filename("model-v1-q4k.gguf")
+                        .revision(revision.as_str())
+                        .send()?],
+                    WhichModel::V1_5 => vec![repo
+                        .download_file()
+                        .filename("model-q4k.gguf")
+                        .revision(revision.as_str())
+                        .send()?],
+                    WhichModel::V2 | WhichModel::V2Old => vec![repo
+                        .download_file()
+                        .filename("model-v2-q4k.gguf")
+                        .revision(revision.as_str())
+                        .send()?],
+                    WhichModel::PuffinPhiV2 => vec![repo
+                        .download_file()
+                        .filename("model-puffin-phi-v2-q4k.gguf")
+                        .revision(revision.as_str())
+                        .send()?],
+                    WhichModel::PhiHermes => vec![repo
+                        .download_file()
+                        .filename("model-phi-hermes-1_3B-q4k.gguf")
+                        .revision(revision.as_str())
+                        .send()?],
                     WhichModel::V3 | WhichModel::V3Medium | WhichModel::V4Mini => anyhow::bail!(
                         "use the quantized or quantized-phi examples for quantized phi-v3"
                     ),
                 }
             } else {
                 match args.model {
-                    WhichModel::V1 | WhichModel::V1_5 => vec![repo.get("model.safetensors")?],
+                    WhichModel::V1 | WhichModel::V1_5 => vec![repo
+                        .download_file()
+                        .filename("model.safetensors")
+                        .revision(revision.as_str())
+                        .send()?],
                     WhichModel::V2
                     | WhichModel::V2Old
                     | WhichModel::V3
                     | WhichModel::V3Medium
                     | WhichModel::V4Mini => candle_examples::hub_load_safetensors(
                         &repo,
+                        revision.as_str(),
                         "model.safetensors.index.json",
                     )?,
-                    WhichModel::PuffinPhiV2 => vec![repo.get("model-puffin-phi-v2.safetensors")?],
-                    WhichModel::PhiHermes => vec![repo.get("model-phi-hermes-1_3B.safetensors")?],
+                    WhichModel::PuffinPhiV2 => vec![repo
+                        .download_file()
+                        .filename("model-puffin-phi-v2.safetensors")
+                        .revision(revision.as_str())
+                        .send()?],
+                    WhichModel::PhiHermes => vec![repo
+                        .download_file()
+                        .filename("model-phi-hermes-1_3B.safetensors")
+                        .revision(revision.as_str())
+                        .send()?],
                 }
             }
         }
@@ -381,14 +421,22 @@ fn main() -> Result<()> {
         let vb = unsafe { VarBuilder::from_mmaped_safetensors(&filenames, dtype, &device)? };
         match args.model {
             WhichModel::V1 | WhichModel::V1_5 | WhichModel::V2 => {
-                let config_filename = repo.get("config.json")?;
+                let config_filename = repo
+                    .download_file()
+                    .filename("config.json")
+                    .revision(revision.as_str())
+                    .send()?;
                 let config = std::fs::read_to_string(config_filename)?;
                 let config: PhiConfig = serde_json::from_str(&config)?;
                 let phi = Phi::new(&config, vb)?;
                 Model::Phi(phi)
             }
             WhichModel::V3 | WhichModel::V3Medium | WhichModel::V4Mini => {
-                let config_filename = repo.get("config.json")?;
+                let config_filename = repo
+                    .download_file()
+                    .filename("config.json")
+                    .revision(revision.as_str())
+                    .send()?;
                 let config = std::fs::read_to_string(config_filename)?;
                 let config: Phi3Config = serde_json::from_str(&config)?;
                 let phi3 = Phi3::new(&config, vb)?;

--- a/candle-examples/examples/pixtral/main.rs
+++ b/candle-examples/examples/pixtral/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Module, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -245,26 +245,32 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => "mistral-community/pixtral-12b".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision;
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+        None => candle_examples::hub_load_safetensors(
+            &repo,
+            revision.as_str(),
+            "model.safetensors.index.json",
+        )?,
     };
     println!("retrieved the files in {:?}", start.elapsed());
 
@@ -277,7 +283,11 @@ fn main() -> Result<()> {
     let config: Config = match args.config_file {
         Some(config_file) => serde_json::from_slice(&std::fs::read(config_file)?)?,
         None => {
-            let config_file = repo.get("config.json")?;
+            let config_file = repo
+                .download_file()
+                .filename("config.json")
+                .revision(revision.as_str())
+                .send()?;
             serde_json::from_slice(&std::fs::read(config_file)?)?
         }
     };

--- a/candle-examples/examples/quantized-gemma/main.rs
+++ b/candle-examples/examples/quantized-gemma/main.rs
@@ -90,11 +90,12 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
-                let repo = "google/gemma-3-4b-it";
-                println!("DEBUG: Downloading tokenizer from {repo}");
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let client = hf_hub::HFClientSync::new()?;
+                let repo_id = "google/gemma-3-4b-it";
+                println!("DEBUG: Downloading tokenizer from {repo_id}");
+                let (owner, name) = hf_hub::split_id(repo_id);
+                let repo = client.model(owner, name);
+                repo.download_file().filename("tokenizer.json").send()?
             }
         };
         println!("DEBUG: Loading tokenizer from {tokenizer_path:?}");
@@ -113,13 +114,14 @@ impl Args {
                         "gemma-3-4b-it-q4_0.gguf",
                     ),
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    "main".to_string(),
-                ))
-                .get(filename)?
+                let client = hf_hub::HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id(repo);
+                client
+                    .model(owner, name)
+                    .download_file()
+                    .filename(filename)
+                    .revision("main")
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/quantized-glm4/main.rs
+++ b/candle-examples/examples/quantized-glm4/main.rs
@@ -96,15 +96,16 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
+                let client = hf_hub::HFClientSync::new()?;
                 let repo = match self.which {
                     Which::Q2k9b => "THUDM/GLM-4-9B-0414",
                     Which::Q2k32b => "THUDM/GLM-4-32B-0414",
                     Which::Q4k9b => "THUDM/GLM-4-9B-0414",
                     Which::Q4k32b => "THUDM/GLM-4-32B-0414",
                 };
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let (owner, name) = hf_hub::split_id(repo);
+                let repo = client.model(owner, name);
+                repo.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
@@ -136,13 +137,14 @@ impl Args {
                         "main",
                     ),
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    revision.to_string(),
-                ))
-                .get(filename)?
+                let client = hf_hub::HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id(repo);
+                client
+                    .model(owner, name)
+                    .download_file()
+                    .filename(filename)
+                    .revision(revision)
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/quantized-lfm2/main.rs
+++ b/candle-examples/examples/quantized-lfm2/main.rs
@@ -110,14 +110,15 @@ impl Args {
             Which::Lfm2_2_6BQ4KM => ("LiquidAI/LFM2-2.6B-GGUF", "LFM2-2.6B-Q4_K_M.gguf"),
             Which::Lfm2_2_6BQ8_0 => ("LiquidAI/LFM2-2.6B-GGUF", "LFM2-2.6B-Q8_0.gguf"),
         };
-        let api = hf_hub::api::sync::Api::new()?;
-        api.repo(hf_hub::Repo::with_revision(
-            repo.to_string(),
-            hf_hub::RepoType::Model,
-            self.revision.clone(),
-        ))
-        .get(filename)
-        .map_err(Into::into)
+        let client = hf_hub::HFClientSync::new()?;
+        let (owner, name) = hf_hub::split_id(repo);
+        client
+            .model(owner, name)
+            .download_file()
+            .filename(filename)
+            .revision(self.revision.as_str())
+            .send()
+            .map_err(Into::into)
     }
 
     fn tokenizer(&self, model_path: &Path) -> Result<Tokenizer> {
@@ -136,14 +137,14 @@ impl Args {
             Which::Lfm2_350MQ4KM | Which::Lfm2_350MQ8_0 => "LiquidAI/LFM2-350M",
             Which::Lfm2_2_6BQ4KM | Which::Lfm2_2_6BQ8_0 => "LiquidAI/LFM2-2.6B",
         };
-        let api = hf_hub::api::sync::Api::new()?;
-        let tokenizer_path = api
-            .repo(hf_hub::Repo::with_revision(
-                tokenizer_repo.to_string(),
-                hf_hub::RepoType::Model,
-                self.revision.clone(),
-            ))
-            .get("tokenizer.json")?;
+        let client = hf_hub::HFClientSync::new()?;
+        let (owner, name) = hf_hub::split_id(tokenizer_repo);
+        let tokenizer_path = client
+            .model(owner, name)
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(self.revision.as_str())
+            .send()?;
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
     }
 }

--- a/candle-examples/examples/quantized-phi/main.rs
+++ b/candle-examples/examples/quantized-phi/main.rs
@@ -102,14 +102,15 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
+                let client = hf_hub::HFClientSync::new()?;
                 let repo = match self.which {
                     Which::Phi2 => "microsoft/phi-2",
                     Which::Phi3 | Which::Phi3b => "microsoft/Phi-3-mini-4k-instruct",
                     Which::Phi4 => "microsoft/phi-4",
                 };
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let (owner, name) = hf_hub::split_id(repo);
+                let repo = client.model(owner, name);
+                repo.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
@@ -133,13 +134,14 @@ impl Args {
                     ),
                     Which::Phi4 => ("microsoft/phi-4-gguf", "phi-4-q4.gguf", "main"),
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    revision.to_string(),
-                ))
-                .get(filename)?
+                let client = hf_hub::HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id(repo);
+                client
+                    .model(owner, name)
+                    .download_file()
+                    .filename(filename)
+                    .revision(revision)
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/quantized-qwen2-instruct/main.rs
+++ b/candle-examples/examples/quantized-qwen2-instruct/main.rs
@@ -98,16 +98,17 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
-                let repo = match self.which {
+                let client = hf_hub::HFClientSync::new()?;
+                let repo_id = match self.which {
                     Which::W2_0_5b => "Qwen/Qwen2-0.5B-Instruct",
                     Which::W2_1_5b => "Qwen/Qwen2-1.5B-Instruct",
                     Which::W2_7b => "Qwen/Qwen2-7B-Instruct",
                     Which::W2_72b => "Qwen/Qwen2-72B-Instruct",
                     Which::DeepseekR1Qwen7B => "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
                 };
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let (owner, name) = hf_hub::split_id(repo_id);
+                let repo = client.model(owner, name);
+                repo.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
@@ -144,13 +145,14 @@ impl Args {
                         "main",
                     ),
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    revision.to_string(),
-                ))
-                .get(filename)?
+                let client = hf_hub::HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id(repo);
+                client
+                    .model(owner, name)
+                    .download_file()
+                    .filename(filename)
+                    .revision(revision)
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/quantized-qwen3-moe/main.rs
+++ b/candle-examples/examples/quantized-qwen3-moe/main.rs
@@ -107,10 +107,10 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
-                let repo = "Qwen/Qwen3-30B-A3B-Instruct-2507";
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let client = hf_hub::HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id("Qwen/Qwen3-30B-A3B-Instruct-2507");
+                let repo = client.model(owner, name);
+                repo.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
@@ -163,13 +163,13 @@ impl Args {
                         "main",
                     ),
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    revision.to_string(),
-                ))
-                .get(filename)?
+                let client = hf_hub::HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id(repo);
+                let repo = client.model(owner, name);
+                repo.download_file()
+                    .filename(filename)
+                    .revision(revision)
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/quantized-qwen3/main.rs
+++ b/candle-examples/examples/quantized-qwen3/main.rs
@@ -102,7 +102,7 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
+                let client = hf_hub::HFClientSync::new()?;
                 let repo = match self.which {
                     Which::W3_0_6b => "Qwen/Qwen3-0.6B",
                     Which::W3_0_6b8_0 => "Qwen/Qwen3-0.6B",
@@ -112,8 +112,12 @@ impl Args {
                     Which::W3_14b => "Qwen/Qwen3-14B",
                     Which::W3_32b => "Qwen/Qwen3-32B",
                 };
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let (owner, name) = hf_hub::split_id(repo);
+                client
+                    .model(owner, name)
+                    .download_file()
+                    .filename("tokenizer.json")
+                    .send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
@@ -134,13 +138,14 @@ impl Args {
                     Which::W3_14b => ("unsloth/Qwen3-14B-GGUF", "Qwen3-14B-Q4_K_M.gguf", "main"),
                     Which::W3_32b => ("unsloth/Qwen3-32B-GGUF", "Qwen3-32B-Q4_K_M.gguf", "main"),
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    revision.to_string(),
-                ))
-                .get(filename)?
+                let client = hf_hub::HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id(repo);
+                client
+                    .model(owner, name)
+                    .download_file()
+                    .filename(filename)
+                    .revision(revision)
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/quantized-t5/main.rs
+++ b/candle-examples/examples/quantized-t5/main.rs
@@ -12,7 +12,7 @@ use anyhow::{Error as E, Result};
 use candle::{Device, Tensor};
 use candle_transformers::generation::LogitsProcessor;
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, api::sync::ApiRepo, Repo, RepoType};
+use hf_hub::{HFClientSync, HFRepositorySync, RepoTypeModel};
 use tokenizers::Tokenizer;
 
 #[derive(Clone, Debug, Copy, ValueEnum)]
@@ -91,31 +91,47 @@ impl T5ModelBuilder {
             (None, None) => (default_model, "main".to_string()),
         };
 
-        let repo = Repo::with_revision(model_id, RepoType::Model, revision);
-        let api = Api::new()?;
-        let api = api.repo(repo);
+        let client = HFClientSync::new()?;
+        let (owner, name) = hf_hub::split_id(&model_id);
+        let repo = client.model(owner, name);
         let config_filename = match &args.config_file {
-            Some(filename) => Self::get_local_or_remote_file(filename, &api)?,
-            None => match args.which {
-                Which::T5Small => api.get("config.json")?,
-                Which::FlanT5Small => api.get("config-flan-t5-small.json")?,
-                Which::FlanT5Base => api.get("config-flan-t5-base.json")?,
-                Which::FlanT5Large => api.get("config-flan-t5-large.json")?,
-                Which::FlanT5Xl => api.get("config-flan-t5-xl.json")?,
-                Which::FlanT5Xxl => api.get("config-flan-t5-xxl.json")?,
-            },
+            Some(filename) => Self::get_local_or_remote_file(filename, &repo, revision.as_str())?,
+            None => {
+                let filename = match args.which {
+                    Which::T5Small => "config.json",
+                    Which::FlanT5Small => "config-flan-t5-small.json",
+                    Which::FlanT5Base => "config-flan-t5-base.json",
+                    Which::FlanT5Large => "config-flan-t5-large.json",
+                    Which::FlanT5Xl => "config-flan-t5-xl.json",
+                    Which::FlanT5Xxl => "config-flan-t5-xxl.json",
+                };
+                repo.download_file()
+                    .filename(filename)
+                    .revision(revision.as_str())
+                    .send()?
+            }
         };
-        let tokenizer_filename = api.get("tokenizer.json")?;
+        let tokenizer_filename = repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?;
         let weights_filename = match &args.weight_file {
-            Some(filename) => Self::get_local_or_remote_file(filename, &api)?,
-            None => match args.which {
-                Which::T5Small => api.get("model.gguf")?,
-                Which::FlanT5Small => api.get("model-flan-t5-small.gguf")?,
-                Which::FlanT5Base => api.get("model-flan-t5-base.gguf")?,
-                Which::FlanT5Large => api.get("model-flan-t5-large.gguf")?,
-                Which::FlanT5Xl => api.get("model-flan-t5-xl.gguf")?,
-                Which::FlanT5Xxl => api.get("model-flan-t5-xxl.gguf")?,
-            },
+            Some(filename) => Self::get_local_or_remote_file(filename, &repo, revision.as_str())?,
+            None => {
+                let filename = match args.which {
+                    Which::T5Small => "model.gguf",
+                    Which::FlanT5Small => "model-flan-t5-small.gguf",
+                    Which::FlanT5Base => "model-flan-t5-base.gguf",
+                    Which::FlanT5Large => "model-flan-t5-large.gguf",
+                    Which::FlanT5Xl => "model-flan-t5-xl.gguf",
+                    Which::FlanT5Xxl => "model-flan-t5-xxl.gguf",
+                };
+                repo.download_file()
+                    .filename(filename)
+                    .revision(revision.as_str())
+                    .send()?
+            }
         };
         let config = std::fs::read_to_string(config_filename)?;
         let mut config: t5::Config = serde_json::from_str(&config)?;
@@ -137,12 +153,20 @@ impl T5ModelBuilder {
         Ok(t5::T5ForConditionalGeneration::load(vb, &self.config)?)
     }
 
-    fn get_local_or_remote_file(filename: &str, api: &ApiRepo) -> Result<PathBuf> {
+    fn get_local_or_remote_file(
+        filename: &str,
+        repo: &HFRepositorySync<RepoTypeModel>,
+        revision: &str,
+    ) -> Result<PathBuf> {
         let local_filename = std::path::PathBuf::from(filename);
         if local_filename.exists() {
             Ok(local_filename)
         } else {
-            Ok(api.get(filename)?)
+            Ok(repo
+                .download_file()
+                .filename(filename)
+                .revision(revision)
+                .send()?)
         }
     }
 }

--- a/candle-examples/examples/quantized/main.rs
+++ b/candle-examples/examples/quantized/main.rs
@@ -309,10 +309,10 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
-                let repo = self.which.tokenizer_repo();
-                let api = api.model(repo.to_string());
-                api.get("tokenizer.json")?
+                let client = hf_hub::HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id(self.which.tokenizer_repo());
+                let repo = client.model(owner, name);
+                repo.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(anyhow::Error::msg)
@@ -408,13 +408,13 @@ impl Args {
                 } else {
                     "main"
                 };
-                let api = hf_hub::api::sync::Api::new()?;
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    revision.to_string(),
-                ))
-                .get(filename)?
+                let client = hf_hub::HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id(repo);
+                let repo = client.model(owner, name);
+                repo.download_file()
+                    .filename(filename)
+                    .revision(revision)
+                    .send()?
             }
         };
         Ok(model_path)

--- a/candle-examples/examples/qwen/main.rs
+++ b/candle-examples/examples/qwen/main.rs
@@ -16,7 +16,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -284,7 +284,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let use_chat_template = args.should_use_chat_template();
     let thinking = args.thinking;
     let model_id = match args.model_id {
@@ -311,21 +311,27 @@ fn main() -> Result<()> {
             format!("Qwen/Qwen{version}-{size}")
         }
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
+    let revision = args.revision;
 
     let tokenizer_filename = match (args.weight_path.as_ref(), args.tokenizer_file.as_ref()) {
         (Some(_), Some(file)) => std::path::PathBuf::from(file),
         (None, Some(file)) => std::path::PathBuf::from(file),
         (Some(path), None) => std::path::Path::new(path).join("tokenizer.json"),
-        (None, None) => repo.get("tokenizer.json")?,
+        (None, None) => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let config_file = match &args.weight_path {
         Some(path) => std::path::Path::new(path).join("config.json"),
-        _ => repo.get("config.json")?,
+        _ => repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.as_str())
+            .send()?,
     };
 
     let filenames = match args.weight_path {
@@ -345,7 +351,11 @@ fn main() -> Result<()> {
             | WhichModel::W2_1_5b
             | WhichModel::W1_8b
             | WhichModel::W3_0_6b => {
-                vec![repo.get("model.safetensors")?]
+                vec![repo
+                    .download_file()
+                    .filename("model.safetensors")
+                    .revision(revision.as_str())
+                    .send()?]
             }
             WhichModel::W4b
             | WhichModel::W7b
@@ -357,9 +367,11 @@ fn main() -> Result<()> {
             | WhichModel::W3_1_7b
             | WhichModel::W3_4b
             | WhichModel::W3_8b
-            | WhichModel::W3MoeA3b => {
-                candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?
-            }
+            | WhichModel::W3MoeA3b => candle_examples::hub_load_safetensors(
+                &repo,
+                revision.as_str(),
+                "model.safetensors.index.json",
+            )?,
         },
     };
     println!("retrieved the files in {:?}", start.elapsed());

--- a/candle-examples/examples/recurrent-gemma/main.rs
+++ b/candle-examples/examples/recurrent-gemma/main.rs
@@ -14,7 +14,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -242,7 +242,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => match args.which {
@@ -250,18 +250,24 @@ fn main() -> Result<()> {
             Which::Instruct2B => "google/recurrentgemma-2b-it".to_string(),
         },
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision;
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -274,10 +280,19 @@ fn main() -> Result<()> {
                     Which::Base2B => "recurrent-gemma-2b-q4k.gguf",
                     Which::Instruct2B => "recurrent-gemma-7b-q4k.gguf",
                 };
-                let filename = api.model("lmz/candle-gemma".to_string()).get(filename)?;
+                let (owner, name) = hf_hub::split_id("lmz/candle-gemma");
+                let filename = client
+                    .model(owner, name)
+                    .download_file()
+                    .filename(filename)
+                    .send()?;
                 vec![filename]
             } else {
-                candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?
+                candle_examples::hub_load_safetensors(
+                    &repo,
+                    revision.as_str(),
+                    "model.safetensors.index.json",
+                )?
             }
         }
     };

--- a/candle-examples/examples/replit-code/main.rs
+++ b/candle-examples/examples/replit-code/main.rs
@@ -13,7 +13,7 @@ use candle_transformers::models::quantized_mpt::Model as Q;
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -208,7 +208,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id.to_string(),
         None => "lmz/candle-replit-code".to_string(),
@@ -217,18 +217,29 @@ fn main() -> Result<()> {
         Some(rev) => rev.to_string(),
         None => "main".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let filename = match args.weight_file {
         Some(weight_file) => std::path::PathBuf::from(weight_file),
         None => {
             if args.quantized {
-                repo.get("model-replit-code-v1_5-q4k.gguf")?
+                repo.download_file()
+                    .filename("model-replit-code-v1_5-q4k.gguf")
+                    .revision(revision.as_str())
+                    .send()?
             } else {
-                repo.get("model.safetensors")?
+                repo.download_file()
+                    .filename("model.safetensors")
+                    .revision(revision.as_str())
+                    .send()?
             }
         }
     };

--- a/candle-examples/examples/repvgg/main.rs
+++ b/candle-examples/examples/repvgg/main.rs
@@ -84,9 +84,10 @@ pub fn main() -> anyhow::Result<()> {
     let model_file = match args.model {
         None => {
             let model_name = args.which.model_filename();
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(model_name);
-            api.get("model.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id(&model_name);
+            let repo = client.model(owner, name);
+            repo.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/resnet/main.rs
+++ b/candle-examples/examples/resnet/main.rs
@@ -50,8 +50,9 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("lmz/candle-resnet".into());
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id("lmz/candle-resnet");
+            let repo = client.model(owner, name);
             let filename = match args.which {
                 Which::Resnet18 => "resnet18.safetensors",
                 Which::Resnet34 => "resnet34.safetensors",
@@ -59,7 +60,7 @@ pub fn main() -> anyhow::Result<()> {
                 Which::Resnet101 => "resnet101.safetensors",
                 Which::Resnet152 => "resnet152.safetensors",
             };
-            api.get(filename)?
+            repo.download_file().filename(filename).send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/rwkv/main.rs
+++ b/candle-examples/examples/rwkv/main.rs
@@ -18,7 +18,7 @@ use candle_transformers::models::rwkv_v7::{
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 
 const EOS_TOKEN_ID: u32 = 261;
 
@@ -622,24 +622,35 @@ fn main() -> Result<()> {
         }
     }
 
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id
-            .unwrap_or_else(|| args.which.model_id().to_string()),
-        RepoType::Model,
-        args.revision
-            .unwrap_or_else(|| args.which.revision().to_string()),
-    ));
+    let client = HFClientSync::new()?;
+    let model_id = args
+        .model_id
+        .unwrap_or_else(|| args.which.model_id().to_string());
+    let revision = args
+        .revision
+        .unwrap_or_else(|| args.which.revision().to_string());
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let tokenizer = match args.tokenizer {
         Some(file) => std::path::PathBuf::from(file),
-        None => api
-            .model("lmz/candle-rwkv".to_string())
-            .get("rwkv_vocab_v20230424.json")?,
+        None => {
+            let (owner, name) = hf_hub::split_id("lmz/candle-rwkv");
+            client
+                .model(owner, name)
+                .download_file()
+                .filename("rwkv_vocab_v20230424.json")
+                .send()?
+        }
     };
     let config_filename = match (&args.config_file, args.which.is_v7()) {
         (Some(file), _) => Some(std::path::PathBuf::from(file)),
         (None, true) => None, // v7 models use built-in config, no config.json needed
-        (None, false) => Some(repo.get("config.json")?),
+        (None, false) => Some(
+            repo.download_file()
+                .filename("config.json")
+                .revision(revision.as_str())
+                .send()?,
+        ),
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -652,48 +663,89 @@ fn main() -> Result<()> {
                     anyhow::bail!("quantized RWKV v7 models are not yet supported");
                 }
                 vec![match args.which {
-                    Which::World1b5 => api
-                        .model("lmz/candle-rwkv".to_string())
-                        .get("world1b5-q4k.gguf")?,
-                    Which::World3b => api
-                        .model("lmz/candle-rwkv".to_string())
-                        .get("world3b-q4k.gguf")?,
-                    Which::Eagle7b => api
-                        .model("lmz/candle-rwkv".to_string())
-                        .get("eagle7b-q4k.gguf")?,
-                    Which::World6_1b6 => repo.get("rwkv-6-world-1b6-q4k.gguf")?,
+                    Which::World1b5 => {
+                        let (owner, name) = hf_hub::split_id("lmz/candle-rwkv");
+                        client
+                            .model(owner, name)
+                            .download_file()
+                            .filename("world1b5-q4k.gguf")
+                            .send()?
+                    }
+                    Which::World3b => {
+                        let (owner, name) = hf_hub::split_id("lmz/candle-rwkv");
+                        client
+                            .model(owner, name)
+                            .download_file()
+                            .filename("world3b-q4k.gguf")
+                            .send()?
+                    }
+                    Which::Eagle7b => {
+                        let (owner, name) = hf_hub::split_id("lmz/candle-rwkv");
+                        client
+                            .model(owner, name)
+                            .download_file()
+                            .filename("eagle7b-q4k.gguf")
+                            .send()?
+                    }
+                    Which::World6_1b6 => repo
+                        .download_file()
+                        .filename("rwkv-6-world-1b6-q4k.gguf")
+                        .revision(revision.as_str())
+                        .send()?,
                     _ => unreachable!(),
                 }]
             } else {
                 vec![match args.which {
-                    Which::World1b5 | Which::World3b | Which::Eagle7b => {
-                        repo.get("model.safetensors")?
-                    }
-                    Which::World6_1b6 => repo.get("rwkv-6-world-1b6.safetensors")?,
-                    Which::Rwkv7G1d0_1b => {
-                        repo.get("rwkv7-g1d-0.1b-20260129-ctx8192.safetensors")?
-                    }
-                    Which::Rwkv7G1d0_4b => {
-                        repo.get("rwkv7-g1d-0.4b-20260210-ctx8192.safetensors")?
-                    }
-                    Which::Rwkv7G1d1_5b => {
-                        repo.get("rwkv7-g1d-1.5b-20260212-ctx8192.safetensors")?
-                    }
-                    Which::Rwkv7G1d2_9b => {
-                        repo.get("rwkv7-g1d-2.9b-20260131-ctx8192.safetensors")?
-                    }
-                    Which::Rwkv7G1d7_2b => {
-                        repo.get("rwkv7-g1d-7.2b-20260131-ctx8192.safetensors")?
-                    }
-                    Which::Rwkv7G1d13_3b => {
-                        repo.get("rwkv7-g1d-13.3b-20260131-ctx8192.safetensors")?
-                    }
-                    Which::Rwkv7aG1d0_1b => {
-                        repo.get("rwkv7a-g1d-0.1b-20260212-ctx8192.safetensors")?
-                    }
-                    Which::Rwkv7bG1b0_1b => {
-                        repo.get("rwkv7b-g1b-0.1b-20250822-ctx4096.safetensors")?
-                    }
+                    Which::World1b5 | Which::World3b | Which::Eagle7b => repo
+                        .download_file()
+                        .filename("model.safetensors")
+                        .revision(revision.as_str())
+                        .send()?,
+                    Which::World6_1b6 => repo
+                        .download_file()
+                        .filename("rwkv-6-world-1b6.safetensors")
+                        .revision(revision.as_str())
+                        .send()?,
+                    Which::Rwkv7G1d0_1b => repo
+                        .download_file()
+                        .filename("rwkv7-g1d-0.1b-20260129-ctx8192.safetensors")
+                        .revision(revision.as_str())
+                        .send()?,
+                    Which::Rwkv7G1d0_4b => repo
+                        .download_file()
+                        .filename("rwkv7-g1d-0.4b-20260210-ctx8192.safetensors")
+                        .revision(revision.as_str())
+                        .send()?,
+                    Which::Rwkv7G1d1_5b => repo
+                        .download_file()
+                        .filename("rwkv7-g1d-1.5b-20260212-ctx8192.safetensors")
+                        .revision(revision.as_str())
+                        .send()?,
+                    Which::Rwkv7G1d2_9b => repo
+                        .download_file()
+                        .filename("rwkv7-g1d-2.9b-20260131-ctx8192.safetensors")
+                        .revision(revision.as_str())
+                        .send()?,
+                    Which::Rwkv7G1d7_2b => repo
+                        .download_file()
+                        .filename("rwkv7-g1d-7.2b-20260131-ctx8192.safetensors")
+                        .revision(revision.as_str())
+                        .send()?,
+                    Which::Rwkv7G1d13_3b => repo
+                        .download_file()
+                        .filename("rwkv7-g1d-13.3b-20260131-ctx8192.safetensors")
+                        .revision(revision.as_str())
+                        .send()?,
+                    Which::Rwkv7aG1d0_1b => repo
+                        .download_file()
+                        .filename("rwkv7a-g1d-0.1b-20260212-ctx8192.safetensors")
+                        .revision(revision.as_str())
+                        .send()?,
+                    Which::Rwkv7bG1b0_1b => repo
+                        .download_file()
+                        .filename("rwkv7b-g1b-0.1b-20250822-ctx4096.safetensors")
+                        .revision(revision.as_str())
+                        .send()?,
                 }]
             }
         }

--- a/candle-examples/examples/segformer/main.rs
+++ b/candle-examples/examples/segformer/main.rs
@@ -61,13 +61,14 @@ fn get_vb_and_config(
     device: &Device,
 ) -> anyhow::Result<(VarBuilder<'_>, Config)> {
     println!("loading model {model_name} via huggingface hub");
-    let api = hf_hub::api::sync::Api::new()?;
-    let api = api.model(model_name.clone());
-    let model_file = api.get("model.safetensors")?;
+    let client = hf_hub::HFClientSync::new()?;
+    let (owner, name) = hf_hub::split_id(&model_name);
+    let repo = client.model(owner, name);
+    let model_file = repo.download_file().filename("model.safetensors").send()?;
     println!("model {model_name} downloaded and loaded");
     let vb =
         unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], candle::DType::F32, device)? };
-    let config = std::fs::read_to_string(api.get("config.json")?)?;
+    let config = std::fs::read_to_string(repo.download_file().filename("config.json").send()?)?;
     let config: Config = serde_json::from_str(&config)?;
     println!("{config:?}");
     Ok((vb, config))

--- a/candle-examples/examples/segment-anything/main.rs
+++ b/candle-examples/examples/segment-anything/main.rs
@@ -74,14 +74,15 @@ pub fn main() -> anyhow::Result<()> {
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("lmz/candle-sam".to_string());
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id("lmz/candle-sam");
+            let repo = client.model(owner, name);
             let filename = if args.use_tiny {
                 "mobile_sam-tiny-vitt.safetensors"
             } else {
                 "sam_vit_b_01ec64.safetensors"
             };
-            api.get(filename)?
+            repo.download_file().filename(filename).send()?
         }
     };
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DType::F32, &device)? };

--- a/candle-examples/examples/siglip/main.rs
+++ b/candle-examples/examples/siglip/main.rs
@@ -110,17 +110,19 @@ pub fn main() -> anyhow::Result<()> {
     };
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(hf_repo.to_string());
-            api.get("model.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id(hf_repo);
+            let repo = client.model(owner, name);
+            repo.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };
     let config_file = match args.config {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(hf_repo.to_string());
-            api.get("config.json")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id(hf_repo);
+            let repo = client.model(owner, name);
+            repo.download_file().filename("config.json").send()?
         }
         Some(config) => config.into(),
     };
@@ -168,9 +170,10 @@ pub fn main() -> anyhow::Result<()> {
 pub fn get_tokenizer(hf_repo: &str, tokenizer: Option<String>) -> anyhow::Result<Tokenizer> {
     let tokenizer = match tokenizer {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model(hf_repo.to_string());
-            api.get("tokenizer.json")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id(hf_repo);
+            let repo = client.model(owner, name);
+            repo.download_file().filename("tokenizer.json").send()?
         }
         Some(file) => file.into(),
     };

--- a/candle-examples/examples/silero-vad/main.rs
+++ b/candle-examples/examples/silero-vad/main.rs
@@ -124,13 +124,22 @@ fn main() -> Result<()> {
     let model_id = match &args.model_id {
         Some(model_id) => std::path::PathBuf::from(model_id),
         None => match args.which {
-            Which::Silero => hf_hub::api::sync::Api::new()?
-                .model("onnx-community/silero-vad".into())
-                .get("onnx/model.onnx")?,
-            // TODO: candle-onnx doesn't support Int8 dtype
-            // Which::SileroQuantized => hf_hub::api::sync::Api::new()?
-            //     .model("onnx-community/silero-vad".into())
-            //     .get("onnx/model_quantized.onnx")?,
+            Which::Silero => {
+                let (owner, name) = hf_hub::split_id("onnx-community/silero-vad");
+                hf_hub::HFClientSync::new()?
+                    .model(owner, name)
+                    .download_file()
+                    .filename("onnx/model.onnx")
+                    .send()?
+            } // TODO: candle-onnx doesn't support Int8 dtype
+              // Which::SileroQuantized => {
+              //     let (owner, name) = hf_hub::split_id("onnx-community/silero-vad");
+              //     hf_hub::HFClientSync::new()?
+              //         .model(owner, name)
+              //         .download_file()
+              //         .filename("onnx/model_quantized.onnx")
+              //         .send()?
+              // }
         },
     };
     let (sample_rate, frame_size, context_size): (i64, usize, usize) = match args.sample_rate {

--- a/candle-examples/examples/smollm3/main.rs
+++ b/candle-examples/examples/smollm3/main.rs
@@ -14,7 +14,7 @@ use candle_examples::token_output_stream::TokenOutputStream;
 
 use candle_nn::VarBuilder;
 use candle_transformers::generation::{LogitsProcessor, Sampling};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 // Import both model implementations
@@ -227,9 +227,10 @@ impl Args {
         let tokenizer_path = match &self.tokenizer {
             Some(path) => std::path::PathBuf::from(path),
             None => {
-                let api = Api::new()?;
-                let api = api.model("HuggingFaceTB/SmolLM3-3B".to_string());
-                api.get("tokenizer.json")?
+                let client = HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id("HuggingFaceTB/SmolLM3-3B");
+                let repo = client.model(owner, name);
+                repo.download_file().filename("tokenizer.json").send()?
             }
         };
         Tokenizer::from_file(tokenizer_path).map_err(E::msg)
@@ -248,19 +249,20 @@ fn load_quantized_model(args: &Args, device: &Device) -> Result<SmolLM3Model> {
         None => {
             let filename = args.quantization.filename_unsloth();
             let repo_id = "unsloth/SmolLM3-3B-GGUF";
-            let api = Api::new()?;
+            let client = HFClientSync::new()?;
             println!(
                 "Downloading {} from {} (~{:.2}GB)...",
                 filename,
                 repo_id,
                 args.quantization.size_gb()
             );
-            api.repo(Repo::with_revision(
-                repo_id.to_string(),
-                RepoType::Model,
-                "main".to_string(),
-            ))
-            .get(filename)?
+            let (owner, name) = hf_hub::split_id(repo_id);
+            client
+                .model(owner, name)
+                .download_file()
+                .filename(filename)
+                .revision("main")
+                .send()?
         }
     };
 
@@ -270,25 +272,28 @@ fn load_quantized_model(args: &Args, device: &Device) -> Result<SmolLM3Model> {
 }
 
 fn load_full_model(args: &Args, device: &Device) -> Result<SmolLM3Model> {
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match args.model {
         WhichModel::W3b => "HuggingFaceTB/SmolLM3-3B",
         WhichModel::W3bBase => "HuggingFaceTB/SmolLM3-3B-Base",
     };
 
     println!("Loading full model from: {}", model_id);
-    let repo = api.repo(Repo::with_revision(
-        model_id.to_string(),
-        RepoType::Model,
-        "main".to_string(),
-    ));
+    let (owner, name) = hf_hub::split_id(model_id);
+    let repo = client.model(owner, name);
 
     let filenames = match &args.model_path {
         Some(path) => vec![std::path::PathBuf::from(path)],
-        None => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+        None => {
+            candle_examples::hub_load_safetensors(&repo, "main", "model.safetensors.index.json")?
+        }
     };
 
-    let config_file = repo.get("config.json")?;
+    let config_file = repo
+        .download_file()
+        .filename("config.json")
+        .revision("main")
+        .send()?;
     let config: Config = serde_json::from_slice(&std::fs::read(config_file)?)?;
 
     let dtype = match args.dtype.as_str() {

--- a/candle-examples/examples/snac/main.rs
+++ b/candle-examples/examples/snac/main.rs
@@ -9,7 +9,7 @@ use candle::{DType, IndexOp, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::snac::{Config, Model};
 use clap::{Parser, ValueEnum};
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 
 mod audio_io;
 
@@ -91,16 +91,23 @@ fn main() -> Result<()> {
     let model_sample_rate = args.which.sample_rate();
     let config = match args.config {
         Some(c) => std::path::PathBuf::from(c),
-        None => Api::new()?
-            .model(args.which.config_repo().to_string())
-            .get("config.json")?,
+        None => {
+            let (owner, name) = hf_hub::split_id(args.which.config_repo());
+            HFClientSync::new()?
+                .model(owner, name)
+                .download_file()
+                .filename("config.json")
+                .send()?
+        }
     };
     let config: Config = serde_json::from_slice(&std::fs::read(config)?)?;
     let model = match args.model {
         Some(model) => std::path::PathBuf::from(model),
-        None => Api::new()?
-            .model("lmz/candle-snac".to_string())
-            .get(args.which.model_file())?,
+        None => HFClientSync::new()?
+            .model("lmz", "candle-snac")
+            .download_file()
+            .filename(args.which.model_file())
+            .send()?,
     };
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model], DType::F32, &device)? };
     let model = Model::new(&config, vb)?;

--- a/candle-examples/examples/splade/main.rs
+++ b/candle-examples/examples/splade/main.rs
@@ -5,7 +5,7 @@ use candle::Tensor;
 use candle_nn::VarBuilder;
 use candle_transformers::models::bert::{self, BertForMaskedLM, Config};
 use clap::Parser;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingParams, Tokenizer};
 
 #[derive(Parser, Debug)]
@@ -45,32 +45,47 @@ struct Args {
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => "prithivida/Splade_PP_en_v1".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
 
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
 
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
 
     let weights_filename = match args.weight_files {
         Some(files) => PathBuf::from(files),
-        None => match repo.get("model.safetensors") {
+        None => match repo
+            .download_file()
+            .filename("model.safetensors")
+            .revision(args.revision.as_str())
+            .send()
+        {
             Ok(safetensors) => safetensors,
-            Err(_) => match repo.get("pytorch_model.bin") {
+            Err(_) => match repo
+                .download_file()
+                .filename("pytorch_model.bin")
+                .revision(args.revision.as_str())
+                .send()
+            {
                 Ok(pytorch_model) => pytorch_model,
                 Err(e) => {
                     return Err(anyhow::Error::msg(format!("Model weights not found. The weights should either be a `model.safetensors` or `pytorch_model.bin` file.  Error: {e}")));

--- a/candle-examples/examples/stable-diffusion-3/clip.rs
+++ b/candle-examples/examples/stable-diffusion-3/clip.rs
@@ -19,9 +19,12 @@ impl ClipWithTokenizer {
         max_position_embeddings: usize,
     ) -> Result<Self> {
         let clip = stable_diffusion::clip::ClipTextTransformer::new(vb, &config)?;
-        let path_buf = hf_hub::api::sync::Api::new()?
-            .model(tokenizer_path.to_string())
-            .get("tokenizer.json")?;
+        let path_buf = {
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id(tokenizer_path);
+            let repo = client.model(owner, name);
+            repo.download_file().filename("tokenizer.json").send()?
+        };
         let tokenizer = Tokenizer::from_file(path_buf.to_str().ok_or(E::msg(
             "Failed to serialize huggingface PathBuf of CLIP tokenizer",
         ))?)
@@ -82,20 +85,26 @@ struct T5WithTokenizer {
 
 impl T5WithTokenizer {
     fn new(vb: candle_nn::VarBuilder, max_position_embeddings: usize) -> Result<Self> {
-        let api = hf_hub::api::sync::Api::new()?;
-        let repo = api.repo(hf_hub::Repo::with_revision(
-            "google/t5-v1_1-xxl".to_string(),
-            hf_hub::RepoType::Model,
-            "refs/pr/2".to_string(),
-        ));
-        let config_filename = repo.get("config.json")?;
+        let client = hf_hub::HFClientSync::new()?;
+        let (owner, name) = hf_hub::split_id("google/t5-v1_1-xxl");
+        let repo = client.model(owner, name);
+        let config_filename = repo
+            .download_file()
+            .filename("config.json")
+            .revision("refs/pr/2")
+            .send()?;
         let config = std::fs::read_to_string(config_filename)?;
         let config: t5::Config = serde_json::from_str(&config)?;
         let model = t5::T5EncoderModel::load(vb, &config)?;
 
-        let tokenizer_filename = api
-            .model("lmz/mt5-tokenizers".to_string())
-            .get("t5-v1_1-xxl.tokenizer.json")?;
+        let tokenizer_filename = {
+            let (owner, name) = hf_hub::split_id("lmz/mt5-tokenizers");
+            client
+                .model(owner, name)
+                .download_file()
+                .filename("t5-v1_1-xxl.tokenizer.json")
+                .send()?
+        };
 
         let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
         Ok(Self {

--- a/candle-examples/examples/stable-diffusion-3/main.rs
+++ b/candle-examples/examples/stable-diffusion-3/main.rs
@@ -137,7 +137,7 @@ fn main() -> Result<()> {
     };
     let cfg_scale = cfg_scale.unwrap_or(default_cfg_scale);
 
-    let api = hf_hub::api::sync::Api::new()?;
+    let client = hf_hub::HFClientSync::new()?;
     let (mmdit_config, mut triple, vb) = if which.is_3_5() {
         let sai_repo_for_text_encoders = {
             let name = match which {
@@ -156,7 +156,8 @@ fn main() -> Result<()> {
                 Which::V3_5Medium => "stabilityai/stable-diffusion-3.5-large",
                 Which::V3Medium => unreachable!(),
             };
-            api.repo(hf_hub::Repo::model(name.to_string()))
+            let (owner, name) = hf_hub::split_id(name);
+            client.model(owner, name)
         };
         let sai_repo_for_mmdit = {
             let name = match which {
@@ -165,11 +166,21 @@ fn main() -> Result<()> {
                 Which::V3_5Medium => "stabilityai/stable-diffusion-3.5-medium",
                 Which::V3Medium => unreachable!(),
             };
-            api.repo(hf_hub::Repo::model(name.to_string()))
+            let (owner, name) = hf_hub::split_id(name);
+            client.model(owner, name)
         };
-        let clip_g_file = sai_repo_for_text_encoders.get("text_encoders/clip_g.safetensors")?;
-        let clip_l_file = sai_repo_for_text_encoders.get("text_encoders/clip_l.safetensors")?;
-        let t5xxl_file = sai_repo_for_text_encoders.get("text_encoders/t5xxl_fp16.safetensors")?;
+        let clip_g_file = sai_repo_for_text_encoders
+            .download_file()
+            .filename("text_encoders/clip_g.safetensors")
+            .send()?;
+        let clip_l_file = sai_repo_for_text_encoders
+            .download_file()
+            .filename("text_encoders/clip_l.safetensors")
+            .send()?;
+        let t5xxl_file = sai_repo_for_text_encoders
+            .download_file()
+            .filename("text_encoders/t5xxl_fp16.safetensors")
+            .send()?;
         let model_file = {
             let model_file = match which {
                 Which::V3_5Large => "sd3.5_large.safetensors",
@@ -177,7 +188,10 @@ fn main() -> Result<()> {
                 Which::V3_5Medium => "sd3.5_medium.safetensors",
                 Which::V3Medium => unreachable!(),
             };
-            sai_repo_for_mmdit.get(model_file)?
+            sai_repo_for_mmdit
+                .download_file()
+                .filename(model_file)
+                .send()?
         };
         let triple = StableDiffusion3TripleClipWithTokenizer::new_split(
             &clip_g_file,
@@ -197,9 +211,13 @@ fn main() -> Result<()> {
     } else {
         let sai_repo = {
             let name = "stabilityai/stable-diffusion-3-medium";
-            api.repo(hf_hub::Repo::model(name.to_string()))
+            let (owner, name) = hf_hub::split_id(name);
+            client.model(owner, name)
         };
-        let model_file = sai_repo.get("sd3_medium_incl_clips_t5xxlfp16.safetensors")?;
+        let model_file = sai_repo
+            .download_file()
+            .filename("sd3_medium_incl_clips_t5xxlfp16.safetensors")
+            .send()?;
         let vb = unsafe {
             candle_nn::VarBuilder::from_mmaped_safetensors(&[&model_file], DType::F16, &device)?
         };

--- a/candle-examples/examples/stable-diffusion/main.rs
+++ b/candle-examples/examples/stable-diffusion/main.rs
@@ -236,7 +236,7 @@ impl ModelFile {
         version: StableDiffusionVersion,
         use_f16: bool,
     ) -> Result<std::path::PathBuf> {
-        use hf_hub::api::sync::Api;
+        use hf_hub::HFClientSync;
         match filename {
             Some(filename) => Ok(std::path::PathBuf::from(filename)),
             None => {
@@ -280,7 +280,12 @@ impl ModelFile {
                         }
                     }
                 };
-                let filename = Api::new()?.model(repo.to_string()).get(path)?;
+                let (owner, name) = hf_hub::split_id(repo);
+                let filename = HFClientSync::new()?
+                    .model(owner, name)
+                    .download_file()
+                    .filename(path)
+                    .send()?;
                 Ok(filename)
             }
         }

--- a/candle-examples/examples/stable-lm/main.rs
+++ b/candle-examples/examples/stable-lm/main.rs
@@ -14,7 +14,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 enum Model {
@@ -219,7 +219,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => match args.which {
@@ -232,14 +232,16 @@ fn main() -> Result<()> {
         },
     };
 
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
+    let revision = args.revision;
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
@@ -247,28 +249,44 @@ fn main() -> Result<()> {
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
         None => match (args.which, args.quantized) {
-            (Which::V1Orig | Which::V1, true) => vec![repo.get("model-q4k.gguf")?],
+            (Which::V1Orig | Which::V1, true) => vec![repo
+                .download_file()
+                .filename("model-q4k.gguf")
+                .revision(revision.as_str())
+                .send()?],
             (Which::V2, true) => {
-                let gguf = api
-                    .model("lmz/candle-stablelm".to_string())
-                    .get("stablelm-2-1_6b-q4k.gguf")?;
+                let (owner, name) = hf_hub::split_id("lmz/candle-stablelm");
+                let gguf = client
+                    .model(owner, name)
+                    .download_file()
+                    .filename("stablelm-2-1_6b-q4k.gguf")
+                    .send()?;
                 vec![gguf]
             }
             (Which::V2Zephyr, true) => {
-                let gguf = api
-                    .model("lmz/candle-stablelm".to_string())
-                    .get("stablelm-2-zephyr-1_6b-q4k.gguf")?;
+                let (owner, name) = hf_hub::split_id("lmz/candle-stablelm");
+                let gguf = client
+                    .model(owner, name)
+                    .download_file()
+                    .filename("stablelm-2-zephyr-1_6b-q4k.gguf")
+                    .send()?;
                 vec![gguf]
             }
             (Which::V1Zephyr | Which::Code, true) => {
                 anyhow::bail!("Quantized {:?} variant not supported.", args.which)
             }
             (Which::V1Orig | Which::V1 | Which::V1Zephyr | Which::V2 | Which::V2Zephyr, false) => {
-                vec![repo.get("model.safetensors")?]
+                vec![repo
+                    .download_file()
+                    .filename("model.safetensors")
+                    .revision(revision.as_str())
+                    .send()?]
             }
-            (Which::Code, false) => {
-                candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?
-            }
+            (Which::Code, false) => candle_examples::hub_load_safetensors(
+                &repo,
+                revision.as_str(),
+                "model.safetensors.index.json",
+            )?,
         },
     };
 
@@ -279,7 +297,11 @@ fn main() -> Result<()> {
     let config = match args.which {
         Which::V1Orig => Config::stablelm_3b_4e1t(args.use_flash_attn),
         Which::V1 | Which::V1Zephyr | Which::V2 | Which::V2Zephyr | Which::Code => {
-            let config_filename = repo.get("config.json")?;
+            let config_filename = repo
+                .download_file()
+                .filename("config.json")
+                .revision(revision.as_str())
+                .send()?;
             let config = std::fs::read_to_string(config_filename)?;
             let mut config: Config = serde_json::from_str(&config)?;
             config.set_use_flash_attn(args.use_flash_attn);

--- a/candle-examples/examples/starcoder2/main.rs
+++ b/candle-examples/examples/starcoder2/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 struct TextGeneration {
@@ -197,30 +197,40 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match args.model_id {
         Some(model_id) => model_id,
         None => "bigcode/starcoder2-3b".to_string(),
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let revision = args.revision;
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
     let config_file = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let tokenizer_file = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => vec![repo.get("model.safetensors")?],
+        None => vec![repo
+            .download_file()
+            .filename("model.safetensors")
+            .revision(revision.as_str())
+            .send()?],
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_file).map_err(E::msg)?;

--- a/candle-examples/examples/stella-en-v5/main.rs
+++ b/candle-examples/examples/stella-en-v5/main.rs
@@ -15,7 +15,7 @@ use candle_transformers::models::stella_en_v5::{
 
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use hf_hub::{api::sync::Api, Repo};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingDirection, PaddingParams, PaddingStrategy, Tokenizer};
 
 struct Embedding {
@@ -313,7 +313,7 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let embed_dim = match args.embed_dim {
         Some(d) => d,
         None => EmbedDim::Dim1024,
@@ -330,10 +330,11 @@ fn main() -> Result<()> {
         ),
     };
 
-    let repo = api.repo(Repo::model(repo.to_string()));
+    let (owner, name) = hf_hub::split_id(repo);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo.download_file().filename("tokenizer.json").send()?,
     };
 
     // Note, if you are providing `weight_files`, ensure that the `--embed_dim` dimensions provided matches the weights
@@ -344,7 +345,7 @@ fn main() -> Result<()> {
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
         None => {
-            vec![repo.get("model.safetensors")?]
+            vec![repo.download_file().filename("model.safetensors").send()?]
         }
     };
 
@@ -355,7 +356,7 @@ fn main() -> Result<()> {
             .collect::<Vec<_>>(),
         None => {
             let head_w_path = format!("{}/model.safetensors", embed_dim.embed_dim_default_dir());
-            vec![repo.get(&head_w_path)?]
+            vec![repo.download_file().filename(head_w_path).send()?]
         }
     };
 

--- a/candle-examples/examples/t5/main.rs
+++ b/candle-examples/examples/t5/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 const DTYPE: DType = DType::F32;
@@ -124,25 +124,39 @@ impl T5ModelBuilder {
             (None, None) => (default_model, default_revision),
         };
 
-        let repo = Repo::with_revision(model_id.clone(), RepoType::Model, revision);
-        let api = Api::new()?;
-        let repo = api.repo(repo);
+        let client = HFClientSync::new()?;
+        let (owner, name) = hf_hub::split_id(&model_id);
+        let repo = client.model(owner, name);
         let config_filename = match &args.config_file {
-            None => repo.get("config.json")?,
+            None => repo
+                .download_file()
+                .filename("config.json")
+                .revision(revision.as_str())
+                .send()?,
             Some(f) => f.into(),
         };
         let tokenizer_filename = match &args.tokenizer_file {
             None => match args.which {
-                Which::Mt5Base => api
-                    .model("lmz/mt5-tokenizers".into())
-                    .get("mt5-base.tokenizer.json")?,
-                Which::Mt5Small => api
-                    .model("lmz/mt5-tokenizers".into())
-                    .get("mt5-small.tokenizer.json")?,
-                Which::Mt5Large => api
-                    .model("lmz/mt5-tokenizers".into())
-                    .get("mt5-large.tokenizer.json")?,
-                _ => repo.get("tokenizer.json")?,
+                Which::Mt5Base => client
+                    .model("lmz", "mt5-tokenizers")
+                    .download_file()
+                    .filename("mt5-base.tokenizer.json")
+                    .send()?,
+                Which::Mt5Small => client
+                    .model("lmz", "mt5-tokenizers")
+                    .download_file()
+                    .filename("mt5-small.tokenizer.json")
+                    .send()?,
+                Which::Mt5Large => client
+                    .model("lmz", "mt5-tokenizers")
+                    .download_file()
+                    .filename("mt5-large.tokenizer.json")
+                    .send()?,
+                _ => repo
+                    .download_file()
+                    .filename("tokenizer.json")
+                    .revision(revision.as_str())
+                    .send()?,
             },
             Some(f) => f.into(),
         };
@@ -150,9 +164,17 @@ impl T5ModelBuilder {
             Some(f) => f.split(',').map(|v| v.into()).collect::<Vec<_>>(),
             None => {
                 if model_id == "google/flan-t5-xxl" || model_id == "google/flan-ul2" {
-                    candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?
+                    candle_examples::hub_load_safetensors(
+                        &repo,
+                        revision.as_str(),
+                        "model.safetensors.index.json",
+                    )?
                 } else {
-                    vec![repo.get("model.safetensors")?]
+                    vec![repo
+                        .download_file()
+                        .filename("model.safetensors")
+                        .revision(revision.as_str())
+                        .send()?]
                 }
             }
         };

--- a/candle-examples/examples/trocr/main.rs
+++ b/candle-examples/examples/trocr/main.rs
@@ -66,13 +66,18 @@ struct Args {
 
 pub fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    let api = hf_hub::api::sync::Api::new()?;
+    let client = hf_hub::HFClientSync::new()?;
 
     let mut tokenizer_dec = {
         let tokenizer_file = match args.tokenizer {
-            None => api
-                .model(String::from("ToluClassics/candle-trocr-tokenizer"))
-                .get("tokenizer.json")?,
+            None => {
+                let (owner, name) = hf_hub::split_id("ToluClassics/candle-trocr-tokenizer");
+                client
+                    .model(owner, name)
+                    .download_file()
+                    .filename("tokenizer.json")
+                    .send()?
+            }
             Some(tokenizer) => std::path::PathBuf::from(tokenizer),
         };
         let tokenizer = Tokenizer::from_file(&tokenizer_file).map_err(E::msg)?;
@@ -85,12 +90,13 @@ pub fn main() -> anyhow::Result<()> {
             Some(model) => std::path::PathBuf::from(model),
             None => {
                 let (repo, branch) = args.which.repo_and_branch_name();
-                api.repo(hf_hub::Repo::with_revision(
-                    repo.to_string(),
-                    hf_hub::RepoType::Model,
-                    branch.to_string(),
-                ))
-                .get("model.safetensors")?
+                let (owner, name) = hf_hub::split_id(repo);
+                client
+                    .model(owner, name)
+                    .download_file()
+                    .filename("model.safetensors")
+                    .revision(branch)
+                    .send()?
             }
         };
         println!("model: {model:?}");
@@ -99,13 +105,13 @@ pub fn main() -> anyhow::Result<()> {
 
     let (encoder_config, decoder_config) = {
         let (repo, branch) = args.which.repo_and_branch_name();
-        let config_filename = api
-            .repo(hf_hub::Repo::with_revision(
-                repo.to_string(),
-                hf_hub::RepoType::Model,
-                branch.to_string(),
-            ))
-            .get("config.json")?;
+        let (owner, name) = hf_hub::split_id(repo);
+        let config_filename = client
+            .model(owner, name)
+            .download_file()
+            .filename("config.json")
+            .revision(branch)
+            .send()?;
         let config: Config = serde_json::from_reader(std::fs::File::open(config_filename)?)?;
         (config.encoder, config.decoder)
     };

--- a/candle-examples/examples/vgg/main.rs
+++ b/candle-examples/examples/vgg/main.rs
@@ -37,15 +37,16 @@ pub fn main() -> anyhow::Result<()> {
 
     println!("loaded image {image:?}");
 
-    let api = hf_hub::api::sync::Api::new()?;
+    let client = hf_hub::HFClientSync::new()?;
     let repo = match args.which {
         Which::Vgg13 => "timm/vgg13.tv_in1k",
         Which::Vgg16 => "timm/vgg16.tv_in1k",
         Which::Vgg19 => "timm/vgg19.tv_in1k",
     };
-    let api = api.model(repo.into());
+    let (owner, name) = hf_hub::split_id(repo);
+    let repo = client.model(owner, name);
     let filename = "model.safetensors";
-    let model_file = api.get(filename)?;
+    let model_file = repo.download_file().filename(filename).send()?;
 
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[model_file], DType::F32, &device)? };
     let model = match args.which {

--- a/candle-examples/examples/vit/main.rs
+++ b/candle-examples/examples/vit/main.rs
@@ -33,9 +33,10 @@ pub fn main() -> anyhow::Result<()> {
 
     let model_file = match args.model {
         None => {
-            let api = hf_hub::api::sync::Api::new()?;
-            let api = api.model("google/vit-base-patch16-224".into());
-            api.get("model.safetensors")?
+            let client = hf_hub::HFClientSync::new()?;
+            let (owner, name) = hf_hub::split_id("google/vit-base-patch16-224");
+            let repo = client.model(owner, name);
+            repo.download_file().filename("model.safetensors").send()?
         }
         Some(model) => model.into(),
     };

--- a/candle-examples/examples/voxtral/download.rs
+++ b/candle-examples/examples/voxtral/download.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 
 /// # Errors
 ///
@@ -13,14 +13,15 @@ use hf_hub::{api::sync::Api, Repo, RepoType};
 pub fn model_files(model_id: &str) -> Result<((PathBuf, Vec<PathBuf>), PathBuf)> {
     let revision = "main";
 
-    let api = Api::new().unwrap();
-    let repo = api.repo(Repo::with_revision(
-        model_id.to_string(),
-        RepoType::Model,
-        revision.to_string(),
-    ));
+    let client = HFClientSync::new().unwrap();
+    let (owner, name) = hf_hub::split_id(model_id);
+    let repo = client.model(owner, name);
 
-    let config = repo.get("config.json")?;
+    let config = repo
+        .download_file()
+        .filename("config.json")
+        .revision(revision)
+        .send()?;
 
     // Download model files - look for safetensors
     let mut model_files = Vec::new();
@@ -56,7 +57,12 @@ pub fn model_files(model_id: &str) -> Result<((PathBuf, Vec<PathBuf>), PathBuf)>
 
     println!("Downloading safetensors files...");
     for filename in &safetensors_files {
-        if let Ok(file) = repo.get(filename) {
+        if let Ok(file) = repo
+            .download_file()
+            .filename(*filename)
+            .revision(revision)
+            .send()
+        {
             println!("{} downloaded", filename);
             model_files.push(file);
         }
@@ -68,8 +74,16 @@ pub fn model_files(model_id: &str) -> Result<((PathBuf, Vec<PathBuf>), PathBuf)>
 
     // Download tokenizer
     let tokenizer_file = repo
-        .get("tekken.json")
-        .or_else(|_| repo.get("tokenizer/tokenizer.json"))?;
+        .download_file()
+        .filename("tekken.json")
+        .revision(revision)
+        .send()
+        .or_else(|_| {
+            repo.download_file()
+                .filename("tokenizer/tokenizer.json")
+                .revision(revision)
+                .send()
+        })?;
 
     Ok(((config, model_files), tokenizer_file))
 }

--- a/candle-examples/examples/voxtral/main.rs
+++ b/candle-examples/examples/voxtral/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use model::VoxtralModel;
 
 mod download;
@@ -46,18 +46,22 @@ fn main() -> Result<()> {
 
     println!("Model loaded successfully on device: {:?}", model.device());
 
-    let api = Api::new()?;
-    let dataset = api.dataset("Narsil/candle-examples".to_string());
+    let client = HFClientSync::new()?;
+    let (owner, name) = hf_hub::split_id("Narsil/candle-examples");
+    let dataset = client.dataset(owner, name);
 
     let audio_file = if let Some(input) = args.input {
         if let Some(sample) = input.strip_prefix("sample:") {
-            dataset.get(&format!("samples_{sample}.wav"))?
+            dataset
+                .download_file()
+                .filename(format!("samples_{sample}.wav"))
+                .send()?
         } else {
             std::path::PathBuf::from(input)
         }
     } else {
         println!("No audio file submitted: Downloading https://huggingface.co/datasets/Narsil/candle_demo/blob/main/samples_jfk.wav");
-        dataset.get("samples_jfk.wav")?
+        dataset.download_file().filename("samples_jfk.wav").send()?
     };
 
     let (audio_data, sample_rate) =

--- a/candle-examples/examples/whisper-microphone/main.rs
+++ b/candle-examples/examples/whisper-microphone/main.rs
@@ -8,7 +8,7 @@ use anyhow::{Error as E, Result};
 use candle::{Device, IndexOp, Tensor};
 use candle_nn::{ops::softmax, VarBuilder};
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use rand::{distr::Distribution, SeedableRng};
 use tokenizers::Tokenizer;
 
@@ -514,8 +514,9 @@ pub fn main() -> Result<()> {
     };
 
     let (config_filename, tokenizer_filename, weights_filename) = {
-        let api = Api::new()?;
-        let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+        let client = HFClientSync::new()?;
+        let (owner, name) = hf_hub::split_id(&model_id);
+        let repo = client.model(owner, name);
         let (config, tokenizer, model) = if args.quantized {
             let ext = match args.model {
                 WhichModel::TinyEn => "tiny-en",
@@ -523,14 +524,35 @@ pub fn main() -> Result<()> {
                 _ => unimplemented!("no quantized support for {:?}", args.model),
             };
             (
-                repo.get(&format!("config-{ext}.json"))?,
-                repo.get(&format!("tokenizer-{ext}.json"))?,
-                repo.get(&format!("model-{ext}-q80.gguf"))?,
+                repo.download_file()
+                    .filename(format!("config-{ext}.json"))
+                    .revision(revision.as_str())
+                    .send()?,
+                repo.download_file()
+                    .filename(format!("tokenizer-{ext}.json"))
+                    .revision(revision.as_str())
+                    .send()?,
+                repo.download_file()
+                    .filename(format!("model-{ext}-q80.gguf"))
+                    .revision(revision.as_str())
+                    .send()?,
             )
         } else {
-            let config = repo.get("config.json")?;
-            let tokenizer = repo.get("tokenizer.json")?;
-            let model = repo.get("model.safetensors")?;
+            let config = repo
+                .download_file()
+                .filename("config.json")
+                .revision(revision.as_str())
+                .send()?;
+            let tokenizer = repo
+                .download_file()
+                .filename("tokenizer.json")
+                .revision(revision.as_str())
+                .send()?;
+            let model = repo
+                .download_file()
+                .filename("model.safetensors")
+                .revision(revision.as_str())
+                .send()?;
             (config, tokenizer, model)
         };
         (config, tokenizer, model)

--- a/candle-examples/examples/whisper/main.rs
+++ b/candle-examples/examples/whisper/main.rs
@@ -16,7 +16,7 @@ use candle_nn::{
     VarBuilder,
 };
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use rand::distr::weighted::WeightedIndex;
 use rand::distr::Distribution;
 use rand::SeedableRng;
@@ -675,18 +675,23 @@ fn main() -> Result<()> {
     };
 
     let (config_filename, tokenizer_filename, weights_filename, input) = {
-        let api = Api::new()?;
-        let dataset = api.dataset("Narsil/candle-examples".to_string());
-        let repo = api.repo(Repo::with_revision(model_id, RepoType::Model, revision));
+        let client = HFClientSync::new()?;
+        let (dataset_owner, dataset_name) = hf_hub::split_id("Narsil/candle-examples");
+        let dataset = client.dataset(dataset_owner, dataset_name);
+        let (owner, name) = hf_hub::split_id(&model_id);
+        let repo = client.model(owner, name);
         let sample = if let Some(input) = args.input {
             if let Some(sample) = input.strip_prefix("sample:") {
-                dataset.get(&format!("samples_{sample}.wav"))?
+                dataset
+                    .download_file()
+                    .filename(format!("samples_{sample}.wav"))
+                    .send()?
             } else {
                 std::path::PathBuf::from(input)
             }
         } else {
             println!("No audio file submitted: Downloading https://huggingface.co/datasets/Narsil/candle_demo/blob/main/samples_jfk.wav");
-            dataset.get("samples_jfk.wav")?
+            dataset.download_file().filename("samples_jfk.wav").send()?
         };
         let (config, tokenizer, model) = if args.quantized {
             let ext = match args.model {
@@ -695,14 +700,35 @@ fn main() -> Result<()> {
                 _ => unimplemented!("no quantized support for {:?}", args.model),
             };
             (
-                repo.get(&format!("config-{ext}.json"))?,
-                repo.get(&format!("tokenizer-{ext}.json"))?,
-                repo.get(&format!("model-{ext}-q80.gguf"))?,
+                repo.download_file()
+                    .filename(format!("config-{ext}.json"))
+                    .revision(revision.as_str())
+                    .send()?,
+                repo.download_file()
+                    .filename(format!("tokenizer-{ext}.json"))
+                    .revision(revision.as_str())
+                    .send()?,
+                repo.download_file()
+                    .filename(format!("model-{ext}-q80.gguf"))
+                    .revision(revision.as_str())
+                    .send()?,
             )
         } else {
-            let config = repo.get("config.json")?;
-            let tokenizer = repo.get("tokenizer.json")?;
-            let model = repo.get("model.safetensors")?;
+            let config = repo
+                .download_file()
+                .filename("config.json")
+                .revision(revision.as_str())
+                .send()?;
+            let tokenizer = repo
+                .download_file()
+                .filename("tokenizer.json")
+                .revision(revision.as_str())
+                .send()?;
+            let model = repo
+                .download_file()
+                .filename("model.safetensors")
+                .revision(revision.as_str())
+                .send()?;
             (config, tokenizer, model)
         };
         (config, tokenizer, model, sample)

--- a/candle-examples/examples/wuerstchen/main.rs
+++ b/candle-examples/examples/wuerstchen/main.rs
@@ -100,7 +100,7 @@ enum ModelFile {
 
 impl ModelFile {
     fn get(&self, filename: Option<String>) -> Result<std::path::PathBuf> {
-        use hf_hub::api::sync::Api;
+        use hf_hub::HFClientSync;
         match filename {
             Some(filename) => Ok(std::path::PathBuf::from(filename)),
             None => {
@@ -115,7 +115,12 @@ impl ModelFile {
                     Self::VqGan => (repo_main, "vqgan/diffusion_pytorch_model.safetensors"),
                     Self::Prior => (repo_prior, "prior/diffusion_pytorch_model.safetensors"),
                 };
-                let filename = Api::new()?.model(repo.to_string()).get(path)?;
+                let (owner, name) = hf_hub::split_id(repo);
+                let filename = HFClientSync::new()?
+                    .model(owner, name)
+                    .download_file()
+                    .filename(path)
+                    .send()?;
                 Ok(filename)
             }
         }

--- a/candle-examples/examples/xlm-roberta/main.rs
+++ b/candle-examples/examples/xlm-roberta/main.rs
@@ -8,7 +8,7 @@ use candle_transformers::models::xlm_roberta::{
     Config, XLMRobertaForMaskedLM, XLMRobertaForSequenceClassification,
 };
 use clap::{Parser, ValueEnum};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::{PaddingParams, Tokenizer};
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -71,7 +71,7 @@ struct Args {
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    let api = Api::new()?;
+    let client = HFClientSync::new()?;
     let model_id = match &args.model_id {
         Some(model_id) => model_id.to_string(),
         None => match args.task {
@@ -94,27 +94,42 @@ fn main() -> Result<()> {
             },
         },
     };
-    let repo = api.repo(Repo::with_revision(
-        model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let (owner, name) = hf_hub::split_id(&model_id);
+    let repo = client.model(owner, name);
 
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
 
     let config_filename = match args.config_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("config.json")?,
+        None => repo
+            .download_file()
+            .filename("config.json")
+            .revision(args.revision.as_str())
+            .send()?,
     };
 
     let weights_filename = match args.weight_files {
         Some(files) => PathBuf::from(files),
-        None => match repo.get("model.safetensors") {
+        None => match repo
+            .download_file()
+            .filename("model.safetensors")
+            .revision(args.revision.as_str())
+            .send()
+        {
             Ok(safetensors) => safetensors,
-            Err(_) => match repo.get("pytorch_model.bin") {
+            Err(_) => match repo
+                .download_file()
+                .filename("pytorch_model.bin")
+                .revision(args.revision.as_str())
+                .send()
+            {
                 Ok(pytorch_model) => pytorch_model,
                 Err(e) => {
                     return Err(anyhow::Error::msg(format!("Model weights not found. The weights should either be a `model.safetensors` or `pytorch_model.bin` file.  Error: {e}")));

--- a/candle-examples/examples/yi/main.rs
+++ b/candle-examples/examples/yi/main.rs
@@ -13,7 +13,7 @@ use candle::{DType, Device, Tensor};
 use candle_examples::token_output_stream::TokenOutputStream;
 use candle_nn::VarBuilder;
 use candle_transformers::generation::LogitsProcessor;
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq, ValueEnum)]
@@ -204,22 +204,28 @@ fn main() -> Result<()> {
     );
 
     let start = std::time::Instant::now();
-    let api = Api::new()?;
-    let repo = api.repo(Repo::with_revision(
-        args.model_id,
-        RepoType::Model,
-        args.revision,
-    ));
+    let client = HFClientSync::new()?;
+    let revision = args.revision;
+    let (owner, name) = hf_hub::split_id(&args.model_id);
+    let repo = client.model(owner, name);
     let tokenizer_filename = match args.tokenizer_file {
         Some(file) => std::path::PathBuf::from(file),
-        None => repo.get("tokenizer.json")?,
+        None => repo
+            .download_file()
+            .filename("tokenizer.json")
+            .revision(revision.as_str())
+            .send()?,
     };
     let filenames = match args.weight_files {
         Some(files) => files
             .split(',')
             .map(std::path::PathBuf::from)
             .collect::<Vec<_>>(),
-        None => candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json")?,
+        None => candle_examples::hub_load_safetensors(
+            &repo,
+            revision.as_str(),
+            "model.safetensors.index.json",
+        )?,
     };
     println!("retrieved the files in {:?}", start.elapsed());
     let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;

--- a/candle-examples/examples/yolo-v3/main.rs
+++ b/candle-examples/examples/yolo-v3/main.rs
@@ -121,9 +121,10 @@ impl Args {
         let path = match &self.config {
             Some(config) => std::path::PathBuf::from(config),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
-                let api = api.model("lmz/candle-yolo-v3".to_string());
-                api.get("yolo-v3.cfg")?
+                let client = hf_hub::HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id("lmz/candle-yolo-v3");
+                let repo = client.model(owner, name);
+                repo.download_file().filename("yolo-v3.cfg").send()?
             }
         };
         Ok(path)
@@ -133,9 +134,12 @@ impl Args {
         let path = match &self.model {
             Some(model) => std::path::PathBuf::from(model),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
-                let api = api.model("lmz/candle-yolo-v3".to_string());
-                api.get("yolo-v3.safetensors")?
+                let client = hf_hub::HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id("lmz/candle-yolo-v3");
+                let repo = client.model(owner, name);
+                repo.download_file()
+                    .filename("yolo-v3.safetensors")
+                    .send()?
             }
         };
         Ok(path)

--- a/candle-examples/examples/yolo-v8/main.rs
+++ b/candle-examples/examples/yolo-v8/main.rs
@@ -296,8 +296,9 @@ impl Args {
         let path = match &self.model {
             Some(model) => std::path::PathBuf::from(model),
             None => {
-                let api = hf_hub::api::sync::Api::new()?;
-                let api = api.model("lmz/candle-yolo-v8".to_string());
+                let client = hf_hub::HFClientSync::new()?;
+                let (owner, name) = hf_hub::split_id("lmz/candle-yolo-v8");
+                let repo = client.model(owner, name);
                 let size = match self.which {
                     Which::N => "n",
                     Which::S => "s",
@@ -309,7 +310,9 @@ impl Args {
                     YoloTask::Pose => "-pose",
                     YoloTask::Detect => "",
                 };
-                api.get(&format!("yolov8{size}{task}.safetensors"))?
+                repo.download_file()
+                    .filename(format!("yolov8{size}{task}.safetensors"))
+                    .send()?
             }
         };
         Ok(path)

--- a/candle-examples/examples/z_image/main.rs
+++ b/candle-examples/examples/z_image/main.rs
@@ -41,7 +41,7 @@ use candle_transformers::models::z_image::{
     ZImageTextEncoder, ZImageTransformer2DModel,
 };
 use clap::Parser;
-use hf_hub::api::sync::Api;
+use hf_hub::HFClientSync;
 use tokenizers::Tokenizer;
 
 /// Z-Image scheduler constants
@@ -154,8 +154,9 @@ fn run(args: Args) -> Result<()> {
     let dtype = device.bf16_default_to_f32();
 
     // Resolve model: use provided path or download from HuggingFace
-    let api = Api::new()?;
-    let repo = api.model(args.model.repo().to_string());
+    let client = HFClientSync::new()?;
+    let (owner, name) = hf_hub::split_id(args.model.repo());
+    let repo = client.model(owner, name);
     let use_local = args.model_path.is_some();
     let model_path = args.model_path.map(std::path::PathBuf::from);
 
@@ -180,7 +181,9 @@ fn run(args: Args) -> Result<()> {
             .join("tokenizer")
             .join("tokenizer.json")
     } else {
-        repo.get("tokenizer/tokenizer.json")?
+        repo.download_file()
+            .filename("tokenizer/tokenizer.json")
+            .send()?
     };
     let tokenizer = Tokenizer::from_file(&tokenizer_path).map_err(E::msg)?;
 
@@ -193,7 +196,9 @@ fn run(args: Args) -> Result<()> {
             .join("text_encoder")
             .join("config.json")
     } else {
-        repo.get("text_encoder/config.json")?
+        repo.download_file()
+            .filename("text_encoder/config.json")
+            .send()?
     };
     let text_encoder_cfg: TextEncoderConfig = if text_encoder_config_path.exists() {
         serde_json::from_reader(std::fs::File::open(&text_encoder_config_path)?)?
@@ -215,7 +220,11 @@ fn run(args: Args) -> Result<()> {
                 .collect()
         } else {
             (1..=3)
-                .map(|i| repo.get(&format!("text_encoder/model-{:05}-of-00003.safetensors", i)))
+                .map(|i| {
+                    repo.download_file()
+                        .filename(format!("text_encoder/model-{:05}-of-00003.safetensors", i))
+                        .send()
+                })
                 .filter_map(|r| r.ok())
                 .collect()
         };
@@ -239,7 +248,9 @@ fn run(args: Args) -> Result<()> {
             .join("transformer")
             .join("config.json")
     } else {
-        repo.get("transformer/config.json")?
+        repo.download_file()
+            .filename("transformer/config.json")
+            .send()?
     };
     let transformer_cfg: Config = if transformer_config_path.exists() {
         serde_json::from_reader(std::fs::File::open(&transformer_config_path)?)?
@@ -265,10 +276,12 @@ fn run(args: Args) -> Result<()> {
         } else {
             (1..=3)
                 .map(|i| {
-                    repo.get(&format!(
-                        "transformer/diffusion_pytorch_model-{:05}-of-00003.safetensors",
-                        i
-                    ))
+                    repo.download_file()
+                        .filename(format!(
+                            "transformer/diffusion_pytorch_model-{:05}-of-00003.safetensors",
+                            i
+                        ))
+                        .send()
                 })
                 .filter_map(|r| r.ok())
                 .collect()
@@ -289,7 +302,7 @@ fn run(args: Args) -> Result<()> {
     let vae_config_path = if use_local {
         model_path.as_ref().unwrap().join("vae").join("config.json")
     } else {
-        repo.get("vae/config.json")?
+        repo.download_file().filename("vae/config.json").send()?
     };
     let vae_cfg: VaeConfig = if vae_config_path.exists() {
         serde_json::from_reader(std::fs::File::open(&vae_config_path)?)?
@@ -308,7 +321,9 @@ fn run(args: Args) -> Result<()> {
         }
         path
     } else {
-        repo.get("vae/diffusion_pytorch_model.safetensors")?
+        repo.download_file()
+            .filename("vae/diffusion_pytorch_model.safetensors")
+            .send()?
     };
 
     let vae_weights = unsafe {

--- a/candle-examples/src/lib.rs
+++ b/candle-examples/src/lib.rs
@@ -123,10 +123,16 @@ pub fn save_image_resize<P: AsRef<std::path::Path>>(
 
 /// Loads the safetensors files for a model from the hub based on a json index file.
 pub fn hub_load_safetensors(
-    repo: &hf_hub::api::sync::ApiRepo,
+    repo: &hf_hub::HFRepositorySync<hf_hub::RepoTypeModel>,
+    revision: &str,
     json_file: &str,
 ) -> Result<Vec<std::path::PathBuf>> {
-    let json_file = repo.get(json_file).map_err(candle::Error::wrap)?;
+    let json_file = repo
+        .download_file()
+        .filename(json_file)
+        .revision(revision)
+        .send()
+        .map_err(candle::Error::wrap)?;
     let json_file = std::fs::File::open(json_file)?;
     let json: serde_json::Value =
         serde_json::from_reader(&json_file).map_err(candle::Error::wrap)?;
@@ -143,7 +149,13 @@ pub fn hub_load_safetensors(
     }
     let safetensors_files = safetensors_files
         .iter()
-        .map(|v| repo.get(v).map_err(candle::Error::wrap))
+        .map(|v| {
+            repo.download_file()
+                .filename(v)
+                .revision(revision)
+                .send()
+                .map_err(candle::Error::wrap)
+        })
         .collect::<Result<Vec<_>>>()?;
     Ok(safetensors_files)
 }


### PR DESCRIPTION
## What

Upgrades the `hf-hub` dependency from `0.5` to `1.0` and migrates all call sites to the new client API.

hf-hub `1.0` is a full rewrite of the crate's public surface. The old `Api` / `ApiRepo` / `Repo` / `RepoType` types are gone, replaced by a client + typed-repository-handle model:

| hf-hub 0.5 | hf-hub 1.0 |
|---|---|
| `hf_hub::api::sync::Api::new()?` | `hf_hub::HFClientSync::new()?` |
| `hf_hub::api::tokio::Api::new()?` | `hf_hub::HFClient::new()?` (async is now the default; sync is behind the `blocking` feature) |
| `api.repo(Repo::with_revision(id, RepoType::Model, rev))` | `let (owner, name) = hf_hub::split_id(&id); api.model(owner, name)` |
| `RepoType::Dataset` | `api.dataset(owner, name)` |
| `repo.get("file")?` | `repo.download_file().filename("file").revision(rev).send()?` |
| `repo.info()?` (`.siblings: Vec<_>`) | `repo.info().revision(rev).send()?` (`.siblings: Option<Vec<_>>`) |
| `ApiBuilder::from_cache(Cache::new(path))` | `HFClient::builder().cache_dir(path).build_sync()?` |
| `hf_hub::api::sync::ApiError` | `hf_hub::HFError` |

Key behavioral difference: in 1.0 a repository handle no longer carries a revision — the revision is a per-`download_file()` argument. Call sites now thread the revision through explicitly, and the shared `candle_examples::hub_load_safetensors` helper gains a `revision: &str` parameter.

## Changes

- `Cargo.toml`: `hf-hub = "1.0"`.
- `candle-examples`, `candle-book`, `candle-datasets`: switch the `hf-hub` feature from `tokio` to `blocking` (the sync client now lives behind `blocking`; the async client is always available by default).
- Migrated every `hf_hub` call site across `candle-examples` (~100 examples), `candle-datasets` (`hub.rs`, `vision/mnist.rs`, `vision/cifar.rs`), and the `candle-book` doctests.

## Notes

- `glm4` / `codegeex4-9b` used `ApiBuilder::from_cache(Cache::new(path))` for a user-supplied local HF cache directory; this maps to `HFClient::builder().cache_dir(path).build_sync()`.
- `llama_multiprocess` (cuda/nccl/flash-attn) and the CUDA-only paths were migrated but not compiled locally (no CUDA on the build host).

Draft PR — opening for review of the migration approach before finalizing.
