### PR TITLE
Fix CPU batched matmul with broadcast views

### DIFF
--- a/candle-core/benches/benchmarks/matmul.rs
+++ b/candle-core/benches/benchmarks/matmul.rs
@@ -24,10 +24,6 @@ fn run(a: &Tensor, b: &Tensor) {
     a.broadcast_matmul(b).unwrap();
 }
 
-fn run_direct(a: &Tensor, b: &Tensor) {
-    a.matmul(b).unwrap();
-}
-
 fn calculate_flops(shape_a: &[usize], shape_b: &[usize]) -> usize {
     let batch: usize = shape_a
         .iter()
@@ -90,7 +86,7 @@ fn run_broadcast_view_bench(c: &mut Criterion, device: &Device) {
             b.iter_custom(|iters| {
                 let start = Instant::now();
                 for _i in 0..iters {
-                    run_direct(black_box(lhs), black_box(rhs));
+                    black_box(lhs).matmul(black_box(rhs)).unwrap();
                 }
                 device.sync().unwrap();
                 start.elapsed()

--- a/candle-core/benches/benchmarks/matmul.rs
+++ b/candle-core/benches/benchmarks/matmul.rs
@@ -24,6 +24,10 @@ fn run(a: &Tensor, b: &Tensor) {
     a.broadcast_matmul(b).unwrap();
 }
 
+fn run_direct(a: &Tensor, b: &Tensor) {
+    a.matmul(b).unwrap();
+}
+
 fn calculate_flops(shape_a: &[usize], shape_b: &[usize]) -> usize {
     let batch: usize = shape_a
         .iter()
@@ -58,12 +62,51 @@ fn run_bench(c: &mut Criterion, device: &Device, name: &str, shape_a: &[usize], 
     group.finish();
 }
 
+fn run_broadcast_view_bench(c: &mut Criterion, device: &Device) {
+    let (batch, m, n, k) = (32, 32, 32, 32);
+    let lhs = Tensor::zeros((batch, m, k), DType::F32, device).unwrap();
+    let rhs = Tensor::zeros((batch, k, n), DType::F32, device).unwrap();
+    let lhs_broadcast = Tensor::zeros((1, m, k), DType::F32, device)
+        .unwrap()
+        .broadcast_as((batch, m, k))
+        .unwrap();
+    let rhs_broadcast = Tensor::zeros((1, k, n), DType::F32, device)
+        .unwrap()
+        .broadcast_as((batch, k, n))
+        .unwrap();
+    let lhs_materialized = lhs_broadcast.contiguous().unwrap();
+    let rhs_materialized = rhs_broadcast.contiguous().unwrap();
+    let flops = 2 * batch * m * n * k;
+
+    let mut group = c.benchmark_group(device.bench_name("matmul_broadcast_view_32"));
+    group.throughput(Throughput::Bytes(flops as u64));
+    for (name, lhs, rhs) in [
+        ("lhs_broadcast", &lhs_broadcast, &rhs),
+        ("lhs_materialized", &lhs_materialized, &rhs),
+        ("rhs_broadcast", &lhs, &rhs_broadcast),
+        ("rhs_materialized", &lhs, &rhs_materialized),
+    ] {
+        group.bench_function(name, |b| {
+            b.iter_custom(|iters| {
+                let start = Instant::now();
+                for _i in 0..iters {
+                    run_direct(black_box(lhs), black_box(rhs));
+                }
+                device.sync().unwrap();
+                start.elapsed()
+            })
+        });
+    }
+    group.finish();
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     let handler = BenchDeviceHandler::new().unwrap();
     for device in handler.devices {
         for (name, shape_a, shape_b) in MATMUL_SHAPES {
             run_bench(c, &device, name, shape_a, shape_b);
         }
+        run_broadcast_view_bench(c, &device);
     }
 }
 

--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -1412,12 +1412,12 @@ impl Map2 for MatMul {
         } else {
             Parallelism::None
         };
-        let (b, m, n, k) = if b_skip == 0 && a_skip == m * k {
+        let (b, m, n, k) = if b_skip == 0 && a_skip == m * lhs_rs {
+            // The lhs batch and row dimensions are adjacent, so they can be
+            // flattened while reusing the broadcast rhs matrix.
             // a_skip and c_skip should be updated but step is always 0 so
             // it wouldn't matter.
             (1, b * m, n, k)
-        } else if a_skip == 0 && b_skip == n * k {
-            (1, m, b * n, k)
         } else {
             (b, m, n, k)
         };

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -64,10 +64,20 @@ fn matmul_grad(device: &Device) -> Result<()> {
     Ok(())
 }
 
-fn assert_close(actual: &Tensor, expected: &Tensor) -> Result<()> {
+fn assert_close(label: &str, actual: &Tensor, expected: &Tensor) -> Result<()> {
     assert_eq!(actual.shape(), expected.shape());
-    let max_diff = (actual - expected)?.abs()?.max_all()?.to_scalar::<f32>()?;
-    assert!(max_diff < 1e-5, "tensor mismatch: {max_diff}");
+    let actual = actual.flatten_all()?.to_vec1::<f32>()?;
+    let expected = expected.flatten_all()?.to_vec1::<f32>()?;
+    // CUDA can accumulate broadcast and materialized batches in different orders.
+    let (atol, rtol) = (1e-5, 1e-6);
+    for (index, (&actual, &expected)) in actual.iter().zip(expected.iter()).enumerate() {
+        let diff = (actual - expected).abs();
+        let tolerance = atol + rtol * expected.abs();
+        assert!(
+            diff <= tolerance,
+            "{label} mismatch at {index}: {actual} != {expected} ({diff} > {tolerance})"
+        );
+    }
     Ok(())
 }
 
@@ -91,12 +101,14 @@ fn matmul_broadcast_grad(device: &Device) -> Result<()> {
     let grads_ref = (&out_ref * &weights)?.sum_all()?.backward()?;
 
     assert_close(
+        "lhs broadcast gradient",
         grads.get(&lhs).context("no grad for lhs")?,
         grads_ref
             .get(&lhs_ref)
             .context("no reference grad for lhs")?,
     )?;
     assert_close(
+        "rhs gradient with lhs broadcast",
         grads.get(&rhs).context("no grad for rhs")?,
         grads_ref
             .get(&rhs_ref)
@@ -119,12 +131,14 @@ fn matmul_broadcast_grad(device: &Device) -> Result<()> {
     let grads_ref = (&out_ref * &weights)?.sum_all()?.backward()?;
 
     assert_close(
+        "transposed lhs gradient",
         grads.get(&lhs).context("no grad for transposed lhs")?,
         grads_ref
             .get(&lhs_ref)
             .context("no reference grad for transposed lhs")?,
     )?;
     assert_close(
+        "broadcast rhs gradient",
         grads.get(&rhs).context("no grad for broadcast rhs")?,
         grads_ref
             .get(&rhs_ref)

--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -64,6 +64,74 @@ fn matmul_grad(device: &Device) -> Result<()> {
     Ok(())
 }
 
+fn assert_close(actual: &Tensor, expected: &Tensor) -> Result<()> {
+    assert_eq!(actual.shape(), expected.shape());
+    let max_diff = (actual - expected)?.abs()?.max_all()?.to_scalar::<f32>()?;
+    assert!(max_diff < 1e-5, "tensor mismatch: {max_diff}");
+    Ok(())
+}
+
+fn matmul_broadcast_grad(device: &Device) -> Result<()> {
+    let (b, m, k, n) = (4, 3, 5, 2);
+    let lhs_data: Vec<_> = (0..m * k).map(|v| v as f32).collect();
+    let rhs_data: Vec<_> = (0..b * k * n).map(|v| v as f32 / 7.).collect();
+    let weights = Tensor::arange(1f32, (b * m * n + 1) as f32, device)?.reshape((b, m, n))?;
+
+    let lhs = Var::from_slice(&lhs_data, (1, m, k), device)?;
+    let rhs = Var::from_slice(&rhs_data, (b, k, n), device)?;
+    let out = lhs.broadcast_as((b, m, k))?.matmul(&rhs)?;
+    let grads = (&out * &weights)?.sum_all()?.backward()?;
+
+    let lhs_ref = Var::from_slice(&lhs_data, (1, m, k), device)?;
+    let rhs_ref = Var::from_slice(&rhs_data, (b, k, n), device)?;
+    let out_ref = lhs_ref
+        .broadcast_as((b, m, k))?
+        .contiguous()?
+        .matmul(&rhs_ref)?;
+    let grads_ref = (&out_ref * &weights)?.sum_all()?.backward()?;
+
+    assert_close(
+        grads.get(&lhs).context("no grad for lhs")?,
+        grads_ref
+            .get(&lhs_ref)
+            .context("no reference grad for lhs")?,
+    )?;
+    assert_close(
+        grads.get(&rhs).context("no grad for rhs")?,
+        grads_ref
+            .get(&rhs_ref)
+            .context("no reference grad for rhs")?,
+    )?;
+
+    let lhs_data: Vec<_> = (0..b * k * m).map(|v| v as f32 / 5.).collect();
+    let rhs_data: Vec<_> = (0..k * n).map(|v| v as f32).collect();
+    let lhs = Var::from_slice(&lhs_data, (b, k, m), device)?;
+    let rhs = Var::from_slice(&rhs_data, (1, k, n), device)?;
+    let out = lhs.transpose(1, 2)?.matmul(&rhs.broadcast_as((b, k, n))?)?;
+    let grads = (&out * &weights)?.sum_all()?.backward()?;
+
+    let lhs_ref = Var::from_slice(&lhs_data, (b, k, m), device)?;
+    let rhs_ref = Var::from_slice(&rhs_data, (1, k, n), device)?;
+    let out_ref = lhs_ref
+        .transpose(1, 2)?
+        .contiguous()?
+        .matmul(&rhs_ref.broadcast_as((b, k, n))?.contiguous()?)?;
+    let grads_ref = (&out_ref * &weights)?.sum_all()?.backward()?;
+
+    assert_close(
+        grads.get(&lhs).context("no grad for transposed lhs")?,
+        grads_ref
+            .get(&lhs_ref)
+            .context("no reference grad for transposed lhs")?,
+    )?;
+    assert_close(
+        grads.get(&rhs).context("no grad for broadcast rhs")?,
+        grads_ref
+            .get(&rhs_ref)
+            .context("no reference grad for broadcast rhs")?,
+    )
+}
+
 // The simplest gradient descent, using scalar variable.
 fn grad_descent(device: &Device) -> Result<()> {
     let x = Var::new(0f32, device)?;
@@ -547,6 +615,12 @@ test_device!(
     matmul_grad_cpu,
     matmul_grad_gpu,
     matmul_grad_metal
+);
+test_device!(
+    matmul_broadcast_grad,
+    matmul_broadcast_grad_cpu,
+    matmul_broadcast_grad_gpu,
+    matmul_broadcast_grad_metal
 );
 test_device!(
     grad_descent,

--- a/candle-core/tests/matmul_tests.rs
+++ b/candle-core/tests/matmul_tests.rs
@@ -82,6 +82,67 @@ fn broadcast_matmul(device: &Device) -> Result<()> {
     Ok(())
 }
 
+fn assert_matmul_matches_contiguous(lhs: &Tensor, rhs: &Tensor) -> Result<()> {
+    let actual = lhs.matmul(rhs)?;
+    let expected = lhs.contiguous()?.matmul(&rhs.contiguous()?)?;
+    assert_eq!(actual.shape(), expected.shape());
+    let max_diff = (actual - expected)?.abs()?.max_all()?.to_scalar::<f32>()?;
+    assert!(
+        max_diff < 1e-5,
+        "matmul mismatch for lhs stride {:?} and rhs stride {:?}: {max_diff}",
+        lhs.stride(),
+        rhs.stride()
+    );
+    Ok(())
+}
+
+fn matmul_lhs_batch_broadcast(device: &Device) -> Result<()> {
+    let (b, m, k, n) = (4, 3, 5, 2);
+    let lhs = Tensor::arange(0f32, (m * k) as f32, device)?
+        .reshape((1, m, k))?
+        .broadcast_as((b, m, k))?;
+    let rhs = Tensor::arange(0f32, (b * k * n) as f32, device)?.reshape((b, k, n))?;
+    assert_matmul_matches_contiguous(&lhs, &rhs)?;
+
+    let rhs = Tensor::arange(0f32, (b * n * k) as f32, device)?
+        .reshape((b, n, k))?
+        .transpose(1, 2)?;
+    assert_matmul_matches_contiguous(&lhs, &rhs)?;
+
+    let lhs = Tensor::ones((1, 32, 32), DType::F32, device)?.broadcast_as((32, 32, 32))?;
+    let rhs = Tensor::ones((32, 32, 32), DType::F32, device)?;
+    assert_matmul_matches_contiguous(&lhs, &rhs)
+}
+
+fn matmul_rhs_batch_broadcast(device: &Device) -> Result<()> {
+    let (b, m, k, n) = (4, 3, 5, 2);
+    let lhs = Tensor::arange(0f32, (b * m * k) as f32, device)?.reshape((b, m, k))?;
+    let rhs = Tensor::arange(0f32, (k * n) as f32, device)?
+        .reshape((1, k, n))?
+        .broadcast_as((b, k, n))?;
+    assert_matmul_matches_contiguous(&lhs, &rhs)?;
+
+    let lhs = Tensor::arange(0f32, (b * k * m) as f32, device)?
+        .reshape((b, k, m))?
+        .transpose(1, 2)?;
+    assert_matmul_matches_contiguous(&lhs, &rhs)
+}
+
+fn matmul_multi_axis_batch_broadcast(device: &Device) -> Result<()> {
+    let (b1, b2, m, k, n) = (2, 3, 2, 4, 3);
+    let lhs = Tensor::arange(0f32, (m * k) as f32, device)?
+        .reshape((1, 1, m, k))?
+        .broadcast_as((b1, b2, m, k))?;
+    let rhs = Tensor::arange(0f32, (k * n) as f32, device)?
+        .reshape((1, 1, k, n))?
+        .broadcast_as((b1, b2, k, n))?;
+    assert_matmul_matches_contiguous(&lhs, &rhs)?;
+
+    let lhs = Tensor::arange(0f32, (m * k) as f32, device)?.reshape((1, m, k))?;
+    let rhs = Tensor::arange(0f32, (k * n) as f32, device)?.reshape((1, k, n))?;
+    assert_matmul_matches_contiguous(&lhs, &rhs)
+}
+
 #[test]
 fn tensor_dot() -> Result<()> {
     let lhs = Tensor::new(&[1., 2., 3.], &Device::Cpu)?;
@@ -141,6 +202,24 @@ test_device!(
     broadcast_matmul_cpu,
     broadcast_matmul_gpu,
     broadcast_matmul_metal
+);
+test_device!(
+    matmul_lhs_batch_broadcast,
+    matmul_lhs_batch_broadcast_cpu,
+    matmul_lhs_batch_broadcast_gpu,
+    matmul_lhs_batch_broadcast_metal
+);
+test_device!(
+    matmul_rhs_batch_broadcast,
+    matmul_rhs_batch_broadcast_cpu,
+    matmul_rhs_batch_broadcast_gpu,
+    matmul_rhs_batch_broadcast_metal
+);
+test_device!(
+    matmul_multi_axis_batch_broadcast,
+    matmul_multi_axis_batch_broadcast_cpu,
+    matmul_multi_axis_batch_broadcast_gpu,
+    matmul_multi_axis_batch_broadcast_metal
 );
 test_device!(squeeze_mm, squeeze_mm_cpu, squeeze_mm_gpu, squeeze_mm_metal);
 test_device!(mm_layout, mm_layout_cpu, mm_layout_gpu, mm_layout_metal);


### PR DESCRIPTION
## Summary

Baseline CPU batched matmul incorrectly flattens a batch-broadcast lhs into one wide GEMM. The rhs is stored batch-major, so it cannot be reinterpreted as a `K x (B*N)` matrix and direct broadcast views return incorrect values.

The opposite rhs-broadcast optimization also assumes lhs rows are adjacent from `a_skip == M*K`, which is insufficient for transposed lhs views.

## Fix

Keep a broadcast lhs on the normal per-batch GEMM loop, reusing its zero batch stride without materializing it. Preserve the rhs-broadcast flattening only when the actual lhs row stride proves the batch and row dimensions are adjacent.

## Test plan

Added device-dispatched regressions covering:

- lhs and rhs batch broadcasts;
- transposed operands and multiple batch axes;
- the original `32 x 32 x 32` failure;
- gradient parity against materialized operands;
- direct broadcast-view benchmarks against materialized references.

Ran:

- `cargo test -p candle-core --test matmul_tests --test grad_tests`
- `cargo test -p candle-core --features accelerate --test matmul_tests --test grad_tests`
- `cargo test -p candle-core --features metal --test matmul_tests --test grad_tests`
- `cargo test -p candle-core --features cuda --test matmul_tests --test grad_tests` (NVIDIA RTX 4070)
- `cargo bench -p candle-core --bench bench_main --no-run`
- `cargo fmt --all -- --check`
- `cargo clippy -p candle-core --tests --benches -- -D warnings -A clippy::useless-borrows-in-formatting`
