### PR TITLE
feat(metal): register external buffers in the device residency set

### DIFF
--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -194,6 +194,35 @@ impl MetalDevice {
         &self.device
     }
 
+    /// Registers externally created buffers in the device's residency set
+    /// (which is attached to its command queue), keeping them permanently
+    /// GPU-resident like buffers from the device's own allocator, instead of
+    /// paying per-command-buffer residency bookkeeping.
+    ///
+    /// Useful for buffers candle did not allocate — e.g.
+    /// `newBufferWithBytesNoCopy` views over an mmap'd weights file — that are
+    /// streamed by many command buffers over their lifetime. The whole batch
+    /// is committed once, so registering many buffers costs one residency-set
+    /// commit. The caller keeps ownership of the buffers; unregister them
+    /// before dropping (the set retains its allocations).
+    ///
+    /// On systems where residency sets are unsupported (creating one failed at
+    /// device init), this is a no-op: the buffers remain fully usable, at the
+    /// default per-command-buffer residency cost.
+    pub fn register_external_buffers<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>) {
+        self.residency_set.insert_batch(bufs);
+    }
+
+    /// Unregisters buffers previously passed to `register_external_buffers`,
+    /// releasing the residency set's retain so they can be deallocated (e.g.
+    /// when unloading a model to free its resources). Only unregister buffers
+    /// you registered yourself — the device's allocator also tracks its pool
+    /// buffers in this set. Ensure GPU work referencing a buffer has completed
+    /// before unregistering and dropping it.
+    pub fn unregister_external_buffers<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>) {
+        self.residency_set.remove_batch(bufs);
+    }
+
     /// Returns a builder for buffer allocation. See `BufferBuilder`.
     pub fn new_buffer_builder(&self) -> BufferBuilder<'_> {
         BufferBuilder::new(self)
@@ -466,6 +495,21 @@ mod tests {
         // BF16 and F16 are 2 bytes per element. A scalar tensor requests
         // a 2-byte buffer. This must not be rounded down to 1.
         assert_eq!(buf_size(2), 2);
+    }
+
+    #[test]
+    fn test_register_external_buffers() {
+        // Skip when no Metal device is available (e.g. a CI runner without a GPU).
+        let Ok(crate::Device::Metal(device)) = crate::Device::new_metal(0) else {
+            return;
+        };
+        // A buffer created outside the device's allocator, as an embedder would.
+        let external = device
+            .device()
+            .new_buffer(16, candle_metal_kernels::RESOURCE_OPTIONS)
+            .unwrap();
+        device.register_external_buffers([&external]);
+        device.unregister_external_buffers([&external]);
     }
 }
 

--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -194,32 +194,19 @@ impl MetalDevice {
         &self.device
     }
 
-    /// Registers externally created buffers in the device's residency set
-    /// (which is attached to its command queue), keeping them permanently
-    /// GPU-resident like buffers from the device's own allocator, instead of
-    /// paying per-command-buffer residency bookkeeping.
-    ///
-    /// Useful for buffers candle did not allocate — e.g.
-    /// `newBufferWithBytesNoCopy` views over an mmap'd weights file — that are
-    /// streamed by many command buffers over their lifetime. The whole batch
-    /// is committed once, so registering many buffers costs one residency-set
-    /// commit. The caller keeps ownership of the buffers; unregister them
-    /// before dropping (the set retains its allocations).
-    ///
-    /// On systems where residency sets are unsupported (creating one failed at
-    /// device init), this is a no-op: the buffers remain fully usable, at the
-    /// default per-command-buffer residency cost.
-    pub fn register_external_buffers<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>) {
+    /// Registers buffers in the device's residency set, keeping them
+    /// permanently GPU-resident instead of paying per-command-buffer residency
+    /// bookkeeping. Useful for buffers candle did not allocate, e.g.
+    /// `newBufferWithBytesNoCopy` views over an mmap'd weights file. No-op on
+    /// systems without residency-set support.
+    pub fn register_buffers<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>) {
         self.residency_set.insert_batch(bufs);
     }
 
