### PR TITLE
Fix attention masks for chunked prefill (seq_len > 1 with a warm KV cache)

### DIFF
--- a/candle-transformers/src/models/falcon.rs
+++ b/candle-transformers/src/models/falcon.rs
@@ -427,18 +427,20 @@ pub struct Falcon {
     config: Config,
 }
 
-fn make_causal_mask(t: usize) -> Result<Tensor> {
+fn make_causal_mask(t: usize, past_kv_len: usize) -> Result<Tensor> {
+    // With a cached prefix of `past_kv_len` tokens the attention scores are
+    // (b * h, t, past_kv_len + t): the prefix is fully visible, the new
+    // chunk is causal.
     let mask: Vec<_> = (0..t)
-        .flat_map(|i| (0..t).map(move |j| u8::from(j > i)))
+        .flat_map(|i| (0..past_kv_len + t).map(move |j| u8::from(j > i + past_kv_len)))
         .collect();
-    let mask = Tensor::from_slice(&mask, (t, t), &Device::Cpu)?;
+    let mask = Tensor::from_slice(&mask, (t, past_kv_len + t), &Device::Cpu)?;
     Ok(mask)
 }
 
-fn prepare_attn_mask(b_sz: usize, seq_len: usize) -> Result<Tensor> {
-    // let mask = Tensor::ones((b_sz, seq_len), DType::U32, &Device::Cpu)?;
-    let mask = make_causal_mask(seq_len)?;
-    let mask = mask.broadcast_as((b_sz, 1, seq_len, seq_len))?;
+fn prepare_attn_mask(b_sz: usize, past_kv_len: usize, seq_len: usize) -> Result<Tensor> {
+    let mask = make_causal_mask(seq_len, past_kv_len)?;
+    let mask = mask.broadcast_as((b_sz, 1, seq_len, past_kv_len + seq_len))?;
     Ok(mask)
 }
 
@@ -481,7 +483,7 @@ impl Falcon {
         let causal_mask = if seq_len <= 1 {
             None
         } else {
-            Some(prepare_attn_mask(b_sz, seq_len)?.to_device(input_ids.device())?)
+            Some(prepare_attn_mask(b_sz, past_kv_len, seq_len)?.to_device(input_ids.device())?)
         };
         for block in self.blocks.iter_mut() {
             hidden_state = block.forward(&hidden_state, causal_mask.as_ref(), past_kv_len)?;

--- a/candle-transformers/src/models/olmo.rs
+++ b/candle-transformers/src/models/olmo.rs
@@ -319,7 +319,7 @@ impl Model {
             .collect();
         let mask = Tensor::from_slice(&mask, (tgt_len, tgt_len), &self.device)?;
         let mask = if seqlen_offset > 0 {
-            let mask0 = Tensor::zeros((tgt_len, seqlen_offset), self.dtype, &self.device)?;
+            let mask0 = Tensor::zeros((tgt_len, seqlen_offset), DType::F32, &self.device)?;
             Tensor::cat(&[&mask0, &mask], D::Minus1)?
         } else {
             mask

--- a/candle-transformers/src/models/olmo2.rs
+++ b/candle-transformers/src/models/olmo2.rs
@@ -314,7 +314,7 @@ impl Model {
             .collect();
         let mask = Tensor::from_slice(&mask, (tgt_len, tgt_len), &self.device)?;
         let mask = if seqlen_offset > 0 {
-            let mask0 = Tensor::zeros((tgt_len, seqlen_offset), self.dtype, &self.device)?;
+            let mask0 = Tensor::zeros((tgt_len, seqlen_offset), DType::F32, &self.device)?;
             Tensor::cat(&[&mask0, &mask], D::Minus1)?
         } else {
             mask

--- a/candle-transformers/src/models/phi.rs
+++ b/candle-transformers/src/models/phi.rs
@@ -133,11 +133,14 @@ struct Attention {
     span: tracing::Span,
 }
 
-fn get_mask(size: usize, device: &Device) -> Result<Tensor> {
+fn get_mask(size: usize, seqlen_offset: usize, device: &Device) -> Result<Tensor> {
+    // With a cached prefix of `seqlen_offset` tokens the attention weights
+    // are (b, h, size, seqlen_offset + size): the prefix is fully visible,
+    // the new chunk is causal.
     let mask: Vec<_> = (0..size)
-        .flat_map(|i| (0..size).map(move |j| u8::from(j > i)))
+        .flat_map(|i| (0..seqlen_offset + size).map(move |j| u8::from(j > i + seqlen_offset)))
         .collect();
-    Tensor::from_slice(&mask, (size, size), device)
+    Tensor::from_slice(&mask, (size, seqlen_offset + size), device)
 }
 
 fn masked_fill(on_false: &Tensor, mask: &Tensor, on_true: f32) -> Result<Tensor> {
@@ -348,7 +351,11 @@ impl Model {
         let mask = if seq_len <= 1 {
             None
         } else {
-            Some(get_mask(seq_len, xs.device())?)
+            let seqlen_offset = match &self.layers[0].self_attn.kv_cache {
+                Some((k, _)) => k.dim(2)?,
+                None => 0,
+            };
+            Some(get_mask(seq_len, seqlen_offset, xs.device())?)
         };
         for layer in self.layers.iter_mut() {
             xs = layer.forward(&xs, mask.as_ref())?;

--- a/candle-transformers/src/models/qwen2.rs
+++ b/candle-transformers/src/models/qwen2.rs
@@ -314,7 +314,7 @@ impl Model {
             .collect();
         let mask = Tensor::from_slice(&mask, (tgt_len, tgt_len), &self.device)?;
         let mask = if seqlen_offset > 0 {
-            let mask0 = Tensor::zeros((tgt_len, seqlen_offset), self.dtype, &self.device)?;
+            let mask0 = Tensor::zeros((tgt_len, seqlen_offset), DType::F32, &self.device)?;
             Tensor::cat(&[&mask0, &mask], D::Minus1)?
         } else {
             mask


### PR DESCRIPTION
## What

Chunked prefill — feeding a long prompt through `forward()` in fixed-size chunks with a growing KV cache, to bound prefill memory — currently breaks on several architectures. A single-shot prefill materializes a `heads × seq²` attention matrix (~51 GB for a 30k-token prompt on a 14-head model), so chunking is the only way to run long prompts on consumer GPUs; the `(input, seqlen_offset)` API supports it, but some models' mask construction does not.

## Fixes

**qwen2, olmo, olmo2 — dtype mismatch in the mask concat.** `prepare_causal_attention_mask` builds the chunk mask as F32 (`Tensor::from_slice` of `f32`s) but creates the cached-prefix zeros in the *model* dtype, and `cat`s them **before** the final `to_dtype`. On BF16 models any chunk with `seqlen_offset > 0` fails with:

```
dtype mismatch in cat, lhs: BF16, rhs: F32
```

mistral, gemma, gemma2, gemma3 and phi3 already create the prefix zeros as `DType::F32`; this aligns the three stragglers with them. (The bug is invisible in the common paths: single-shot prefill has `offset = 0`, so there is no cat; single-token decode has `seq_len = 1`, so there is no mask.)

**phi — mask ignores the cached prefix.** The causal mask is built as `(seq, seq)` with no knowledge of the KV cache, so `masked_fill` fails against attention weights of shape `(b, h, seq, past + seq)`. The mask now spans the prefix (fully visible) plus the causal chunk, with the offset derived from the first layer's KV cache — the same approach llama already uses (`Cache::mask(seq_len, index_pos)`).

**falcon — same problem.** `forward()` already computes `past_kv_len` but did not pass it to `prepare_attn_mask`; the mask now spans `(b, 1, seq, past + seq)`.

## Behavior

- Single-shot prefill (`offset = 0`) and single-token decode (`seq_len = 1`) are byte-for-byte unchanged on every architecture.
- Chunked prefill produces identical logits to single-shot (the prefix is fully visible, the chunk is causal — the same mask a single shot would apply, split at the chunk boundary).