### PR TITLE
Use shared locks for Metal cache hits

### DIFF
--- a/candle-metal-kernels/src/kernel.rs
+++ b/candle-metal-kernels/src/kernel.rs
@@ -59,7 +59,7 @@ impl From<String> for KernelName {
 }
 
 type Libraries = HashMap<Source, Library>;
-type Pipelines = HashMap<(KernelName, Option<ConstantValues>), ComputePipeline>;
+type Pipelines = HashMap<(Source, KernelName, Option<ConstantValues>), ComputePipeline>;
 
 #[derive(Debug)]
 pub struct Kernels {
@@ -151,16 +151,16 @@ impl Kernels {
         constants: Option<ConstantValues>,
     ) -> Result<ComputePipeline, MetalKernelError> {
         let mut pipelines = self.pipelines.write()?;
-        let key = (name.into(), constants);
+        let key = (source, name.into(), constants);
         if let Some(pipeline) = pipelines.get(&key) {
             Ok(pipeline.clone())
         } else {
-            let (name, constants) = key;
+            let (source, name, constants) = key;
             let func = self.load_function(device, source, name.as_ref(), constants.as_ref())?;
             let pipeline = device
                 .new_compute_pipeline_state_with_function(&func)
                 .map_err(|e| MetalKernelError::FailedToCreatePipeline(e.to_string()))?;
-            pipelines.insert((name, constants), pipeline.clone());
+            pipelines.insert((source, name, constants), pipeline.clone());
 
             Ok(pipeline)
         }

--- a/candle-metal-kernels/src/kernel.rs
+++ b/candle-metal-kernels/src/kernel.rs
@@ -111,7 +111,12 @@ impl Kernels {
         device: &Device,
         source: Source,
     ) -> Result<Library, MetalKernelError> {
+        if let Some(lib) = self.libraries.read()?.get(&source) {
+            return Ok(lib.clone());
+        }
+
         let mut libraries = self.libraries.write()?;
+        // Recheck after acquiring the write lock in case another thread inserted it.
         if let Some(lib) = libraries.get(&source) {
             Ok(lib.clone())
         } else {
@@ -150,8 +155,13 @@ impl Kernels {
         name: impl Into<KernelName>,
         constants: Option<ConstantValues>,
     ) -> Result<ComputePipeline, MetalKernelError> {
-        let mut pipelines = self.pipelines.write()?;
         let key = (source, name.into(), constants);
+        if let Some(pipeline) = self.pipelines.read()?.get(&key) {
+            return Ok(pipeline.clone());
+        }
+
+        let mut pipelines = self.pipelines.write()?;
+        // Recheck after acquiring the write lock in case another thread inserted it.
         if let Some(pipeline) = pipelines.get(&key) {
             Ok(pipeline.clone())
         } else {
@@ -200,4 +210,51 @@ fn get_compile_options() -> Retained<MTLCompileOptions> {
         compile_options.setFastMathEnabled(fast_math_enabled);
     }
     compile_options
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Barrier;
+
+    #[test]
+    fn concurrent_cache_loads_insert_once() {
+        const THREADS: usize = 8;
+        const WARM_HITS: usize = 100;
+
+        let device = Device::system_default().unwrap();
+        let kernels = Kernels::new();
+        let barrier = Barrier::new(THREADS);
+
+        let pipelines = std::thread::scope(|scope| {
+            let handles = (0..THREADS)
+                .map(|_| {
+                    scope.spawn(|| {
+                        barrier.wait();
+                        let pipeline = kernels
+                            .load_pipeline(&device, Source::Unary, "cos_f32")
+                            .unwrap();
+                        for _ in 0..WARM_HITS {
+                            let cached = kernels
+                                .load_pipeline(&device, Source::Unary, "cos_f32")
+                                .unwrap();
+                            assert!(std::ptr::eq(pipeline.as_ref(), cached.as_ref()));
+                            kernels.load_library(&device, Source::Unary).unwrap();
+                        }
+                        pipeline
+                    })
+                })
+                .collect::<Vec<_>>();
+            handles
+                .into_iter()
+                .map(|handle| handle.join().unwrap())
+                .collect::<Vec<_>>()
+        });
+
+        assert!(pipelines
+            .iter()
+            .all(|pipeline| std::ptr::eq(pipelines[0].as_ref(), pipeline.as_ref())));
+        assert_eq!(kernels.libraries.read().unwrap().len(), 1);
+        assert_eq!(kernels.pipelines.read().unwrap().len(), 1);
+    }
 }

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -31,6 +31,21 @@ fn device() -> Device {
     Device::system_default().unwrap()
 }
 
+#[test]
+fn pipeline_cache_distinguishes_sources() {
+    let device = device();
+    let kernels = Kernels::new();
+
+    // Prime the cache with a name that is not present in the binary library.
+    kernels
+        .load_pipeline(&device, Source::Unary, "cos_f32")
+        .unwrap();
+    assert!(matches!(
+        kernels.load_pipeline(&device, Source::Binary, "cos_f32"),
+        Err(MetalKernelError::LoadFunctionError(_))
+    ));
+}
+
 fn approx(v: Vec<f32>, digits: i32) -> Vec<f32> {
     let b = 10f32.powi(digits);
     v.iter().map(|t| f32::round(t * b) / b).collect()


### PR DESCRIPTION
## Summary

Metal pipeline and library cache hits currently take an exclusive write lock, serializing concurrent readers even though cached entries are not modified.

Depends on #3760.

## Fix

Use a shared read lock for cache hits. On a miss, acquire the write lock and recheck the cache before compiling and inserting, preserving single-entry initialization when callers race.

Cold compilation and failure behavior remain unchanged.

## Test plan

Added a concurrent regression covering same-key cold loads, pipeline reuse, and warm pipeline/library cache hits.

Ran:

- `cargo test --manifest-path candle-metal-kernels/Cargo.toml`
- `cargo test -p candle-core --features metal`
- `cargo test --workspace`
- `cargo check --workspace --features metal`
- `cargo fmt --all -- --check`
