### PR TITLE
Add no_repeat_ngram logits utility for generation

### DIFF
--- a/candle-examples/examples/llama/main.rs
+++ b/candle-examples/examples/llama/main.rs
@@ -120,6 +120,10 @@ struct Args {
     /// The context size to consider for the repeat penalty.
     #[arg(long, default_value_t = 128)]
     repeat_last_n: usize,
+
+    /// Prevent repeating any n-gram of this size, 0 disables the constraint.
+    #[arg(long, default_value_t = 0)]
+    no_repeat_ngram_size: usize,
 }
 
 fn main() -> Result<()> {
@@ -253,17 +257,22 @@ fn main() -> Result<()> {
         let ctxt = &tokens[tokens.len().saturating_sub(context_size)..];
         let input = Tensor::new(ctxt, &device)?.unsqueeze(0)?;
         let logits = llama.forward(&input, context_index, &mut cache)?;
-        let logits = logits.squeeze(0)?;
-        let logits = if args.repeat_penalty == 1. {
-            logits
-        } else {
+        let mut logits = logits.squeeze(0)?;
+        if args.repeat_penalty != 1. {
             let start_at = tokens.len().saturating_sub(args.repeat_last_n);
-            candle_transformers::utils::apply_repeat_penalty(
+            logits = candle_transformers::utils::apply_repeat_penalty(
                 &logits,
                 args.repeat_penalty,
                 &tokens[start_at..],
-            )?
-        };
+            )?;
+        }
+        if args.no_repeat_ngram_size > 0 {
+            logits = candle_transformers::utils::apply_no_repeat_ngram(
+                &logits,
+                args.no_repeat_ngram_size,
+                &tokens,
+            )?;
+        }
         index_pos += ctxt.len();
 
         let next_token = logits_processor.sample(&logits)?;

--- a/candle-transformers/src/utils.rs
+++ b/candle-transformers/src/utils.rs
@@ -1,4 +1,4 @@
-//! Shared utilities: repeat_kv, repeat_penalty, causal mask.
+//! Shared utilities: repeat_kv, repeat_penalty, no_repeat_ngram, causal mask.
 
 use candle::{Device, Result, Tensor};
 
@@ -36,6 +36,63 @@ pub fn apply_repeat_penalty(logits: &Tensor, penalty: f32, context: &[u32]) -> R
                 *logit /= penalty
             } else {
                 *logit *= penalty
+            }
+        }
+    }
+    let logits_len = logits.len();
+    Tensor::from_vec(logits, logits_len, device)
+}
+
+/// Bans tokens that would complete a previously-seen n-gram of length `ngram_size`
+/// (equivalent to Hugging Face's `no_repeat_ngram_size`).
+///
+/// Given the already-generated `context`, the last `ngram_size - 1` tokens form the current
+/// prefix. Any token that has previously followed that exact prefix in `context` has its
+/// logit set to `-inf` so it cannot be sampled, preventing the model from repeating an
+/// n-gram it has already produced.
+///
+/// `ngram_size == 0`, or a `context` shorter than `ngram_size`, is a no-op. `ngram_size == 1`
+/// bans every token already present in `context`.
+///
+/// Use it in a decode loop just like [`apply_repeat_penalty`], applying it to the logits
+/// before sampling the next token:
+///
+/// ```rust
+/// use candle::{Device, Tensor};
+/// use candle_transformers::utils::apply_no_repeat_ngram;
+///
+/// # fn main() -> candle::Result<()> {
+/// let device = Device::Cpu;
+/// // Tokens generated so far. The last token (`1`) forms the current 1-token prefix.
+/// let context = [1u32, 2, 1];
+/// let logits = Tensor::new(&[1.0f32, 1.0, 1.0, 1.0], &device)?;
+///
+/// // With `ngram_size = 2`, the bigram `[1, 2]` already occurred, so `2` is banned
+/// // as the next token after `1` (its logit becomes -inf) and will not be sampled.
+/// let logits = apply_no_repeat_ngram(&logits, 2, &context)?;
+/// assert_eq!(logits.to_vec1::<f32>()?, [1.0, 1.0, f32::NEG_INFINITY, 1.0]);
+/// # Ok(())
+/// # }
+/// ```
+pub fn apply_no_repeat_ngram(
+    logits: &Tensor,
+    ngram_size: usize,
+    context: &[u32],
+) -> Result<Tensor> {
+    if ngram_size == 0 || context.len() < ngram_size {
+        return Ok(logits.clone());
+    }
+    let device = logits.device();
+    let mut logits = logits.to_dtype(candle::DType::F32)?.to_vec1::<f32>()?;
+    // The prefix that must not be extended into a repeated n-gram.
+    let prefix = &context[context.len() - (ngram_size - 1)..];
+    // Scan every complete n-gram already in the context; when its first `ngram_size - 1`
+    // tokens match the current prefix, its final token is a banned continuation.
+    for window in context.windows(ngram_size) {
+        if &window[..ngram_size - 1] == prefix {
+            let banned = window[ngram_size - 1];
+            if let Some(logit) = logits.get_mut(banned as usize) {
+                *logit = f32::NEG_INFINITY;
             }
         }
     }

--- a/candle-transformers/tests/generation_utils.rs
+++ b/candle-transformers/tests/generation_utils.rs
@@ -1,0 +1,54 @@
+use candle::{Device, Result, Tensor};
+use candle_transformers::utils::apply_no_repeat_ngram;
+
+const NEG_INF: f32 = f32::NEG_INFINITY;
+
+#[test]
+fn no_repeat_ngram_bigram() -> Result<()> {
+    let device = &Device::Cpu;
+    // vocab size 4, all logits equal.
+    let logits = Tensor::new(&[0f32, 0., 0., 0.], device)?;
+    // context: [1, 2, 1] -> prefix is [1]; token 2 previously followed 1, so it is banned.
+    let out = apply_no_repeat_ngram(&logits, 2, &[1, 2, 1])?;
+    assert_eq!(out.to_vec1::<f32>()?, [0., 0., NEG_INF, 0.]);
+    Ok(())
+}
+
+#[test]
+fn no_repeat_ngram_trigram() -> Result<()> {
+    let device = &Device::Cpu;
+    let logits = Tensor::zeros(8, candle::DType::F32, device)?;
+    // context: [5, 6, 7, 5, 6] -> prefix [5, 6] was previously followed by 7 -> ban 7.
+    let out = apply_no_repeat_ngram(&logits, 3, &[5, 6, 7, 5, 6])?;
+    let v = out.to_vec1::<f32>()?;
+    assert_eq!(v[7], NEG_INF);
+    // Nothing else is banned.
+    assert_eq!(v.iter().filter(|x| x.is_infinite()).count(), 1);
+    Ok(())
+}
+
+#[test]
+fn no_repeat_ngram_unigram_bans_all_seen() -> Result<()> {
+    let device = &Device::Cpu;
+    let logits = Tensor::zeros(4, candle::DType::F32, device)?;
+    // ngram_size == 1 bans every token already present in the context.
+    let out = apply_no_repeat_ngram(&logits, 1, &[0, 2])?;
+    assert_eq!(out.to_vec1::<f32>()?, [NEG_INF, 0., NEG_INF, 0.]);
+    Ok(())
+}
+
+#[test]
+fn no_repeat_ngram_noop() -> Result<()> {
+    let device = &Device::Cpu;
+    let logits = Tensor::new(&[1f32, 2., 3.], device)?;
+    // ngram_size == 0 and context shorter than ngram_size are both no-ops.
+    assert_eq!(
+        apply_no_repeat_ngram(&logits, 0, &[1, 2])?.to_vec1::<f32>()?,
+        [1., 2., 3.]
+    );
+    assert_eq!(
+        apply_no_repeat_ngram(&logits, 3, &[1])?.to_vec1::<f32>()?,
+        [1., 2., 3.]
+    );
+    Ok(())
+}


### PR DESCRIPTION
This adds a way to stop the model from repeating the same phrases while generating text (the same idea as Hugging Face's `no_repeat_ngram_size`).

If the model already said a group of words, it won't be allowed to say that same group again — that word's score is set to -infinity so it can't be picked.

What's included:
- A helper function `apply_no_repeat_ngram(...)` next to the existing `apply_repeat_penalty`.
- A new `--no-repeat-ngram-size` option in the llama example (default 0 = off).
- Tests covering the main cases and edge cases.
