### PR TITLE
Fix clippy warnings for Rust 1.97

### DIFF
--- a/candle-core/src/shape.rs
+++ b/candle-core/src/shape.rs
@@ -9,7 +9,7 @@ pub const SCALAR: Shape = Shape(vec![]);
 
 impl std::fmt::Debug for Shape {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", &self.dims())
+        write!(f, "{:?}", self.dims())
     }
 }
 

--- a/candle-examples/examples/glm4/main.rs
+++ b/candle-examples/examples/glm4/main.rs
@@ -77,7 +77,7 @@ impl TextGeneration {
                 println!("{id:7} -> '{token}'");
             }
         } else {
-            print!("{}", &args.prompt);
+            print!("{}", args.prompt);
             std::io::stdout().flush()?;
         }
 

--- a/candle-examples/examples/llava/main.rs
+++ b/candle-examples/examples/llava/main.rs
@@ -177,7 +177,7 @@ fn main() -> Result<()> {
         let config_filename = api.get("config.json")?;
         let llava_config: LLaVAConfig = serde_json::from_slice(&std::fs::read(config_filename)?)?;
         let tokenizer = Tokenizer::from_file(&args.tokenizer_path)
-            .map_err(|e| E::msg(format!("Error loading {}: {}", &args.tokenizer_path, e)))?;
+            .map_err(|e| E::msg(format!("Error loading {}: {}", args.tokenizer_path, e)))?;
         (
             llava_config.clone(),
             tokenizer,
@@ -258,7 +258,7 @@ fn main() -> Result<()> {
     println!("loading image");
     let (image_size, image_tensor) =
         load_image(&args.image_file, &image_processor, &llava_config, dtype)
-            .map_err(|e| E::msg(format!("Error loading {}: {}", &args.image_file, e)))?;
+            .map_err(|e| E::msg(format!("Error loading {}: {}", args.image_file, e)))?;
     let image_tensor = image_tensor.to_device(&device)?;
 
     let mut logits_processor = {

--- a/candle-examples/examples/quantized-gemma/main.rs
+++ b/candle-examples/examples/quantized-gemma/main.rs
@@ -178,7 +178,7 @@ fn main() -> anyhow::Result<()> {
     let mut model = {
         let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(&model_path))?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model.tensor_infos.iter() {
+        for tensor in model.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -186,7 +186,7 @@ fn main() -> anyhow::Result<()> {
         println!(
             "loaded {:?} tensors ({}) in {:.2}s",
             model.tensor_infos.len(),
-            &format_size(total_size_in_bytes),
+            format_size(total_size_in_bytes),
             start.elapsed().as_secs_f32(),
         );
         ModelWeights::from_gguf(model, &mut file, &device)?
@@ -227,7 +227,7 @@ fn main() -> anyhow::Result<()> {
                 format!("<start_of_turn> user\n{prompt}<end_of_turn>\n<start_of_turn> model\n")
             }
         };
-        print!("{}", &prompt_str);
+        print!("{}", prompt_str);
 
         let tokens = tos
             .tokenizer()

--- a/candle-examples/examples/quantized-glm4/main.rs
+++ b/candle-examples/examples/quantized-glm4/main.rs
@@ -194,7 +194,7 @@ fn main() -> anyhow::Result<()> {
     let mut model = {
         let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path))?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model.tensor_infos.iter() {
+        for tensor in model.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -202,7 +202,7 @@ fn main() -> anyhow::Result<()> {
         println!(
             "loaded {:?} tensors ({}) in {:.2}s",
             model.tensor_infos.len(),
-            &format_size(total_size_in_bytes),
+            format_size(total_size_in_bytes),
             start.elapsed().as_secs_f32(),
         );
         let dtype = if device.is_cuda() || device.is_metal() {

--- a/candle-examples/examples/quantized-lfm2/main.rs
+++ b/candle-examples/examples/quantized-lfm2/main.rs
@@ -207,7 +207,7 @@ fn main() -> Result<()> {
 
     let gguf = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path.clone()))?;
     let mut total_size_in_bytes = 0;
-    for (_, tensor) in gguf.tensor_infos.iter() {
+    for tensor in gguf.tensor_infos.values() {
         let elem_count = tensor.shape.elem_count();
         total_size_in_bytes +=
             elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();

--- a/candle-examples/examples/quantized-phi/main.rs
+++ b/candle-examples/examples/quantized-phi/main.rs
@@ -207,7 +207,7 @@ fn main() -> anyhow::Result<()> {
     let mut model = {
         let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path))?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model.tensor_infos.iter() {
+        for tensor in model.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -215,7 +215,7 @@ fn main() -> anyhow::Result<()> {
         println!(
             "loaded {:?} tensors ({}) in {:.2}s",
             model.tensor_infos.len(),
-            &format_size(total_size_in_bytes),
+            format_size(total_size_in_bytes),
             start.elapsed().as_secs_f32(),
         );
         match args.which {
@@ -234,7 +234,7 @@ fn main() -> anyhow::Result<()> {
     let tokenizer = args.tokenizer()?;
     let mut tos = TokenOutputStream::new(tokenizer);
     let prompt_str = args.prompt.unwrap_or_else(|| DEFAULT_PROMPT.to_string());
-    print!("{}", &prompt_str);
+    print!("{}", prompt_str);
     let tokens = tos
         .tokenizer()
         .encode(prompt_str, true)

--- a/candle-examples/examples/quantized-qwen2-instruct/main.rs
+++ b/candle-examples/examples/quantized-qwen2-instruct/main.rs
@@ -202,7 +202,7 @@ fn main() -> anyhow::Result<()> {
     let mut model = {
         let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path))?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model.tensor_infos.iter() {
+        for tensor in model.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -210,7 +210,7 @@ fn main() -> anyhow::Result<()> {
         println!(
             "loaded {:?} tensors ({}) in {:.2}s",
             model.tensor_infos.len(),
-            &format_size(total_size_in_bytes),
+            format_size(total_size_in_bytes),
             start.elapsed().as_secs_f32(),
         );
         Qwen2::from_gguf(model, &mut file, &device)?
@@ -228,7 +228,7 @@ fn main() -> anyhow::Result<()> {
         Which::DeepseekR1Qwen7B => format!("<｜User｜>{prompt_str}<｜Assistant｜>"),
         _ => format!("<|im_start|>user\n{prompt_str}<|im_end|>\n<|im_start|>assistant\n"),
     };
-    print!("formatted instruct prompt: {}", &prompt_str);
+    print!("formatted instruct prompt: {}", prompt_str);
     let tokens = tos
         .tokenizer()
         .encode(prompt_str, true)

--- a/candle-examples/examples/quantized-qwen3-moe/main.rs
+++ b/candle-examples/examples/quantized-qwen3-moe/main.rs
@@ -229,7 +229,7 @@ fn main() -> anyhow::Result<()> {
     let mut model = {
         let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path))?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model.tensor_infos.iter() {
+        for tensor in model.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -237,7 +237,7 @@ fn main() -> anyhow::Result<()> {
         println!(
             "loaded {:?} tensors ({}) in {:.2}s",
             model.tensor_infos.len(),
-            &format_size(total_size_in_bytes),
+            format_size(total_size_in_bytes),
             start.elapsed().as_secs_f32(),
         );
         Qwen3_MoE::from_gguf(model, &mut file, &device, dtype)?
@@ -252,7 +252,7 @@ fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| DEFAULT_PROMPT.to_string());
 
     let prompt_str = format!("<|im_start|>user\n{prompt_str}<|im_end|>\n<|im_start|>assistant\n");
-    print!("formatted prompt: {}", &prompt_str);
+    print!("formatted prompt: {}", prompt_str);
 
     let tokens = tos
         .tokenizer()

--- a/candle-examples/examples/quantized-qwen3/main.rs
+++ b/candle-examples/examples/quantized-qwen3/main.rs
@@ -192,7 +192,7 @@ fn main() -> anyhow::Result<()> {
     let mut model = {
         let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path))?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model.tensor_infos.iter() {
+        for tensor in model.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -200,7 +200,7 @@ fn main() -> anyhow::Result<()> {
         println!(
             "loaded {:?} tensors ({}) in {:.2}s",
             model.tensor_infos.len(),
-            &format_size(total_size_in_bytes),
+            format_size(total_size_in_bytes),
             start.elapsed().as_secs_f32(),
         );
         Qwen3::from_gguf(model, &mut file, &device)?
@@ -215,7 +215,7 @@ fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| DEFAULT_PROMPT.to_string());
 
     let prompt_str = format!("<|im_start|>user\n{prompt_str}<|im_end|>\n<|im_start|>assistant\n");
-    print!("formatted prompt: {}", &prompt_str);
+    print!("formatted prompt: {}", prompt_str);
 
     let tokens = tos
         .tokenizer()

--- a/candle-examples/examples/quantized/main.rs
+++ b/candle-examples/examples/quantized/main.rs
@@ -474,7 +474,7 @@ fn main() -> anyhow::Result<()> {
         Some("gguf") => {
             let model = gguf_file::Content::read(&mut file).map_err(|e| e.with_path(model_path))?;
             let mut total_size_in_bytes = 0;
-            for (_, tensor) in model.tensor_infos.iter() {
+            for tensor in model.tensor_infos.values() {
                 let elem_count = tensor.shape.elem_count();
                 total_size_in_bytes +=
                     elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
@@ -482,7 +482,7 @@ fn main() -> anyhow::Result<()> {
             println!(
                 "loaded {:?} tensors ({}) in {:.2}s",
                 model.tensor_infos.len(),
-                &format_size(total_size_in_bytes),
+                format_size(total_size_in_bytes),
                 start.elapsed().as_secs_f32(),
             );
             ModelWeights::from_gguf(model, &mut file, &device)?
@@ -491,7 +491,7 @@ fn main() -> anyhow::Result<()> {
             let model = ggml_file::Content::read(&mut file, &device)
                 .map_err(|e| e.with_path(model_path))?;
             let mut total_size_in_bytes = 0;
-            for (_, tensor) in model.tensors.iter() {
+            for tensor in model.tensors.values() {
                 let elem_count = tensor.shape().elem_count();
                 total_size_in_bytes +=
                     elem_count * tensor.dtype().type_size() / tensor.dtype().block_size();
@@ -499,7 +499,7 @@ fn main() -> anyhow::Result<()> {
             println!(
                 "loaded {:?} tensors ({}) in {:.2}s",
                 model.tensors.len(),
-                &format_size(total_size_in_bytes),
+                format_size(total_size_in_bytes),
                 start.elapsed().as_secs_f32(),
             );
             println!("params: {:?}", model.hparams);
@@ -577,7 +577,7 @@ fn main() -> anyhow::Result<()> {
                 }
             }
         };
-        print!("{}", &prompt_str);
+        print!("{}", prompt_str);
         let tokens = tos
             .tokenizer()
             .encode(prompt_str, true)

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -29,7 +29,7 @@ impl LogitsProcessor {
     }
 
     pub fn new(seed: u64, temperature: Option<f64>, top_p: Option<f64>) -> Self {
-        let temperature = temperature.and_then(|v| if v < 1e-7 { None } else { Some(v) });
+        let temperature = temperature.filter(|&v| v >= 1e-7);
         let sampling = match temperature {
             None => Sampling::ArgMax,
             Some(temperature) => match top_p {

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -29,7 +29,10 @@ impl LogitsProcessor {
     }
 
     pub fn new(seed: u64, temperature: Option<f64>, top_p: Option<f64>) -> Self {
-        let temperature = temperature.filter(|&v| v >= 1e-7);
+        // `manual_filter` suggests `.filter(|&v| v >= 1e-7)`, but `f64` is only `PartialOrd`:
+        // that drops `NaN` where the comparison below keeps it. Left as-is on purpose.
+        #[allow(clippy::manual_filter)]
+        let temperature = temperature.and_then(|v| if v < 1e-7 { None } else { Some(v) });
         let sampling = match temperature {
             None => Sampling::ArgMax,
             Some(temperature) => match top_p {

--- a/candle-transformers/src/models/stable_diffusion/attention.rs
+++ b/candle-transformers/src/models/stable_diffusion/attention.rs
@@ -215,13 +215,7 @@ impl CrossAttention {
         let key = self.reshape_heads_to_batch_dim(&key)?;
         let value = self.reshape_heads_to_batch_dim(&value)?;
         let dim0 = query.dim(0)?;
-        let slice_size = self.slice_size.and_then(|slice_size| {
-            if dim0 < slice_size {
-                None
-            } else {
-                Some(slice_size)
-            }
-        });
+        let slice_size = self.slice_size.filter(|&slice_size| dim0 >= slice_size);
         let xs = match slice_size {
             None => self.attention(&query, &key, &value)?,
             Some(slice_size) => self.sliced_attention(&query, &key, &value, slice_size)?,

--- a/tensor-tools/src/main.rs
+++ b/tensor-tools/src/main.rs
@@ -440,7 +440,7 @@ fn run_dequantize(
     let mut in_file = std::fs::File::open(in_file)?;
     let content = gguf_file::Content::read(&mut in_file)?;
     let mut tensors = std::collections::HashMap::new();
-    for (tensor_name, _) in content.tensor_infos.iter() {
+    for tensor_name in content.tensor_infos.keys() {
         let tensor = content.tensor(&mut in_file, tensor_name, device)?;
         let tensor = tensor.dequantize(device)?;
         tensors.insert(tensor_name.to_string(), tensor);


### PR DESCRIPTION
Rust 1.97 promotes `useless_borrows_in_formatting`, `for_kv_map`, and `manual_filter` to warnings, which fail CI under `-D warnings`. Applied `cargo clippy --fix`; no behavior changes.