-    /// Unregisters buffers previously passed to `register_external_buffers`,
-    /// releasing the residency set's retain so they can be deallocated (e.g.
-    /// when unloading a model to free its resources). Only unregister buffers
-    /// you registered yourself — the device's allocator also tracks its pool
-    /// buffers in this set. Ensure GPU work referencing a buffer has completed
-    /// before unregistering and dropping it.
-    pub fn unregister_external_buffers<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>) {
+    /// Unregisters buffers previously passed to `register_buffers`, releasing
+    /// the set's retain so they can be deallocated. Only unregister buffers
+    /// you registered yourself, after GPU work referencing them has completed.
+    pub fn unregister_buffers<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>) {
         self.residency_set.remove_batch(bufs);
     }
 
@@ -495,21 +482,6 @@ mod tests {
         // BF16 and F16 are 2 bytes per element. A scalar tensor requests
         // a 2-byte buffer. This must not be rounded down to 1.
         assert_eq!(buf_size(2), 2);
-    }
-
-    #[test]
-    fn test_register_external_buffers() {
-        // Skip when no Metal device is available (e.g. a CI runner without a GPU).
-        let Ok(crate::Device::Metal(device)) = crate::Device::new_metal(0) else {
-            return;
-        };
-        // A buffer created outside the device's allocator, as an embedder would.
-        let external = device
-            .device()
-            .new_buffer(16, candle_metal_kernels::RESOURCE_OPTIONS)
-            .unwrap();
-        device.register_external_buffers([&external]);
-        device.unregister_external_buffers([&external]);
     }
 }
 

--- a/candle-metal-kernels/src/metal/residency_set.rs
+++ b/candle-metal-kernels/src/metal/residency_set.rs
@@ -29,17 +29,43 @@ impl ResidencySet {
     }
 
     pub fn insert(&self, buf: &Buffer) {
+        self.insert_batch(std::iter::once(buf));
+    }
+
+    /// Adds many buffers with a single commit: each commit synchronously
+    /// applies the pending changes, so batching a large set (e.g. weights at
+    /// model load) avoids paying that cost once per buffer. An empty batch is
+    /// a no-op.
+    pub fn insert_batch<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>) {
         if let Some(set) = &self.raw {
-            set.addAllocation(as_allocation(buf));
-            set.commit();
+            let mut any = false;
+            for buf in bufs {
+                set.addAllocation(as_allocation(buf));
+                any = true;
+            }
+            if any {
+                set.commit();
+            }
+        }
+    }
+
+    /// Removes many buffers with a single commit; the batch counterpart of
+    /// `insert_batch`. An empty batch is a no-op.
+    pub fn remove_batch<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>) {
+        if let Some(set) = &self.raw {
+            let mut any = false;
+            for buf in bufs {
+                set.removeAllocation(as_allocation(buf));
+                any = true;
+            }
+            if any {
+                set.commit();
+            }
         }
     }
 
     pub fn remove(&self, buf: &Buffer) {
-        if let Some(set) = &self.raw {
-            set.removeAllocation(as_allocation(buf));
-            set.commit();
-        }
+        self.remove_batch(std::iter::once(buf));
     }
 }
 

--- a/candle-metal-kernels/src/metal/residency_set.rs
+++ b/candle-metal-kernels/src/metal/residency_set.rs
@@ -32,10 +32,7 @@ impl ResidencySet {
         self.insert_batch(std::iter::once(buf));
     }
 
