### PR TITLE
Add l1 (MAE) loss to candle-nn

### DIFF
--- a/candle-nn/src/loss.rs
+++ b/candle-nn/src/loss.rs
@@ -102,3 +102,11 @@ pub fn huber(inp: &Tensor, target: &Tensor, delta: f64) -> Result<Tensor> {
     let loss = mask.where_cond(&squared_loss, &linear_loss)?;
     loss.mean_all()
 }
+
+/// The mean absolute error loss (L1 loss).
+///
+/// Computes the element-wise absolute difference between `inp` and `target`,
+/// matching `torch.nn.functional.l1_loss` with the default `mean` reduction.
+pub fn l1(inp: &Tensor, target: &Tensor) -> Result<Tensor> {
+    (inp - target)?.abs()?.mean_all()
+}

--- a/candle-nn/tests/loss.rs
+++ b/candle-nn/tests/loss.rs
@@ -132,3 +132,44 @@ fn huber_loss() -> Result<()> {
     assert_eq!(to_vec0_round(&loss, 4)?, 0.4483);
     Ok(())
 }
+
+/* Equivalent python code:
+import torch
+import torch.nn.functional as F
+inp = torch.tensor([
+    [ 2.3611, -0.8813, -0.5006, -0.2178],
+    [ 0.0419,  0.0763, -1.0457, -1.6692],
+    [-1.0494,  0.8111,  1.5723,  1.2315],
+    [ 1.3081,  0.6641,  1.1802, -0.2547],
+    [ 0.5292,  0.7636,  0.3692, -0.8318]])
+target = torch.tensor([
+    [0., 1., 0., 0.],
+    [0., 1., 0., 0.],
+    [0., 0., 0., 1.],
+    [1., 0., 0., 0.],
+    [0., 0., 1., 0.]])
+print(F.l1_loss(inp, target))  # tensor(0.8734)
+*/
+#[test]
+fn l1_loss() -> Result<()> {
+    let cpu = Device::Cpu;
+    let inp = [
+        [2.3611f32, -0.8813, -0.5006, -0.2178],
+        [0.0419, 0.0763, -1.0457, -1.6692],
+        [-1.0494, 0.8111, 1.5723, 1.2315],
+        [1.3081, 0.6641, 1.1802, -0.2547],
+        [0.5292, 0.7636, 0.3692, -0.8318],
+    ];
+    let target = [
+        [0.0f32, 1., 0., 0.],
+        [0., 1., 0., 0.],
+        [0., 0., 0., 1.],
+        [1., 0., 0., 0.],
+        [0., 0., 1., 0.],
+    ];
+    let inp = Tensor::new(&inp, &cpu)?;
+    let target = Tensor::new(&target, &cpu)?;
+    let loss = candle_nn::loss::l1(&inp, &target)?;
+    assert_eq!(to_vec0_round(&loss, 4)?, 0.8734);
+    Ok(())
+}


### PR DESCRIPTION
Adds `l1`, the mean absolute error loss, matching `torch.nn.functional.l1_loss`
with the default `mean` reduction.

The per-element loss is `|inp - target|`, reduced by mean over all elements —
mirroring the existing one-line `mse` implementation:

    pub fn l1(inp: &Tensor, target: &Tensor) -> Result<Tensor> {
        (inp - target)?.abs()?.mean_all()
    }

Includes a test validated against PyTorch (expects 0.8734), reusing the same
input/target pair as the existing `huber` test for consistency.