### PR TITLE
Fix NaN-confidence panic in non-maximum suppression

### DIFF
--- a/candle-transformers/src/object_detection.rs
+++ b/candle-transformers/src/object_detection.rs
@@ -37,7 +37,7 @@ pub fn iou<D>(b1: &Bbox<D>, b2: &Bbox<D>) -> f32 {
 pub fn non_maximum_suppression<D>(bboxes: &mut [Vec<Bbox<D>>], threshold: f32) {
     // Perform non-maximum suppression.
     for bboxes_for_class in bboxes.iter_mut() {
-        bboxes_for_class.sort_by(|b1, b2| b2.confidence.partial_cmp(&b1.confidence).unwrap());
+        bboxes_for_class.sort_by(|b1, b2| b2.confidence.total_cmp(&b1.confidence));
         let mut current_index = 0;
         for index in 0..bboxes_for_class.len() {
             let mut drop = false;
@@ -93,7 +93,7 @@ pub fn soft_non_maximum_suppression<D>(
 
     for bboxes_for_class in bboxes.iter_mut() {
         // Sort boxes by confidence in descending order
-        bboxes_for_class.sort_by(|b1, b2| b2.confidence.partial_cmp(&b1.confidence).unwrap());
+        bboxes_for_class.sort_by(|b1, b2| b2.confidence.total_cmp(&b1.confidence));
         let mut updated_confidences = bboxes_for_class
             .iter()
             .map(|bbox| bbox.confidence)

--- a/candle-transformers/tests/nms_tests.rs
+++ b/candle-transformers/tests/nms_tests.rs
@@ -42,6 +42,34 @@ fn nms_basic() -> Result<()> {
 }
 
 #[test]
+fn nms_handles_nan_confidence_without_panicking() {
+    let mut bboxes = vec![vec![
+        Bbox {
+            xmin: 0.0,
+            ymin: 0.0,
+            xmax: 1.0,
+            ymax: 1.0,
+            confidence: 0.9,
+            data: (),
+        },
+        Bbox {
+            xmin: 2.0,
+            ymin: 2.0,
+            xmax: 3.0,
+            ymax: 3.0,
+            confidence: f32::NAN,
+            data: (),
+        },
+    ]];
+
+    non_maximum_suppression(&mut bboxes, 0.5);
+
+    assert_eq!(bboxes[0].len(), 2);
+    assert!(bboxes[0].iter().any(|bbox| bbox.confidence == 0.9));
+    assert!(bboxes[0].iter().any(|bbox| bbox.confidence.is_nan()));
+}
+
+#[test]
 fn softnms_basic_functionality() -> Result<()> {
     let mut bboxes = vec![vec![
         Bbox {
@@ -77,6 +105,34 @@ fn softnms_basic_functionality() -> Result<()> {
     assert!(bboxes[0][1].confidence < 0.5);
     assert!(bboxes[0][2].confidence < 0.6);
     Ok(())
+}
+
+#[test]
+fn softnms_handles_nan_confidence_without_panicking() {
+    let mut bboxes = vec![vec![
+        Bbox {
+            xmin: 0.0,
+            ymin: 0.0,
+            xmax: 1.0,
+            ymax: 1.0,
+            confidence: 0.9,
+            data: (),
+        },
+        Bbox {
+            xmin: 2.0,
+            ymin: 2.0,
+            xmax: 3.0,
+            ymax: 3.0,
+            confidence: f32::NAN,
+            data: (),
+        },
+    ]];
+
+    soft_non_maximum_suppression(&mut bboxes, Some(0.5), Some(0.1), Some(0.5));
+
+    assert_eq!(bboxes[0].len(), 2);
+    assert!(bboxes[0].iter().any(|bbox| bbox.confidence == 0.9));
+    assert!(bboxes[0].iter().any(|bbox| bbox.confidence.is_nan()));
 }
 
 #[test]

--- a/candle-wasm-examples/yolo/src/model.rs
+++ b/candle-wasm-examples/yolo/src/model.rs
@@ -792,7 +792,7 @@ pub fn report_detect(
 fn non_maximum_suppression(bboxes: &mut [Vec<Bbox>], threshold: f32) {
     // Perform non-maximum suppression.
     for bboxes_for_class in bboxes.iter_mut() {
-        bboxes_for_class.sort_by(|b1, b2| b2.confidence.partial_cmp(&b1.confidence).unwrap());
+        bboxes_for_class.sort_by(|b1, b2| b2.confidence.total_cmp(&b1.confidence));
         let mut current_index = 0;
         for index in 0..bboxes_for_class.len() {
             let mut drop = false;


### PR DESCRIPTION
## Problem
NMS sorts boxes by confidence using `partial_cmp(..).unwrap()`. This crashes
(panics) if any box has a `NaN` confidence.

## Fix
Use `f32::total_cmp` instead — it handles `NaN` safely and never panics.
(The same file already uses `total_cmp` at `model.rs:752`.)

## Changes
- `object_detection.rs` — fixed both NMS functions
- `yolo/model.rs` — fixed the same bug in the yolo example
- `nms_tests.rs` — added tests for NaN confidence

