### PR TITLE
Fix wasm32+simd128 build: gate f16/bf16 kernels on avx2/neon only

### DIFF
--- a/candle-core/src/cpu/mod.rs
+++ b/candle-core/src/cpu/mod.rs
@@ -249,11 +249,7 @@ pub(crate) unsafe fn vec_dot_bf16(a_row: *const bf16, b_row: *const bf16, c: *mu
     *c = sum;
 }
 
-#[cfg(any(
-    target_feature = "neon",
-    target_feature = "avx2",
-    target_feature = "simd128"
-))]
+#[cfg(any(target_feature = "avx2", target_feature = "neon"))]
 pub(crate) unsafe fn vec_add_f16(a_row: *const f16, b_row: *const f16, c: *mut f16, k: usize) {
     let mut i = 0;
     while i + CurrentCpuF16::STEP <= k {
@@ -275,11 +271,7 @@ pub(crate) unsafe fn vec_add_f16(a_row: *const f16, b_row: *const f16, c: *mut f
     }
 }
 
-#[cfg(not(any(
-    target_feature = "neon",
-    target_feature = "avx2",
-    target_feature = "simd128"
-)))]
+#[cfg(not(any(target_feature = "avx2", target_feature = "neon")))]
 #[inline(always)]
 pub(crate) unsafe fn vec_add_f16(a_row: *const f16, b_row: *const f16, c: *mut f16, k: usize) {
     for i in 0..k {
@@ -287,11 +279,7 @@ pub(crate) unsafe fn vec_add_f16(a_row: *const f16, b_row: *const f16, c: *mut f
     }
 }
 
-#[cfg(any(
-    target_feature = "neon",
-    target_feature = "avx2",
-    target_feature = "simd128"
-))]
+#[cfg(any(target_feature = "avx2", target_feature = "neon"))]
 pub(crate) unsafe fn vec_add_bf16(a_row: *const bf16, b_row: *const bf16, c: *mut bf16, k: usize) {
     let mut i = 0;
     while i + CurrentCpuBF16::STEP <= k {
@@ -313,11 +301,7 @@ pub(crate) unsafe fn vec_add_bf16(a_row: *const bf16, b_row: *const bf16, c: *mu
     }
 }
 
-#[cfg(not(any(
-    target_feature = "neon",
-    target_feature = "avx2",
-    target_feature = "simd128"
-)))]
+#[cfg(not(any(target_feature = "avx2", target_feature = "neon")))]
 #[inline(always)]
 pub(crate) unsafe fn vec_add_bf16(a_row: *const bf16, b_row: *const bf16, c: *mut bf16, k: usize) {
     for i in 0..k {
@@ -325,11 +309,7 @@ pub(crate) unsafe fn vec_add_bf16(a_row: *const bf16, b_row: *const bf16, c: *mu
     }
 }
 
-#[cfg(any(
-    target_feature = "neon",
-    target_feature = "avx2",
-    target_feature = "simd128"
-))]
+#[cfg(any(target_feature = "avx2", target_feature = "neon"))]
 #[inline(always)]
 pub(crate) unsafe fn vec_scalar_add_f16(scalar: f16, xs: *const f16, ys: *mut f16, k: usize) {
     let sv = CurrentCpuF16::from_f32(scalar.to_f32());
@@ -348,11 +328,7 @@ pub(crate) unsafe fn vec_scalar_add_f16(scalar: f16, xs: *const f16, ys: *mut f1
     }
 }
 
-#[cfg(not(any(
-    target_feature = "neon",
-    target_feature = "avx2",
-    target_feature = "simd128"
-)))]
+#[cfg(not(any(target_feature = "avx2", target_feature = "neon")))]
 #[inline(always)]
 pub(crate) unsafe fn vec_scalar_add_f16(scalar: f16, xs: *const f16, ys: *mut f16, k: usize) {
     for i in 0..k {
@@ -360,11 +336,7 @@ pub(crate) unsafe fn vec_scalar_add_f16(scalar: f16, xs: *const f16, ys: *mut f1
     }
 }
 
-#[cfg(any(
-    target_feature = "neon",
-    target_feature = "avx2",
-    target_feature = "simd128"
-))]
+#[cfg(any(target_feature = "avx2", target_feature = "neon"))]
 #[inline(always)]
 pub(crate) unsafe fn vec_scalar_add_bf16(scalar: bf16, xs: *const bf16, ys: *mut bf16, k: usize) {
     let sv = CurrentCpuBF16::from_f32(scalar.to_f32());
@@ -386,11 +358,7 @@ pub(crate) unsafe fn vec_scalar_add_bf16(scalar: bf16, xs: *const bf16, ys: *mut
     }
 }
 
