### PR TITLE
fix(models): correct batched causal mask under-sizing tensor storage

### DIFF
--- a/candle-transformers/src/models/glm4_new.rs
+++ b/candle-transformers/src/models/glm4_new.rs
@@ -329,13 +329,7 @@ impl Model {
         }
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
+    fn causal_mask(&self, tgt: usize, offset: usize, sw: Option<usize>) -> Result<Tensor> {
         let minf = f32::NEG_INFINITY;
         let mask: Vec<_> = (0..tgt)
             .flat_map(|i| {
@@ -353,17 +347,20 @@ impl Model {
                 })
             })
             .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
+        // Batch-independent mask: built with a batch dim of 1 and broadcast. A
+        // batch dim > 1 would claim `b` copies while the slice holds one,
+        // under-sizing storage (from_slice skips a concrete shape's length check).
+        Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
     }
 
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
-        let (b, l) = input.dims2()?;
+        let (_, l) = input.dims2()?;
         let mut h = self.embed_tokens.forward(input)?;
 
         let causal = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(self.causal_mask(l, offset, None)?)
         };
 
         for layer in &mut self.layers {

--- a/candle-transformers/src/models/quantized_glm4.rs
+++ b/candle-transformers/src/models/quantized_glm4.rs
@@ -427,13 +427,7 @@ impl ModelWeights {
         })
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
+    fn causal_mask(&self, tgt: usize, offset: usize, sw: Option<usize>) -> Result<Tensor> {
         let minf = f32::NEG_INFINITY;
         let mask: Vec<_> = (0..tgt)
             .flat_map(|i| {
@@ -451,18 +445,21 @@ impl ModelWeights {
                 })
             })
             .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
+        // Batch-independent mask: built with a batch dim of 1 and broadcast. A
+        // batch dim > 1 would claim `b` copies while the slice holds one,
+        // under-sizing storage (from_slice skips a concrete shape's length check).
+        Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
     }
 
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
         let _enter = self.span.enter();
-        let (b, l) = input.dims2()?;
+        let (_, l) = input.dims2()?;
         let mut h = self.embed_tokens.forward(input)?;
 
         let causal_mask = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(self.causal_mask(l, offset, None)?)
         };
 
         for layer in &mut self.layers {

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -535,13 +535,7 @@ impl ModelWeights {
         })
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
+    fn causal_mask(&self, tgt: usize, offset: usize, sw: Option<usize>) -> Result<Tensor> {
         let minf = f32::NEG_INFINITY;
         let mask: Vec<_> = (0..tgt)
             .flat_map(|i| {
@@ -559,18 +553,21 @@ impl ModelWeights {
                 })
             })
             .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
+        // Batch-independent mask: built with a batch dim of 1 and broadcast. A
+        // batch dim > 1 would claim `b` copies while the slice holds one,
+        // under-sizing storage (from_slice skips a concrete shape's length check).
+        Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
     }
 
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
         let _enter = self.span.enter();
-        let (b, l) = input.dims2()?;
+        let (_, l) = input.dims2()?;
         let mut h = self.embed_tokens.forward(input)?;
         // Skip mask materialization when using CPU flash attention
         let causal_mask = if l == 1 || self.device.is_cpu() {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(self.causal_mask(l, offset, None)?)
         };
         for layer in &mut self.layers {
             h = layer.forward(&h, causal_mask.as_ref(), offset)?;

--- a/candle-transformers/src/models/quantized_qwen3_moe.rs
+++ b/candle-transformers/src/models/quantized_qwen3_moe.rs
@@ -391,13 +391,7 @@ impl GGUFQWenMoE {
         })
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
+    fn causal_mask(&self, tgt: usize, offset: usize, sw: Option<usize>) -> Result<Tensor> {
         let minf = f32::NEG_INFINITY;
         let mask: Vec<_> = (0..tgt)
             .flat_map(|i| {
@@ -415,17 +409,20 @@ impl GGUFQWenMoE {
                 })
             })
             .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
+        // Batch-independent mask: built with a batch dim of 1 and broadcast. A
+        // batch dim > 1 would claim `b` copies while the slice holds one,
+        // under-sizing storage (from_slice skips a concrete shape's length check).
+        Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
     }
 
     pub fn forward(&mut self, x: &Tensor, offset: usize) -> Result<Tensor> {
         let mut xs = self.tok_embeddings.forward(x)?;
-        let (b, l) = x.dims2()?;
+        let (_, l) = x.dims2()?;
 
         let causal_mask = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(self.causal_mask(l, offset, None)?)
         };
 
         for layer in self.layers.iter_mut() {

--- a/candle-transformers/src/models/qwen3.rs
+++ b/candle-transformers/src/models/qwen3.rs
@@ -396,6 +396,39 @@ impl DecoderLayer {
     }
 }
 
