### PR TITLE
Fix empty binary validation and gradients

### DIFF
--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -212,6 +212,12 @@ impl Tensor {
                     }
                     Op::Binary(lhs, rhs, BinaryOp::Minimum)
                     | Op::Binary(lhs, rhs, BinaryOp::Maximum) => {
+                        // There are no ties to split on an empty domain.
+                        if node.elem_count() == 0 {
+                            grads.or_insert(lhs)?;
+                            grads.or_insert(rhs)?;
+                            continue;
+                        }
                         let mask_lhs = node.eq(lhs)?.to_dtype(grad.dtype())?;
                         let mask_rhs = node.eq(rhs)?.to_dtype(grad.dtype())?;
 
@@ -477,6 +483,12 @@ impl Tensor {
                         }
                     }
                     Op::Broadcast(arg) => {
+                        // Summing an empty broadcast gradient is always zero, even when the
+                        // source tensor is non-empty.
+                        if node.elem_count() == 0 {
+                            grads.or_insert(arg)?;
+                            continue;
+                        }
                         let arg_dims = arg.dims();
                         let node_dims = node.dims();
                         // The number of dims that have been inserted on the left.

--- a/candle-core/src/shape.rs
+++ b/candle-core/src/shape.rs
@@ -9,7 +9,7 @@ pub const SCALAR: Shape = Shape(vec![]);
 
 impl std::fmt::Debug for Shape {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", &self.dims())
+        write!(f, "{:?}", self.dims())
     }
 }
 

--- a/candle-core/src/shape.rs
+++ b/candle-core/src/shape.rs
@@ -9,7 +9,7 @@ pub const SCALAR: Shape = Shape(vec![]);
 
 impl std::fmt::Debug for Shape {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.dims())
