### PR TITLE
Fix DeBERTa-v2 models failing to run at F16

### DIFF
--- a/candle-transformers/src/models/debertav2.rs
+++ b/candle-transformers/src/models/debertav2.rs
@@ -290,12 +290,16 @@ impl XSoftmax {
             .broadcast_lt(&Tensor::new(&[1.0_f32], device)?)?
             .to_dtype(DType::U8)?;
 
-        let min_value_tensor = Tensor::new(&[f32::MIN], device)?.broadcast_as(input.shape())?;
+        let min_value_tensor = Tensor::new(&[f32::MIN], device)?
+            .to_dtype(input.dtype())?
+            .broadcast_as(input.shape())?;
         let mut output = rmask.where_cond(&min_value_tensor, input)?;
 
         output = candle_nn::ops::softmax(&output, dim)?;
 
-        let t_zeroes = Tensor::new(&[0f32], device)?.broadcast_as(input.shape())?;
+        let t_zeroes = Tensor::new(&[0f32], device)?
+            .to_dtype(input.dtype())?
+            .broadcast_as(input.shape())?;
         output = rmask.where_cond(&t_zeroes, &output)?;
 
         Ok(output)
@@ -608,7 +612,7 @@ impl DebertaV2DisentangledSelfAttention {
             }
         }
 
-        let mut score = Tensor::new(&[0 as f32], &self.device)?;
+        let mut score = Tensor::new(&[0f32], &self.device)?.to_dtype(query_layer.dtype())?;
 
         if self.config.pos_att_type.iter().any(|s| s == "c2p") {
             let pos_key_layer = pos_key_layer.context("c2p without pos_key_layer")?;

--- a/candle-transformers/tests/debertav2_tests.rs
+++ b/candle-transformers/tests/debertav2_tests.rs
@@ -1,0 +1,57 @@
+// Regression test for #3750: F16 forward failed with a dtype mismatch from
+// hardcoded F32 scalars.
+use candle::{DType, Device, Result, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::models::debertav2::{Config, DebertaV2Model};
+
+fn small_config() -> Config {
+    serde_json::from_value(serde_json::json!({
+        "vocab_size": 32,
+        "hidden_size": 16,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "intermediate_size": 32,
+        "hidden_act": "gelu",
+        "hidden_dropout_prob": 0.0,
+        "attention_probs_dropout_prob": 0.0,
+        "max_position_embeddings": 32,
+        "type_vocab_size": 0,
+        "initializer_range": 0.02,
+        "layer_norm_eps": 1e-7,
+        "relative_attention": true,
+        "max_relative_positions": -1,
+        "pad_token_id": 0,
+        "position_biased_input": true,
+        "pos_att_type": ["p2c", "c2p"],
+        "position_buckets": 8,
+        "norm_rel_ebd": "layer_norm"
+    }))
+    .unwrap()
+}
+
+fn forward_with_dtype(dtype: DType) -> Result<DType> {
+    let device = Device::Cpu;
+    let vb = VarBuilder::zeros(dtype, &device);
+    let model = DebertaV2Model::load(vb, &small_config())?;
+    let input_ids = Tensor::zeros((1, 6), DType::U32, &device)?;
+    let attention_mask = Tensor::new(&[[1u32, 1, 1, 1, 0, 0]], &device)?;
+    let output = model.forward(&input_ids, Some(attention_mask), None)?;
+    let values = output
+        .to_dtype(DType::F32)?
+        .flatten_all()?
+        .to_vec1::<f32>()?;
+    assert!(values.iter().all(|v| v.is_finite()));
+    Ok(output.dtype())
+}
+
+#[test]
+fn forward_f32() -> Result<()> {
+    assert_eq!(forward_with_dtype(DType::F32)?, DType::F32);
+    Ok(())
+}
+
+#[test]
+fn forward_f16() -> Result<()> {
+    assert_eq!(forward_with_dtype(DType::F16)?, DType::F16);
+    Ok(())
+}


### PR DESCRIPTION
## Problem

`DebertaV2Model::forward` fails for F16 models with `dtype mismatch in add, lhs: F32, rhs: F16`.

Fixes #3750.

## Solution

Two spots in `debertav2.rs` build F32 scalar tensors and combine them with tensors of the model's dtype:

- the `score` accumulator in `disentangled_attention_bias`
- the mask fill values in `XSoftmax::apply`

Cast them to the working dtype — same pattern as `scale` in this file and the mask fill in `bert.rs`. The F32 path is unchanged.

## Testing

New regression test runs a tiny DeBERTa-v2 forward at F32 and F16; the F16 case fails without this fix. Workspace tests, clippy, and fmt all pass.