### PR TITLE
Add batch-native multi-prompt decode loop for heterogeneous LoRA serving

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
     "candle-flash-attn",
     "candle-flash-attn-v3",
     "candle-kernels",
+    "candle-lora-kernels",
     "candle-metal-kernels",
     "candle-onnx",
 ]
@@ -40,6 +41,7 @@ candle-datasets = { path = "./candle-datasets", version = "0.11.0" }
 candle-flash-attn = { path = "./candle-flash-attn", version = "0.11.0" }
 candle-flash-attn-v3 = { path = "./candle-flash-attn-v3", version = "0.11.0" }
 candle-kernels = { path = "./candle-kernels", version = "0.11.0" }
+candle-lora-kernels = { path = "./candle-lora-kernels", version = "0.11.0" }
 candle-metal-kernels = { path = "./candle-metal-kernels", version = "0.11.0" }
 candle-nn = { path = "./candle-nn", version = "0.11.0" }
 candle-onnx = { path = "./candle-onnx", version = "0.11.0" }

--- a/candle-lora-kernels/Cargo.toml
+++ b/candle-lora-kernels/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "candle-lora-kernels"
+version = "0.11.0"
+edition = "2021"
+
+description = "Heterogeneous multi-LoRA batching CUDA kernels (S-LoRA / Punica style BGMV) for the candle ML framework."
+repository = "https://github.com/huggingface/candle"
+keywords = ["blas", "tensor", "machine-learning"]
+categories = ["science"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+
+[dependencies]
+candle = { path = "../candle-core", features = ["cuda"], package = "candle-core", version = "0.11.0" }
+half = { version = "2.3.1", features = ["num-traits"] }
+
+[build-dependencies]
+cudaforge = "0.1.2"

--- a/candle-lora-kernels/README.md
+++ b/candle-lora-kernels/README.md
@@ -1,0 +1,16 @@
+# candle-lora-kernels
+
+Heterogeneous multi-LoRA batching CUDA kernels (S-LoRA / Punica style BGMV) for
+the candle ML framework.
+
+This crate is the fused-kernel fast path for
+`candle_nn::lora::LoraLinear::forward_with_adapters`. A decode-step batch in
+which every row selects its own LoRA adapter is applied as two gather-GEMV
+passes — "shrink" (`in -> r`) then "expand" (`r -> out`) — that read the stacked
+adapter matrices in place through a per-row slot index, instead of materializing
+the per-row gather that the pure-tensor reference path builds before its batched
+matmuls.
+
+It is CUDA-only (requires `nvcc`) and is enabled through candle-nn's `lora-cuda`
+feature; without that feature candle-nn uses the equivalent pure-tensor path on
+every backend.

--- a/candle-lora-kernels/build.rs
+++ b/candle-lora-kernels/build.rs
@@ -1,0 +1,42 @@
+// Build script that compiles the LoRA BGMV CUDA kernels into a static library
+// and links it. Requires the CUDA toolchain (nvcc); this crate is CUDA-only and
+// is pulled in by candle-nn's `lora-cuda` feature.
+use cudaforge::{KernelBuilder, Result};
+use std::path::PathBuf;
+
+fn main() -> Result<()> {
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=src/lora_sgmv.cu");
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR not set"));
+
+    let mut builder = KernelBuilder::default()
+        .source_files(vec!["src/lora_sgmv.cu"])
+        .arg("-std=c++17")
+        .arg("-O3")
+        .arg("--expt-relaxed-constexpr")
+        .arg("-U__CUDA_NO_HALF_OPERATORS__")
+        .arg("-U__CUDA_NO_HALF_CONVERSIONS__")
+        .arg("-U__CUDA_NO_BFLOAT16_CONVERSIONS__");
+
+    let mut is_target_msvc = false;
+    if let Ok(target) = std::env::var("TARGET") {
+        if target.contains("msvc") {
+            is_target_msvc = true;
+            builder = builder.arg("-D_USE_MATH_DEFINES");
+        }
+    }
+    if !is_target_msvc {
+        builder = builder.arg("-Xcompiler").arg("-fPIC");
+    }
+
+    builder.build_lib(out_dir.join("liblorakernels.a"))?;
+
+    println!("cargo::rustc-link-search={}", out_dir.display());
+    println!("cargo::rustc-link-lib=lorakernels");
+    println!("cargo::rustc-link-lib=dylib=cudart");
+    if !is_target_msvc {
+        println!("cargo::rustc-link-lib=dylib=stdc++");
+    }
+    Ok(())
+}

--- a/candle-lora-kernels/src/ffi.rs
+++ b/candle-lora-kernels/src/ffi.rs
@@ -1,0 +1,27 @@
+use core::ffi::c_void;
+
+extern "C" {
+    pub(crate) fn lora_bgmv_shrink(
+        x: *const c_void,
+        a: *const c_void,
+        slots: *const u32,
+        tmp: *mut c_void,
+        batch: u32,
+        in_dim: u32,
+        r: u32,
+        dtype: u32,
+        stream: *mut c_void,
+    );
+
+    pub(crate) fn lora_bgmv_expand(
+        tmp: *const c_void,
+        b: *const c_void,
+        slots: *const u32,
+        delta: *mut c_void,
+        batch: u32,
+        r: u32,
+        out_dim: u32,
+        dtype: u32,
+        stream: *mut c_void,
+    );
+}

--- a/candle-lora-kernels/src/lib.rs
+++ b/candle-lora-kernels/src/lib.rs
@@ -1,0 +1,233 @@
+//! Heterogeneous multi-LoRA batching CUDA kernels (S-LoRA / Punica style BGMV).
+//!
+//! This crate provides the fused-kernel fast path for
+//! [`candle_nn::lora::LoraLinear::forward_with_adapters`]: a single decode-step
+//! batch where every row selects its own LoRA adapter is applied as two
+//! gather-GEMV passes ("shrink" `in -> r`, then "expand" `r -> out`) that read
+//! the stacked adapter matrices in place through a per-row slot index, instead
+//! of materializing the per-row gather that the pure-tensor reference path
+//! builds before its batched matmuls.
+//!
+//! [`bgmv_delta`] is numerically equivalent to that reference path and returns
+//! the same `delta` tensor; candle-nn selects it behind the `lora-cuda`
+//! feature when the input is on a CUDA device and the sequence length is 1.
+
+mod ffi;
+
+use candle::backend::BackendStorage;
+use candle::cuda_backend::cudarc::driver::{DevicePtr, DevicePtrMut};
+use candle::{CpuStorage, CudaStorage, DType, Layout, Result, Shape, Tensor};
+use core::ffi::c_void;
+use half::{bf16, f16};
+
+fn dtype_code(dt: DType) -> Result<u32> {
+    match dt {
+        DType::F32 => Ok(0),
+        DType::F16 => Ok(1),
+        DType::BF16 => Ok(2),
+        dt => candle::bail!("lora kernels only support f32/f16/bf16 inputs, got {dt:?}"),
+    }
+}
+
+/// `tmp[i, :] = x[i, :] · A_stack[slot(i)]`, gathering `A_stack` by `slot`.
+struct LoraShrink;
+
+impl LoraShrink {
+    fn fwd_t<T: candle::cuda_backend::CudaDType + candle::cuda_backend::cudarc::driver::DeviceRepr>(
+        &self,
+        x: &CudaStorage,
+        x_l: &Layout,
+        a: &CudaStorage,
+        a_l: &Layout,
+        slots: &CudaStorage,
+        slots_l: &Layout,
+        dtype: u32,
+    ) -> Result<(CudaStorage, Shape)> {
+        if !x_l.is_contiguous() || !a_l.is_contiguous() || !slots_l.is_contiguous() {
+            candle::bail!("lora bgmv shrink expects contiguous inputs")
+        }
+        let (batch, in_dim) = x_l.shape().dims2()?;
+        let (_n_slots, a_in, r) = a_l.shape().dims3()?;
+        if a_in != in_dim {
+            candle::bail!("lora bgmv shrink: x in_dim {in_dim} != A_stack in_dim {a_in}")
+        }
+        if slots_l.shape().dims1()? != batch {
+            candle::bail!("lora bgmv shrink: expected {batch} slots")
+        }
+        let dev = x.device();
+        let x = x.as_cuda_slice::<T>()?.slice(x_l.start_offset()..);
+        let a = a.as_cuda_slice::<T>()?.slice(a_l.start_offset()..);
+        let slots = slots.as_cuda_slice::<u32>()?.slice(slots_l.start_offset()..);
+        let out_shape = Shape::from((batch, r));
+        let mut dst = unsafe { dev.alloc::<T>(batch * r)? };
+        let stream = dev.cuda_stream();
+        unsafe {
+            let (x_ptr, _g) = x.device_ptr(&stream);
+            let (a_ptr, _g) = a.device_ptr(&stream);
+            let (slots_ptr, _g) = slots.device_ptr(&stream);
+            let (dst_ptr, _g) = dst.device_ptr_mut(&stream);
+            ffi::lora_bgmv_shrink(
+                x_ptr as *const c_void,
+                a_ptr as *const c_void,
+                slots_ptr as *const u32,
+                dst_ptr as *mut c_void,
+                batch as u32,
+                in_dim as u32,
+                r as u32,
+                dtype,
+                stream.cu_stream() as *mut c_void,
+            );
+        }
+        Ok((CudaStorage::wrap_cuda_slice(dst, dev.clone()), out_shape))
+    }
+}
+
+impl candle::CustomOp3 for LoraShrink {
+    fn name(&self) -> &'static str {
+        "lora-bgmv-shrink"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+    ) -> Result<(CpuStorage, Shape)> {
+        candle::bail!("no cpu support for lora-bgmv kernels")
+    }
+
+    fn cuda_fwd(
+        &self,
+        x: &CudaStorage,
+        x_l: &Layout,
+        a: &CudaStorage,
+        a_l: &Layout,
+        slots: &CudaStorage,
+        slots_l: &Layout,
+    ) -> Result<(CudaStorage, Shape)> {
+        match x.dtype() {
+            DType::F32 => self.fwd_t::<f32>(x, x_l, a, a_l, slots, slots_l, 0),
+            DType::F16 => self.fwd_t::<f16>(x, x_l, a, a_l, slots, slots_l, 1),
+            DType::BF16 => self.fwd_t::<bf16>(x, x_l, a, a_l, slots, slots_l, 2),
+            dt => candle::bail!("lora-bgmv-shrink only supports f32/f16/bf16, got {dt:?}"),
+        }
+    }
+}
+
+/// `delta[i, :] = tmp[i, :] · B_stack[slot(i)]`, gathering `B_stack` by `slot`.
+struct LoraExpand;
+
+impl LoraExpand {
+    fn fwd_t<T: candle::cuda_backend::CudaDType + candle::cuda_backend::cudarc::driver::DeviceRepr>(
+        &self,
+        tmp: &CudaStorage,
+        tmp_l: &Layout,
+        b: &CudaStorage,
+        b_l: &Layout,
+        slots: &CudaStorage,
+        slots_l: &Layout,
+        dtype: u32,
+    ) -> Result<(CudaStorage, Shape)> {
+        if !tmp_l.is_contiguous() || !b_l.is_contiguous() || !slots_l.is_contiguous() {
+            candle::bail!("lora bgmv expand expects contiguous inputs")
+        }
+        let (batch, r) = tmp_l.shape().dims2()?;
+        let (_n_slots, b_r, out_dim) = b_l.shape().dims3()?;
+        if b_r != r {
+            candle::bail!("lora bgmv expand: tmp rank {r} != B_stack rank {b_r}")
+        }
+        if slots_l.shape().dims1()? != batch {
+            candle::bail!("lora bgmv expand: expected {batch} slots")
+        }
+        let dev = tmp.device();
+        let tmp = tmp.as_cuda_slice::<T>()?.slice(tmp_l.start_offset()..);
+        let b = b.as_cuda_slice::<T>()?.slice(b_l.start_offset()..);
+        let slots = slots.as_cuda_slice::<u32>()?.slice(slots_l.start_offset()..);
+        let out_shape = Shape::from((batch, out_dim));
+        let mut dst = unsafe { dev.alloc::<T>(batch * out_dim)? };
+        let stream = dev.cuda_stream();
+        unsafe {
+            let (tmp_ptr, _g) = tmp.device_ptr(&stream);
+            let (b_ptr, _g) = b.device_ptr(&stream);
+            let (slots_ptr, _g) = slots.device_ptr(&stream);
+            let (dst_ptr, _g) = dst.device_ptr_mut(&stream);
+            ffi::lora_bgmv_expand(
+                tmp_ptr as *const c_void,
+                b_ptr as *const c_void,
+                slots_ptr as *const u32,
+                dst_ptr as *mut c_void,
+                batch as u32,
+                r as u32,
+                out_dim as u32,
+                dtype,
+                stream.cu_stream() as *mut c_void,
+            );
+        }
+        Ok((CudaStorage::wrap_cuda_slice(dst, dev.clone()), out_shape))
+    }
+}
+
+impl candle::CustomOp3 for LoraExpand {
+    fn name(&self) -> &'static str {
+        "lora-bgmv-expand"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+    ) -> Result<(CpuStorage, Shape)> {
+        candle::bail!("no cpu support for lora-bgmv kernels")
+    }
+
+    fn cuda_fwd(
+        &self,
+        tmp: &CudaStorage,
+        tmp_l: &Layout,
+        b: &CudaStorage,
+        b_l: &Layout,
+        slots: &CudaStorage,
+        slots_l: &Layout,
+    ) -> Result<(CudaStorage, Shape)> {
+        match tmp.dtype() {
+            DType::F32 => self.fwd_t::<f32>(tmp, tmp_l, b, b_l, slots, slots_l, 0),
+            DType::F16 => self.fwd_t::<f16>(tmp, tmp_l, b, b_l, slots, slots_l, 1),
+            DType::BF16 => self.fwd_t::<bf16>(tmp, tmp_l, b, b_l, slots, slots_l, 2),
+            dt => candle::bail!("lora-bgmv-expand only supports f32/f16/bf16, got {dt:?}"),
+        }
+    }
+}
+
+/// Batched heterogeneous LoRA delta for a decode step (one token per row).
+///
+/// Computes `delta[i] = x[i] · A_stack[slot(i)] · B_stack[slot(i)]` for every
+/// row of the batch, gathering the adapter matrices in place by `row_slots`.
+///
+/// * `x`         — `[batch, in_dim]`, one of f32/f16/bf16.
+/// * `a_stack`   — `[n_slots, in_dim, r]`, `A^T` per slot, rank-padded with
+///   zeros; slot 0 is the all-zero (no-adapter) slot.
+/// * `b_stack`   — `[n_slots, r, out_dim]`, `B^T · (alpha/r)` per slot, rank-padded.
+/// * `row_slots` — `[batch]`, `u32`, the slot index selected by each row.
+///
+/// The result matches candle-nn's pure-tensor `batched_lora_delta`.
+pub fn bgmv_delta(
+    x: &Tensor,
+    a_stack: &Tensor,
+    b_stack: &Tensor,
+    row_slots: &Tensor,
+) -> Result<Tensor> {
+    dtype_code(x.dtype())?;
+    let x = x.contiguous()?;
+    let a_stack = a_stack.contiguous()?;
+    let b_stack = b_stack.contiguous()?;
+    let row_slots = row_slots.contiguous()?;
+    let tmp = x.apply_op3(&a_stack, &row_slots, LoraShrink)?;
+    tmp.apply_op3(&b_stack, &row_slots, LoraExpand)
+}