+        write!(f, "{:?}", &self.dims())
     }
 }
 

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -96,7 +96,7 @@ macro_rules! binary_op {
         pub fn $fn_name(&self, rhs: &Self) -> Result<Self> {
             let shape = self.same_shape_binary_op(rhs, stringify!($fn_name))?;
             if shape.elem_count() == 0 {
-                return Ok(self.clone());
+                return self.empty_binary_op::<crate::op::$op_name>(rhs, shape, BinaryOp::$op_name);
             }
             let storage = self.storage().binary_impl::<crate::op::$op_name>(
                 &*rhs.storage(),
@@ -120,8 +120,12 @@ macro_rules! binary_op_scalar {
                     .broadcast_as(self.shape())?,
             };
             let shape = self.same_shape_binary_op(&rhs, stringify!($fn_name))?;
-            if self.elem_count() == 0 {
-                return Ok(self.clone());
+            if shape.elem_count() == 0 {
+                return self.empty_binary_op::<crate::op::$op_name>(
+                    &rhs,
+                    shape,
+                    BinaryOp::$op_name,
+                );
             }
             let storage = self.storage().binary_impl::<crate::op::$op_name>(
                 &*rhs.storage(),
@@ -585,6 +589,24 @@ impl Tensor {
         } else {
             Ok(lhs)
         }
+    }
+
+    fn empty_binary_op<B: crate::op::BinaryOpT>(
+        &self,
+        rhs: &Self,
+        shape: &Shape,
+        binary_op: BinaryOp,
+    ) -> Result<Self> {
+        {
+            let lhs_storage = self.storage();
+            let rhs_storage = rhs.storage();
+            lhs_storage.same_device(&rhs_storage, B::NAME)?;
+            lhs_storage.same_dtype(&rhs_storage, B::NAME)?;
+        }
+
+        let storage = self.device().zeros(shape, self.dtype())?;
+        let op = BackpropOp::new2(self, rhs, |lhs, rhs| Op::Binary(lhs, rhs, binary_op));
+        Ok(from_storage(storage, shape.clone(), op, false))
     }
 
     /// Returns true if the computation graph should track this op, that is if it is

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::approx_constant)]
 use anyhow::{Context, Result};
-use candle_core::{test_device, test_utils, DType, Device, Shape, Tensor, Var};
+use candle_core::{op::BinaryOp, test_device, test_utils, DType, Device, Shape, Tensor, Var};
 
 fn simple_grad(device: &Device) -> Result<()> {
     let x = Var::new(&[3f32, 1., 4.], device)?;
@@ -61,6 +61,154 @@ fn matmul_grad(device: &Device) -> Result<()> {
             [[15., 15.], [17., 17.], [19., 19.]]
         ]
     );
+    Ok(())
+}
+
+const BINARY_OPS: [BinaryOp; 6] = [
+    BinaryOp::Add,
+    BinaryOp::Sub,
+    BinaryOp::Mul,
+    BinaryOp::Div,
+    BinaryOp::Minimum,
+    BinaryOp::Maximum,
+];
+
+fn binary_op_name(op: BinaryOp) -> &'static str {
+    match op {
+        BinaryOp::Add => "add",
+        BinaryOp::Sub => "sub",
+        BinaryOp::Mul => "mul",
+        BinaryOp::Div => "div",
+        BinaryOp::Minimum => "minimum",
+        BinaryOp::Maximum => "maximum",
+    }
+}
+
+fn apply_binary_op(op: BinaryOp, lhs: &Tensor, rhs: &Tensor) -> candle_core::Result<Tensor> {
+    match op {
+        BinaryOp::Add => lhs.add(rhs),
+        BinaryOp::Sub => lhs.sub(rhs),
+        BinaryOp::Mul => lhs.mul(rhs),
+        BinaryOp::Div => lhs.div(rhs),
+        BinaryOp::Minimum => lhs.minimum(rhs),
+        BinaryOp::Maximum => lhs.maximum(rhs),
+    }
+}
+
+fn apply_broadcast_binary_op(
+    op: BinaryOp,
+    lhs: &Tensor,
+    rhs: &Tensor,
+) -> candle_core::Result<Tensor> {
+    match op {
+        BinaryOp::Add => lhs.broadcast_add(rhs),
+        BinaryOp::Sub => lhs.broadcast_sub(rhs),
+        BinaryOp::Mul => lhs.broadcast_mul(rhs),
+        BinaryOp::Div => lhs.broadcast_div(rhs),
+        BinaryOp::Minimum => lhs.broadcast_minimum(rhs),
+        BinaryOp::Maximum => lhs.broadcast_maximum(rhs),
+    }
+}
+
+fn assert_zero_grad(grads: &candle_core::backprop::GradStore, var: &Var) -> Result<()> {
+    let grad = grads.get(var).context("no gradient for variable")?;
+    assert_eq!(grad.dims(), var.dims());
+    assert_eq!(
+        grad.flatten_all()?.to_vec1::<f32>()?,
+        vec![0.; grad.elem_count()]
+    );
+    Ok(())
+}
+
+fn empty_binary_grad(device: &Device) -> Result<()> {
+    for op in BINARY_OPS {
+        let lhs = Var::zeros((0, 3), DType::F32, device)?;
+        let rhs = Var::zeros((0, 3), DType::F32, device)?;
+        let output = apply_binary_op(op, &lhs, &rhs)?;
+        assert_ne!(output.id(), lhs.id(), "{} returned lhs", binary_op_name(op));
+        assert_eq!(output.dims(), &[0, 3]);
+        assert!(output.is_contiguous());
+        assert_eq!(output.flatten_all()?.to_vec1::<f32>()?, Vec::<f32>::new());
+
+        let grads = output.sum_all()?.backward()?;
+        assert_zero_grad(&grads, &lhs)?;
+        assert_zero_grad(&grads, &rhs)?;
+    }
+
+    for op in [BinaryOp::Add, BinaryOp::Minimum] {
+        let lhs = Tensor::zeros((0, 3), DType::F32, device)?;
+        let rhs = Var::zeros((0, 3), DType::F32, device)?;
+        let output = apply_binary_op(op, &lhs, &rhs)?;
+        let grads = output.sum_all()?.backward()?;
+        assert_zero_grad(&grads, &rhs)?;
+    }
+
+    let lhs = Var::zeros((0, 3), DType::F32, device)?;
+    for output in [lhs.minimum(1f64)?, lhs.maximum(1f64)?] {
+        assert_ne!(output.id(), lhs.id());
+        let grads = output.sum_all()?.backward()?;
+        assert_zero_grad(&grads, &lhs)?;
+    }
+
+    for op in [BinaryOp::Add, BinaryOp::Minimum] {
+        let lhs = Var::zeros((0, 2, 3), DType::F32, device)?;
+        let rhs = Var::zeros((0, 2, 3), DType::F32, device)?;
+        let lhs_view = lhs.transpose(1, 2)?;
+        let rhs_view = rhs.transpose(1, 2)?;
+        assert!(!lhs_view.is_contiguous());
+        assert!(!rhs_view.is_contiguous());
+        let output = apply_binary_op(op, &lhs_view, &rhs_view)?;
+        assert!(output.is_contiguous());
+        let grads = output.sum_all()?.backward()?;
+        assert_zero_grad(&grads, &lhs)?;
+        assert_zero_grad(&grads, &rhs)?;
+    }
+    Ok(())
+}
+
+fn empty_broadcast_binary_grad(device: &Device) -> Result<()> {
+    for op in BINARY_OPS {
+        let lhs = Var::zeros((0, 1), DType::F32, device)?;
+        let rhs = Var::zeros((1, 3), DType::F32, device)?;
+        let output = apply_broadcast_binary_op(op, &lhs, &rhs)?;
+        assert_eq!(output.dims(), &[0, 3]);
+        let grads = output.sum_all()?.backward()?;
+        assert_zero_grad(&grads, &lhs)?;
+        assert_zero_grad(&grads, &rhs)?;
+    }
+    Ok(())
+}
+
+fn empty_binary_validation(device: &Device) -> Result<()> {
+    for op in BINARY_OPS {
+        let name = binary_op_name(op);
+        let lhs = Tensor::zeros((0, 3), DType::F32, device)?;
+        let rhs = Tensor::zeros((0, 4), DType::F64, device)?;
+        let err = apply_binary_op(op, &lhs, &rhs).unwrap_err();
+        assert!(
+            err.to_string()
+                .starts_with(&format!("shape mismatch in {name}")),
+            "unexpected error: {err}"
+        );
+
+        let rhs = Tensor::zeros((0, 3), DType::F64, device)?;
+        let err = apply_binary_op(op, &lhs, &rhs).unwrap_err();
+        assert!(
+            err.to_string()
+                .starts_with(&format!("dtype mismatch in {name}")),
+            "unexpected error: {err}"
+        );
+
+        if !device.is_cpu() {
+            let lhs = Tensor::zeros((0, 3), DType::F32, &Device::Cpu)?;
+            let err = apply_binary_op(op, &lhs, &rhs).unwrap_err();
+            assert!(
+                err.to_string()
+                    .starts_with(&format!("device mismatch in {name}")),
+                "unexpected error: {err}"
+            );
+        }
+    }
     Ok(())
 }
 