-    /// Adds many buffers with a single commit: each commit synchronously
-    /// applies the pending changes, so batching a large set (e.g. weights at
-    /// model load) avoids paying that cost once per buffer. An empty batch is
-    /// a no-op.
+    /// Adds multiple buffers in a single commit.
     pub fn insert_batch<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>) {
         if let Some(set) = &self.raw {
             let mut any = false;
@@ -49,8 +46,7 @@ impl ResidencySet {
         }
     }
 
-    /// Removes many buffers with a single commit; the batch counterpart of
-    /// `insert_batch`. An empty batch is a no-op.
+    /// Removes multiple buffers in a single commit.
     pub fn remove_batch<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>) {
         if let Some(set) = &self.raw {
             let mut any = false;

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2466,3 +2466,28 @@ fn commands_concurrent_acquisition() {
 
     commands.wait_until_completed().unwrap();
 }
+
+#[test]
+fn residency_set_batch_insert_remove() {
+    use objc2_metal::MTLResidencySet;
+
+    let device = device();
+    let set = ResidencySet::new(&device);
+    let Some(raw) = set.raw() else {
+        // Residency sets are unsupported on this device/OS; the set no-ops.
+        return;
+    };
+
+    let bufs: Vec<Buffer> = (0..3).map(|i| new_buffer(&device, &[i as f32])).collect();
+    let base = raw.allocationCount();
+
+    set.insert_batch(&bufs);
+    assert_eq!(raw.allocationCount(), base + bufs.len());
+    set.remove_batch(&bufs);
+    assert_eq!(raw.allocationCount(), base);
+
+    // Empty batches are valid and leave the set untouched.
+    set.insert_batch(std::iter::empty());
+    set.remove_batch(std::iter::empty());
+    assert_eq!(raw.allocationCount(), base);
+}


### PR DESCRIPTION
Two small additive APIs, no default behavior changes.

`MetalDevice` in candle-core:

```rust
pub fn register_buffers<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>);
pub fn unregister_buffers<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>);
```

`ResidencySet` in candle-metal-kernels, the primitives the above are built on:

```rust
pub fn insert_batch<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>);
pub fn remove_batch<'a>(&self, bufs: impl IntoIterator<Item = &'a Buffer>);
```

Each batch call performs the `addAllocation`/`removeAllocation` loop followed by a single `commit()` (skipped for an empty batch). The existing per-buffer `insert`/`remove` now delegate to the batch versions, so there's one commit path.

**Why**

An embedder can create MTLBuffers candle's allocator never sees. The motivating case is llama.cpp-style mmap weight loading on unified memory: `newBufferWithBytesNoCopy` views over an mmap'd GGUF, so model weights alias the page cache with zero copies and a 75GB model loads in ~4s warm (instead of 20+s)

Candle already keeps every buffer it allocates permanently GPU-resident by registering it in a residency set attached to the command queue (`Commands::new` → `addResidencySet`). External buffers have no way to join that set today (`MetalDevice.residency_set` is `pub(crate)`), so they fall back to per-command-buffer residency bookkeeping. For a large weight set streamed by every command buffer this is measurable: on an M5 Max (128GB, macOS 26.5.1), a 70GB mmap'd working set cost ~10% of sustained prefill throughput versus the same weights in candle-allocated buffers. Registering the views in the queue-attached set recovered it exactly.

**Why batch**

`commit()` applies pending changes synchronously, so registering a large model one buffer at a time is slow: 381 view buffers registered via the per-buffer `insert()` added ~7s to model load. The same registrations as one batch + single commit are effectively free.

**Why unregister**

The residency set retains its allocations (candle's own `drop_unused_buffers` relies on this and removes buffers from the set before dropping them). An embedder that unloads a model to free resources (e.g. an API server that loads on demand, keeps the model hot, and dumps it after idling) must be able to release those retains, or every registered buffer (and its GPU mapping) stays alive for the process lifetime.

**Safety / scope notes**

- Residency-set membership itself is perf-only. Buffers bound via `setBuffer` are made resident per command buffer by the driver regardless, so registering or not registering a buffer can only affect throughput, never results. The usual Metal lifetime rules are unchanged on the unregister side: dropping a buffer that in-flight GPU work still references is invalid with or without this API, and the doc comment tells callers to quiesce before unregistering and dropping.
- On systems where residency sets are unsupported (`ResidencySet::new` already tolerates creation failure), the new methods are no-ops like the existing `insert`/`remove`; buffers stay fully usable at per-command-buffer cost. This is documented on `register_buffers `.
- Thread safety is the same as the existing `insert`/`remove`.
- The parameter type is `candle_metal_kernels::metal::Buffer`, which candle-core doesn't re-export. Matches the existing public Metal surface (`MetalStorage::buffer()` already returns it), and an embedder creating its own MTLBuffers necessarily depends on candle-metal-kernels (or objc2-metal) anyway. Happy to add a re-export if you'd prefer.
- Nothing new is exposed beyond the four methods; `MetalDevice`'s internal residency mechanism stays private and free to change.

**Tested**

- `residency_set_batch_insert_remove` (candle-metal-kernels) asserts allocation counts across batch insert/remove and empty batches, and skips where residency sets are unsupported.
- I use this in a Metal inference engine that mmap-loads a 118B MoE (Laguna S 2.1 - Q4_K_M, 75GB): warm load went from ~20s to ~4.2s, sustained prefill throughput matches copied weights, and repeated load→unload cycles don't leak (register after load, unregister + quiesce in Drop).

**AI disclosure**: This patch was developed with AI assistance. I fully understand the change and take complete ownership of it.