### PR TITLE
Fix quantized Gemma 3 MLP activation (gelu_pytorch_tanh, not SiLU)

### DIFF
--- a/candle-transformers/src/models/quantized_gemma3.rs
+++ b/candle-transformers/src/models/quantized_gemma3.rs
@@ -57,8 +57,8 @@ impl Module for Mlp {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         let gate = self.feed_forward_gate.forward(xs)?;
         let up = self.feed_forward_up.forward(xs)?;
-        let silu = candle_nn::ops::silu(&gate)?;
-        let gated = (silu * up)?;
+        let gate = gate.apply(&candle_nn::Activation::GeluPytorchTanh)?;
+        let gated = (gate * up)?;
         self.feed_forward_down.forward(&gated)
     }
 }


### PR DESCRIPTION
Fixes #3745

The quantized Gemma 3 MLP hardcoded SiLU, but Gemma 3 gates its feed-forward network with gelu_pytorch_tanh. The non-quantized gemma3.rs applies cfg.hidden_activation (gelu_pytorch_tanh for Gemma 3 checkpoints). The quantized model loads from GGUF metadata and has no config field, so it applies the activation directly, the same way quantized_glm4.rs hardcodes its Activation. This routes through the same code path as the non-quantized model (Activation::GeluPytorchTanh, the gelu tanh approximation).

SiLU and gelu_pytorch_tanh behave similarly, so the wrong one does not crash or produce obvious garbage; it just makes the output worse, which is why it went unnoticed. #3326 attempted a sliding-window plus GELU rework but was self-closed by its author, so this is the focused activation-only fix.