### PR TITLE
Fix Metal memory leak by draining autorelease pools (#2271)

### DIFF
--- a/candle-core/examples/matmul_leak.rs
+++ b/candle-core/examples/matmul_leak.rs
@@ -48,9 +48,10 @@ fn main() -> Result<()> {
     println!("start RSS: {:.2} MB", start_rss as f64 / 1e6);
 
     for i in 0..iterations {
-        let c = a.matmul(&b)?;
-        // Force the computation to actually run and read the result back to the CPU.
-        let _ = c.sum_all()?.to_scalar::<f32>()?;
+        // Exactly as in the issue reproducer: enqueue matmuls without ever reading a result back
+        // to the CPU and without wrapping the loop body in an autorelease pool. The backend must
+        // keep memory flat on its own; see huggingface/candle#2271.
+        let _ = a.matmul(&b)?;
 
         if i % 5_000 == 0 {
             let rss = rss_bytes();

--- a/candle-core/examples/matmul_leak.rs
+++ b/candle-core/examples/matmul_leak.rs
@@ -1,0 +1,72 @@
+// Regression check for https://github.com/huggingface/candle/issues/2271
+//
+// Repeatedly multiplying a 784x100 matrix by a 100x10 matrix used to leak memory
+// on the Metal backend: autoreleased command buffers / encoders accumulated in the
+// thread's autorelease pool, so the resident set grew without bound (>5 GB reported,
+// >100 GB for BERT-sized models). The CPU backend never leaked.
+//
+// With the fix the resident set stays flat on both backends.
+//
+// Run with:
+//   cargo run --release --example matmul_leak --features metal
+//   cargo run --release --example matmul_leak            # CPU baseline
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+use anyhow::Result;
+use candle_core::{Device, Tensor};
+
+// Read the current process resident set size (RSS) in bytes via ps.
+fn rss_bytes() -> u64 {
+    let pid = std::process::id();
+    let out = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &pid.to_string()])
+        .output()
+        .expect("failed to run ps");
+    let s = String::from_utf8_lossy(&out.stdout);
+    // ps reports RSS in kilobytes.
+    s.trim().parse::<u64>().unwrap_or(0) * 1024
+}
+
+fn main() -> Result<()> {
+    let device = if cfg!(feature = "metal") {
+        Device::new_metal(0)?
+    } else {
+        Device::Cpu
+    };
+    println!("device: {device:?}");
+
+    let a = Tensor::randn(0f32, 1.0, (784, 100), &device)?;
+    let b = Tensor::randn(0f32, 1.0, (100, 10), &device)?;
+
+    let iterations = 200_000usize;
+    let start_rss = rss_bytes();
+    println!("start RSS: {:.2} MB", start_rss as f64 / 1e6);
+
+    for i in 0..iterations {
+        let c = a.matmul(&b)?;
+        // Force the computation to actually run and read the result back to the CPU.
+        let _ = c.sum_all()?.to_scalar::<f32>()?;
+
+        if i % 5_000 == 0 {
+            let rss = rss_bytes();
+            println!(
+                "iter {i:>7}  RSS {:>8.2} MB  (delta {:>8.2} MB)",
+                rss as f64 / 1e6,
+                (rss as i64 - start_rss as i64) as f64 / 1e6,
+            );
+        }
+    }
+
+    let end_rss = rss_bytes();
+    println!(
+        "end RSS: {:.2} MB  (grew {:.2} MB over {iterations} iterations)",
+        end_rss as f64 / 1e6,
+        (end_rss as i64 - start_rss as i64) as f64 / 1e6,
+    );
+    Ok(())
+}

--- a/candle-metal-kernels/src/metal/commands.rs
+++ b/candle-metal-kernels/src/metal/commands.rs
@@ -4,14 +4,21 @@ use crate::metal::{
 };
 use crate::MetalKernelError;
 use block2::RcBlock;
-use objc2::{rc::Retained, runtime::ProtocolObject};
+use objc2::{
+    rc::{autoreleasepool, Retained},
+    runtime::ProtocolObject,
+};
 use objc2_metal::{MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandQueue};
 use std::collections::HashMap;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 
-// Use Retained when appropriate. Gives us a more elegant way of handling memory (peaks) than autoreleasepool.
+// We track owned Metal resources with `Retained`, but that only manages ownership,
+// not the thread's autorelease pool. Many Metal APIs (command buffer / encoder creation,
+// commit, waits) still return autoreleased temporaries; without a pool to drain them in a
+// tight loop they accumulate for the whole program lifetime. The creation and sync paths
+// below are therefore wrapped in `autoreleasepool`. See huggingface/candle#2271.
 // https://docs.rs/objc2/latest/objc2/rc/struct.Retained.html
 pub type CommandQueue = Retained<ProtocolObject<dyn MTLCommandQueue>>;
 
@@ -162,29 +169,38 @@ impl Commands {
         let count = self.compute_count.fetch_add(1, Ordering::Relaxed);
         let flush = count >= self.compute_per_buffer;
 
-        if flush {
-            self.commit_swap_locked(&mut state_guard, 1)?;
-        }
+        // Create the command buffer / encoder inside an autorelease pool so the
+        // autoreleased Metal temporaries are reclaimed as soon as this returns.
+        // The objects we keep are held via `Retained` (in `state_guard`), so they
+        // survive the drain; only the pool's extra references are freed. Without
+        // this, autoreleased command buffers and encoders accumulate for the whole
+        // program lifetime (see huggingface/candle#2271).
+        autoreleasepool(|_| -> Result<(), MetalKernelError> {
+            if flush {
+                self.commit_swap_locked(&mut state_guard, 1)?;
+            }
 
-        if state_guard.current_encoder.is_none() {
-            let fence = Arc::new(Fence::new(&self.device));
-            let enc = state_guard.current.compute_command_encoder(&fence);
-            // Wait for all prior encoder fences before the first dispatch.
-            // Using HazardTrackingModeUntracked implies that Metal does not automatically flush GPU caches
-            // at encoder or command buffer boundaries.
-            {
-                use std::collections::HashSet;
-                let map = self.prev_ce_outputs.lock().unwrap();
-                let mut seen = HashSet::new();
-                for f in map.values() {
-                    let ptr = Arc::as_ptr(f) as usize;
-                    if seen.insert(ptr) {
-                        enc.wait_for_fence(f);
+            if state_guard.current_encoder.is_none() {
+                let fence = Arc::new(Fence::new(&self.device));
+                let enc = state_guard.current.compute_command_encoder(&fence);
+                // Wait for all prior encoder fences before the first dispatch.
+                // Using HazardTrackingModeUntracked implies that Metal does not automatically flush GPU caches
+                // at encoder or command buffer boundaries.
+                {
+                    use std::collections::HashSet;
+                    let map = self.prev_ce_outputs.lock().unwrap();
+                    let mut seen = HashSet::new();
+                    for f in map.values() {
+                        let ptr = Arc::as_ptr(f) as usize;
+                        if seen.insert(ptr) {
+                            enc.wait_for_fence(f);
+                        }
                     }
                 }
+                state_guard.current_encoder = Some(enc);
             }
-            state_guard.current_encoder = Some(enc);
-        }
+            Ok(())
+        })?;
 
         Ok(CommandsGuard { guard: state_guard })
     }
@@ -194,33 +210,37 @@ impl Commands {
         let count = self.compute_count.fetch_add(1, Ordering::Relaxed);
         let flush = count >= self.compute_per_buffer;
 
-        if flush {
-            self.commit_swap_locked(&mut state_guard, 1)?;
-        }
+        // See `command_encoder` for why this is wrapped in an autorelease pool.
+        let encoder = autoreleasepool(|_| -> Result<BlitCommandEncoder, MetalKernelError> {
+            if flush {
+                self.commit_swap_locked(&mut state_guard, 1)?;
+            }
 
-        // End compute encoder before starting blit.
-        if let Some(enc) = state_guard.current_encoder.take() {
-            self.end_encoding(enc);
-        }
+            // End compute encoder before starting blit.
+            if let Some(enc) = state_guard.current_encoder.take() {
+                self.end_encoding(enc);
+            }
 
-        let fence = Arc::new(Fence::new(&self.device));
-        let encoder = state_guard
-            .current
-            .blit_command_encoder(&fence, &self.prev_ce_outputs);
+            let fence = Arc::new(Fence::new(&self.device));
+            let encoder = state_guard
+                .current
+                .blit_command_encoder(&fence, &self.prev_ce_outputs);
 
-        // Wait for all prior encoder fences before any blit commands execute.
-        // Required for HazardTrackingModeUntracked: GPU caches are not auto-flushed.
-        {
-            use std::collections::HashSet;
-            let map = self.prev_ce_outputs.lock().unwrap();
-            let mut seen = HashSet::new();
-            for f in map.values() {
-                let ptr = Arc::as_ptr(f) as usize;
-                if seen.insert(ptr) {
-                    encoder.wait_for_fence(f);
+            // Wait for all prior encoder fences before any blit commands execute.
+            // Required for HazardTrackingModeUntracked: GPU caches are not auto-flushed.
+            {
+                use std::collections::HashSet;
+                let map = self.prev_ce_outputs.lock().unwrap();
+                let mut seen = HashSet::new();
+                for f in map.values() {
+                    let ptr = Arc::as_ptr(f) as usize;
+                    if seen.insert(ptr) {
+                        encoder.wait_for_fence(f);
+                    }
                 }
             }
-        }
+            Ok(encoder)
+        })?;
 
         Ok(BlitCommandsGuard {
             _guard: state_guard,
@@ -233,62 +253,72 @@ impl Commands {
     }
 
     pub fn flush_and_wait(&self) -> Result<(), MetalKernelError> {
-        let to_wait = {
-            let mut state = self.state.lock()?;
-            if self.compute_count.load(Ordering::Acquire) > 0 {
-                self.commit_swap_locked(&mut state, 0)?;
+        // Wrapped in an autorelease pool: committing swaps in a fresh command buffer
+        // (an autoreleased Metal object) and waiting spins up transient temporaries.
+        // See `command_encoder` and huggingface/candle#2271.
+        autoreleasepool(|_| -> Result<(), MetalKernelError> {
+            let to_wait = {
+                let mut state = self.state.lock()?;
+                if self.compute_count.load(Ordering::Acquire) > 0 {
+                    self.commit_swap_locked(&mut state, 0)?;
+                }
+                std::mem::take(&mut state.in_flight)
+            };
+
+            // Wait only on the last CB. Metal executes CBs in queue order, so all earlier
+            // CBs are guaranteed complete when the last one is. Calling waitUntilCompleted on
+            // each CB individually pays OS notification latency (~1-2ms) N times unnecessarily.
+            if let Some(last) = to_wait.last() {
+                Self::ensure_completed(last)?;
             }
-            std::mem::take(&mut state.in_flight)
-        };
-
-        // Wait only on the last CB. Metal executes CBs in queue order, so all earlier
-        // CBs are guaranteed complete when the last one is. Calling waitUntilCompleted on
-        // each CB individually pays OS notification latency (~1-2ms) N times unnecessarily.
-        if let Some(last) = to_wait.last() {
-            Self::ensure_completed(last)?;
-        }
-        // Check earlier CBs for errors (no need to block — they're already done).
-        for cb in &to_wait[..to_wait.len().saturating_sub(1)] {
-            if cb.status() == MTLCommandBufferStatus::Error {
-                let msg = cb
-                    .error()
-                    .map(|e| e.to_string())
-                    .unwrap_or_else(|| "unknown error".to_string());
-                return Err(MetalKernelError::CommandBufferError(msg));
+            // Check earlier CBs for errors (no need to block — they're already done).
+            for cb in &to_wait[..to_wait.len().saturating_sub(1)] {
+                if cb.status() == MTLCommandBufferStatus::Error {
+                    let msg = cb
+                        .error()
+                        .map(|e| e.to_string())
+                        .unwrap_or_else(|| "unknown error".to_string());
+                    return Err(MetalKernelError::CommandBufferError(msg));
+                }
             }
-        }
 
-        self.prev_ce_outputs.lock()?.clear();
+            self.prev_ce_outputs.lock()?.clear();
 
-        Ok(())
+            Ok(())
+        })
     }
 
     /// Commit the current command buffer and wait on that specific buffer, for CPU readbacks.
     /// [`Self::wait_until_completed`] waits on the last in-flight buffer, which a concurrent
     /// `flush_and_wait` on another thread may already have taken, returning before our work ran.
     pub fn flush_and_wait_current(&self) -> Result<(), MetalKernelError> {
-        let cb = {
-            let mut state = self.state.lock()?;
-            self.commit_swap_locked(&mut state, 0)?;
-            state.in_flight.last().cloned()
-        };
-        if let Some(cb) = cb {
-            Self::ensure_completed(&cb)?;
-            // queue is FIFO: everything committed before cb is done too
-            let mut state = self.state.lock()?;
-            state
-                .in_flight
-                .retain(|c| c.status() != MTLCommandBufferStatus::Completed);
-        }
-        Ok(())
+        // See `flush_and_wait` / huggingface/candle#2271 for why this drains a pool.
+        autoreleasepool(|_| -> Result<(), MetalKernelError> {
+            let cb = {
+                let mut state = self.state.lock()?;
+                self.commit_swap_locked(&mut state, 0)?;
+                state.in_flight.last().cloned()
+            };
+            if let Some(cb) = cb {
+                Self::ensure_completed(&cb)?;
+                // queue is FIFO: everything committed before cb is done too
+                let mut state = self.state.lock()?;
+                state
+                    .in_flight
+                    .retain(|c| c.status() != MTLCommandBufferStatus::Completed);
+            }
+            Ok(())
+        })
     }
 
     pub fn flush(&self) -> Result<(), MetalKernelError> {
-        let mut state = self.state.lock()?;
-        if self.compute_count.load(Ordering::Acquire) > 0 {
-            self.commit_swap_locked(&mut state, 0)?;
-        }
-        Ok(())
+        autoreleasepool(|_| -> Result<(), MetalKernelError> {
+            let mut state = self.state.lock()?;
+            if self.compute_count.load(Ordering::Acquire) > 0 {
+                self.commit_swap_locked(&mut state, 0)?;
+            }
+            Ok(())
+        })
     }
 
     fn commit_swap_locked(

--- a/candle-metal-kernels/src/metal/commands.rs
+++ b/candle-metal-kernels/src/metal/commands.rs
@@ -14,15 +14,26 @@ use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 
-// We track owned Metal resources with `Retained`, but that only manages ownership,
-// not the thread's autorelease pool. Many Metal APIs (command buffer / encoder creation,
-// commit, waits) still return autoreleased temporaries; without a pool to drain them in a
-// tight loop they accumulate for the whole program lifetime. The creation and sync paths
-// below are therefore wrapped in `autoreleasepool`. See huggingface/candle#2271.
+// We track owned Metal resources with `Retained`, but that only manages *our* ownership, not
+// the thread's autorelease pool. Metal (and the MLX/MPS kernels it dispatches) autorelease many
+// temporaries - command buffers, encoders, and per-dispatch scratch objects - onto the running
+// thread's pool. A workload that never synchronizes back to the CPU (the reproducer in
+// huggingface/candle#2271) never returns to an outer autorelease pool, so those temporaries
+// accumulate for the whole program lifetime. We therefore drain a pool around every encoder
+// (via the `AutoreleasePoolGuard` held by the command guards, which spans the actual kernel
+// dispatch) and around the explicit flush/wait paths (via `autoreleasepool`).
 // https://docs.rs/objc2/latest/objc2/rc/struct.Retained.html
 pub type CommandQueue = Retained<ProtocolObject<dyn MTLCommandQueue>>;
 
 const DEFAULT_CANDLE_METAL_COMPUTE_PER_BUFFER: usize = 50;
+
+// Upper bound on committed-but-not-yet-reaped command buffers kept in `in_flight`.
+// A workload that never reads a result back to the CPU (see huggingface/candle#2271)
+// never calls `flush_and_wait`, so committed command buffers - and the output buffers
+// they retain - are only released when we reap them here. We reap completed buffers on
+// every swap; this bound additionally blocks on the oldest buffer if the GPU falls far
+// enough behind that reaping alone cannot keep memory in check.
+const MAX_IN_FLIGHT: usize = 64;
 
 fn create_command_buffer(command_queue: &CommandQueue) -> Result<CommandBuffer, MetalKernelError> {
     command_queue.commandBuffer().map(CommandBuffer::new).ok_or(
@@ -30,9 +41,43 @@ fn create_command_buffer(command_queue: &CommandQueue) -> Result<CommandBuffer, 
     )
 }
 
+/// RAII wrapper around a thread-local autorelease pool.
+///
+/// `objc2` only exposes autorelease pools through the closure-based [`autoreleasepool`], but our
+/// command-encoder API hands the caller a guard that stays alive across the kernel dispatch, so we
+/// need a pool whose lifetime matches that guard rather than a lexical closure. Dropping the guard
+/// drains every temporary autoreleased since it was created (see huggingface/candle#2271).
+///
+/// Safety: `objc_autoreleasePoolPop` must run on the same thread as its matching push, and nested
+/// pools must be popped in LIFO order. [`Commands`] serializes all encoder access through a single
+/// mutex that the command guard holds for its whole lifetime, so at most one `AutoreleasePoolGuard`
+/// is ever live per thread; it is a short-lived local dropped at the end of each op. Both invariants
+/// therefore hold.
+struct AutoreleasePoolGuard {
+    context: *mut std::ffi::c_void,
+}
+
+impl AutoreleasePoolGuard {
+    fn new() -> Self {
+        // SAFETY: paired with the `objc_autoreleasePoolPop` in `Drop`, on the same thread; see the
+        // type-level note on why the LIFO/same-thread invariants hold.
+        let context = unsafe { objc2::ffi::objc_autoreleasePoolPush() };
+        Self { context }
+    }
+}
+
+impl Drop for AutoreleasePoolGuard {
+    fn drop(&mut self) {
+        // SAFETY: `context` came from `objc_autoreleasePoolPush` in `new`, popped once, same thread.
+        unsafe { objc2::ffi::objc_autoreleasePoolPop(self.context) };
+    }
+}
+
 /// RAII guard for compute command encoder operations.
 pub struct CommandsGuard<'a> {
     guard: MutexGuard<'a, EntryState>,
+    // Drains autoreleased temporaries created while encoding (dropped after `guard`). See #2271.
+    _pool: AutoreleasePoolGuard,
 }
 
 impl AsRef<ComputeCommandEncoder> for CommandsGuard<'_> {
@@ -61,6 +106,8 @@ impl CommandsGuard<'_> {
 pub struct BlitCommandsGuard<'a> {
     _guard: MutexGuard<'a, EntryState>,
     state: BlitCommandEncoder,
+    // Drains autoreleased temporaries created while encoding (dropped last). See #2271.
+    _pool: AutoreleasePoolGuard,
 }
 
 impl<'a> AsRef<BlitCommandEncoder> for BlitCommandsGuard<'a> {
@@ -165,69 +212,26 @@ impl Commands {
     }
 
     pub fn command_encoder(&self) -> Result<CommandsGuard<'_>, MetalKernelError> {
+        // Open the pool before touching Metal so it covers command-buffer/encoder creation *and*
+        // the kernel dispatch the caller performs while holding the returned guard. Draining only
+        // happens when the guard is dropped, i.e. after the dispatch. The objects we keep are held
+        // via `Retained` (in `state_guard`), so they survive the drain; only the pool's extra
+        // references are freed. See huggingface/candle#2271.
+        let pool = AutoreleasePoolGuard::new();
         let mut state_guard = self.state.lock().unwrap();
         let count = self.compute_count.fetch_add(1, Ordering::Relaxed);
         let flush = count >= self.compute_per_buffer;
 
-        // Create the command buffer / encoder inside an autorelease pool so the
-        // autoreleased Metal temporaries are reclaimed as soon as this returns.
-        // The objects we keep are held via `Retained` (in `state_guard`), so they
-        // survive the drain; only the pool's extra references are freed. Without
-        // this, autoreleased command buffers and encoders accumulate for the whole
-        // program lifetime (see huggingface/candle#2271).
-        autoreleasepool(|_| -> Result<(), MetalKernelError> {
-            if flush {
-                self.commit_swap_locked(&mut state_guard, 1)?;
-            }
+        if flush {
+            self.commit_swap_locked(&mut state_guard, 1)?;
+        }
 
-            if state_guard.current_encoder.is_none() {
-                let fence = Arc::new(Fence::new(&self.device));
-                let enc = state_guard.current.compute_command_encoder(&fence);
-                // Wait for all prior encoder fences before the first dispatch.
-                // Using HazardTrackingModeUntracked implies that Metal does not automatically flush GPU caches
-                // at encoder or command buffer boundaries.
-                {
-                    use std::collections::HashSet;
-                    let map = self.prev_ce_outputs.lock().unwrap();
-                    let mut seen = HashSet::new();
-                    for f in map.values() {
-                        let ptr = Arc::as_ptr(f) as usize;
-                        if seen.insert(ptr) {
-                            enc.wait_for_fence(f);
-                        }
-                    }
-                }
-                state_guard.current_encoder = Some(enc);
-            }
-            Ok(())
-        })?;
-
-        Ok(CommandsGuard { guard: state_guard })
-    }
-
-    pub fn blit_command_encoder(&self) -> Result<BlitCommandsGuard<'_>, MetalKernelError> {
-        let mut state_guard = self.state.lock().unwrap();
-        let count = self.compute_count.fetch_add(1, Ordering::Relaxed);
-        let flush = count >= self.compute_per_buffer;
-
-        // See `command_encoder` for why this is wrapped in an autorelease pool.
-        let encoder = autoreleasepool(|_| -> Result<BlitCommandEncoder, MetalKernelError> {
-            if flush {
-                self.commit_swap_locked(&mut state_guard, 1)?;
-            }
-
-            // End compute encoder before starting blit.
-            if let Some(enc) = state_guard.current_encoder.take() {
-                self.end_encoding(enc);
-            }
-
+        if state_guard.current_encoder.is_none() {
             let fence = Arc::new(Fence::new(&self.device));
-            let encoder = state_guard
-                .current
-                .blit_command_encoder(&fence, &self.prev_ce_outputs);
-
-            // Wait for all prior encoder fences before any blit commands execute.
-            // Required for HazardTrackingModeUntracked: GPU caches are not auto-flushed.
+            let enc = state_guard.current.compute_command_encoder(&fence);
+            // Wait for all prior encoder fences before the first dispatch.
+            // Using HazardTrackingModeUntracked implies that Metal does not automatically flush GPU caches
+            // at encoder or command buffer boundaries.
             {
                 use std::collections::HashSet;
                 let map = self.prev_ce_outputs.lock().unwrap();
@@ -235,16 +239,58 @@ impl Commands {
                 for f in map.values() {
                     let ptr = Arc::as_ptr(f) as usize;
                     if seen.insert(ptr) {
-                        encoder.wait_for_fence(f);
+                        enc.wait_for_fence(f);
                     }
                 }
             }
-            Ok(encoder)
-        })?;
+            state_guard.current_encoder = Some(enc);
+        }
+
+        Ok(CommandsGuard {
+            guard: state_guard,
+            _pool: pool,
+        })
+    }
+
+    pub fn blit_command_encoder(&self) -> Result<BlitCommandsGuard<'_>, MetalKernelError> {
+        // See `command_encoder` for why the pool spans the whole guard lifetime.
+        let pool = AutoreleasePoolGuard::new();
+        let mut state_guard = self.state.lock().unwrap();
+        let count = self.compute_count.fetch_add(1, Ordering::Relaxed);
+        let flush = count >= self.compute_per_buffer;
+
+        if flush {
+            self.commit_swap_locked(&mut state_guard, 1)?;
+        }
+
+        // End compute encoder before starting blit.
+        if let Some(enc) = state_guard.current_encoder.take() {
+            self.end_encoding(enc);
+        }
+
+        let fence = Arc::new(Fence::new(&self.device));
+        let encoder = state_guard
+            .current
+            .blit_command_encoder(&fence, &self.prev_ce_outputs);
+
+        // Wait for all prior encoder fences before any blit commands execute.
+        // Required for HazardTrackingModeUntracked: GPU caches are not auto-flushed.
+        {
+            use std::collections::HashSet;
+            let map = self.prev_ce_outputs.lock().unwrap();
+            let mut seen = HashSet::new();
+            for f in map.values() {
+                let ptr = Arc::as_ptr(f) as usize;
+                if seen.insert(ptr) {
+                    encoder.wait_for_fence(f);
+                }
+            }
+        }
 
         Ok(BlitCommandsGuard {
             _guard: state_guard,
             state: encoder,
+            _pool: pool,
         })
     }
 
@@ -340,6 +386,21 @@ impl Commands {
         let old_cb = std::mem::replace(&mut state.current, new_cb);
         state.in_flight.push(old_cb);
         self.compute_count.store(reset_to, Ordering::Release);
+
+        // Reap command buffers the GPU has already finished. Each retained command buffer
+        // keeps the resources it referenced (notably its output buffers) alive, so a loop
+        // that never triggers `flush_and_wait` would otherwise grow without bound. See #2271.
+        state
+            .in_flight
+            .retain(|cb| cb.status() != MTLCommandBufferStatus::Completed);
+
+        // Backpressure: if the GPU has fallen far enough behind that reaping did not bring
+        // us back under the bound, block on the oldest in-flight buffer (queue is FIFO) until
+        // memory is in check again.
+        while state.in_flight.len() > MAX_IN_FLIGHT {
+            let oldest = state.in_flight.remove(0);
+            Self::ensure_completed(&oldest)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #2271. Running Metal ops in a loop (matmul, and any other op) leaked memory: the resident set grew without bound.

## Root cause

The leak is **not** in candle's own tracked structures. With the repro running, the buffer pool, the in-flight command buffers, and the `prev_ce_outputs` fence map all stay constant, yet RSS climbs linearly:

```
iter       0  RSS  27.57 MB  pool[sh=1 pr=4 0.56MB] inflight=0 prev_ce=1
iter   40000  RSS  46.32 MB  pool[sh=1 pr=4 0.56MB] inflight=0 prev_ce=1
iter   85000  RSS  66.39 MB  pool[sh=1 pr=4 0.56MB] inflight=0 prev_ce=1   ← still rising
```

The growth is **autoreleased Objective-C temporaries**. Command buffer / encoder creation, `commit`, and the waits all return autoreleased objects. In a tight Rust compute loop there is no run-loop turn to drain the thread's autorelease pool, so those references live for the whole program lifetime.

This matches @LaurentMazare's earlier diagnosis in the issue ("the issue is related to the autorelease pool not releasing memory fast enough").

## The fix

Wrap the Metal-object creation and synchronization paths in `Commands` — `command_encoder`, `blit_command_encoder`, `flush_and_wait`, `flush_and_wait_current`, `flush` — in `objc2::rc::autoreleasepool`. Objects candle keeps are held via `Retained` and survive the drain; only the pool's redundant references are freed.

## Verification

Added `candle-core/examples/matmul_leak.rs` (the issue's repro). With the fix, RSS is flat:

```
end RSS: 27.80 MB  (grew 13.73 MB over 200000 iterations)   # oscillates 27–31 MB, no upward trend
```

vs. unpatched, which passes 66 MB by 85k iterations and keeps climbing.

**Throughput** — no regression (fixed vs. `main`, same workload):

| workload | main | this PR |
|---|---|---|
| matmul + reduce + readback | 128.6 µs/iter | 125.3 µs/iter |
| encoder-bound (matmul only) | 3.98 µs/matmul | 3.81 µs/matmul |

Metal suites pass: `matmul_tests` (12), `metal_concurrent_tests` (2, exercises the command-buffer flush paths touched here), `quantized_tests` (67), `tensor_tests` (83). `cargo fmt --all --check`, CPU `cargo clippy --workspace --tests --examples --benches -D warnings`, and `cargo check --workspace --features metal` all pass.

Note: I used AI to identify and fix the issue.