### PR TITLE
fix(candle-core):Enable simd128 for target wasm32-wasip2

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,9 @@
 [build]
 rustflags = ["-C", "target-cpu=native"]
 
+[target.wasm32-wasip2]
+rustflags = ["-C", "target-feature=+simd128"]
+
 [target.wasm32-unknown-unknown]
 rustflags = ["-C", "target-feature=+simd128", "--cfg", 'getrandom_backend="wasm_js"']
 

--- a/candle-core/src/cpu/kernels.rs
+++ b/candle-core/src/cpu/kernels.rs
@@ -119,10 +119,12 @@ impl VecOps for half::f16 {
         Self::max(self, other)
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     fn vec_add(lhs: &[Self], rhs: &[Self], res: &mut [Self]) {
         unsafe { super::vec_add_f16(lhs.as_ptr(), rhs.as_ptr(), res.as_mut_ptr(), lhs.len()) }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[inline(always)]
     fn scalar_add(scalar: Self, xs: &[Self], ys: &mut [Self]) {
         unsafe { super::vec_scalar_add_f16(scalar, xs.as_ptr(), ys.as_mut_ptr(), xs.len()) }
@@ -171,11 +173,13 @@ impl VecOps for half::bf16 {
         Self::max(self, other)
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[inline(always)]
     fn vec_add(lhs: &[Self], rhs: &[Self], res: &mut [Self]) {
         unsafe { super::vec_add_bf16(lhs.as_ptr(), rhs.as_ptr(), res.as_mut_ptr(), lhs.len()) }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[inline(always)]
     fn scalar_add(scalar: Self, xs: &[Self], ys: &mut [Self]) {
         unsafe { super::vec_scalar_add_bf16(scalar, xs.as_ptr(), ys.as_mut_ptr(), xs.len()) }

--- a/candle-core/src/cpu/mod.rs
+++ b/candle-core/src/cpu/mod.rs
@@ -249,11 +249,10 @@ pub(crate) unsafe fn vec_dot_bf16(a_row: *const bf16, b_row: *const bf16, c: *mu
     *c = sum;
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+
 #[cfg(any(
     target_feature = "neon",
     target_feature = "avx2",
-    target_feature = "simd128"
 ))]
 pub(crate) unsafe fn vec_add_f16(a_row: *const f16, b_row: *const f16, c: *mut f16, k: usize) {
     let mut i = 0;
@@ -288,11 +287,10 @@ pub(crate) unsafe fn vec_add_f16(a_row: *const f16, b_row: *const f16, c: *mut f
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+
 #[cfg(any(
     target_feature = "neon",
     target_feature = "avx2",
-    target_feature = "simd128"
 ))]
 pub(crate) unsafe fn vec_add_bf16(a_row: *const bf16, b_row: *const bf16, c: *mut bf16, k: usize) {
     let mut i = 0;
@@ -327,11 +325,10 @@ pub(crate) unsafe fn vec_add_bf16(a_row: *const bf16, b_row: *const bf16, c: *mu
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+
 #[cfg(any(
     target_feature = "neon",
     target_feature = "avx2",
-    target_feature = "simd128"
 ))]
 #[inline(always)]
 pub(crate) unsafe fn vec_scalar_add_f16(scalar: f16, xs: *const f16, ys: *mut f16, k: usize) {
@@ -363,11 +360,9 @@ pub(crate) unsafe fn vec_scalar_add_f16(scalar: f16, xs: *const f16, ys: *mut f1
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 #[cfg(any(
     target_feature = "neon",
     target_feature = "avx2",
-    target_feature = "simd128"
 ))]
 #[inline(always)]
 pub(crate) unsafe fn vec_scalar_add_bf16(scalar: bf16, xs: *const bf16, ys: *mut bf16, k: usize) {

--- a/candle-core/src/cpu/mod.rs
+++ b/candle-core/src/cpu/mod.rs
@@ -249,6 +249,7 @@ pub(crate) unsafe fn vec_dot_bf16(a_row: *const bf16, b_row: *const bf16, c: *mu
     *c = sum;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(any(
     target_feature = "neon",
     target_feature = "avx2",
@@ -287,6 +288,7 @@ pub(crate) unsafe fn vec_add_f16(a_row: *const f16, b_row: *const f16, c: *mut f
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(any(
     target_feature = "neon",
     target_feature = "avx2",
@@ -325,6 +327,7 @@ pub(crate) unsafe fn vec_add_bf16(a_row: *const bf16, b_row: *const bf16, c: *mu
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(any(
     target_feature = "neon",
     target_feature = "avx2",
@@ -360,6 +363,7 @@ pub(crate) unsafe fn vec_scalar_add_f16(scalar: f16, xs: *const f16, ys: *mut f1
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(any(
     target_feature = "neon",
     target_feature = "avx2",


### PR DESCRIPTION
Problem Description:

Wasm-wasip2 SIMD128 does not support native f16 vector instructions or the CurrentCpuF16 type. 
Currently, vec_add_f16 in candle-core/src/cpu/mod.rs includes target_feature = "simd128" in its #[cfg(...)] guard. When compiling for wasm32-wasip2 with -C target-feature=+simd128, compilation fails with E0433: cannot find type CurrentCpuF16 in this scope.

Solution:

    Add not(target_arch = "wasm32") to the cfg attribute / remove target_feature = "simd128" on 
    vec_add_f16 , vec_add_bf16, vec_scalar_add_f16, vec_scalar_add_bf16 
    allowing WASM to use the scalar fallback for f16 while retaining SIMD acceleration for f32.
    
    Changes Made:

    1. candle-core/src/cpu/mod.rs: Excluded target_arch = "wasm32" from the #[cfg(...)] guards on f16 and bf16 SIMD functions.

    2. candle-core/src/cpu/kernels.rs: Guarded half::f16 and half::bf16 VecOps trait calls to the underlying SIMD helper functions with #[cfg(not(target_arch = "wasm32"))].

Signed-off-by: Bharat Shinde <bharattech@protonmail.com>