### PR TITLE
Fix zero-sized matmul validation and gradients

### DIFF
--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -1513,9 +1513,6 @@ impl Tensor {
         let n = b_dims[dim - 1];
 
         let c_shape = Shape::from(&a_dims[..dim - 2]).extend(&[m, n]);
-        if c_shape.elem_count() == 0 || k == 0 {
-            return Tensor::zeros(c_shape, self.dtype(), self.device());
-        }
         let batching: usize = a_dims[..dim - 2].iter().product();
         let batching_b: usize = b_dims[..dim - 2].iter().product();
         if k != k2 || batching != batching_b {
@@ -1525,6 +1522,18 @@ impl Tensor {
                 op: "matmul",
             }
             .bt())?
+        }
+        if c_shape.elem_count() == 0 || k == 0 {
+            {
+                let lhs_storage = self.storage();
+                let rhs_storage = rhs.storage();
+                lhs_storage.same_device(&rhs_storage, "matmul")?;
+                lhs_storage.same_dtype(&rhs_storage, "matmul")?;
+            }
+
+            let storage = self.device().zeros(&c_shape, self.dtype())?;
+            let op = BackpropOp::new2(self, rhs, Op::Matmul);
+            return Ok(from_storage(storage, c_shape, op, false));
         }
 
         let storage = self.storage().matmul(

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::approx_constant)]
 use anyhow::{Context, Result};
-use candle_core::{test_device, test_utils, DType, Device, Shape, Tensor, Var};
+use candle_core::{
+    backprop::GradStore, test_device, test_utils, DType, Device, Shape, Tensor, Var,
+};
 
 fn simple_grad(device: &Device) -> Result<()> {
     let x = Var::new(&[3f32, 1., 4.], device)?;
@@ -61,6 +63,49 @@ fn matmul_grad(device: &Device) -> Result<()> {
             [[15., 15.], [17., 17.], [19., 19.]]
         ]
     );
+    Ok(())
+}
+
+fn assert_zero_grad(grads: &GradStore, var: &Var, shape: &[usize]) -> Result<()> {
+    let grad = grads.get(var).context("no gradient for variable")?;
+    assert_eq!(grad.dims(), shape);
+    assert_eq!(
+        grad.flatten_all()?.to_vec1::<f32>()?,
+        vec![0.; grad.elem_count()]
+    );
+    Ok(())
+}
+
+fn assert_zero_matmul_grads(
+    device: &Device,
+    lhs_shape: &[usize],
+    rhs_shape: &[usize],
+    output_shape: &[usize],
+) -> Result<()> {
+    let lhs = Var::zeros(lhs_shape, DType::F32, device)?;
+    let rhs = Var::zeros(rhs_shape, DType::F32, device)?;
+    let output = lhs.matmul(&rhs)?;
+    assert_eq!(output.dims(), output_shape);
+    assert_eq!(
+        output.flatten_all()?.to_vec1::<f32>()?,
+        vec![0.; output.elem_count()]
+    );
+    let grads = output.sum_all()?.backward()?;
+    assert_zero_grad(&grads, &lhs, lhs_shape)?;
+    assert_zero_grad(&grads, &rhs, rhs_shape)
+}
+
+fn zero_matmul_grad(device: &Device) -> Result<()> {
+    let cases: &[(&[usize], &[usize], &[usize])] = &[
+        (&[2, 0], &[0, 3], &[2, 3]),
+        (&[0, 2], &[2, 3], &[0, 3]),
+        (&[2, 3], &[3, 0], &[2, 0]),
+        (&[0, 2, 3], &[0, 3, 4], &[0, 2, 4]),
+        (&[2, 3, 0], &[2, 0, 4], &[2, 3, 4]),
+    ];
+    for &(lhs_shape, rhs_shape, output_shape) in cases {
+        assert_zero_matmul_grads(device, lhs_shape, rhs_shape, output_shape)?;
+    }
     Ok(())
 }
 
