### PR TITLE
Fix Metal pipeline cache source identity

### DIFF
--- a/candle-metal-kernels/src/kernel.rs
+++ b/candle-metal-kernels/src/kernel.rs
@@ -59,7 +59,7 @@ impl From<String> for KernelName {
 }
 
 type Libraries = HashMap<Source, Library>;
-type Pipelines = HashMap<(KernelName, Option<ConstantValues>), ComputePipeline>;
+type Pipelines = HashMap<(Source, KernelName, Option<ConstantValues>), ComputePipeline>;
 
 #[derive(Debug)]
 pub struct Kernels {
@@ -151,16 +151,16 @@ impl Kernels {
         constants: Option<ConstantValues>,
     ) -> Result<ComputePipeline, MetalKernelError> {
         let mut pipelines = self.pipelines.write()?;
-        let key = (name.into(), constants);
+        let key = (source, name.into(), constants);
         if let Some(pipeline) = pipelines.get(&key) {
             Ok(pipeline.clone())
         } else {
-            let (name, constants) = key;
+            let (source, name, constants) = key;
             let func = self.load_function(device, source, name.as_ref(), constants.as_ref())?;
             let pipeline = device
                 .new_compute_pipeline_state_with_function(&func)
                 .map_err(|e| MetalKernelError::FailedToCreatePipeline(e.to_string()))?;
-            pipelines.insert((name, constants), pipeline.clone());
+            pipelines.insert((source, name, constants), pipeline.clone());
 
             Ok(pipeline)
         }

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -31,6 +31,21 @@ fn device() -> Device {
     Device::system_default().unwrap()
 }
 
+#[test]
+fn pipeline_cache_distinguishes_sources() {
+    let device = device();
+    let kernels = Kernels::new();
+
+    // Prime the cache with a name that is not present in the binary library.
+    kernels
+        .load_pipeline(&device, Source::Unary, "cos_f32")
+        .unwrap();
+    assert!(matches!(
+        kernels.load_pipeline(&device, Source::Binary, "cos_f32"),
+        Err(MetalKernelError::LoadFunctionError(_))
+    ));
+}
+
 fn approx(v: Vec<f32>, digits: i32) -> Vec<f32> {
     let b = 10f32.powi(digits);
     v.iter().map(|t| f32::round(t * b) / b).collect()


### PR DESCRIPTION
## Summary

The Metal pipeline cache is keyed by function name and constants, but pipeline loading also takes a `Source`. Different Metal libraries that expose the same function name and constants can therefore collide, returning a pipeline compiled from the wrong source.

## Fix

Include `Source` in the pipeline cache key and use `(source, name, constants)` consistently for lookup and insertion. Existing compilation and locking behavior remains unchanged.

## Test plan

Added a regression that primes the cache with `cos_f32` from the unary source, then requests the same name from the binary source, confirming the second source is consulted instead of returning the cached unary pipeline.

Ran:

- `cargo test --manifest-path candle-metal-kernels/Cargo.toml`
- `cargo test -p candle-core --features metal`
- `cargo test --workspace`
- `cargo check --workspace --features metal`
- `cargo fmt --all -- --check`
