### PR TITLE
Skip gradient computation for frozen operands in matmul backward

### DIFF
--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -458,13 +458,26 @@ impl Tensor {
                         // Skipping checks, the op went ok, we can skip
                         // the matmul size checks for now.
 
-                        let lhs_grad = grad.matmul(&rhs.t()?)?;
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&lhs_grad)?;
+                        // Only materialize a gradient for an operand that can
+                        // receive one. `track_op()` is `is_variable ||
+                        // op.is_some()`, so an operand that is neither a
+                        // variable nor a computed node (e.g. a frozen weight in
+                        // a LoRA / partial fine-tune) is skipped — otherwise we
+                        // allocate a full weight-sized gradient in the grad
+                        // store for every frozen matmul and keep them all alive
+                        // for the whole backward pass, which dominates peak
+                        // memory even though those grads are never read.
+                        if lhs.track_op() {
+                            let lhs_grad = grad.matmul(&rhs.t()?)?;
+                            let lhs_sum_grad = grads.or_insert(lhs)?;
+                            *lhs_sum_grad = lhs_sum_grad.add(&lhs_grad)?;
+                        }
 
-                        let rhs_grad = lhs.t()?.matmul(&grad)?;
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        *rhs_sum_grad = rhs_sum_grad.add(&rhs_grad)?;
+                        if rhs.track_op() {
+                            let rhs_grad = lhs.t()?.matmul(&grad)?;
+                            let rhs_sum_grad = grads.or_insert(rhs)?;
+                            *rhs_sum_grad = rhs_sum_grad.add(&rhs_grad)?;
+                        }
                     }
                     Op::Cat(args, dim) => {
                         let mut start_idx = 0;


### PR DESCRIPTION
### Problem

`Op::Matmul` backward computes and stores a gradient for **both** operands unconditionally:

```rust
let rhs_grad = lhs.t()?.matmul(&grad)?;
let rhs_sum_grad = grads.or_insert(rhs)?;   // zeros_like(rhs) — full weight-sized
*rhs_sum_grad = rhs_sum_grad.add(&rhs_grad)?;
```

When one operand is a **frozen** (non-variable) weight — the norm for LoRA / partial fine-tuning, where the base model is frozen and only small adapters are trainable — candle still allocates a full weight-sized gradient (`zeros_like`) in the `GradStore` for it and keeps all of them alive for the whole backward pass. Those gradients are never read (the weight isn't a variable), but they dominate peak memory.

### Fix

Guard each side with `track_op()` (`== is_variable || op.is_some()` — precisely "this operand can receive a gradient"). An operand that is neither a variable nor a computed node cannot need a gradient, so skipping it is always safe. Variables (adapters) and intermediate activations are unaffected, so gradients — and training results — are unchanged.

### Impact

Measured LoRA fine-tuning peak GPU memory (Qwen2.5-Coder, bf16):

| model | frozen base | peak before | peak after |
|-------|-------------|-------------|------------|
| 0.5B  | ~1 GB  | 4.36 GB | 1.54 GB |
| 1.5B  | ~3 GB  | 12.4 GB | 3.56 GB |
| 7B    | 15 GB  | OOM (>60 GB, 40 GB card) | 15.2 GB (fits) |

Loss trajectories are bit-identical before/after; full-finetune paths (weights are variables → `track_op()` true) are unaffected.