--- a/candle-lora-kernels/src/lib.rs
+++ b/candle-lora-kernels/src/lib.rs
@@ -33,7 +33,9 @@ fn dtype_code(dt: DType) -> Result<u32> {
 struct LoraShrink;
 
 impl LoraShrink {
-    fn fwd_t<T: candle::cuda_backend::CudaDType + candle::cuda_backend::cudarc::driver::DeviceRepr>(
+    fn fwd_t<
+        T: candle::cuda_backend::CudaDType + candle::cuda_backend::cudarc::driver::DeviceRepr,
+    >(
         &self,
         x: &CudaStorage,
         x_l: &Layout,
@@ -57,7 +59,9 @@ impl LoraShrink {
         let dev = x.device();
         let x = x.as_cuda_slice::<T>()?.slice(x_l.start_offset()..);
         let a = a.as_cuda_slice::<T>()?.slice(a_l.start_offset()..);
-        let slots = slots.as_cuda_slice::<u32>()?.slice(slots_l.start_offset()..);
+        let slots = slots
+            .as_cuda_slice::<u32>()?
+            .slice(slots_l.start_offset()..);
         let out_shape = Shape::from((batch, r));
         let mut dst = unsafe { dev.alloc::<T>(batch * r)? };
         let stream = dev.cuda_stream();
@@ -121,7 +125,9 @@ impl candle::CustomOp3 for LoraShrink {
 struct LoraExpand;
 
 impl LoraExpand {
-    fn fwd_t<T: candle::cuda_backend::CudaDType + candle::cuda_backend::cudarc::driver::DeviceRepr>(
+    fn fwd_t<
+        T: candle::cuda_backend::CudaDType + candle::cuda_backend::cudarc::driver::DeviceRepr,
+    >(
         &self,
         tmp: &CudaStorage,
         tmp_l: &Layout,
@@ -145,7 +151,9 @@ impl LoraExpand {
         let dev = tmp.device();
         let tmp = tmp.as_cuda_slice::<T>()?.slice(tmp_l.start_offset()..);
         let b = b.as_cuda_slice::<T>()?.slice(b_l.start_offset()..);
-        let slots = slots.as_cuda_slice::<u32>()?.slice(slots_l.start_offset()..);
+        let slots = slots
+            .as_cuda_slice::<u32>()?
+            .slice(slots_l.start_offset()..);
         let out_shape = Shape::from((batch, out_dim));
         let mut dst = unsafe { dev.alloc::<T>(batch * out_dim)? };
         let stream = dev.cuda_stream();

--- a/candle-lora-kernels/src/lora_sgmv.cu
+++ b/candle-lora-kernels/src/lora_sgmv.cu
@@ -1,0 +1,140 @@
+// Heterogeneous multi-LoRA batching kernels (S-LoRA / Punica style BGMV).
+//
+// The batched LoRA delta `delta[i] = x[i] · A_stack[slot(i)] · B_stack[slot(i)]`
+// is computed in two gather-GEMV passes, exactly matching the reference
+// gather + batched-matmul path in candle-nn (`batched_lora_delta`):
+//
+//   shrink:  tmp[i, :]   = x[i, :]   · A_stack[slot(i)]   (in  -> r)
+//   expand:  delta[i, :] = tmp[i, :] · B_stack[slot(i)]   (r   -> out)
+//
+// `A_stack` holds `A^T` per slot (rank-padded to `r` with zeros); `B_stack`
+// holds `B^T` per slot with the `alpha/r` scaling already folded in and the
+// same rank padding. Slot 0 is an all-zero adapter used by the rows that
+// select no adapter, so those rows produce a zero delta. Reading the stacks
+// in place through `slots` avoids materializing the per-row gather of `A`/`B`
+// that the reference path builds before its matmuls.
+
+#include <cstdint>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#define LORA_DTYPE_F32 0
+#define LORA_DTYPE_F16 1
+#define LORA_DTYPE_BF16 2
+
+template <typename T> __device__ __forceinline__ float to_f32(T v);
+template <> __device__ __forceinline__ float to_f32<float>(float v) { return v; }
+template <> __device__ __forceinline__ float to_f32<__half>(__half v) { return __half2float(v); }
+template <> __device__ __forceinline__ float to_f32<__nv_bfloat16>(__nv_bfloat16 v) {
+  return __bfloat162float(v);
+}
+
+template <typename T> __device__ __forceinline__ T from_f32(float v);
+template <> __device__ __forceinline__ float from_f32<float>(float v) { return v; }
+template <> __device__ __forceinline__ __half from_f32<__half>(float v) { return __float2half(v); }
+template <> __device__ __forceinline__ __nv_bfloat16 from_f32<__nv_bfloat16>(float v) {
+  return __float2bfloat16(v);
+}
+
+// tmp[i, j] = sum_k x[i, k] * A_stack[slot(i), k, j]
+// x:   [batch, in_dim]            (row-major, contiguous)
+// A:   [n_slots, in_dim, r]       (row-major, contiguous)
+// tmp: [batch, r]
+// slots: [batch]                  (u32, one slot index per row)
+template <typename T>
+__global__ void lora_bgmv_shrink_kernel(const T *__restrict__ x, const T *__restrict__ a,
+                                        const uint32_t *__restrict__ slots, T *__restrict__ tmp,
+                                        uint32_t batch, uint32_t in_dim, uint32_t r) {
+  uint32_t i = blockIdx.x;
+  uint32_t j = blockIdx.y * blockDim.x + threadIdx.x;
+  if (i >= batch || j >= r) {
+    return;
+  }
+  uint32_t slot = slots[i];
+  const T *xrow = x + (size_t)i * in_dim;
+  const T *aslot = a + ((size_t)slot * in_dim) * r; // A_stack[slot], layout [in_dim, r]
+  float acc = 0.f;
+  for (uint32_t k = 0; k < in_dim; ++k) {
+    acc += to_f32<T>(xrow[k]) * to_f32<T>(aslot[(size_t)k * r + j]);
+  }
+  tmp[(size_t)i * r + j] = from_f32<T>(acc);
+}
+
+// delta[i, o] = sum_j tmp[i, j] * B_stack[slot(i), j, o]
+// tmp:   [batch, r]
+// B:     [n_slots, r, out_dim]    (row-major, contiguous)
+// delta: [batch, out_dim]
+// slots: [batch]
+template <typename T>
+__global__ void lora_bgmv_expand_kernel(const T *__restrict__ tmp, const T *__restrict__ b,
+                                        const uint32_t *__restrict__ slots, T *__restrict__ delta,
+                                        uint32_t batch, uint32_t r, uint32_t out_dim) {
+  uint32_t i = blockIdx.x;
+  uint32_t o = blockIdx.y * blockDim.x + threadIdx.x;
+  if (i >= batch || o >= out_dim) {
+    return;
+  }
+  uint32_t slot = slots[i];
+  const T *trow = tmp + (size_t)i * r;
+  const T *bslot = b + ((size_t)slot * r) * out_dim; // B_stack[slot], layout [r, out_dim]
+  float acc = 0.f;
+  for (uint32_t j = 0; j < r; ++j) {
+    acc += to_f32<T>(trow[j]) * to_f32<T>(bslot[(size_t)j * out_dim + o]);
+  }
+  delta[(size_t)i * out_dim + o] = from_f32<T>(acc);
+}
+
+#define BLOCK 256
+
+extern "C" void lora_bgmv_shrink(const void *x, const void *a, const uint32_t *slots, void *tmp,
+                                 uint32_t batch, uint32_t in_dim, uint32_t r, uint32_t dtype,
+                                 void *stream) {
+  if (batch == 0 || r == 0) {
+    return;
+  }
+  cudaStream_t s = (cudaStream_t)stream;
+  dim3 grid(batch, (r + BLOCK - 1) / BLOCK);
+  dim3 block(BLOCK);
+  switch (dtype) {
+  case LORA_DTYPE_F32:
+    lora_bgmv_shrink_kernel<float><<<grid, block, 0, s>>>(
+        (const float *)x, (const float *)a, slots, (float *)tmp, batch, in_dim, r);
+    break;
+  case LORA_DTYPE_F16:
+    lora_bgmv_shrink_kernel<__half><<<grid, block, 0, s>>>(
+        (const __half *)x, (const __half *)a, slots, (__half *)tmp, batch, in_dim, r);
+    break;
+  case LORA_DTYPE_BF16:
+    lora_bgmv_shrink_kernel<__nv_bfloat16><<<grid, block, 0, s>>>(
+        (const __nv_bfloat16 *)x, (const __nv_bfloat16 *)a, slots, (__nv_bfloat16 *)tmp, batch,
+        in_dim, r);
+    break;
+  }
+}
+
+extern "C" void lora_bgmv_expand(const void *tmp, const void *b, const uint32_t *slots, void *delta,
+                                 uint32_t batch, uint32_t r, uint32_t out_dim, uint32_t dtype,
+                                 void *stream) {
+  if (batch == 0 || out_dim == 0) {
+    return;
+  }
+  cudaStream_t s = (cudaStream_t)stream;
+  dim3 grid(batch, (out_dim + BLOCK - 1) / BLOCK);
+  dim3 block(BLOCK);
+  switch (dtype) {
+  case LORA_DTYPE_F32:
+    lora_bgmv_expand_kernel<float><<<grid, block, 0, s>>>(
+        (const float *)tmp, (const float *)b, slots, (float *)delta, batch, r, out_dim);
+    break;
+  case LORA_DTYPE_F16:
+    lora_bgmv_expand_kernel<__half><<<grid, block, 0, s>>>(
+        (const __half *)tmp, (const __half *)b, slots, (__half *)delta, batch, r, out_dim);
+    break;
+  case LORA_DTYPE_BF16:
+    lora_bgmv_expand_kernel<__nv_bfloat16><<<grid, block, 0, s>>>(
+        (const __nv_bfloat16 *)tmp, (const __nv_bfloat16 *)b, slots, (__nv_bfloat16 *)delta, batch,
+        r, out_dim);
+    break;
+  }
+}

--- a/candle-nn/Cargo.toml
+++ b/candle-nn/Cargo.toml
@@ -21,6 +21,7 @@ safetensors = { workspace = true }
 serde = { workspace = true }
 objc2-metal = { workspace = true, optional = true }
 candle-metal-kernels = { workspace = true, optional = true }
+candle-lora-kernels = { workspace = true, optional = true }
 libc = { workspace = true }
 
 [dev-dependencies]
@@ -35,6 +36,7 @@ default = []
 accelerate = ["dep:accelerate-src", "candle/accelerate"]
 cuda = ["candle/cuda"]
 cudnn = ["candle/cudnn"]
+lora-cuda = ["cuda", "dep:candle-lora-kernels"]
 mkl = ["dep:intel-mkl-src", "candle/mkl"]
 metal = ["candle/metal", "dep:candle-metal-kernels", "dep:objc2-metal"]
 metal-debug-labels = ["metal", "candle/metal-debug-labels"]

--- a/candle-nn/benches/bench_main.rs
+++ b/candle-nn/benches/bench_main.rs
@@ -4,5 +4,6 @@ use criterion::criterion_main;
 criterion_main!(
     benchmarks::norm::benches,
     benchmarks::softmax::benches,
-    benchmarks::conv::benches
+    benchmarks::conv::benches,
+    benchmarks::lora::benches
 );

--- a/candle-nn/benches/benchmarks/lora.rs
+++ b/candle-nn/benches/benchmarks/lora.rs
@@ -1,0 +1,122 @@
+use crate::benchmarks::{BenchDevice, BenchDeviceHandler};
+use candle::{DType, Device, Module, Tensor};
+use candle_nn::{linear_no_bias, LoraLinear, VarBuilder, VarMap};
+use criterion::{criterion_group, Criterion};
+use std::hint::black_box;
+use std::time::Instant;
+
+const HIDDEN: usize = 1024;
+const RANK: usize = 16;
+const N_ADAPTERS: usize = 4;
+const BATCH: usize = 16;
+
+fn make_lora(device: &Device) -> (LoraLinear, Vec<String>) {
+    let varmap = VarMap::new();
+    let vb = VarBuilder::from_varmap(&varmap, DType::F32, device);
+    let base = linear_no_bias(HIDDEN, HIDDEN, vb.pp("base")).unwrap();
+    let mut lora = LoraLinear::new(base);
+    let names: Vec<String> = (0..N_ADAPTERS).map(|i| format!("adapter_{i}")).collect();
+    for name in names.iter() {
+        lora.load_adapter(name, vb.pp(name), RANK, 16.0).unwrap();
+    }
+    (lora, names)
+}
+
+/// Round-robin over the adapters with every fourth row left on the base
+/// layer, so the batch is genuinely heterogeneous.
+fn make_assignments(names: &[String]) -> Vec<Option<&str>> {
+    (0..BATCH)
+        .map(|i| {
+            if i % 4 == 3 {
+                None
+            } else {
+                Some(names[i % names.len()].as_str())
+            }
+        })
+        .collect()
+}
+
+/// The host-side loop the batched path replaces: group rows by adapter, run
+/// one forward per group, then scatter the group outputs back to their rows.
+fn sequential_grouped_forward(
+    lora: &LoraLinear,
+    x: &Tensor,
+    assignments: &[Option<&str>],
+) -> Tensor {
+    let device = x.device();
+    let mut lora = lora.clone();
+    let mut groups: Vec<(Option<&str>, Vec<u32>)> = Vec::new();
+    for (i, assignment) in assignments.iter().enumerate() {
+        match groups.iter_mut().find(|(name, _)| name == assignment) {
+            Some((_, rows)) => rows.push(i as u32),
+            None => groups.push((*assignment, vec![i as u32])),
+        }
+    }
+    let mut outputs = Vec::with_capacity(groups.len());
+    let mut order = Vec::with_capacity(assignments.len());
+    for (name, rows) in groups {
+        lora.set_active_adapter(name).unwrap();
+        let idx = Tensor::from_vec(rows.clone(), rows.len(), device).unwrap();
+        outputs.push(lora.forward(&x.index_select(&idx, 0).unwrap()).unwrap());
+        order.extend(rows);
+    }
+    let mut inverse = vec![0u32; order.len()];
+    for (pos, row) in order.iter().enumerate() {
+        inverse[*row as usize] = pos as u32;
+    }
+    let inverse = Tensor::from_vec(inverse, order.len(), device).unwrap();
+    Tensor::cat(&outputs, 0)
+        .unwrap()
+        .index_select(&inverse, 0)
+        .unwrap()
+}
+
+fn run_lora_benchmark(c: &mut Criterion, device: &Device, seq_len: usize) {
+    let (lora, names) = make_lora(device);
+    let assignments = make_assignments(&names);
+    let x = Tensor::randn(0f32, 1., (BATCH, seq_len, HIDDEN), device).unwrap();
+
+    let mut group = c.benchmark_group(device.bench_name(format!("lora_multi_adapter_s{seq_len}")));
+    {
+        let (lora, x, assignments) = (lora.clone(), x.clone(), assignments.clone());
+        group.bench_function("batched", move |b| {
+            b.iter_custom(|iters| {
+                let start = Instant::now();
+                for _ in 0..iters {
+                    black_box(
+                        lora.forward_with_adapters(black_box(&x), black_box(&assignments))
+                            .unwrap(),
+                    );
+                }
+                x.device().sync().unwrap();
+                start.elapsed()
+            })
+        });
+    }
+    group.bench_function("sequential", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            for _ in 0..iters {
+                black_box(sequential_grouped_forward(
+                    black_box(&lora),
+                    black_box(&x),
+                    black_box(&assignments),
+                ));
+            }
+            x.device().sync().unwrap();
+            start.elapsed()
+        })
+    });
+    group.finish();
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let device = BenchDeviceHandler::new().unwrap();
+    for d in device.devices {
+        // Decode-style (one token per sequence) and prefill-style batches.
+        run_lora_benchmark(c, &d, 1);
+        run_lora_benchmark(c, &d, 128);
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);

--- a/candle-nn/benches/benchmarks/mod.rs
+++ b/candle-nn/benches/benchmarks/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod conv;
+pub(crate) mod lora;
 pub(crate) mod norm;
 pub(crate) mod softmax;
 

--- a/candle-nn/src/lib.rs
+++ b/candle-nn/src/lib.rs
@@ -28,6 +28,7 @@ pub mod init;
 pub mod kv_cache;
 pub mod layer_norm;
 pub mod linear;
+pub mod lora;
 pub mod loss;
 pub mod moe;
 pub mod ops;
@@ -58,6 +59,7 @@ pub use layer_norm::{
     layer_norm, layer_norm_no_bias, rms_norm, LayerNorm, LayerNormConfig, RmsNorm,
 };
 pub use linear::{linear, linear_b, linear_no_bias, Linear};
+pub use lora::LoraLinear;
 pub use ops::Dropout;
 pub use optim::{AdamW, Optimizer, ParamsAdamW, SGD};
 pub use rnn::{gru, lstm, GRUConfig, LSTMConfig, GRU, LSTM, RNN};

--- a/candle-nn/src/lora.rs
+++ b/candle-nn/src/lora.rs
@@ -10,6 +10,11 @@
 //! and several adapters can coexist so that the active one can be swapped at
 //! runtime with [`LoraLinear::set_active_adapter`].
 //!
+//! For serving scenarios where a single batch mixes sequences that target
+//! different adapters (S-LoRA / Punica style multi-tenant inference),
+//! [`LoraLinear::forward_with_adapters`] applies a per-row adapter selection
+//! in one batched computation instead of one forward per adapter group.
+//!
 //! ```rust
 //! use candle::{Device, Tensor};
 //! use candle_nn::{linear, lora::LoraLinear, Module, VarBuilder};
@@ -42,6 +47,32 @@ impl Adapter {
     /// `(B·A) * scale`, i.e. the delta that gets added to the base weight.
     fn delta_weight(&self) -> Result<Tensor> {
         self.lora_b.matmul(&self.lora_a)?.affine(self.scale, 0.)
+    }
+
+    fn rank(&self) -> Result<usize> {
+        self.lora_a.dim(0)
+    }
+
+    /// `A^T [in, r]` zero-padded along the rank dimension to `r_max`.
+    fn a_t_padded(&self, r_max: usize) -> Result<Tensor> {
+        let a_t = self.lora_a.t()?.contiguous()?;
+        let (in_dim, r) = a_t.dims2()?;
+        if r == r_max {
+            return Ok(a_t);
+        }
+        let pad = Tensor::zeros((in_dim, r_max - r), a_t.dtype(), a_t.device())?;
+        Tensor::cat(&[a_t, pad], 1)
+    }
+
+    /// `B^T * scale [r, out]` zero-padded along the rank dimension to `r_max`.
+    fn b_t_scaled_padded(&self, r_max: usize) -> Result<Tensor> {
+        let b_t = self.lora_b.t()?.affine(self.scale, 0.)?;
+        let (r, out_dim) = b_t.dims2()?;
+        if r == r_max {
+            return Ok(b_t);
+        }
+        let pad = Tensor::zeros((r_max - r, out_dim), b_t.dtype(), b_t.device())?;
+        Tensor::cat(&[b_t, pad], 0)
     }
 
     /// `(x·A^T)·B^T * scale`, i.e. the LoRA contribution to the output.
@@ -222,6 +253,99 @@ impl LoraLinear {
     /// The underlying base layer.
     pub fn base(&self) -> &Linear {
         &self.base
+    }
+
+    /// Forward pass over a heterogeneous batch where each row selects its own
+    /// adapter (S-LoRA / Punica style multi-adapter batching).
+    ///
+    /// `x` has shape `[batch, in_dim]` or `[batch, seq, in_dim]` and
+    /// `assignments` holds, for each batch row, either `Some(adapter_name)` or
+    /// `None` for rows that should only go through the base layer. The
+    /// currently active adapter is ignored by this method.
+    ///
+    /// Rather than splitting the batch and running one forward per adapter
+    /// group, the selected `A`/`B` matrices are gathered into per-row stacks
+    /// (zero-padded to the largest rank, with the `alpha/r` scaling folded in)
+    /// and applied with two batched matmuls, SGMV-style:
+    /// `y = W·x + gather(B_all)·gather(A_all)·x`. Rows with no adapter hit an
+    /// all-zero slot, so the base-only path is preserved exactly and the
+    /// result matches running each row separately with its own adapter.
+    pub fn forward_with_adapters(
+        &self,
+        x: &Tensor,
+        assignments: &[Option<&str>],
+    ) -> Result<Tensor> {
+        if let Some(merged) = &self.merged {
+            candle::bail!(
+                "cannot use forward_with_adapters while adapter {merged} is merged into the base \
+                 weight, call unmerge first"
+            )
+        }
+        let batch = x.dim(0)?;
+        if assignments.len() != batch {
+            candle::bail!(
+                "forward_with_adapters: {} adapter assignments for a batch of {batch} rows",
+                assignments.len()
+            )
+        }
+        let base_out = self.base.forward(x)?;
+        // Map each row to a slot in the gathered stacks; slot 0 is an all-zero
+        // adapter used by the `None` rows.
+        let mut involved: Vec<&str> = Vec::new();
+        let mut row_slots: Vec<u32> = Vec::with_capacity(batch);
+        for assignment in assignments {
+            match assignment {
+                None => row_slots.push(0),
+                Some(name) => {
+                    if !self.adapters.contains_key(*name) {
+                        candle::bail!("no such LoRA adapter: {name}")
+                    }
+                    let slot = match involved.iter().position(|n| n == name) {
+                        Some(i) => i + 1,
+                        None => {
+                            involved.push(name);
+                            involved.len()
+                        }
+                    };
+                    row_slots.push(slot as u32);
+                }
+            }
+        }
+        if involved.is_empty() {
+            return Ok(base_out);
+        }
+        let (out_dim, in_dim) = self.base.weight().dims2()?;
+        let r_max = involved
+            .iter()
+            .map(|name| self.adapters[*name].rank())
+            .try_fold(0, |acc, r| r.map(|r| acc.max(r)))?;
+        let (dtype, device) = (x.dtype(), x.device());
+        let mut a_stack = vec![Tensor::zeros((in_dim, r_max), dtype, device)?];
+        let mut b_stack = vec![Tensor::zeros((r_max, out_dim), dtype, device)?];
+        for name in involved {
+            let adapter = &self.adapters[name];
+            a_stack.push(adapter.a_t_padded(r_max)?.to_dtype(dtype)?);
+            b_stack.push(adapter.b_t_scaled_padded(r_max)?.to_dtype(dtype)?);
+        }
+        let row_slots = Tensor::from_vec(row_slots, batch, device)?;
+        // [batch, in_dim, r_max] and [batch, r_max, out_dim].
+        let a_sel = Tensor::stack(&a_stack, 0)?.index_select(&row_slots, 0)?;
+        let b_sel = Tensor::stack(&b_stack, 0)?.index_select(&row_slots, 0)?;
+        let x3 = match x.rank() {
+            2 => x.unsqueeze(1)?,
+            3 => x.clone(),
+            rank => candle::bail!(
+                "forward_with_adapters expects a [batch, in] or [batch, seq, in] input, got a \
+                 rank {rank} tensor"
+            ),
+        };
+        let delta = x3.contiguous()?.matmul(&a_sel)?.matmul(&b_sel)?;
+        let delta = if x.rank() == 2 {
+            delta.squeeze(1)?
+        } else {
+            delta
+        };
+        base_out.add(&delta)
     }
 }
 

--- a/candle-nn/src/lora.rs
+++ b/candle-nn/src/lora.rs
@@ -160,8 +160,23 @@ impl LoraLinear {
         lora_b: Tensor,
         alpha: f64,
     ) -> Result<()> {
+        // Overwriting the adapter that is currently merged into the base weight
+        // would make `unmerge` subtract the new delta from a base that still
+        // holds the old one, corrupting the weights. Refuse it, as
+        // `set_active_adapter` does for switching.
+        if self.merged.as_deref() == Some(name) {
+            candle::bail!(
+                "adapter {name} is merged into the base weight, unmerge it before overwriting"
+            )
+        }
         let rank = lora_a.dim(0)?;
         let scale = alpha / rank as f64;
+        // Align the adapter tensors with the base weight's dtype so the plain
+        // `forward` (and `merge`/`delta_weight`) never hit a mixed-dtype matmul
+        // when a PEFT checkpoint is stored in a different dtype than the model.
+        let dtype = self.base.weight().dtype();
+        let lora_a = lora_a.to_dtype(dtype)?;
+        let lora_b = lora_b.to_dtype(dtype)?;
         self.adapters.insert(
             name.to_string(),
             Adapter {
@@ -322,10 +337,14 @@ impl LoraLinear {
         let (dtype, device) = (x.dtype(), x.device());
         let mut a_stack = vec![Tensor::zeros((in_dim, r_max), dtype, device)?];
         let mut b_stack = vec![Tensor::zeros((r_max, out_dim), dtype, device)?];
+        // Adapter tensors are stored in the base weight's dtype (see
+        // `add_adapter_tensors`), which equals `x`'s dtype here since
+        // `base.forward(x)` above already ran, so the stacks are homogeneous
+        // with the zero slot without a per-adapter cast.
         for name in involved {
             let adapter = &self.adapters[name];
-            a_stack.push(adapter.a_t_padded(r_max)?.to_dtype(dtype)?);
-            b_stack.push(adapter.b_t_scaled_padded(r_max)?.to_dtype(dtype)?);
+            a_stack.push(adapter.a_t_padded(r_max)?);
+            b_stack.push(adapter.b_t_scaled_padded(r_max)?);
         }
         let row_slots = Tensor::from_vec(row_slots, batch, device)?;
         let a_stack = Tensor::stack(&a_stack, 0)?;

--- a/candle-nn/src/lora.rs
+++ b/candle-nn/src/lora.rs
@@ -379,12 +379,30 @@ impl LoraLinear {
 /// implementation below gathers per-row copies of the adapter matrices and
 /// applies them with two batched matmuls, whereas a dedicated kernel can read
 /// the stacks in place through `row_slots` without materializing the gather.
+///
+/// With the `lora-cuda` feature, a decode-step batch (`seq == 1`) on a CUDA
+/// device is routed through the [`candle_lora_kernels`] BGMV kernels, which
+/// return the same delta; every other case uses the reference path below.
 fn batched_lora_delta(
     x: &Tensor,
     a_stack: &Tensor,
     b_stack: &Tensor,
     row_slots: &Tensor,
 ) -> Result<Tensor> {
+    #[cfg(feature = "lora-cuda")]
+    {
+        let (batch, seq, in_dim) = x.dims3()?;
+        let supported = matches!(
+            x.dtype(),
+            candle::DType::F32 | candle::DType::F16 | candle::DType::BF16
+        );
+        if seq == 1 && x.device().is_cuda() && supported {
+            let x2d = x.reshape((batch, in_dim))?;
+            let delta = candle_lora_kernels::bgmv_delta(&x2d, a_stack, b_stack, row_slots)?;
+            let out_dim = delta.dim(1)?;
+            return delta.reshape((batch, 1, out_dim));
+        }
+    }
     // [batch, in, r_max] and [batch, r_max, out].
     let a_sel = a_stack.index_select(row_slots, 0)?;
     let b_sel = b_stack.index_select(row_slots, 0)?;

--- a/candle-nn/src/lora.rs
+++ b/candle-nn/src/lora.rs
@@ -1,0 +1,239 @@
+//! LoRA (Low-Rank Adaptation) layers.
+//!
+//! This module provides a `Linear` wrapper that adds one or more low-rank
+//! adapters on top of a frozen base layer, computing
+//! `y = W·x + (B·A)·x·(alpha/r)` for the currently active adapter.
+//!
+//! Adapters can be loaded from PEFT-style `.safetensors` checkpoints (tensors
+//! named `lora_A.weight` of shape `[r, in_dim]` and `lora_B.weight` of shape
+//! `[out_dim, r]`) via [`LoraLinear::from_peft`] / [`LoraLinear::load_adapter`],
+//! and several adapters can coexist so that the active one can be swapped at
+//! runtime with [`LoraLinear::set_active_adapter`].
+//!
+//! ```rust
+//! use candle::{Device, Tensor};
+//! use candle_nn::{linear, lora::LoraLinear, Module, VarBuilder};
+//! # fn main() -> candle::Result<()> {
+//! let dev = &Device::Cpu;
+//! let varmap = candle_nn::VarMap::new();
+//! let vb = VarBuilder::from_varmap(&varmap, candle::DType::F32, dev);
+//! let base = linear(8, 4, vb.pp("q_proj"))?;
+//! let mut lora = LoraLinear::new(base);
+//! lora.add_adapter("default", vb.pp("lora.q_proj"), 2, 16.0)?;
+//! let x = Tensor::zeros((1, 8), candle::DType::F32, dev)?;
+//! let y = lora.forward(&x)?; // base + LoRA delta
+//! # Ok(()) }
+//! ```
+use std::collections::HashMap;
+
+use candle::{Result, Tensor};
+
+use crate::{Init, Linear, Module, VarBuilder};
+
+/// A single low-rank adapter: `B [out, r]`, `A [r, in]` and the `alpha/r` scaling.
+#[derive(Clone, Debug)]
+struct Adapter {
+    lora_a: Tensor,
+    lora_b: Tensor,
+    scale: f64,
+}
+
+impl Adapter {
+    /// `(B·A) * scale`, i.e. the delta that gets added to the base weight.
+    fn delta_weight(&self) -> Result<Tensor> {
+        self.lora_b.matmul(&self.lora_a)?.affine(self.scale, 0.)
+    }
+
+    /// `(x·A^T)·B^T * scale`, i.e. the LoRA contribution to the output.
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let lora_a = self.lora_a.t()?;
+        let lora_b = self.lora_b.t()?;
+        x.broadcast_matmul(&lora_a)?
+            .broadcast_matmul(&lora_b)?
+            .affine(self.scale, 0.)
+    }
+}
+
+/// A `Linear` layer augmented with zero or more named LoRA adapters.
+///
+/// At most one adapter is active at a time (see [`Self::set_active_adapter`]).
+/// The active adapter can be folded into the base weight with [`Self::merge`]
+/// for inference, and restored with [`Self::unmerge`].
+#[derive(Clone, Debug)]
+pub struct LoraLinear {
+    base: Linear,
+    adapters: HashMap<String, Adapter>,
+    active: Option<String>,
+    merged: Option<String>,
+}
+
+impl LoraLinear {
+    /// Wrap a base `Linear` layer with no adapters attached.
+    pub fn new(base: Linear) -> Self {
+        Self {
+            base,
+            adapters: HashMap::new(),
+            active: None,
+            merged: None,
+        }
+    }
+
+    /// Load a PEFT-style adapter (a freshly initialized `B` matrix and a
+    /// Kaiming-initialized `A` matrix, as is standard for LoRA) under `name`,
+    /// pulling `lora_A.weight` and `lora_B.weight` from `vb`, and make it the
+    /// active adapter.
+    pub fn from_peft(base: Linear, vb: VarBuilder, rank: usize, alpha: f64) -> Result<Self> {
+        let mut lora = Self::new(base);
+        lora.load_adapter("default", vb, rank, alpha)?;
+        lora.set_active_adapter(Some("default"))?;
+        Ok(lora)
+    }
+
+    /// Load (or create, if the tensors are not present in `vb`) an adapter
+    /// named `name` with the given `rank` and `alpha`, without changing which
+    /// adapter is currently active.
+    pub fn load_adapter(
+        &mut self,
+        name: &str,
+        vb: VarBuilder,
+        rank: usize,
+        alpha: f64,
+    ) -> Result<()> {
+        let (out_dim, in_dim) = self.base.weight().dims2()?;
+        let lora_a = vb.get_with_hints(
+            (rank, in_dim),
+            "lora_A.weight",
+            crate::init::DEFAULT_KAIMING_UNIFORM,
+        )?;
+        let lora_b = vb.get_with_hints((out_dim, rank), "lora_B.weight", Init::Const(0.))?;
+        self.add_adapter_tensors(name, lora_a, lora_b, alpha)
+    }
+
+    /// Load an adapter (see [`Self::load_adapter`]) and make it the active
+    /// adapter.
+    pub fn add_adapter(
+        &mut self,
+        name: &str,
+        vb: VarBuilder,
+        rank: usize,
+        alpha: f64,
+    ) -> Result<()> {
+        self.load_adapter(name, vb, rank, alpha)?;
+        self.set_active_adapter(Some(name))
+    }
+
+    fn add_adapter_tensors(
+        &mut self,
+        name: &str,
+        lora_a: Tensor,
+        lora_b: Tensor,
+        alpha: f64,
+    ) -> Result<()> {
+        let rank = lora_a.dim(0)?;
+        let scale = alpha / rank as f64;
+        self.adapters.insert(
+            name.to_string(),
+            Adapter {
+                lora_a,
+                lora_b,
+                scale,
+            },
+        );
+        Ok(())
+    }
+
+    /// Remove an adapter. If it was the active or merged one, it is
+    /// unmerged/deactivated first.
+    pub fn remove_adapter(&mut self, name: &str) -> Result<()> {
+        if self.merged.as_deref() == Some(name) {
+            self.unmerge()?;
+        }
+        if self.active.as_deref() == Some(name) {
+            self.active = None;
+        }
+        self.adapters.remove(name);
+        Ok(())
+    }
+
+    /// Select the active adapter (or `None` to bypass all adapters and use
+    /// only the base layer). Fails if `name` is not a known adapter, or if a
+    /// different adapter is currently merged into the base weight.
+    pub fn set_active_adapter(&mut self, name: Option<&str>) -> Result<()> {
+        if let Some(name) = name {
+            if !self.adapters.contains_key(name) {
+                candle::bail!("no such LoRA adapter: {name}");
+            }
+        }
+        if let Some(merged) = &self.merged {
+            if name != Some(merged.as_str()) {
+                candle::bail!(
+                    "adapter {merged} is merged into the base weight, unmerge it before switching"
+                );
+            }
+        }
+        self.active = name.map(|s| s.to_string());
+        Ok(())
+    }
+
+    /// Name of the currently active adapter, if any.
+    pub fn active_adapter(&self) -> Option<&str> {
+        self.active.as_deref()
+    }
+
+    /// Names of all the adapters currently registered.
+    pub fn adapter_names(&self) -> Vec<&str> {
+        self.adapters.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Fold the active adapter's weights into the base layer, so that
+    /// `forward` no longer needs to compute the low-rank update separately.
+    /// This is a no-op if no adapter is active or one is already merged.
+    pub fn merge(&mut self) -> Result<()> {
+        if self.merged.is_some() {
+            return Ok(());
+        }
+        let Some(active) = self.active.clone() else {
+            return Ok(());
+        };
+        let adapter = &self.adapters[&active];
+        let weight = self.base.weight().add(&adapter.delta_weight()?)?;
+        self.base = Linear::new(weight, self.base.bias().cloned());
+        self.merged = Some(active);
+        Ok(())
+    }
+
+    /// Undo a previous [`Self::merge`], restoring the base layer's original
+    /// weights. This is a no-op if no adapter is currently merged.
+    pub fn unmerge(&mut self) -> Result<()> {
+        let Some(merged) = self.merged.take() else {
+            return Ok(());
+        };
+        let adapter = &self.adapters[&merged];
+        let weight = self.base.weight().sub(&adapter.delta_weight()?)?;
+        self.base = Linear::new(weight, self.base.bias().cloned());
+        Ok(())
+    }
+
+    /// Whether an adapter is currently merged into the base weight.
+    pub fn is_merged(&self) -> bool {
+        self.merged.is_some()
+    }
+
+    /// The underlying base layer.
+    pub fn base(&self) -> &Linear {
+        &self.base
+    }
+}
+
+impl Module for LoraLinear {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let base_out = self.base.forward(x)?;
+        if self.merged.is_some() {
+            return Ok(base_out);
+        }
+        match &self.active {
+            None => Ok(base_out),
+            Some(name) => base_out.add(&self.adapters[name].forward(x)?),
+        }
+    }
+}

--- a/candle-nn/src/lora.rs
+++ b/candle-nn/src/lora.rs
@@ -328,9 +328,8 @@ impl LoraLinear {
             b_stack.push(adapter.b_t_scaled_padded(r_max)?.to_dtype(dtype)?);
         }
         let row_slots = Tensor::from_vec(row_slots, batch, device)?;
-        // [batch, in_dim, r_max] and [batch, r_max, out_dim].
-        let a_sel = Tensor::stack(&a_stack, 0)?.index_select(&row_slots, 0)?;
-        let b_sel = Tensor::stack(&b_stack, 0)?.index_select(&row_slots, 0)?;
+        let a_stack = Tensor::stack(&a_stack, 0)?;
+        let b_stack = Tensor::stack(&b_stack, 0)?;
         let x3 = match x.rank() {
             2 => x.unsqueeze(1)?,
             3 => x.clone(),
@@ -339,7 +338,7 @@ impl LoraLinear {
                  rank {rank} tensor"
             ),
         };
-        let delta = x3.contiguous()?.matmul(&a_sel)?.matmul(&b_sel)?;
+        let delta = batched_lora_delta(&x3, &a_stack, &b_stack, &row_slots)?;
         let delta = if x.rank() == 2 {
             delta.squeeze(1)?
         } else {
@@ -347,6 +346,30 @@ impl LoraLinear {
         };
         base_out.add(&delta)
     }
+}
+
+/// Computes the LoRA delta for a prepared heterogeneous batch:
+/// `delta[i] = x[i] · a_stack[slot(i)] · b_stack[slot(i)]` for every batch
+/// row `i`, where `x` is `[batch, seq, in]`, `a_stack` is
+/// `[n_slots, in, r_max]` (`A^T`, rank-padded with zeros), `b_stack` is
+/// `[n_slots, r_max, out]` (`B^T`, rank-padded, `alpha/r` scaling folded in,
+/// slot 0 all-zero for no-adapter rows) and `row_slots` is a `[batch]` u32
+/// tensor mapping every row to its slot.
+///
+/// This is the seam a fused SGMV/BGMV kernel can replace: the reference
+/// implementation below gathers per-row copies of the adapter matrices and
+/// applies them with two batched matmuls, whereas a dedicated kernel can read
+/// the stacks in place through `row_slots` without materializing the gather.
+fn batched_lora_delta(
+    x: &Tensor,
+    a_stack: &Tensor,
+    b_stack: &Tensor,
+    row_slots: &Tensor,
+) -> Result<Tensor> {
+    // [batch, in, r_max] and [batch, r_max, out].
+    let a_sel = a_stack.index_select(row_slots, 0)?;
+    let b_sel = b_stack.index_select(row_slots, 0)?;
+    x.contiguous()?.matmul(&a_sel)?.matmul(&b_sel)
 }
 
 impl Module for LoraLinear {

--- a/candle-nn/tests/lora.rs
+++ b/candle-nn/tests/lora.rs
@@ -1,0 +1,115 @@
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use anyhow::Result;
+use candle::{test_utils::to_vec2_round, DType, Device, Tensor};
+use candle_nn::{linear_no_bias, lora::LoraLinear, Module, VarBuilder, VarMap};
+
+fn make_base(device: &Device) -> Result<candle_nn::Linear> {
+    // in_dim = 3, out_dim = 2
+    let mut varmap = VarMap::new();
+    let vb = VarBuilder::from_varmap(&varmap, DType::F32, device);
+    let base = linear_no_bias(3, 2, vb.pp("q_proj"))?;
+    varmap.set_one(
+        "q_proj.weight",
+        Tensor::new(&[[1f32, 0., 0.], [0., 1., 0.]], device)?,
+    )?;
+    Ok(base)
+}
+
+#[test]
+fn lora_forward_matches_manual_computation() -> Result<()> {
+    let device = Device::Cpu;
+    let base = make_base(&device)?;
+
+    let mut varmap = VarMap::new();
+    let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+    let mut lora =
+        LoraLinear::from_peft(base, vb.pp("q_proj"), /*rank=*/ 2, /*alpha=*/ 4.0)?;
+
+    // lora_A: [r=2, in=3], lora_B: [out=2, r=2]
+    varmap.set_one(
+        "q_proj.lora_A.weight",
+        Tensor::new(&[[1f32, 0., 0.], [0., 1., 0.]], &device)?,
+    )?;
+    varmap.set_one(
+        "q_proj.lora_B.weight",
+        Tensor::new(&[[1f32, 0.], [0., 1.]], &device)?,
+    )?;
+
+    let x = Tensor::new(&[[1f32, 2., 3.]], &device)?;
+    let y = lora.forward(&x)?;
+    // base_out = [1, 2]; delta = scale * B@A@x with scale = alpha/r = 2.0
+    // A@x = [1, 2] (selects first two components), B@(A@x) = [1, 2], * scale(2.0) = [2, 4]
+    // y = base_out + delta = [3, 6]
+    assert_eq!(to_vec2_round(&y, 4)?, vec![vec![3f32, 6.]]);
+
+    lora.merge()?;
+    assert!(lora.is_merged());
+    let y_merged = lora.forward(&x)?;
+    assert_eq!(to_vec2_round(&y_merged, 4)?, vec![vec![3f32, 6.]]);
+
+    lora.unmerge()?;
+    assert!(!lora.is_merged());
+    let y_unmerged = lora.forward(&x)?;
+    assert_eq!(to_vec2_round(&y_unmerged, 4)?, vec![vec![3f32, 6.]]);
+
+    Ok(())
+}
+
+#[test]
+fn lora_multi_adapter_switching() -> Result<()> {
+    let device = Device::Cpu;
+    let base = make_base(&device)?;
+
+    let mut varmap = VarMap::new();
+    let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+    let mut lora = LoraLinear::new(base);
+
+    lora.add_adapter("a", vb.pp("lora_a"), 2, 2.0)?;
+    varmap.set_one(
+        "lora_a.lora_A.weight",
+        Tensor::new(&[[1f32, 0., 0.], [0., 0., 0.]], &device)?,
+    )?;
+    varmap.set_one(
+        "lora_a.lora_B.weight",
+        Tensor::new(&[[1f32, 0.], [0., 0.]], &device)?,
+    )?;
+
+    lora.add_adapter("b", vb.pp("lora_b"), 2, 2.0)?;
+    varmap.set_one(
+        "lora_b.lora_A.weight",
+        Tensor::new(&[[0f32, 1., 0.], [0., 0., 0.]], &device)?,
+    )?;
+    varmap.set_one(
+        "lora_b.lora_B.weight",
+        Tensor::new(&[[0f32, 0.], [1., 0.]], &device)?,
+    )?;
+
+    let x = Tensor::new(&[[1f32, 2., 3.]], &device)?;
+
+    assert_eq!(lora.active_adapter(), Some("b"));
+    let y_b = lora.forward(&x)?;
+    // base_out = [1, 2]; adapter b: A@x = [2, 0], B@(A@x) = [0, 2], scale=1.0 -> delta=[0, 2]
+    assert_eq!(to_vec2_round(&y_b, 4)?, vec![vec![1f32, 4.]]);
+
+    lora.set_active_adapter(Some("a"))?;
+    let y_a = lora.forward(&x)?;
+    // adapter a: A@x = [1, 0], B@(A@x) = [1, 0], scale=1.0 -> delta=[1, 0]
+    assert_eq!(to_vec2_round(&y_a, 4)?, vec![vec![2f32, 2.]]);
+
+    lora.merge()?;
+    assert!(lora.set_active_adapter(Some("b")).is_err());
+    lora.unmerge()?;
+    lora.set_active_adapter(Some("b"))?;
+    assert_eq!(lora.active_adapter(), Some("b"));
+
+    lora.set_active_adapter(None)?;
+    let y_base = lora.forward(&x)?;
+    assert_eq!(to_vec2_round(&y_base, 4)?, vec![vec![1f32, 2.]]);
+
+    Ok(())
+}

--- a/candle-nn/tests/lora.rs
+++ b/candle-nn/tests/lora.rs
@@ -337,3 +337,52 @@ test_device!(
     lora_batched_forward_errors_gpu,
     lora_batched_forward_errors_metal
 );
+
+/// Multi-step decode-loop parity for the CUDA BGMV kernel.
+///
+/// Every one of the `test_device!`-generated `_gpu` tests above still runs
+/// with a single `seq > 1` or one-shot call, and without the `lora-cuda`
+/// feature they never touch `candle_lora_kernels::bgmv_delta` at all (see
+/// `batched_lora_delta` in `candle-nn/src/lora.rs`, which only routes to it
+/// for `seq == 1` batches on a CUDA device). A generation loop such as
+/// `Llama::generate_with_adapters` calls `forward_with_adapters` with a
+/// `[batch, 1, in]` input once per decode step, reusing the same adapter
+/// stacks and CUDA buffers across many kernel launches in a row, which is a
+/// different code path than a single isolated call. This test drives several
+/// such steps back to back on a heterogeneous batch (two adapters and a
+/// base-only row) and checks the GPU kernel path matches the CPU gather +
+/// batched matmul reference at every step, not just the first.
+#[cfg(feature = "lora-cuda")]
+#[test]
+fn lora_batched_forward_multistep_decode_gpu_matches_cpu() -> Result<()> {
+    let cpu = Device::Cpu;
+    let gpu = Device::new_cuda(0)?;
+    let lora_cpu = make_multi_lora(&cpu)?;
+    let lora_gpu = make_multi_lora(&gpu)?;
+
+    // Two different adapters and a base-only row, as in the other batched
+    // tests; a different input per step stands in for the evolving hidden
+    // state a real decode loop would feed in at each new token.
+    let assignments = [Some("a"), Some("b"), None];
+    let steps: &[[[f32; 3]; 3]] = &[
+        [[1., 2., 3.], [-1., 0.5, 2.], [0.25, -1., 1.]],
+        [[0.1, -0.2, 0.3], [1.5, -1., 0.], [-0.5, 0.5, 0.5]],
+        [[2., 1., -1.], [0., 0., 1.], [-1., -1., -1.]],
+        [[0.5, 0.5, 0.5], [-2., 1., 0.5], [1., -1., 0.]],
+    ];
+
+    for (step, values) in steps.iter().enumerate() {
+        // [batch, 1, in]: the shape a decode step feeds through the model.
+        let x_cpu = Tensor::new(values, &cpu)?.unsqueeze(1)?;
+        let x_gpu = Tensor::new(values, &gpu)?.unsqueeze(1)?;
+
+        let cpu_out = lora_cpu.forward_with_adapters(&x_cpu, &assignments)?;
+        let gpu_out = lora_gpu.forward_with_adapters(&x_gpu, &assignments)?;
+        assert_eq!(
+            to_vec3_round(&gpu_out, 4)?,
+            to_vec3_round(&cpu_out, 4)?,
+            "decode step {step} diverged between the CUDA BGMV kernel and the CPU reference"
+        );
+    }
+    Ok(())
+}

--- a/candle-nn/tests/lora.rs
+++ b/candle-nn/tests/lora.rs
@@ -4,8 +4,8 @@ extern crate intel_mkl_src;
 #[cfg(feature = "accelerate")]
 extern crate accelerate_src;
 
-use anyhow::Result;
-use candle::{test_utils::to_vec2_round, DType, Device, Tensor};
+use candle::test_utils::{to_vec2_round, to_vec3_round};
+use candle::{test_device, DType, Device, Result, Tensor};
 use candle_nn::{linear_no_bias, lora::LoraLinear, Module, VarBuilder, VarMap};
 
 fn make_base(device: &Device) -> Result<candle_nn::Linear> {
@@ -20,27 +20,25 @@ fn make_base(device: &Device) -> Result<candle_nn::Linear> {
     Ok(base)
 }
 
-#[test]
-fn lora_forward_matches_manual_computation() -> Result<()> {
-    let device = Device::Cpu;
-    let base = make_base(&device)?;
+fn lora_forward_matches_manual_computation(device: &Device) -> Result<()> {
+    let base = make_base(device)?;
 
     let mut varmap = VarMap::new();
-    let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+    let vb = VarBuilder::from_varmap(&varmap, DType::F32, device);
     let mut lora =
         LoraLinear::from_peft(base, vb.pp("q_proj"), /*rank=*/ 2, /*alpha=*/ 4.0)?;
 
     // lora_A: [r=2, in=3], lora_B: [out=2, r=2]
     varmap.set_one(
         "q_proj.lora_A.weight",
-        Tensor::new(&[[1f32, 0., 0.], [0., 1., 0.]], &device)?,
+        Tensor::new(&[[1f32, 0., 0.], [0., 1., 0.]], device)?,
     )?;
     varmap.set_one(
         "q_proj.lora_B.weight",
-        Tensor::new(&[[1f32, 0.], [0., 1.]], &device)?,
+        Tensor::new(&[[1f32, 0.], [0., 1.]], device)?,
     )?;
 
-    let x = Tensor::new(&[[1f32, 2., 3.]], &device)?;
+    let x = Tensor::new(&[[1f32, 2., 3.]], device)?;
     let y = lora.forward(&x)?;
     // base_out = [1, 2]; delta = scale * B@A@x with scale = alpha/r = 2.0
     // A@x = [1, 2] (selects first two components), B@(A@x) = [1, 2], * scale(2.0) = [2, 4]
@@ -60,36 +58,34 @@ fn lora_forward_matches_manual_computation() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn lora_multi_adapter_switching() -> Result<()> {
-    let device = Device::Cpu;
-    let base = make_base(&device)?;
+fn lora_multi_adapter_switching(device: &Device) -> Result<()> {
+    let base = make_base(device)?;
 
     let mut varmap = VarMap::new();
-    let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+    let vb = VarBuilder::from_varmap(&varmap, DType::F32, device);
     let mut lora = LoraLinear::new(base);
 
     lora.add_adapter("a", vb.pp("lora_a"), 2, 2.0)?;
     varmap.set_one(
         "lora_a.lora_A.weight",
-        Tensor::new(&[[1f32, 0., 0.], [0., 0., 0.]], &device)?,
+        Tensor::new(&[[1f32, 0., 0.], [0., 0., 0.]], device)?,
     )?;
     varmap.set_one(
         "lora_a.lora_B.weight",
-        Tensor::new(&[[1f32, 0.], [0., 0.]], &device)?,
+        Tensor::new(&[[1f32, 0.], [0., 0.]], device)?,
     )?;
 
     lora.add_adapter("b", vb.pp("lora_b"), 2, 2.0)?;
     varmap.set_one(
         "lora_b.lora_A.weight",
-        Tensor::new(&[[0f32, 1., 0.], [0., 0., 0.]], &device)?,
+        Tensor::new(&[[0f32, 1., 0.], [0., 0., 0.]], device)?,
     )?;
     varmap.set_one(
         "lora_b.lora_B.weight",
-        Tensor::new(&[[0f32, 0.], [1., 0.]], &device)?,
+        Tensor::new(&[[0f32, 0.], [1., 0.]], device)?,
     )?;
 
-    let x = Tensor::new(&[[1f32, 2., 3.]], &device)?;
+    let x = Tensor::new(&[[1f32, 2., 3.]], device)?;
 
     assert_eq!(lora.active_adapter(), Some("b"));
     let y_b = lora.forward(&x)?;
@@ -113,3 +109,170 @@ fn lora_multi_adapter_switching() -> Result<()> {
 
     Ok(())
 }
+
+/// A `LoraLinear` with two adapters of different ranks, for the heterogeneous
+/// batching tests: "a" (rank 2, alpha 4) and "b" (rank 1, alpha 3).
+fn make_multi_lora(device: &Device) -> Result<LoraLinear> {
+    let base = make_base(device)?;
+    let mut varmap = VarMap::new();
+    let vb = VarBuilder::from_varmap(&varmap, DType::F32, device);
+    let mut lora = LoraLinear::new(base);
+
+    lora.add_adapter("a", vb.pp("lora_a"), 2, 4.0)?;
+    varmap.set_one(
+        "lora_a.lora_A.weight",
+        Tensor::new(&[[1f32, -1., 0.5], [0.5, 1., -1.]], device)?,
+    )?;
+    varmap.set_one(
+        "lora_a.lora_B.weight",
+        Tensor::new(&[[1f32, 0.5], [-0.5, 1.]], device)?,
+    )?;
+
+    lora.add_adapter("b", vb.pp("lora_b"), 1, 3.0)?;
+    varmap.set_one(
+        "lora_b.lora_A.weight",
+        Tensor::new(&[[0.25f32, -0.5, 1.]], device)?,
+    )?;
+    varmap.set_one(
+        "lora_b.lora_B.weight",
+        Tensor::new(&[[2f32], [-1.]], device)?,
+    )?;
+
+    Ok(lora)
+}
+
+/// Reference implementation: run each batch row on its own with the row's
+/// adapter activated, then stitch the rows back together.
+fn sequential_forward(
+    lora: &LoraLinear,
+    x: &Tensor,
+    assignments: &[Option<&str>],
+) -> Result<Tensor> {
+    let mut lora = lora.clone();
+    let mut rows = Vec::with_capacity(assignments.len());
+    for (i, assignment) in assignments.iter().enumerate() {
+        lora.set_active_adapter(*assignment)?;
+        rows.push(lora.forward(&x.narrow(0, i, 1)?)?);
+    }
+    Tensor::cat(&rows, 0)
+}
+
+fn lora_batched_forward_matches_sequential(device: &Device) -> Result<()> {
+    let lora = make_multi_lora(device)?;
+
+    // A mixed batch: two adapters (of different ranks), a base-only row, and a
+    // repeated adapter.
+    let x = Tensor::new(
+        &[
+            [1f32, 2., 3.],
+            [-1., 0.5, 2.],
+            [0.25, -1., 1.],
+            [3., -2., 0.5],
+        ],
+        device,
+    )?;
+    let assignments = [Some("a"), Some("b"), None, Some("a")];
+
+    let batched = lora.forward_with_adapters(&x, &assignments)?;
+    let sequential = sequential_forward(&lora, &x, &assignments)?;
+    assert_eq!(to_vec2_round(&batched, 4)?, to_vec2_round(&sequential, 4)?);
+
+    // Adapter isolation: each row must be unaffected by the other adapters in
+    // the batch, i.e. match a batch where it is the only row.
+    for (i, assignment) in assignments.iter().enumerate() {
+        let row = lora.forward_with_adapters(&x.narrow(0, i, 1)?, &[*assignment])?;
+        assert_eq!(
+            to_vec2_round(&row, 4)?,
+            vec![to_vec2_round(&batched, 4)?[i].clone()]
+        );
+    }
+    Ok(())
+}
+
+fn lora_batched_forward_all_base_matches_base(device: &Device) -> Result<()> {
+    let lora = make_multi_lora(device)?;
+    let x = Tensor::new(&[[1f32, 2., 3.], [-1., 0.5, 2.]], device)?;
+
+    let batched = lora.forward_with_adapters(&x, &[None, None])?;
+    let base = lora.base().forward(&x)?;
+    assert_eq!(to_vec2_round(&batched, 4)?, to_vec2_round(&base, 4)?);
+    Ok(())
+}
+
+fn lora_batched_forward_3d_input(device: &Device) -> Result<()> {
+    let lora = make_multi_lora(device)?;
+
+    // [batch=3, seq=2, in=3]: the adapter assignment applies to every token of
+    // a sequence.
+    let x = Tensor::new(
+        &[
+            [[1f32, 2., 3.], [0.5, -1., 2.]],
+            [[-1., 0.5, 2.], [2., 1., -0.5]],
+            [[0.25, -1., 1.], [1., 1., 1.]],
+        ],
+        device,
+    )?;
+    let assignments = [Some("b"), None, Some("a")];
+
+    let batched = lora.forward_with_adapters(&x, &assignments)?;
+    let sequential = sequential_forward(&lora, &x, &assignments)?;
+    assert_eq!(batched.dims(), &[3, 2, 2]);
+    assert_eq!(to_vec3_round(&batched, 4)?, to_vec3_round(&sequential, 4)?);
+    Ok(())
+}
+
+fn lora_batched_forward_errors(device: &Device) -> Result<()> {
+    let mut lora = make_multi_lora(device)?;
+    let x = Tensor::new(&[[1f32, 2., 3.], [-1., 0.5, 2.]], device)?;
+
+    // Assignment count must match the batch size.
+    assert!(lora.forward_with_adapters(&x, &[Some("a")]).is_err());
+    // Unknown adapter names are rejected.
+    assert!(lora
+        .forward_with_adapters(&x, &[Some("a"), Some("nope")])
+        .is_err());
+    // A merged adapter would be double-counted, so this must fail.
+    lora.set_active_adapter(Some("a"))?;
+    lora.merge()?;
+    assert!(lora.forward_with_adapters(&x, &[Some("a"), None]).is_err());
+    lora.unmerge()?;
+    assert!(lora.forward_with_adapters(&x, &[Some("a"), None]).is_ok());
+    Ok(())
+}
+
+test_device!(
+    lora_forward_matches_manual_computation,
+    lora_forward_matches_manual_computation_cpu,
+    lora_forward_matches_manual_computation_gpu,
+    lora_forward_matches_manual_computation_metal
+);
+test_device!(
+    lora_multi_adapter_switching,
+    lora_multi_adapter_switching_cpu,
+    lora_multi_adapter_switching_gpu,
+    lora_multi_adapter_switching_metal
+);
+test_device!(
+    lora_batched_forward_matches_sequential,
+    lora_batched_forward_matches_sequential_cpu,
+    lora_batched_forward_matches_sequential_gpu,
+    lora_batched_forward_matches_sequential_metal
+);
+test_device!(
+    lora_batched_forward_all_base_matches_base,
+    lora_batched_forward_all_base_matches_base_cpu,
+    lora_batched_forward_all_base_matches_base_gpu,
+    lora_batched_forward_all_base_matches_base_metal
+);
+test_device!(
+    lora_batched_forward_3d_input,
+    lora_batched_forward_3d_input_cpu,
+    lora_batched_forward_3d_input_gpu,
+    lora_batched_forward_3d_input_metal
+);
+test_device!(
+    lora_batched_forward_errors,
+    lora_batched_forward_errors_cpu,
+    lora_batched_forward_errors_gpu,
+    lora_batched_forward_errors_metal
+);

--- a/candle-nn/tests/lora.rs
+++ b/candle-nn/tests/lora.rs
@@ -240,6 +240,67 @@ fn lora_batched_forward_errors(device: &Device) -> Result<()> {
     Ok(())
 }
 
+/// Reloading the adapter that is currently merged into the base weight would
+/// make `unmerge` subtract the new delta from a base still holding the old one;
+/// it must be rejected instead. Device-independent control-flow, so CPU only.
+#[test]
+fn lora_reload_while_merged_is_rejected() -> Result<()> {
+    let device = Device::Cpu;
+    let base = make_base(&device)?;
+    let mut varmap = VarMap::new();
+    let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+    let mut lora = LoraLinear::new(base);
+    lora.add_adapter("a", vb.pp("lora_a"), 2, 2.0)?;
+    varmap.set_one(
+        "lora_a.lora_A.weight",
+        Tensor::new(&[[1f32, 0., 0.], [0., 1., 0.]], &device)?,
+    )?;
+    varmap.set_one(
+        "lora_a.lora_B.weight",
+        Tensor::new(&[[1f32, 0.], [0., 1.]], &device)?,
+    )?;
+    let x = Tensor::new(&[[1f32, 2., 3.]], &device)?;
+
+    lora.set_active_adapter(Some("a"))?;
+    let active = to_vec2_round(&lora.forward(&x)?, 4)?;
+    lora.merge()?;
+    assert_eq!(to_vec2_round(&lora.forward(&x)?, 4)?, active);
+
+    // Overwriting the merged adapter must be rejected, not silently corrupt base.
+    assert!(lora.load_adapter("a", vb.pp("lora_a"), 2, 2.0).is_err());
+    // The rejected reload left the merged state untouched.
+    assert_eq!(to_vec2_round(&lora.forward(&x)?, 4)?, active);
+
+    // Unmerge restores the same output, and the base weight exactly.
+    lora.unmerge()?;
+    assert_eq!(to_vec2_round(&lora.forward(&x)?, 4)?, active);
+    lora.set_active_adapter(None)?;
+    assert_eq!(to_vec2_round(&lora.forward(&x)?, 4)?, vec![vec![1f32, 2.]]);
+    // Reloading is allowed once nothing is merged.
+    assert!(lora.load_adapter("a", vb.pp("lora_a"), 2, 2.0).is_ok());
+    Ok(())
+}
+
+/// An adapter checkpoint stored in a different dtype than the model must load
+/// and run: `add_adapter_tensors` casts it to the base weight's dtype so the
+/// plain `forward` does not hit a mixed-dtype matmul. CPU only (uses f64).
+#[test]
+fn lora_adapter_dtype_cast_to_base() -> Result<()> {
+    let device = Device::Cpu;
+    let base = make_base(&device)?; // f32, weight [[1, 0, 0], [0, 1, 0]]
+    let avm = VarMap::new();
+    let avb = VarBuilder::from_varmap(&avm, DType::F64, &device);
+    let mut lora = LoraLinear::new(base);
+    lora.add_adapter("a", avb.pp("a"), 2, 4.0)?;
+    let x = Tensor::new(&[[1f32, 2., 3.]], &device)?;
+    let y = lora.forward(&x)?;
+    // lora_B is zero-initialized, so the delta is zero and the output equals
+    // the base layer; the point is that the f64 adapter runs against f32 x.
+    assert_eq!(y.dtype(), DType::F32);
+    assert_eq!(to_vec2_round(&y, 4)?, vec![vec![1f32, 2.]]);
+    Ok(())
+}
+
 test_device!(
     lora_forward_matches_manual_computation,
     lora_forward_matches_manual_computation_cpu,

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -782,6 +782,81 @@ impl Llama {
         logits.to_dtype(DType::F32)
     }
 
+    /// Batch-native, adapter-aware autoregressive decode loop for
+    /// heterogeneous multi-LoRA serving.
+    ///
+    /// `prompt_tokens` is `[batch, prompt_len]`: every row is prefilled
+    /// together in a single [`Self::forward_with_adapters`] call, then
+    /// decoded one token per row per step for up to `max_new_tokens` steps,
+    /// again through one batched call per step. `adapter_assignments` picks,
+    /// per row, `Some(adapter_name)` or `None` for a base-model-only row;
+    /// rows are never grouped or re-batched by adapter, so the whole batch
+    /// (prefill and every decode step) goes through exactly one forward
+    /// pass. `logits_processors` supplies one sampler per row, so each
+    /// sequence can use its own temperature/sampling strategy. `cache` must
+    /// have `use_kv_cache` set, since decode steps rely on each row's own
+    /// past keys/values (isolated by the batch dimension) rather than
+    /// recomputing them.
+    ///
+    /// Returns, for each row, the `max_new_tokens` newly generated token ids
+    /// (the prompt itself is not included).
+    pub fn generate_with_adapters(
+        &self,
+        prompt_tokens: &Tensor,
+        adapter_assignments: &[Option<&str>],
+        max_new_tokens: usize,
+        cache: &mut Cache,
+        logits_processors: &mut [crate::generation::LogitsProcessor],
+    ) -> Result<Vec<Vec<u32>>> {
+        let (b_sz, prompt_len) = prompt_tokens.dims2()?;
+        if adapter_assignments.len() != b_sz {
+            candle::bail!(
+                "generate_with_adapters: {} adapter assignments for a batch of {b_sz} sequences",
+                adapter_assignments.len()
+            )
+        }
+        if logits_processors.len() != b_sz {
+            candle::bail!(
+                "generate_with_adapters: {} logits processors for a batch of {b_sz} sequences",
+                logits_processors.len()
+            )
+        }
+        if !cache.use_kv_cache {
+            candle::bail!(
+                "generate_with_adapters requires a cache with use_kv_cache set, so that each \
+                 sequence's past keys/values stay isolated across decode steps"
+            )
+        }
+        let mut generated: Vec<Vec<u32>> = vec![Vec::with_capacity(max_new_tokens); b_sz];
+        if max_new_tokens == 0 {
+            return Ok(generated);
+        }
+
+        let device = prompt_tokens.device();
+        let logits = self.forward_with_adapters(prompt_tokens, 0, cache, adapter_assignments)?;
+        let mut index_pos = prompt_len;
+        let mut next_tokens = Vec::with_capacity(b_sz);
+        for (row, processor) in logits_processors.iter_mut().enumerate() {
+            let token = processor.sample(&logits.i(row)?)?;
+            generated[row].push(token);
+            next_tokens.push(token);
+        }
+
+        for _ in 1..max_new_tokens {
+            let input = Tensor::from_vec(next_tokens.clone(), (b_sz, 1), device)?;
+            let logits =
+                self.forward_with_adapters(&input, index_pos, cache, adapter_assignments)?;
+            index_pos += 1;
+            next_tokens.clear();
+            for (row, processor) in logits_processors.iter_mut().enumerate() {
+                let token = processor.sample(&logits.i(row)?)?;
+                generated[row].push(token);
+                next_tokens.push(token);
+            }
+        }
+        Ok(generated)
+    }
+
     pub fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
         Self::load_with_config(vb, cfg, LlamaLoadConfig::default())
     }
@@ -1147,6 +1222,127 @@ mod tests {
         // the base weights.
         assert!(model
             .forward_with_adapters(&input, 0, &mut cache, &[Some("a"), Some("nope")])
+            .is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn generate_with_adapters_matches_sequential_reference() -> Result<()> {
+        use crate::generation::{LogitsProcessor, Sampling};
+
+        let dev = Device::Cpu;
+        let cfg = tiny_config();
+        let model = multi_adapter_model(&cfg, &dev)?;
+
+        // Three concurrent rows in one batch: adapter "a", adapter "b", and
+        // no adapter at all.
+        let prompts = Tensor::new(&[[1u32, 2, 3], [4, 5, 6], [2, 4, 6]], &dev)?;
+        let assignments = [Some("a"), Some("b"), None];
+        let max_new_tokens = 3;
+
+        let mut cache = Cache::new(true, DType::F32, &cfg, &dev)?;
+        let mut processors: Vec<_> = (0..assignments.len())
+            .map(|_| LogitsProcessor::from_sampling(0, Sampling::ArgMax))
+            .collect();
+        let batched = model.generate_with_adapters(
+            &prompts,
+            &assignments,
+            max_new_tokens,
+            &mut cache,
+            &mut processors,
+        )?;
+        assert_eq!(batched.len(), assignments.len());
+        for row in &batched {
+            assert_eq!(row.len(), max_new_tokens);
+        }
+
+        // Reference: drive every row through the same prefill + decode steps
+        // on its own (batch size 1), never grouping rows by adapter.
+        for (row, assignment) in assignments.iter().enumerate() {
+            let mut cache = Cache::new(true, DType::F32, &cfg, &dev)?;
+            let mut processor = LogitsProcessor::from_sampling(0, Sampling::ArgMax);
+            let prompt = prompts.narrow(0, row, 1)?;
+            let logits = model.forward_with_adapters(&prompt, 0, &mut cache, &[*assignment])?;
+            let mut index_pos = prompt.dim(1)?;
+            let mut next_token = processor.sample(&logits.i(0)?)?;
+            let mut expected = vec![next_token];
+            for _ in 1..max_new_tokens {
+                let input = Tensor::new(&[[next_token]], &dev)?;
+                let logits =
+                    model.forward_with_adapters(&input, index_pos, &mut cache, &[*assignment])?;
+                index_pos += 1;
+                next_token = processor.sample(&logits.i(0)?)?;
+                expected.push(next_token);
+            }
+            assert_eq!(batched[row], expected);
+        }
+
+        // The no-adapter row must match the plain base decode path too, not
+        // only `forward_with_adapters(&[None])`.
+        let mut plain_cache = Cache::new(true, DType::F32, &cfg, &dev)?;
+        let mut plain_processor = LogitsProcessor::from_sampling(0, Sampling::ArgMax);
+        let base_prompt = prompts.narrow(0, 2, 1)?;
+        let logits = model.forward(&base_prompt, 0, &mut plain_cache)?;
+        let mut index_pos = base_prompt.dim(1)?;
+        let mut next_token = plain_processor.sample(&logits.i(0)?)?;
+        let mut expected_plain = vec![next_token];
+        for _ in 1..max_new_tokens {
+            let input = Tensor::new(&[[next_token]], &dev)?;
+            let logits = model.forward(&input, index_pos, &mut plain_cache)?;
+            index_pos += 1;
+            next_token = plain_processor.sample(&logits.i(0)?)?;
+            expected_plain.push(next_token);
+        }
+        assert_eq!(batched[2], expected_plain);
+        Ok(())
+    }
+
+    #[test]
+    fn generate_with_adapters_requires_kv_cache() -> Result<()> {
+        use crate::generation::{LogitsProcessor, Sampling};
+
+        let dev = Device::Cpu;
+        let cfg = tiny_config();
+        let model = multi_adapter_model(&cfg, &dev)?;
+        let prompts = Tensor::new(&[[1u32, 2, 3]], &dev)?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let mut processors = vec![LogitsProcessor::from_sampling(0, Sampling::ArgMax)];
+        assert!(model
+            .generate_with_adapters(&prompts, &[Some("a")], 2, &mut cache, &mut processors)
+            .is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn generate_with_adapters_rejects_mismatched_counts() -> Result<()> {
+        use crate::generation::{LogitsProcessor, Sampling};
+
+        let dev = Device::Cpu;
+        let cfg = tiny_config();
+        let model = multi_adapter_model(&cfg, &dev)?;
+        let prompts = Tensor::new(&[[1u32, 2, 3], [4, 5, 6]], &dev)?;
+
+        // Only one adapter assignment for a batch of two rows.
+        let mut cache = Cache::new(true, DType::F32, &cfg, &dev)?;
+        let mut processors = vec![
+            LogitsProcessor::from_sampling(0, Sampling::ArgMax),
+            LogitsProcessor::from_sampling(0, Sampling::ArgMax),
+        ];
+        assert!(model
+            .generate_with_adapters(&prompts, &[Some("a")], 2, &mut cache, &mut processors)
+            .is_err());
+
+        // Two assignments but only one logits processor.
+        let mut cache = Cache::new(true, DType::F32, &cfg, &dev)?;
+        let mut one_processor = vec![LogitsProcessor::from_sampling(0, Sampling::ArgMax)];
+        assert!(model
+            .generate_with_adapters(
+                &prompts,
+                &[Some("a"), None],
+                2,
+                &mut cache,
+                &mut one_processor
+            )
             .is_err());
         Ok(())
     }

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -91,6 +91,26 @@ impl Proj {
         }
     }
 
+    /// Forward pass with an optional per-row adapter assignment (see
+    /// [`LoraLinear::forward_with_adapters`]). Adapters only live on the
+    /// projections their config targeted, so rows selecting an adapter that
+    /// is not registered on this projection fall back to the base layer here.
+    fn forward_with_adapters(
+        &self,
+        x: &Tensor,
+        assignments: Option<&[Option<&str>]>,
+    ) -> Result<Tensor> {
+        let (Self::Lora(l), Some(assignments)) = (self, assignments) else {
+            return self.forward(x);
+        };
+        let names = l.adapter_names();
+        let mapped: Vec<Option<&str>> = assignments
+            .iter()
+            .map(|a| (*a).filter(|name| names.contains(name)))
+            .collect();
+        l.forward_with_adapters(x, &mapped)
+    }
+
     fn has_adapter(&self, name: &str) -> bool {
         match self {
             Self::Plain(_) => false,
@@ -399,12 +419,13 @@ impl CausalSelfAttention {
         index_pos: usize,
         block_idx: usize,
         cache: &mut Cache,
+        adapters: Option<&[Option<&str>]>,
     ) -> Result<Tensor> {
         let _enter = self.span.enter();
         let (b_sz, seq_len, hidden_size) = x.dims3()?;
-        let q = self.q_proj.forward(x)?;
-        let k = self.k_proj.forward(x)?;
-        let v = self.v_proj.forward(x)?;
+        let q = self.q_proj.forward_with_adapters(x, adapters)?;
+        let k = self.k_proj.forward_with_adapters(x, adapters)?;
+        let v = self.v_proj.forward_with_adapters(x, adapters)?;
 
         let q = q
             .reshape((b_sz, seq_len, self.num_attention_heads, self.head_dim))?
@@ -477,7 +498,7 @@ impl CausalSelfAttention {
             att.matmul(&v.contiguous()?)?.to_dtype(in_dtype)?
         };
         let y = y.transpose(1, 2)?.reshape(&[b_sz, seq_len, hidden_size])?;
-        let y = self.o_proj.forward(&y)?;
+        let y = self.o_proj.forward_with_adapters(&y, adapters)?;
         Ok(y)
     }
 
@@ -549,10 +570,11 @@ struct Mlp {
 }
 
 impl Mlp {
-    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+    fn forward(&self, x: &Tensor, adapters: Option<&[Option<&str>]>) -> Result<Tensor> {
         let _enter = self.span.enter();
-        let x = (candle_nn::ops::silu(&self.c_fc1.forward(x)?)? * self.c_fc2.forward(x)?)?;
-        self.c_proj.forward(&x)
+        let x = (candle_nn::ops::silu(&self.c_fc1.forward_with_adapters(x, adapters)?)?
+            * self.c_fc2.forward_with_adapters(x, adapters)?)?;
+        self.c_proj.forward_with_adapters(&x, adapters)
     }
 
     fn has_adapter(&self, name: &str) -> bool {
@@ -616,13 +638,17 @@ impl Block {
         index_pos: usize,
         block_idx: usize,
         cache: &mut Cache,
+        adapters: Option<&[Option<&str>]>,
     ) -> Result<Tensor> {
         let _enter = self.span.enter();
         let residual = x;
         let x = self.rms_1.forward(x)?;
-        let x = (self.attn.forward(&x, index_pos, block_idx, cache)? + residual)?;
+        let x = (self
+            .attn
+            .forward(&x, index_pos, block_idx, cache, adapters)?
+            + residual)?;
         let residual = &x;
-        let x = (self.mlp.forward(&self.rms_2.forward(&x)?)? + residual)?;
+        let x = (self.mlp.forward(&self.rms_2.forward(&x)?, adapters)? + residual)?;
         Ok(x)
     }
 
@@ -693,7 +719,7 @@ impl Llama {
         let (_, seq_len, _) = input_embed.dims3()?;
         let mut x = input_embed.clone();
         for (block_idx, block) in self.blocks.iter().enumerate() {
-            x = block.forward(&x, index_pos, block_idx, cache)?;
+            x = block.forward(&x, index_pos, block_idx, cache, None)?;
         }
         let x = self.ln_f.forward(&x)?;
         let x = x.i((.., seq_len - 1, ..))?.contiguous()?;
@@ -705,7 +731,50 @@ impl Llama {
         let (_b_sz, seq_len) = x.dims2()?;
         let mut x = self.wte.forward(x)?;
         for (block_idx, block) in self.blocks.iter().enumerate() {
-            x = block.forward(&x, index_pos, block_idx, cache)?;
+            x = block.forward(&x, index_pos, block_idx, cache, None)?;
+        }
+        let x = self.ln_f.forward(&x)?;
+        let x = x.i((.., seq_len - 1, ..))?.contiguous()?;
+        let logits = self.lm_head.forward(&x)?;
+        logits.to_dtype(DType::F32)
+    }
+
+    /// Like [`Llama::forward`], but every sequence in the batch selects its
+    /// own LoRA adapter (S-LoRA / Punica style heterogeneous batching).
+    ///
+    /// `adapter_assignments` holds one entry per batch row: `Some(name)` to
+    /// route that sequence through a registered adapter, `None` to run it on
+    /// the frozen base weights only. The adapter deltas are applied through
+    /// [`LoraLinear::forward_with_adapters`]' batched gather + matmul path
+    /// rather than one forward per adapter group, and the result matches
+    /// running each sequence separately with its own adapter. The currently
+    /// active adapter (see [`Llama::set_active_adapter`]) is ignored by this
+    /// method.
+    pub fn forward_with_adapters(
+        &self,
+        x: &Tensor,
+        index_pos: usize,
+        cache: &mut Cache,
+        adapter_assignments: &[Option<&str>],
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len) = x.dims2()?;
+        if adapter_assignments.len() != b_sz {
+            candle::bail!(
+                "forward_with_adapters: {} adapter assignments for a batch of {b_sz} sequences",
+                adapter_assignments.len()
+            )
+        }
+        // Projections silently fall back to the base weights for adapter
+        // names they don't carry, so catch typos at the model level where
+        // the full adapter registry is known.
+        for name in adapter_assignments.iter().flatten() {
+            if !self.blocks.iter().any(|b| b.has_adapter(name)) {
+                candle::bail!("no such LoRA adapter: {name}")
+            }
+        }
+        let mut x = self.wte.forward(x)?;
+        for (block_idx, block) in self.blocks.iter().enumerate() {
+            x = block.forward(&x, index_pos, block_idx, cache, Some(adapter_assignments))?;
         }
         let x = self.ln_f.forward(&x)?;
         let x = x.i((.., seq_len - 1, ..))?.contiguous()?;
@@ -855,6 +924,16 @@ mod tests {
         dev: &Device,
         prefix: &str,
     ) -> HashMap<String, Tensor> {
+        lora_adapter_weights_valued(cfg, rank, dev, prefix, 1.0)
+    }
+
+    fn lora_adapter_weights_valued(
+        cfg: &Config,
+        rank: usize,
+        dev: &Device,
+        prefix: &str,
+        value: f64,
+    ) -> HashMap<String, Tensor> {
         let h = cfg.hidden_size;
         let mut ts = HashMap::new();
         for i_layer in 0..cfg.num_hidden_layers {
@@ -865,11 +944,11 @@ mod tests {
             };
             ts.insert(
                 format!("{p}.lora_A.weight"),
-                Tensor::ones((rank, h), DType::F32, dev).unwrap(),
+                (Tensor::ones((rank, h), DType::F32, dev).unwrap() * value).unwrap(),
             );
             ts.insert(
                 format!("{p}.lora_B.weight"),
-                Tensor::ones((h, rank), DType::F32, dev).unwrap(),
+                (Tensor::ones((h, rank), DType::F32, dev).unwrap() * value).unwrap(),
             );
         }
         ts
@@ -964,6 +1043,111 @@ mod tests {
         let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
         let adapter_logits = model.forward(&input, 0, &mut cache)?.to_vec2::<f32>()?;
         assert_ne!(base_logits, adapter_logits);
+        Ok(())
+    }
+
+    /// A model with two adapters of different ranks and weights on o_proj:
+    /// "a" (rank 2, alpha 4) and "b" (rank 1, alpha 3).
+    fn multi_adapter_model(cfg: &Config, dev: &Device) -> Result<Llama> {
+        let base_vb = VarBuilder::from_tensors(base_weights(cfg, dev), DType::F32, dev);
+        let vb_a = VarBuilder::from_tensors(
+            lora_adapter_weights_valued(cfg, 2, dev, PEFT_ADAPTER_PREFIX, 1.0),
+            DType::F32,
+            dev,
+        );
+        let vb_b = VarBuilder::from_tensors(
+            lora_adapter_weights_valued(cfg, 1, dev, PEFT_ADAPTER_PREFIX, 0.5),
+            DType::F32,
+            dev,
+        );
+        let target = LoraConfig {
+            rank: 2,
+            alpha: 4.0,
+            target_modules: vec!["o_proj".to_string()],
+        };
+        let load_config = LlamaLoadConfig::default()
+            .with_lora_adapter("a", vb_a, target.clone())
+            .with_lora_adapter(
+                "b",
+                vb_b,
+                LoraConfig {
+                    rank: 1,
+                    alpha: 3.0,
+                    ..target
+                },
+            );
+        Llama::load_with_config(base_vb, cfg, load_config)
+    }
+
+    fn round4(rows: Vec<Vec<f32>>) -> Vec<Vec<f32>> {
+        rows.into_iter()
+            .map(|r| r.into_iter().map(|v| (v * 1e4).round() / 1e4).collect())
+            .collect()
+    }
+
+    #[test]
+    fn forward_with_adapters_matches_per_sequence_execution() -> Result<()> {
+        let dev = Device::Cpu;
+        let cfg = tiny_config();
+        let mut model = multi_adapter_model(&cfg, &dev)?;
+
+        // A heterogeneous batch: two different adapters, a base-only row, and
+        // a repeated adapter.
+        let input = Tensor::new(&[[1u32, 2, 3], [4, 5, 6], [2, 4, 6], [3, 1, 7]], &dev)?;
+        let assignments = [Some("a"), None, Some("b"), Some("a")];
+
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let batched = model.forward_with_adapters(&input, 0, &mut cache, &assignments)?;
+        let batched = round4(batched.to_vec2::<f32>()?);
+
+        // Reference: run every sequence on its own with its adapter active.
+        for (i, assignment) in assignments.iter().enumerate() {
+            model.set_active_adapter(*assignment)?;
+            let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+            let row = model.forward(&input.narrow(0, i, 1)?, 0, &mut cache)?;
+            assert_eq!(round4(row.to_vec2::<f32>()?), vec![batched[i].clone()]);
+        }
+
+        // The active adapter must not leak into the batched path.
+        model.set_active_adapter(Some("b"))?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let rerun = model.forward_with_adapters(&input, 0, &mut cache, &assignments)?;
+        assert_eq!(round4(rerun.to_vec2::<f32>()?), batched);
+        Ok(())
+    }
+
+    #[test]
+    fn forward_with_adapters_all_none_matches_plain_forward() -> Result<()> {
+        let dev = Device::Cpu;
+        let cfg = tiny_config();
+        let model = multi_adapter_model(&cfg, &dev)?;
+        let input = Tensor::new(&[[1u32, 2, 3], [4, 5, 6]], &dev)?;
+
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let batched = model.forward_with_adapters(&input, 0, &mut cache, &[None, None])?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let plain = model.forward(&input, 0, &mut cache)?;
+        assert_eq!(batched.to_vec2::<f32>()?, plain.to_vec2::<f32>()?);
+        Ok(())
+    }
+
+    #[test]
+    fn forward_with_adapters_rejects_bad_assignments() -> Result<()> {
+        let dev = Device::Cpu;
+        let cfg = tiny_config();
+        let model = multi_adapter_model(&cfg, &dev)?;
+        let input = Tensor::new(&[[1u32, 2, 3], [4, 5, 6]], &dev)?;
+
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        // Assignment count must match the batch size.
+        assert!(model
+            .forward_with_adapters(&input, 0, &mut cache, &[Some("a")])
+            .is_err());
+        // Unknown adapter names are rejected instead of silently running on
+        // the base weights.
+        assert!(model
+            .forward_with_adapters(&input, 0, &mut cache, &[Some("a"), Some("nope")])
+            .is_err());
         Ok(())
     }
 }

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -6,8 +6,134 @@
 
 use super::with_tracing::{linear_no_bias as linear, Linear, RmsNorm};
 use candle::{DType, Device, IndexOp, Result, Tensor, D};
+use candle_nn::lora::LoraLinear;
 use candle_nn::{embedding, Embedding, Module, VarBuilder};
 use std::{collections::HashMap, f32::consts::PI};
+
+/// Rank, scaling and target projections for a LoRA adapter to inject into a
+/// [`Llama`] model at load time. `target_modules` is matched against the
+/// projection names `q_proj`, `k_proj`, `v_proj`, `o_proj`, `gate_proj`,
+/// `up_proj` and `down_proj`.
+#[derive(Debug, Clone)]
+pub struct LoraConfig {
+    pub rank: usize,
+    pub alpha: f64,
+    pub target_modules: Vec<String>,
+}
+
+impl LoraConfig {
+    fn wants(&self, module: &str) -> bool {
+        self.target_modules.iter().any(|m| m == module)
+    }
+}
+
+type LoraSpec<'a> = (String, VarBuilder<'a>, LoraConfig);
+
+/// Prefix under which a standard PEFT `PeftModel` checkpoint stores its base
+/// model's weights, e.g. `base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight`.
+/// This is the default root [`LlamaLoadConfig::with_lora_adapter`] resolves
+/// LoRA tensor paths against.
+pub const PEFT_ADAPTER_PREFIX: &str = "base_model.model";
+
+/// Configuration used by [`Llama::load_with_config`] to inject one or more
+/// named LoRA adapters into the base model's attention and MLP projections.
+/// Building a model with an empty (default) config is equivalent to
+/// [`Llama::load`].
+#[derive(Clone, Default)]
+pub struct LlamaLoadConfig<'a> {
+    lora_adapters: Vec<LoraSpec<'a>>,
+}
+
+impl<'a> LlamaLoadConfig<'a> {
+    /// Registers a named LoRA adapter, loaded from `vb`, to be injected into
+    /// the projections listed in `config.target_modules`. `vb` is assumed to
+    /// be rooted at the standard PEFT checkpoint layout, i.e. tensors live
+    /// under [`PEFT_ADAPTER_PREFIX`] `.model.layers.{i}.self_attn.q_proj` (and
+    /// so on), each holding `lora_A.weight` / `lora_B.weight`. Use
+    /// [`LlamaLoadConfig::with_lora_adapter_prefixed`] if the checkpoint was
+    /// saved under a different root, or if `vb` is already scoped past that
+    /// prefix.
+    pub fn with_lora_adapter(self, name: &str, vb: VarBuilder<'a>, config: LoraConfig) -> Self {
+        self.with_lora_adapter_prefixed(name, vb, config, PEFT_ADAPTER_PREFIX)
+    }
+
+    /// Like [`LlamaLoadConfig::with_lora_adapter`], but resolves LoRA tensors
+    /// under `prefix` instead of the standard [`PEFT_ADAPTER_PREFIX`]. Pass an
+    /// empty string if `vb` is already scoped to the model root (i.e. tensors
+    /// live directly under `model.layers.{i}...`).
+    pub fn with_lora_adapter_prefixed(
+        mut self,
+        name: &str,
+        vb: VarBuilder<'a>,
+        config: LoraConfig,
+        prefix: &str,
+    ) -> Self {
+        let vb = if prefix.is_empty() { vb } else { vb.pp(prefix) };
+        self.lora_adapters.push((name.to_string(), vb, config));
+        self
+    }
+}
+
+/// A linear projection that is either a plain frozen layer or one augmented
+/// with LoRA adapters, depending on whether the loader was asked to inject
+/// adapters into it.
+#[derive(Debug, Clone)]
+enum Proj {
+    Plain(Linear),
+    Lora(LoraLinear),
+}
+
+impl Proj {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::Plain(l) => l.forward(x),
+            Self::Lora(l) => l.forward(x),
+        }
+    }
+
+    fn has_adapter(&self, name: &str) -> bool {
+        match self {
+            Self::Plain(_) => false,
+            Self::Lora(l) => l.adapter_names().contains(&name),
+        }
+    }
+
+    /// Activates `name` on this projection if it carries an adapter under
+    /// that name, deactivates any adapter when `name` is `None`, and is a
+    /// no-op otherwise (this projection simply wasn't targeted by `name`).
+    fn set_active_adapter(&mut self, name: Option<&str>) -> Result<()> {
+        let Self::Lora(l) = self else {
+            return Ok(());
+        };
+        match name {
+            None => l.set_active_adapter(None),
+            Some(name) if l.adapter_names().contains(&name) => l.set_active_adapter(Some(name)),
+            Some(_) => Ok(()),
+        }
+    }
+}
+
+fn load_projection(
+    module: &str,
+    size_in: usize,
+    size_out: usize,
+    vb: VarBuilder,
+    lora_adapters: &[LoraSpec],
+) -> Result<Proj> {
+    let matching: Vec<_> = lora_adapters
+        .iter()
+        .filter(|(_, _, cfg)| cfg.wants(module))
+        .collect();
+    if matching.is_empty() {
+        return Ok(Proj::Plain(linear(size_in, size_out, vb)?));
+    }
+    let base = candle_nn::linear_no_bias(size_in, size_out, vb)?;
+    let mut lora = LoraLinear::new(base);
+    for (name, adapter_vb, cfg) in matching {
+        lora.load_adapter(name, adapter_vb.pp(module), cfg.rank, cfg.alpha)?;
+    }
+    Ok(Proj::Lora(lora))
+}
 
 pub const DEFAULT_MAX_SEQ_LEN: usize = 4096;
 
@@ -229,10 +355,10 @@ impl Cache {
 
 #[derive(Debug, Clone)]
 struct CausalSelfAttention {
-    q_proj: Linear,
-    k_proj: Linear,
-    v_proj: Linear,
-    o_proj: Linear,
+    q_proj: Proj,
+    k_proj: Proj,
+    v_proj: Proj,
+    o_proj: Proj,
     num_attention_heads: usize,
     num_key_value_heads: usize,
     head_dim: usize,
@@ -359,16 +485,38 @@ impl CausalSelfAttention {
         crate::utils::repeat_kv(x, self.num_attention_heads / self.num_key_value_heads)
     }
 
-    fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+    fn has_adapter(&self, name: &str) -> bool {
+        [&self.q_proj, &self.k_proj, &self.v_proj, &self.o_proj]
+            .into_iter()
+            .any(|p| p.has_adapter(name))
+    }
+
+    fn set_active_adapter(&mut self, name: Option<&str>) -> Result<()> {
+        for p in [
+            &mut self.q_proj,
+            &mut self.k_proj,
+            &mut self.v_proj,
+            &mut self.o_proj,
+        ] {
+            p.set_active_adapter(name)?;
+        }
+        Ok(())
+    }
+
+    fn load(vb: VarBuilder, cfg: &Config, lora_adapters: &[LoraSpec]) -> Result<Self> {
         let span = tracing::span!(tracing::Level::TRACE, "attn");
         let span_rot = tracing::span!(tracing::Level::TRACE, "attn-rot");
         let size_in = cfg.hidden_size;
         let size_q = (cfg.hidden_size / cfg.num_attention_heads) * cfg.num_attention_heads;
         let size_kv = (cfg.hidden_size / cfg.num_attention_heads) * cfg.num_key_value_heads;
-        let q_proj = linear(size_in, size_q, vb.pp("q_proj"))?;
-        let k_proj = linear(size_in, size_kv, vb.pp("k_proj"))?;
-        let v_proj = linear(size_in, size_kv, vb.pp("v_proj"))?;
-        let o_proj = linear(size_q, size_in, vb.pp("o_proj"))?;
+        let lora_adapters: Vec<_> = lora_adapters
+            .iter()
+            .map(|(name, vb, cfg)| (name.clone(), vb.pp("self_attn"), cfg.clone()))
+            .collect();
+        let q_proj = load_projection("q_proj", size_in, size_q, vb.pp("q_proj"), &lora_adapters)?;
+        let k_proj = load_projection("k_proj", size_in, size_kv, vb.pp("k_proj"), &lora_adapters)?;
+        let v_proj = load_projection("v_proj", size_in, size_kv, vb.pp("v_proj"), &lora_adapters)?;
+        let o_proj = load_projection("o_proj", size_q, size_in, vb.pp("o_proj"), &lora_adapters)?;
         Ok(Self {
             q_proj,
             k_proj,
@@ -394,9 +542,9 @@ fn masked_fill(on_false: &Tensor, mask: &Tensor, on_true: f32) -> Result<Tensor>
 
 #[derive(Debug, Clone)]
 struct Mlp {
-    c_fc1: Linear,
-    c_fc2: Linear,
-    c_proj: Linear,
+    c_fc1: Proj,
+    c_fc2: Proj,
+    c_proj: Proj,
     span: tracing::Span,
 }
 
@@ -407,13 +555,42 @@ impl Mlp {
         self.c_proj.forward(&x)
     }
 
-    fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+    fn has_adapter(&self, name: &str) -> bool {
+        [&self.c_fc1, &self.c_fc2, &self.c_proj]
+            .into_iter()
+            .any(|p| p.has_adapter(name))
+    }
+
+    fn set_active_adapter(&mut self, name: Option<&str>) -> Result<()> {
+        for p in [&mut self.c_fc1, &mut self.c_fc2, &mut self.c_proj] {
+            p.set_active_adapter(name)?;
+        }
+        Ok(())
+    }
+
+    fn load(vb: VarBuilder, cfg: &Config, lora_adapters: &[LoraSpec]) -> Result<Self> {
         let span = tracing::span!(tracing::Level::TRACE, "mlp");
         let h_size = cfg.hidden_size;
         let i_size = cfg.intermediate_size;
-        let c_fc1 = linear(h_size, i_size, vb.pp("gate_proj"))?;
-        let c_fc2 = linear(h_size, i_size, vb.pp("up_proj"))?;
-        let c_proj = linear(i_size, h_size, vb.pp("down_proj"))?;
+        let lora_adapters: Vec<_> = lora_adapters
+            .iter()
+            .map(|(name, vb, cfg)| (name.clone(), vb.pp("mlp"), cfg.clone()))
+            .collect();
+        let c_fc1 = load_projection(
+            "gate_proj",
+            h_size,
+            i_size,
+            vb.pp("gate_proj"),
+            &lora_adapters,
+        )?;
+        let c_fc2 = load_projection("up_proj", h_size, i_size, vb.pp("up_proj"), &lora_adapters)?;
+        let c_proj = load_projection(
+            "down_proj",
+            i_size,
+            h_size,
+            vb.pp("down_proj"),
+            &lora_adapters,
+        )?;
         Ok(Self {
             c_fc1,
             c_fc2,
@@ -449,10 +626,34 @@ impl Block {
         Ok(x)
     }
 
-    fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+    fn has_adapter(&self, name: &str) -> bool {
+        self.attn.has_adapter(name) || self.mlp.has_adapter(name)
+    }
+
+    fn set_active_adapter(&mut self, name: Option<&str>) -> Result<()> {
+        self.attn.set_active_adapter(name)?;
+        self.mlp.set_active_adapter(name)
+    }
+
+    fn load(
+        vb: VarBuilder,
+        cfg: &Config,
+        layer_idx: usize,
+        lora_adapters: &[LoraSpec],
+    ) -> Result<Self> {
         let span = tracing::span!(tracing::Level::TRACE, "block");
-        let attn = CausalSelfAttention::load(vb.pp("self_attn"), cfg)?;
-        let mlp = Mlp::load(vb.pp("mlp"), cfg)?;
+        let block_lora: Vec<_> = lora_adapters
+            .iter()
+            .map(|(name, vb, cfg)| {
+                (
+                    name.clone(),
+                    vb.pp(format!("model.layers.{layer_idx}")),
+                    cfg.clone(),
+                )
+            })
+            .collect();
+        let attn = CausalSelfAttention::load(vb.pp("self_attn"), cfg, &block_lora)?;
+        let mlp = Mlp::load(vb.pp("mlp"), cfg, &block_lora)?;
         let rms_1 = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
         let rms_2 = RmsNorm::new(
             cfg.hidden_size,
@@ -513,6 +714,20 @@ impl Llama {
     }
 
     pub fn load(vb: VarBuilder, cfg: &Config) -> Result<Self> {
+        Self::load_with_config(vb, cfg, LlamaLoadConfig::default())
+    }
+
+    /// Like [`Llama::load`], but additionally injects the LoRA adapters
+    /// listed in `load_config` into the matching attention/MLP projections.
+    /// With no adapters registered this behaves exactly like `Llama::load`.
+    /// Use [`Llama::set_active_adapter`] to select which (if any) of the
+    /// registered adapters applies to subsequent forward passes.
+    pub fn load_with_config(
+        vb: VarBuilder,
+        cfg: &Config,
+        load_config: LlamaLoadConfig,
+    ) -> Result<Self> {
+        let lora_adapters = load_config.lora_adapters;
         let wte = embedding(cfg.vocab_size, cfg.hidden_size, vb.pp("model.embed_tokens"))?;
         let lm_head = if cfg.tie_word_embeddings {
             Linear::from_weights(wte.embeddings().clone(), None)
@@ -521,8 +736,8 @@ impl Llama {
         };
         let ln_f = RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("model.norm"))?;
         let blocks: Vec<_> = (0..cfg.num_hidden_layers)
-            .map(|i| Block::load(vb.pp(format!("model.layers.{i}")), cfg).unwrap())
-            .collect();
+            .map(|i| Block::load(vb.pp(format!("model.layers.{i}")), cfg, i, &lora_adapters))
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(Self {
             wte,
@@ -530,5 +745,225 @@ impl Llama {
             ln_f,
             lm_head,
         })
+    }
+
+    /// Selects the LoRA adapter that subsequent calls to `forward` /
+    /// `forward_input_embed` should use, or falls back to the frozen base
+    /// weights when `name` is `None`. Switching adapters does not reload or
+    /// duplicate the base model weights.
+    pub fn set_active_adapter(&mut self, name: Option<&str>) -> Result<()> {
+        if let Some(name) = name {
+            if !self.blocks.iter().any(|b| b.has_adapter(name)) {
+                candle::bail!("no such LoRA adapter: {name}")
+            }
+        }
+        for block in &mut self.blocks {
+            block.set_active_adapter(name)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tiny_config() -> Config {
+        Config {
+            hidden_size: 4,
+            intermediate_size: 4,
+            vocab_size: 8,
+            num_hidden_layers: 1,
+            num_attention_heads: 2,
+            num_key_value_heads: 2,
+            use_flash_attn: false,
+            rms_norm_eps: 1e-5,
+            rope_theta: 10_000.0,
+            bos_token_id: None,
+            eos_token_id: None,
+            rope_scaling: None,
+            max_position_embeddings: 16,
+            tie_word_embeddings: false,
+        }
+    }
+
+    fn base_weights(cfg: &Config, dev: &Device) -> HashMap<String, Tensor> {
+        let h = cfg.hidden_size;
+        let i = cfg.intermediate_size;
+        let v = cfg.vocab_size;
+        let mut ts = HashMap::new();
+        ts.insert(
+            "model.embed_tokens.weight".to_string(),
+            Tensor::ones((v, h), DType::F32, dev).unwrap(),
+        );
+        ts.insert(
+            "model.norm.weight".to_string(),
+            Tensor::ones(h, DType::F32, dev).unwrap(),
+        );
+        ts.insert(
+            "lm_head.weight".to_string(),
+            (Tensor::ones((v, h), DType::F32, dev).unwrap() * 0.1).unwrap(),
+        );
+        for i_layer in 0..cfg.num_hidden_layers {
+            let p = format!("model.layers.{i_layer}");
+            ts.insert(
+                format!("{p}.input_layernorm.weight"),
+                Tensor::ones(h, DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.post_attention_layernorm.weight"),
+                Tensor::ones(h, DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.self_attn.q_proj.weight"),
+                Tensor::zeros((h, h), DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.self_attn.k_proj.weight"),
+                Tensor::zeros((h, h), DType::F32, dev).unwrap(),
+            );
+            // Non-zero v_proj so the attention output (and thus o_proj's
+            // input) is non-zero, letting a LoRA adapter on o_proj have an
+            // observable effect even with a single-token sequence.
+            ts.insert(
+                format!("{p}.self_attn.v_proj.weight"),
+                (Tensor::ones((h, h), DType::F32, dev).unwrap() * 0.1).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.self_attn.o_proj.weight"),
+                Tensor::zeros((h, h), DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.mlp.gate_proj.weight"),
+                Tensor::zeros((i, h), DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.mlp.up_proj.weight"),
+                Tensor::zeros((i, h), DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.mlp.down_proj.weight"),
+                Tensor::zeros((h, i), DType::F32, dev).unwrap(),
+            );
+        }
+        ts
+    }
+
+    fn lora_adapter_weights(
+        cfg: &Config,
+        rank: usize,
+        dev: &Device,
+        prefix: &str,
+    ) -> HashMap<String, Tensor> {
+        let h = cfg.hidden_size;
+        let mut ts = HashMap::new();
+        for i_layer in 0..cfg.num_hidden_layers {
+            let p = if prefix.is_empty() {
+                format!("model.layers.{i_layer}.self_attn.o_proj")
+            } else {
+                format!("{prefix}.model.layers.{i_layer}.self_attn.o_proj")
+            };
+            ts.insert(
+                format!("{p}.lora_A.weight"),
+                Tensor::ones((rank, h), DType::F32, dev).unwrap(),
+            );
+            ts.insert(
+                format!("{p}.lora_B.weight"),
+                Tensor::ones((h, rank), DType::F32, dev).unwrap(),
+            );
+        }
+        ts
+    }
+
+    #[test]
+    fn load_without_lora_matches_plain_load() -> Result<()> {
+        let dev = Device::Cpu;
+        let cfg = tiny_config();
+        let vb = VarBuilder::from_tensors(base_weights(&cfg, &dev), DType::F32, &dev);
+        let mut model = Llama::load(vb, &cfg)?;
+        let input = Tensor::new(&[[1u32, 2, 3]], &dev)?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        // Should run without error and produce the expected output shape.
+        let logits = model.forward(&input, 0, &mut cache)?;
+        assert_eq!(logits.dims(), &[1, cfg.vocab_size]);
+        // No adapters were registered, so activating one must fail.
+        assert!(model.set_active_adapter(Some("missing")).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn lora_adapter_changes_output_only_when_active() -> Result<()> {
+        let dev = Device::Cpu;
+        let cfg = tiny_config();
+        let base_vb = VarBuilder::from_tensors(base_weights(&cfg, &dev), DType::F32, &dev);
+        // Adapter weights follow the standard PEFT `base_model.model.` layout;
+        // `with_lora_adapter` should resolve them without any extra scoping.
+        let adapter_vb = VarBuilder::from_tensors(
+            lora_adapter_weights(&cfg, 2, &dev, PEFT_ADAPTER_PREFIX),
+            DType::F32,
+            &dev,
+        );
+        let load_config = LlamaLoadConfig::default().with_lora_adapter(
+            "adapter",
+            adapter_vb,
+            LoraConfig {
+                rank: 2,
+                alpha: 4.0,
+                target_modules: vec!["o_proj".to_string()],
+            },
+        );
+        let mut model = Llama::load_with_config(base_vb, &cfg, load_config)?;
+
+        let input = Tensor::new(&[[1u32, 2, 3]], &dev)?;
+
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let base_logits = model.forward(&input, 0, &mut cache)?.to_vec2::<f32>()?;
+
+        model.set_active_adapter(Some("adapter"))?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let adapter_logits = model.forward(&input, 0, &mut cache)?.to_vec2::<f32>()?;
+        assert_ne!(base_logits, adapter_logits);
+
+        model.set_active_adapter(None)?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let back_to_base_logits = model.forward(&input, 0, &mut cache)?.to_vec2::<f32>()?;
+        assert_eq!(base_logits, back_to_base_logits);
+
+        assert!(model.set_active_adapter(Some("missing")).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn lora_adapter_with_custom_prefix() -> Result<()> {
+        let dev = Device::Cpu;
+        let cfg = tiny_config();
+        let base_vb = VarBuilder::from_tensors(base_weights(&cfg, &dev), DType::F32, &dev);
+        // Adapter checkpoint saved without any wrapping prefix (tensors live
+        // directly under `model.layers.{i}...`), as if already unwrapped from
+        // a PeftModel. `with_lora_adapter` alone would look under
+        // `base_model.model.` and fail to find these tensors.
+        let adapter_vb =
+            VarBuilder::from_tensors(lora_adapter_weights(&cfg, 2, &dev, ""), DType::F32, &dev);
+        let load_config = LlamaLoadConfig::default().with_lora_adapter_prefixed(
+            "adapter",
+            adapter_vb,
+            LoraConfig {
+                rank: 2,
+                alpha: 4.0,
+                target_modules: vec!["o_proj".to_string()],
+            },
+            "",
+        );
+        let mut model = Llama::load_with_config(base_vb, &cfg, load_config)?;
+
+        let input = Tensor::new(&[[1u32, 2, 3]], &dev)?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let base_logits = model.forward(&input, 0, &mut cache)?.to_vec2::<f32>()?;
+
+        model.set_active_adapter(Some("adapter"))?;
+        let mut cache = Cache::new(false, DType::F32, &cfg, &dev)?;
+        let adapter_logits = model.forward(&input, 0, &mut cache)?.to_vec2::<f32>()?;
+        assert_ne!(base_logits, adapter_logits);
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Llama::generate_with_adapters`, a batch-native autoregressive decode loop where every row in the batch can select its own LoRA adapter (`Some(adapter_id)`) or run base-model-only (`None`). Prefill and every decode step go through a single `forward_with_adapters` call for the whole batch — the batch is never split or re-grouped by adapter on the host side.
- Requires a `Cache` with `use_kv_cache` set, since decode steps rely on each row's own past keys/values, isolated by the batch dimension, rather than recomputing them.
- Adds `lora_batched_forward_multistep_decode_gpu_matches_cpu` to `candle-nn/tests/lora.rs`, gated behind the `lora-cuda` feature: it drives several `seq == 1` decode-step batches (two adapters + a base-only row) back to back through `forward_with_adapters` on both CPU and CUDA, checking the `candle_lora_kernels` BGMV kernel path stays correct across repeated kernel launches, not just on a single isolated call.

This builds on #3762 (heterogeneous multi-LoRA batching APIs) and #3763 (CUDA BGMV kernels for the decode-step fast path), closing the gap #3759 identified: those PRs cover a single batched forward, but serving needs a full generation loop that drives prefill/decode across steps without host-side per-adapter sub-batches.

Closes #3766.

## Required behavior (from the issue)

- [x] Batch prefill accepts multiple prompt rows for the same base model.
- [x] Batch decode accepts one token per active sequence per step.
- [x] Each row selects `Some(adapter_id)` or `None`.
- [x] Logits are `[batch, vocab]`, one row per active sequence.
- [x] KV cache updates stay isolated per sequence.
- [x] `None` rows remain strict base-model execution.
- [x] Output matches sequential per-row/per-adapter generation within numeric tolerance.
- [x] Composes with the APIs from #3762 and the CUDA fast path from #3763 (decode steps are `seq == 1`, so they automatically route through the BGMV kernel when `lora-cuda` is enabled on a CUDA device).

## Acceptance criteria (from the issue)

- [x] A test runs at least three active rows in one decode step: adapter A, adapter B, and no adapter (`generate_with_adapters_matches_sequential_reference`, CPU).
- [x] Batched decode output matches sequential reference output.
- [x] The no-adapter row is equivalent to the plain base path (checked against `Llama::forward` directly, not only `forward_with_adapters(&[None])`).
- [x] The decode loop does not split the batch by adapter on the host side (`generate_with_adapters` issues exactly one `forward_with_adapters` call per step for the whole batch).
- [x] Existing `forward`, `forward_with_adapters`, and sequential generation behavior remain backward-compatible (no changes to existing APIs; all prior tests still pass).

## Testing

- `cargo test -p candle-transformers --lib models::llama` — 9 tests, including 4 new ones covering the multi-row decode loop (sequential-reference parity, `use_kv_cache` requirement, mismatched-count rejection).
- `cargo test -p candle-nn --test lora` — 8 tests (CPU-only build).
- `cargo test -p candle-nn --features cuda,lora-cuda --test lora` — 15 tests, run on a real GPU via CI (`arc-gpu-candle` runner), including the new multi-step BGMV kernel parity test:
  ```
  test lora_batched_forward_multistep_decode_gpu_matches_cpu ... ok
  test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
  ```
- `cargo fmt --check` and `cargo clippy` clean on both crates.

## Test plan

- [x] CI passes (CPU + GPU cuda jobs)
- [x] Review of `Llama::generate_with_adapters`'s KV-cache/index_pos bookkeeping across decode steps