+// Build the additive causal mask for `tgt` query positions over `tgt + offset`
+// keys. The mask is identical for every batch row, so it is built with a batch
+// dim of `1` and broadcast across the batch at use. A batch dim > 1 would claim
+// `b` copies of the data while the slice holds only one, silently under-sizing
+// the tensor's storage: `Tensor::from_slice` does not check the element count of
+// a fully-concrete shape.
+fn causal_mask(
+    device: &Device,
+    dtype: DType,
+    tgt: usize,
+    offset: usize,
+    sw: Option<usize>,
+) -> Result<Tensor> {
+    let minf = f32::NEG_INFINITY;
+    let mask: Vec<_> = (0..tgt)
+        .flat_map(|i| {
+            (0..(tgt + offset)).map(move |j| {
+                let past_ok = j <= i + offset;
+                let sw_ok = match sw {
+                    Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
+                    None => true,
+                };
+                if past_ok && sw_ok {
+                    0.
+                } else {
+                    minf
+                }
+            })
+        })
+        .collect();
+    Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), device)?.to_dtype(dtype)
+}
+
 #[derive(Debug, Clone)]
 pub struct Model {
     embed_tokens: candle_nn::Embedding,
@@ -438,35 +471,8 @@ impl Model {
         }
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| {
-                    let past_ok = j <= i + offset;
-                    let sw_ok = match sw {
-                        Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
-                        None => true,
-                    };
-                    if past_ok && sw_ok {
-                        0.
-                    } else {
-                        minf
-                    }
-                })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
-        let (b, l) = input.dims2()?;
+        let (_, l) = input.dims2()?;
         let mut h = self.embed_tokens.forward(input)?;
 
         // Build causal mask only for the standard attention fallback path.