@@ -547,6 +695,24 @@ test_device!(
     matmul_grad_cpu,
     matmul_grad_gpu,
     matmul_grad_metal
+);
+test_device!(
+    empty_binary_grad,
+    empty_binary_grad_cpu,
+    empty_binary_grad_gpu,
+    empty_binary_grad_metal
+);
+test_device!(
+    empty_broadcast_binary_grad,
+    empty_broadcast_binary_grad_cpu,
+    empty_broadcast_binary_grad_gpu,
+    empty_broadcast_binary_grad_metal
+);
+test_device!(
+    empty_binary_validation,
+    empty_binary_validation_cpu,
+    empty_binary_validation_gpu,
+    empty_binary_validation_metal
 );
 test_device!(
     grad_descent,


### PR DESCRIPTION
## Summary

Empty binary operations currently return `self.clone()`, which drops the rhs from autograd and skips device/dtype validation.

This preserves the kernel-free path while creating a normal binary node backed by fresh zero-sized storage. It also handles empty `minimum`/`maximum` and broadcast gradients without dispatching empty comparison or reduction kernels.

Covers `add`, `sub`, `mul`, `div`, `minimum`, and `maximum`, including scalar, broadcast, and non-contiguous inputs.

## Testing

- `cargo test --workspace`
- `cargo test -p candle-core --features metal`
- `cargo test -p candle-core --features accelerate --test grad_tests`
- `cargo test -p candle-core --features cuda --test grad_tests` (NVIDIA RTX 4070)