@@ -547,6 +592,12 @@ test_device!(
     matmul_grad_cpu,
     matmul_grad_gpu,
     matmul_grad_metal
+);
+test_device!(
+    zero_matmul_grad,
+    zero_matmul_grad_cpu,
+    zero_matmul_grad_gpu,
+    zero_matmul_grad_metal
 );
 test_device!(
     grad_descent,

--- a/candle-core/tests/matmul_tests.rs
+++ b/candle-core/tests/matmul_tests.rs
@@ -82,6 +82,73 @@ fn broadcast_matmul(device: &Device) -> Result<()> {
     Ok(())
 }
 
+fn zero_matmul(device: &Device) -> Result<()> {
+    let lhs = Tensor::zeros((2, 0), DType::F32, device)?;
+    let rhs = Tensor::zeros((0, 3), DType::F32, device)?;
+    let output = lhs.matmul(&rhs)?;
+    assert_eq!(output.dims(), &[2, 3]);
+    assert_eq!(output.to_vec2::<f32>()?, &[[0., 0., 0.], [0., 0., 0.]]);
+
+    let lhs = Tensor::zeros((2, 3, 4), DType::F32, device)?
+        .transpose(1, 2)?
+        .narrow(1, 0, 0)?;
+    let rhs = Tensor::zeros((2, 4, 3), DType::F32, device)?
+        .transpose(1, 2)?
+        .narrow(2, 0, 0)?;
+    assert!(!lhs.is_contiguous());
+    assert!(!rhs.is_contiguous());
+    assert_eq!(lhs.dims(), &[2, 0, 3]);
+    assert_eq!(rhs.dims(), &[2, 3, 0]);
+    assert_eq!(lhs.matmul(&rhs)?.dims(), &[2, 0, 0]);
+    Ok(())
+}
+
+fn assert_matmul_error(
+    device: &Device,
+    lhs: (&[usize], DType),
+    rhs: (&[usize], DType),
+    expected: &str,
+) -> Result<()> {
+    let lhs = Tensor::zeros(lhs.0, lhs.1, device)?;
+    let rhs = Tensor::zeros(rhs.0, rhs.1, device)?;
+    let err = lhs.matmul(&rhs).unwrap_err();
+    assert!(
+        err.to_string().starts_with(expected),
+        "unexpected error: {err}"
+    );
+    Ok(())
+}
+
+fn zero_matmul_validation(device: &Device) -> Result<()> {
+    use DType::{F16, F32};
+
+    let shape_error = "shape mismatch in matmul";
+    assert_matmul_error(device, (&[0, 2], F32), (&[3, 4], F16), shape_error)?;
+    assert_matmul_error(device, (&[2, 3], F32), (&[4, 0], F32), shape_error)?;
+    assert_matmul_error(device, (&[0, 2, 3], F32), (&[1, 3, 4], F32), shape_error)?;
+    assert_matmul_error(
+        device,
+        (&[0, 2], F32),
+        (&[2, 3], F16),
+        "dtype mismatch in matmul",
+    )?;
+    Ok(())
+}
+
+fn zero_matmul_device_validation(device: &Device) -> Result<()> {
+    if device.is_cpu() {
+        return Ok(());
+    }
+    let lhs = Tensor::zeros((0, 2), DType::F32, &Device::Cpu)?;
+    let rhs = Tensor::zeros((2, 3), DType::F16, device)?;
+    let err = lhs.matmul(&rhs).unwrap_err();
+    assert!(
+        err.to_string().starts_with("device mismatch in matmul"),
+        "unexpected error: {err}"
+    );
+    Ok(())
+}
+
 #[test]
 fn tensor_dot() -> Result<()> {
     let lhs = Tensor::new(&[1., 2., 3.], &Device::Cpu)?;
@@ -141,6 +208,24 @@ test_device!(
     broadcast_matmul_cpu,
     broadcast_matmul_gpu,
     broadcast_matmul_metal
+);
+test_device!(
+    zero_matmul,
+    zero_matmul_cpu,
+    zero_matmul_gpu,
+    zero_matmul_metal
+);
+test_device!(
+    zero_matmul_validation,
+    zero_matmul_validation_cpu,
+    zero_matmul_validation_gpu,
+    zero_matmul_validation_metal
+);
+test_device!(
+    zero_matmul_device_validation,
+    zero_matmul_device_validation_cpu,
+    zero_matmul_device_validation_gpu,
+    zero_matmul_device_validation_metal
 );
 test_device!(squeeze_mm, squeeze_mm_cpu, squeeze_mm_gpu, squeeze_mm_metal);
 test_device!(mm_layout, mm_layout_cpu, mm_layout_gpu, mm_layout_metal);


### PR DESCRIPTION
## Summary

Zero-sized `Tensor::matmul` returns a detached zero tensor before contracted/batch shape validation and before storage validates device and dtype. This can accept invalid operands and drops both autograd edges.

Follow-up to #2064.

## Fix

Validate shapes and storage compatibility first. For valid zero work, allocate zero storage without dispatching GEMM and construct the result with the normal `Op::Matmul`, preserving both dependencies.

## Test plan

Added device-dispatched regressions covering:

- zero `M`, `N`, `K`, batch, and batched `K=0`;
- non-contiguous zero-extent operands;
- hidden shape mismatches and device/dtype error ordering;
- present, correctly shaped zero gradients for both operands.

Ran:

- `cargo test -p candle-core`
- `cargo test -p candle-core --features accelerate --test matmul_tests --test grad_tests`
- `cargo test -p candle-core --features metal --test matmul_tests --test grad_tests`
- `cargo fmt --all -- --check`
- `cargo clippy -p candle-core --tests -- -D warnings -A clippy::useless-borrows-in-formatting`