### PR TITLE
CudaDevice on existing context and stream

### DIFF
--- a/candle-core/src/cuda_backend/device.rs
+++ b/candle-core/src/cuda_backend/device.rs
@@ -289,6 +289,14 @@ impl CudaDevice {
         self.stream.clone()
     }
 
+    /// The underlying CUDA context, so a second `CudaDevice` can be built on
+    /// a fresh stream (via `new_stream()` + `from_context_and_stream`) while
+    /// sharing this device's already-loaded modules/weights, instead of
+    /// paying for a second `CudaContext::new()` (device init + full reload).
+    pub fn cuda_context(&self) -> Arc<cudarc::driver::CudaContext> {
+        self.context.clone()
+    }
+
     /// When turned on, all cuda tensors **created after calling this function** will
     /// not track uses via cuda events.
     ///
@@ -390,7 +398,12 @@ impl CudaDevice {
         Self::from_context_and_stream(context, stream)
     }
 
-    fn from_context_and_stream(
+    /// Builds a `CudaDevice` on an existing context with an explicit stream —
+    /// public so callers that already hold a loaded device's context (e.g. to
+    /// share cached weights/modules across concurrent streams) can build
+    /// additional stream-bound views without re-initializing the context or
+    /// reloading anything onto it.
+    pub fn from_context_and_stream(
         context: Arc<cudarc::driver::CudaContext>,
         stream: Arc<cudarc::driver::CudaStream>,
     ) -> Result<Self> {


### PR DESCRIPTION
visibility-only change, no new logic 

exposes two previously-private items on CudaDevice:
* `cuda_context(&self)` — accessor for the device's underlying `CudaContext`
* `from_context_and_stream(...)` — build a new `CudaDevice` on an existing context and stream, instead of always creating a fresh context

To run several concurrent streams efficiently, they need to share one CUDA context rather than each getting its own — right now there's no public way to do that. 

Exposing these two enabled a 2-3x speedup in a concurrent-inference workload (forced alignment) — tested and confirmed working on Blackwell.

relevant to: https://github.com/huggingface/candle/issues/1751

Happy to add doc comments / test coverage, just wanted to submit first to see if there is interest.