-#[cfg(not(any(
-    target_feature = "neon",
-    target_feature = "avx2",
-    target_feature = "simd128"
-)))]
+#[cfg(not(any(target_feature = "avx2", target_feature = "neon")))]
 #[inline(always)]
 pub(crate) unsafe fn vec_scalar_add_bf16(scalar: bf16, xs: *const bf16, ys: *mut bf16, k: usize) {
     for i in 0..k {

--- a/candle-core/src/shape.rs
+++ b/candle-core/src/shape.rs
@@ -9,7 +9,7 @@ pub const SCALAR: Shape = Shape(vec![]);
 
 impl std::fmt::Debug for Shape {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", &self.dims())
+        write!(f, "{:?}", self.dims())
     }
 }
 

--- a/candle-examples/examples/glm4/main.rs
+++ b/candle-examples/examples/glm4/main.rs
@@ -77,7 +77,7 @@ impl TextGeneration {
                 println!("{id:7} -> '{token}'");
             }
         } else {
-            print!("{}", &args.prompt);
+            print!("{}", args.prompt);
             std::io::stdout().flush()?;
         }
 

--- a/candle-examples/examples/llava/main.rs
+++ b/candle-examples/examples/llava/main.rs
@@ -177,7 +177,7 @@ fn main() -> Result<()> {
         let config_filename = api.get("config.json")?;
         let llava_config: LLaVAConfig = serde_json::from_slice(&std::fs::read(config_filename)?)?;
         let tokenizer = Tokenizer::from_file(&args.tokenizer_path)
-            .map_err(|e| E::msg(format!("Error loading {}: {}", &args.tokenizer_path, e)))?;
+            .map_err(|e| E::msg(format!("Error loading {}: {}", args.tokenizer_path, e)))?;
         (
             llava_config.clone(),
             tokenizer,
@@ -258,7 +258,7 @@ fn main() -> Result<()> {
     println!("loading image");
     let (image_size, image_tensor) =
         load_image(&args.image_file, &image_processor, &llava_config, dtype)
-            .map_err(|e| E::msg(format!("Error loading {}: {}", &args.image_file, e)))?;
+            .map_err(|e| E::msg(format!("Error loading {}: {}", args.image_file, e)))?;
     let image_tensor = image_tensor.to_device(&device)?;
 
     let mut logits_processor = {

--- a/candle-examples/examples/quantized-gemma/main.rs
+++ b/candle-examples/examples/quantized-gemma/main.rs
@@ -178,7 +178,7 @@ fn main() -> anyhow::Result<()> {
     let mut model = {
         let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(&model_path))?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model.tensor_infos.iter() {
+        for tensor in model.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -186,7 +186,7 @@ fn main() -> anyhow::Result<()> {
         println!(
             "loaded {:?} tensors ({}) in {:.2}s",
             model.tensor_infos.len(),
-            &format_size(total_size_in_bytes),
+            format_size(total_size_in_bytes),
             start.elapsed().as_secs_f32(),
         );
         ModelWeights::from_gguf(model, &mut file, &device)?
@@ -227,7 +227,7 @@ fn main() -> anyhow::Result<()> {
                 format!("<start_of_turn> user\n{prompt}<end_of_turn>\n<start_of_turn> model\n")
             }
         };
-        print!("{}", &prompt_str);
+        print!("{}", prompt_str);
 
         let tokens = tos
             .tokenizer()

--- a/candle-examples/examples/quantized-glm4/main.rs
+++ b/candle-examples/examples/quantized-glm4/main.rs
@@ -194,7 +194,7 @@ fn main() -> anyhow::Result<()> {
     let mut model = {
         let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path))?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model.tensor_infos.iter() {
+        for tensor in model.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -202,7 +202,7 @@ fn main() -> anyhow::Result<()> {
         println!(
             "loaded {:?} tensors ({}) in {:.2}s",
             model.tensor_infos.len(),
-            &format_size(total_size_in_bytes),
+            format_size(total_size_in_bytes),
             start.elapsed().as_secs_f32(),
         );
         let dtype = if device.is_cuda() || device.is_metal() {

--- a/candle-examples/examples/quantized-lfm2/main.rs
+++ b/candle-examples/examples/quantized-lfm2/main.rs
@@ -207,7 +207,7 @@ fn main() -> Result<()> {
 
     let gguf = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path.clone()))?;
     let mut total_size_in_bytes = 0;
-    for (_, tensor) in gguf.tensor_infos.iter() {
+    for tensor in gguf.tensor_infos.values() {
         let elem_count = tensor.shape.elem_count();
         total_size_in_bytes +=
             elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();

--- a/candle-examples/examples/quantized-phi/main.rs
+++ b/candle-examples/examples/quantized-phi/main.rs
@@ -207,7 +207,7 @@ fn main() -> anyhow::Result<()> {
     let mut model = {
         let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path))?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model.tensor_infos.iter() {
+        for tensor in model.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -215,7 +215,7 @@ fn main() -> anyhow::Result<()> {
         println!(
             "loaded {:?} tensors ({}) in {:.2}s",
             model.tensor_infos.len(),
-            &format_size(total_size_in_bytes),
+            format_size(total_size_in_bytes),
             start.elapsed().as_secs_f32(),
         );
         match args.which {
@@ -234,7 +234,7 @@ fn main() -> anyhow::Result<()> {
     let tokenizer = args.tokenizer()?;
     let mut tos = TokenOutputStream::new(tokenizer);
     let prompt_str = args.prompt.unwrap_or_else(|| DEFAULT_PROMPT.to_string());
-    print!("{}", &prompt_str);
+    print!("{}", prompt_str);
     let tokens = tos
         .tokenizer()
         .encode(prompt_str, true)

--- a/candle-examples/examples/quantized-qwen2-instruct/main.rs
+++ b/candle-examples/examples/quantized-qwen2-instruct/main.rs
@@ -202,7 +202,7 @@ fn main() -> anyhow::Result<()> {
     let mut model = {
         let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path))?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model.tensor_infos.iter() {
+        for tensor in model.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -210,7 +210,7 @@ fn main() -> anyhow::Result<()> {
         println!(
             "loaded {:?} tensors ({}) in {:.2}s",
             model.tensor_infos.len(),
-            &format_size(total_size_in_bytes),
+            format_size(total_size_in_bytes),
             start.elapsed().as_secs_f32(),
         );
         Qwen2::from_gguf(model, &mut file, &device)?
@@ -228,7 +228,7 @@ fn main() -> anyhow::Result<()> {
         Which::DeepseekR1Qwen7B => format!("<｜User｜>{prompt_str}<｜Assistant｜>"),
         _ => format!("<|im_start|>user\n{prompt_str}<|im_end|>\n<|im_start|>assistant\n"),
     };
-    print!("formatted instruct prompt: {}", &prompt_str);
+    print!("formatted instruct prompt: {}", prompt_str);
     let tokens = tos
         .tokenizer()
         .encode(prompt_str, true)

--- a/candle-examples/examples/quantized-qwen3-moe/main.rs
+++ b/candle-examples/examples/quantized-qwen3-moe/main.rs
@@ -229,7 +229,7 @@ fn main() -> anyhow::Result<()> {
     let mut model = {
         let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path))?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model.tensor_infos.iter() {
+        for tensor in model.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -237,7 +237,7 @@ fn main() -> anyhow::Result<()> {
         println!(
             "loaded {:?} tensors ({}) in {:.2}s",
             model.tensor_infos.len(),
-            &format_size(total_size_in_bytes),
+            format_size(total_size_in_bytes),
             start.elapsed().as_secs_f32(),
         );
         Qwen3_MoE::from_gguf(model, &mut file, &device, dtype)?
@@ -252,7 +252,7 @@ fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| DEFAULT_PROMPT.to_string());
 
     let prompt_str = format!("<|im_start|>user\n{prompt_str}<|im_end|>\n<|im_start|>assistant\n");
-    print!("formatted prompt: {}", &prompt_str);
+    print!("formatted prompt: {}", prompt_str);
 
     let tokens = tos
         .tokenizer()

--- a/candle-examples/examples/quantized-qwen3/main.rs
+++ b/candle-examples/examples/quantized-qwen3/main.rs
@@ -192,7 +192,7 @@ fn main() -> anyhow::Result<()> {
     let mut model = {
         let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path))?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model.tensor_infos.iter() {
+        for tensor in model.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -200,7 +200,7 @@ fn main() -> anyhow::Result<()> {
         println!(
             "loaded {:?} tensors ({}) in {:.2}s",
             model.tensor_infos.len(),
-            &format_size(total_size_in_bytes),
+            format_size(total_size_in_bytes),
             start.elapsed().as_secs_f32(),
         );
         Qwen3::from_gguf(model, &mut file, &device)?
@@ -215,7 +215,7 @@ fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| DEFAULT_PROMPT.to_string());
 
     let prompt_str = format!("<|im_start|>user\n{prompt_str}<|im_end|>\n<|im_start|>assistant\n");
-    print!("formatted prompt: {}", &prompt_str);
+    print!("formatted prompt: {}", prompt_str);
 
     let tokens = tos
         .tokenizer()

--- a/candle-examples/examples/quantized/main.rs
+++ b/candle-examples/examples/quantized/main.rs
@@ -474,7 +474,7 @@ fn main() -> anyhow::Result<()> {
         Some("gguf") => {
             let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path))?;
             let mut total_size_in_bytes = 0;
-            for (_, tensor) in model.tensor_infos.iter() {
+            for tensor in model.tensor_infos.values() {
                 let elem_count = tensor.shape.elem_count();
                 total_size_in_bytes +=
                     elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -482,7 +482,7 @@ fn main() -> anyhow::Result<()> {
             println!(
                 "loaded {:?} tensors ({}) in {:.2}s",
                 model.tensor_infos.len(),
-                &format_size(total_size_in_bytes),
+                format_size(total_size_in_bytes),
                 start.elapsed().as_secs_f32(),
             );
             ModelWeights::from_gguf(model, &mut file, &device)?
@@ -491,7 +491,7 @@ fn main() -> anyhow::Result<()> {
             let model = ggml_file::Content::read(&mut file, &device)
                 .map_err(|e| e.with_path(model_path))?;
             let mut total_size_in_bytes = 0;
-            for (_, tensor) in model.tensors.iter() {
+            for tensor in model.tensors.values() {
                 let elem_count = tensor.shape().elem_count();
                 total_size_in_bytes +=
                     elem_count * tensor.dtype().type_size() / tensor.dtype().block_size();
@@ -499,7 +499,7 @@ fn main() -> anyhow::Result<()> {
             println!(
                 "loaded {:?} tensors ({}) in {:.2}s",
                 model.tensors.len(),
-                &format_size(total_size_in_bytes),
+                format_size(total_size_in_bytes),
                 start.elapsed().as_secs_f32(),
             );
             println!("params: {:?}", model.hparams);
@@ -577,7 +577,7 @@ fn main() -> anyhow::Result<()> {
                 }
             }
         };
-        print!("{}", &prompt_str);
+        print!("{}", prompt_str);
         let tokens = tos
             .tokenizer()
             .encode(prompt_str, true)

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -29,7 +29,7 @@ impl LogitsProcessor {
     }
 
     pub fn new(seed: u64, temperature: Option<f64>, top_p: Option<f64>) -> Self {
-        let temperature = temperature.and_then(|v| if v < 1e-7 { None } else { Some(v) });
+        let temperature = temperature.filter(|&v| v >= 1e-7);
         let sampling = match temperature {
             None => Sampling::ArgMax,
             Some(temperature) => match top_p {

--- a/candle-transformers/src/models/stable_diffusion/attention.rs
+++ b/candle-transformers/src/models/stable_diffusion/attention.rs
@@ -215,13 +215,7 @@ impl CrossAttention {
         let key = self.reshape_heads_to_batch_dim(&key)?;
         let value = self.reshape_heads_to_batch_dim(&value)?;
         let dim0 = query.dim(0)?;
-        let slice_size = self.slice_size.and_then(|slice_size| {
-            if dim0 < slice_size {
-                None
-            } else {
-                Some(slice_size)
-            }
-        });
+        let slice_size = self.slice_size.filter(|&slice_size| dim0 >= slice_size);
         let xs = match slice_size {
             None => self.attention(&query, &key, &value)?,
             Some(slice_size) => self.sliced_attention(&query, &key, &value, slice_size)?,

--- a/tensor-tools/src/main.rs
+++ b/tensor-tools/src/main.rs
@@ -440,7 +440,7 @@ fn run_dequantize(
     let mut in_file = std::fs::File::open(in_file)?;
     let content = gguf_file::Content::read(&mut in_file)?;
     let mut tensors = std::collections::HashMap::new();
-    for (tensor_name, _) in content.tensor_infos.iter() {
+    for tensor_name in content.tensor_infos.keys() {
         let tensor = content.tensor(&mut in_file, tensor_name, device)?;
         let tensor = tensor.dequantize(device)?;
         tensors.insert(tensor_name.to_string(), tensor);


### PR DESCRIPTION
The f16/bf16 elementwise kernels (vec_add_f16, vec_add_bf16, vec_scalar_add_f16, vec_scalar_add_bf16) were gated on any(neon, avx2, simd128) but use CurrentCpuF16/CurrentCpuBF16, which cpu/simd128.rs never defines (it only implements the f32 CurrentCpu). Any wasm32 build with +simd128 failed with 38 unresolved-type errors.

Gate these kernels on any(avx2, neon) like vec_dot_f16/vec_dot_bf16 already are, so wasm32+simd128 uses the scalar fallbacks. f32 paths (vec_dot_f32, vec_sum) keep their simd128 kernels. No behavior change on x86/aarch64.