@@ -476,7 +482,7 @@ impl Model {
         #[cfg(feature = "flash-attn")]
         let needs_mask = self.device.is_cpu() && l > 1;
         let causal = if needs_mask {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(causal_mask(&self.device, self.dtype, l, offset, None)?)
         } else {
             None
         };
@@ -515,5 +521,37 @@ impl ModelForCausalLM {
 
     pub fn clear_kv_cache(&mut self) {
         self.base.clear_kv_cache();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The causal mask must be batch-independent so a single copy broadcasts
+    // across every row. Building it with the full batch dim used to under-size
+    // the storage, giving garbage/NaN for batch > 1 on the GPU attention path.
+    #[test]
+    fn causal_mask_is_batch_independent() -> Result<()> {
+        let device = Device::Cpu;
+        let (tgt, offset) = (3, 0);
+        let mask = causal_mask(&device, DType::F32, tgt, offset, None)?;
+        assert_eq!(mask.dims(), &[1, 1, tgt, tgt + offset]);
+
+        // Lower triangle is attended (0), the strict upper triangle is masked.
+        let neg_inf = f32::NEG_INFINITY;
+        assert_eq!(
+            mask.squeeze(0)?.squeeze(0)?.to_vec2::<f32>()?,
+            [[0., neg_inf, neg_inf], [0., 0., neg_inf], [0., 0., 0.]],
+        );
+
+        // Broadcasting onto batched scores gives every row the same mask.
+        let b = 4;
+        let scores = Tensor::zeros((b, 1, tgt, tgt + offset), DType::F32, &device)?;
+        let rows = scores.broadcast_add(&mask)?.squeeze(1)?.to_vec3::<f32>()?;
+        for row in &rows[1..] {
+            assert_eq!(row, &rows[0]);
+        }
+        Ok(())
     }
 }

--- a/candle-transformers/src/models/qwen3_moe.rs
+++ b/candle-transformers/src/models/qwen3_moe.rs
@@ -299,13 +299,7 @@ impl Model {
         }
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
+    fn causal_mask(&self, tgt: usize, offset: usize, sw: Option<usize>) -> Result<Tensor> {
         let minf = f32::NEG_INFINITY;
         let mask: Vec<_> = (0..tgt)
             .flat_map(|i| {
@@ -323,17 +317,20 @@ impl Model {
                 })
             })
             .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
+        // Batch-independent mask: built with a batch dim of 1 and broadcast. A
+        // batch dim > 1 would claim `b` copies while the slice holds one,
+        // under-sizing storage (from_slice skips a concrete shape's length check).
+        Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
     }
 
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
-        let (b, l) = input.dims2()?;
+        let (_, l) = input.dims2()?;
         let mut h = self.embed_tokens.forward(input)?;
 
         let causal = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(self.causal_mask(l, offset, None)?)
         };
 
         for layer in &mut self.layers {

--- a/candle-transformers/src/models/smol/smollm3.rs
+++ b/candle-transformers/src/models/smol/smollm3.rs
@@ -393,13 +393,7 @@ impl Model {
         }
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
+    fn causal_mask(&self, tgt: usize, offset: usize, sw: Option<usize>) -> Result<Tensor> {
         let minf = f32::NEG_INFINITY;
         let mask: Vec<_> = (0..tgt)
             .flat_map(|i| {
@@ -417,18 +411,21 @@ impl Model {
                 })
             })
             .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
+        // Batch-independent mask: built with a batch dim of 1 and broadcast. A
+        // batch dim > 1 would claim `b` copies while the slice holds one,
+        // under-sizing storage (from_slice skips a concrete shape's length check).
+        Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
     }
 
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
-        let (b, l) = input.dims2()?;
+        let (_, l) = input.dims2()?;
 
         let mut h = self.embed_tokens.forward(input)?;
 
         let causal = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(self.causal_mask(l, offset, None)?)
         };
 
         for layer in &mut self.layers {

--- a/candle-transformers/src/models/z_image/text_encoder.rs
+++ b/candle-transformers/src/models/z_image/text_encoder.rs
@@ -400,14 +400,17 @@ impl ZImageTextEncoder {
     }
 
     /// Create causal attention mask
-    fn causal_mask(&self, b: usize, tgt: usize, offset: usize) -> Result<Tensor> {
+    fn causal_mask(&self, tgt: usize, offset: usize) -> Result<Tensor> {
         let minf = f32::NEG_INFINITY;
         let mask: Vec<_> = (0..tgt)
             .flat_map(|i| {
                 (0..(tgt + offset)).map(move |j| if j <= i + offset { 0.0 } else { minf })
             })
             .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
+        // Batch-independent mask: built with a batch dim of 1 and broadcast. A
+        // batch dim > 1 would claim `b` copies while the slice holds one,
+        // under-sizing storage (from_slice skips a concrete shape's length check).
+        Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
     }
 
     /// Encode text, returning second-to-last layer hidden states
@@ -420,13 +423,13 @@ impl ZImageTextEncoder {
     ///
     /// **Important**: Returns raw output from layer[-2] WITHOUT final RMSNorm
     pub fn forward(&self, input_ids: &Tensor) -> Result<Tensor> {
-        let (b, l) = input_ids.dims2()?;
+        let (_, l) = input_ids.dims2()?;
         let mut hidden_states = self.embed_tokens.forward(input_ids)?;
 
         let causal = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, 0)?)
+            Some(self.causal_mask(l, 0)?)
         };
 
         // num_hidden_layers = 36, second-to-last layer index = 34


### PR DESCRIPTION
Fixes #3764.

Hit this batching a few equal-length sequences through a Qwen3 model for embeddings. One at a time was fine, batched gave row 0 correct and the rest NaN. Traced it to the causal mask, found #3764 already open with nobody on it, so I fixed it properly.

`causal_mask` fills the mask for one batch element (`tgt * (tgt + offset)` values) but shapes the tensor `(b, 1, tgt, tgt + offset)`. `from_slice` doesn't check length against a fully-concrete shape, so for `b > 1` the storage is `b`x too small and the next `broadcast_add` reads off the end. That gives NaN on CUDA and a hard panic on CPU.

The mask is the same for every row, so build it once and let the existing broadcast stretch it:

```rust
Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
```

Dropping the batch dim makes `b` dead, so it's gone from each `causal_mask`.

The same `(b, 1, ...)`-from-single-batch-data pattern is in eight models, all broadcasting the mask, so the one change is correct for each: `qwen3`, `qwen3_moe`, `quantized_qwen3`, `quantized_qwen3_moe`, `glm4_new`, `quantized_glm4`, `smol/smollm3`, `z_image/text_encoder`. Split into two commits: qwen3 plus the test, then the siblings.

**Repro (CPU, no GPU or weights).** qwen3 only builds the mask off-CPU, but `smol/smollm3` has the identical code and builds it anywhere:

```
batch = 1 ... all finite
batch = 2 ... panicked: range end index 32 out of range for slice of length 16
```

The mask holds 16 elements but its shape claims 32. On GPU that same read is silent and returns NaN.

**Test.** `forward` only builds the mask off-CPU, so I extracted qwen3's `causal_mask` to a free fn (already the crate idiom) to make it testable on CPU, and added a test pinning the shape and checking it broadcasts to identical rows. Fails on the old shape, passes on the new. The other seven are character-identical, so one canonical test rather than eight copies. Happy to add per-model if you prefer.
