### PR TITLE
Fix Yi RoPE ignoring cfg.rope_theta (hardcoded 10000)

### DIFF
--- a/candle-transformers/src/models/yi.rs
+++ b/candle-transformers/src/models/yi.rs
@@ -85,7 +85,7 @@ impl RotaryEmbedding {
         let max_seq_len = cfg.max_position_embeddings;
         let inv_freq: Vec<_> = (0..dim)
             .step_by(2)
-            .map(|i| 1f32 / 10000f32.powf(i as f32 / dim as f32))
+            .map(|i| 1f32 / (cfg.rope_theta as f32).powf(i as f32 / dim as f32))
             .collect();
         let inv_freq_len = inv_freq.len();
         let inv_freq = Tensor::from_vec(inv_freq, (1, inv_freq_len), dev)?.to_dtype(dtype)?;


### PR DESCRIPTION
## Problem

The Yi model's `Config` declares `rope_theta: f64`, and both constructors set it to the value Yi was trained with:

```rust
// candle-transformers/src/models/yi.rs
pub(crate) rope_theta: f64,
...
rope_theta: 5_000_000.,   // config_6b()
rope_theta: 5_000_000.,   // config_34b()
```

But `RotaryEmbedding::new` hardcodes `10000f32` and never reads `cfg.rope_theta`:

```rust
let inv_freq: Vec<_> = (0..dim)
    .step_by(2)
    .map(|i| 1f32 / 10000f32.powf(i as f32 / dim as f32))   // hardcoded base
    .collect();
```

A grep confirms `rope_theta` is populated but read nowhere in `yi.rs`. So the rotary positional frequencies are computed with base `10_000` instead of `5_000_000`, corrupting positional encoding for all Yi inference (long-context behavior in particular).

## Evidence this is unintended

Every other model that carries a `rope_theta` config threads it into the identical `inv_freq` loop — e.g. `mistral.rs`, whose `RotaryEmbedding` is otherwise structurally identical to `yi.rs`:

```rust
// candle-transformers/src/models/mistral.rs
let rope_theta = cfg.rope_theta as f32;
...
.map(|i| 1f32 / rope_theta.powf(i as f32 / dim as f32))
```

(Same pattern in `mixtral.rs`, `olmo.rs`, `olmo2.rs`, `stable_lm.rs`, `starcoder2.rs`.) `yi.rs` is the only one that carries a `rope_theta` in its config and then discards it.

## Fix

Use `cfg.rope_theta` for the base, matching the sibling models:

```rust
.map(|i| 1f32 / (cfg.rope_theta as f32).powf(i as f32 / dim as f32))
```

One line. `falcon.rs` also uses `10000` but has no `rope_theta` config field and genuinely uses base 10000, so it is correct and left untouched.
