### PR TITLE
Add margin_ranking loss to candle-nn

### DIFF
--- a/candle-nn/src/loss.rs
+++ b/candle-nn/src/loss.rs
@@ -102,3 +102,22 @@ pub fn huber(inp: &Tensor, target: &Tensor, delta: f64) -> Result<Tensor> {
     let loss = mask.where_cond(&squared_loss, &linear_loss)?;
     loss.mean_all()
 }
+
+/// The margin ranking loss.
+///
+/// Measures the loss for ranking two inputs, matching `torch.nn.MarginRankingLoss`.
+///
+/// Arguments
+///
+/// * [x1], [x2]: The two input score tensors of the same shape.
+/// * [target]: A tensor whose elements are `+1` or `-1`. `+1` means `x1` should be
+///   ranked higher than `x2`, `-1` the reverse.
+/// * [margin]: A non-negative margin by which the ranking should hold.
+///
+/// The per-element loss is `max(0, -target * (x1 - x2) + margin)`, and the resulting
+/// tensor is a scalar containing the mean over all elements.
+pub fn margin_ranking(x1: &Tensor, x2: &Tensor, target: &Tensor, margin: f64) -> Result<Tensor> {
+    let diff = (x1 - x2)?;
+    let scaled = (target * &diff)?.neg()?.affine(1.0, margin)?;
+    scaled.relu()?.mean_all()
+}

--- a/candle-nn/tests/loss.rs
+++ b/candle-nn/tests/loss.rs
@@ -132,3 +132,22 @@ fn huber_loss() -> Result<()> {
     assert_eq!(to_vec0_round(&loss, 4)?, 0.4483);
     Ok(())
 }
+
+/* Equivalent python code:
+import torch
+import torch.nn.functional as F
+x1 = torch.tensor([1.0, 2.0, 3.0])
+x2 = torch.tensor([2.0, 1.0, 0.5])
+target = torch.tensor([1.0, -1.0, 1.0])
+print(F.margin_ranking_loss(x1, x2, target, margin=0.5))  # tensor(1.)
+*/
+#[test]
+fn margin_ranking() -> Result<()> {
+    let cpu = Device::Cpu;
+    let x1 = Tensor::new(&[1f32, 2., 3.], &cpu)?;
+    let x2 = Tensor::new(&[2f32, 1., 0.5], &cpu)?;
+    let target = Tensor::new(&[1f32, -1., 1.], &cpu)?;
+    let loss = candle_nn::loss::margin_ranking(&x1, &x2, &target, 0.5)?;
+    assert_eq!(to_vec0_round(&loss, 4)?, 1.0);
+    Ok(())
+}


### PR DESCRIPTION
Adds `margin_ranking`, matching `torch.nn.functional.margin_ranking_loss`.

Per-element loss is `max(0, -target * (x1 - x2) + margin)`, reduced by mean.
Implemented with the existing functional style (`affine`/`neg`/`relu`/`mean_all`),
alongside a test validated against PyTorch (expects `1.0`).