### PR TITLE
Add kl_div loss to candle-nn

### DIFF
--- a/candle-nn/src/loss.rs
+++ b/candle-nn/src/loss.rs
@@ -102,3 +102,24 @@ pub fn huber(inp: &Tensor, target: &Tensor, delta: f64) -> Result<Tensor> {
     let loss = mask.where_cond(&squared_loss, &linear_loss)?;
     loss.mean_all()
 }
+
+/// The Kullback-Leibler divergence loss.
+///
+/// Matches `torch.nn.functional.kl_div` with the default `mean` reduction and
+/// `log_target = false`.
+///
+/// Arguments
+///
+/// * [inp]: The input tensor, expected to contain **log-probabilities**.
+/// * [target]: The target tensor, expected to contain **probabilities**.
+///
+/// The per-element loss is `target * (log(target) - inp)`, using the convention
+/// that elements where `target == 0` contribute `0` (matching PyTorch). The
+/// resulting tensor is a scalar containing the mean over all elements.
+pub fn kl_div(inp: &Tensor, target: &Tensor) -> Result<Tensor> {
+    let pointwise = (target * (target.log()? - inp)?)?;
+    let zeros = pointwise.zeros_like()?;
+    let mask = target.gt(0f64)?;
+    let pointwise = mask.where_cond(&pointwise, &zeros)?;
+    pointwise.mean_all()
+}

--- a/candle-nn/tests/loss.rs
+++ b/candle-nn/tests/loss.rs
@@ -132,3 +132,38 @@ fn huber_loss() -> Result<()> {
     assert_eq!(to_vec0_round(&loss, 4)?, 0.4483);
     Ok(())
 }
+
+/* Equivalent python code:
+import torch
+import torch.nn.functional as F
+logits = torch.tensor([
+    [1.1050,  0.3013, -1.5394],
+    [1.0730, -0.9419, -0.1670],
+    [0.8318,  1.1154, -0.3610]])
+inp = F.log_softmax(logits, dim=1)
+target = torch.tensor([
+    [0.2, 0.5, 0.3],
+    [0.1, 0.6, 0.3],
+    [0.4, 0.4, 0.2]])
+print(F.kl_div(inp, target, reduction="mean"))  # tensor(0.1841)
+*/
+#[test]
+fn kl_div_loss() -> Result<()> {
+    let cpu = Device::Cpu;
+    let logits = Tensor::new(
+        &[
+            [1.1050f32, 0.3013, -1.5394],
+            [1.0730, -0.9419, -0.1670],
+            [0.8318, 1.1154, -0.3610],
+        ],
+        &cpu,
+    )?;
+    let inp = candle_nn::ops::log_softmax(&logits, 1)?;
+    let target = Tensor::new(
+        &[[0.2f32, 0.5, 0.3], [0.1, 0.6, 0.3], [0.4, 0.4, 0.2]],
+        &cpu,
+    )?;
+    let loss = candle_nn::loss::kl_div(&inp, &target)?;
+    assert_eq!(to_vec0_round(&loss, 4)?, 0.1841);
+    Ok(())
+}


### PR DESCRIPTION
Adds `kl_div`, the Kullback-Leibler divergence loss, matching
`torch.nn.functional.kl_div` with the default `mean` reduction and
`log_target = false`.

`inp` is expected to contain log-probabilities and `target` probabilities.
The per-element loss is `target * (log(target) - inp)`, following PyTorch's
convention that elements where `target == 0` contribute `0` (handled via a
mask so zero targets don't produce NaN). Reduced by mean over all elements.

Includes a test validated against PyTorch (expects 0.1841).