### PR TITLE
Add KV cache state extraction/restoration to quantized_qwen2 and quantized_qwen3_moe

### DIFF
--- a/candle-transformers/src/models/quantized_qwen2.rs
+++ b/candle-transformers/src/models/quantized_qwen2.rs
@@ -314,23 +314,10 @@ impl ModelWeights {
         }
     }
 
-    /// Extracts every layer's current KV cache state, in layer order --
-    /// added for session checkpoint/restore (a caller can persist this and
-    /// later hand it back to `set_kv_cache_state` on a fresh or
-    /// freshly-cleared model to continue a session without reprocessing
-    /// already-seen tokens). `None` per layer means that layer hasn't been
-    /// forwarded through yet (e.g. a session extracted before any tokens
-    /// were processed).
     pub fn kv_cache_state(&self) -> Vec<Option<(Tensor, Tensor)>> {
         self.layers.iter().map(|l| l.kv_cache.clone()).collect()
     }
 
-    /// Restores a previously-extracted KV cache state, one entry per layer
-    /// in the same order `kv_cache_state` returned them. Errors rather than
-    /// silently partial-restoring if the layer count doesn't match --
-    /// mismatched state (e.g. from a different model/architecture) must be
-    /// rejected loudly, not applied to whichever prefix of layers happens
-    /// to line up.
     pub fn set_kv_cache_state(&mut self, state: Vec<Option<(Tensor, Tensor)>>) -> Result<()> {
         if state.len() != self.layers.len() {
             candle::bail!(

--- a/candle-transformers/src/models/quantized_qwen2.rs
+++ b/candle-transformers/src/models/quantized_qwen2.rs
@@ -314,6 +314,37 @@ impl ModelWeights {
         }
     }
 
+    /// Extracts every layer's current KV cache state, in layer order --
+    /// added for session checkpoint/restore (a caller can persist this and
+    /// later hand it back to `set_kv_cache_state` on a fresh or
+    /// freshly-cleared model to continue a session without reprocessing
+    /// already-seen tokens). `None` per layer means that layer hasn't been
+    /// forwarded through yet (e.g. a session extracted before any tokens
+    /// were processed).
+    pub fn kv_cache_state(&self) -> Vec<Option<(Tensor, Tensor)>> {
+        self.layers.iter().map(|l| l.kv_cache.clone()).collect()
+    }
+
+    /// Restores a previously-extracted KV cache state, one entry per layer
+    /// in the same order `kv_cache_state` returned them. Errors rather than
+    /// silently partial-restoring if the layer count doesn't match --
+    /// mismatched state (e.g. from a different model/architecture) must be
+    /// rejected loudly, not applied to whichever prefix of layers happens
+    /// to line up.
+    pub fn set_kv_cache_state(&mut self, state: Vec<Option<(Tensor, Tensor)>>) -> Result<()> {
+        if state.len() != self.layers.len() {
+            candle::bail!(
+                "kv cache state has {} layers, model has {} -- refusing a partial restore",
+                state.len(),
+                self.layers.len()
+            );
+        }
+        for (layer, s) in self.layers.iter_mut().zip(state) {
+            layer.kv_cache = s;
+        }
+        Ok(())
+    }
+
     pub fn forward(&mut self, x: &Tensor, index_pos: usize) -> Result<Tensor> {
         let (_b_sz, seq_len) = x.dims2()?;
         let mask = if seq_len == 1 {

--- a/candle-transformers/src/models/quantized_qwen3_moe.rs
+++ b/candle-transformers/src/models/quantized_qwen3_moe.rs
@@ -223,6 +223,28 @@ impl QuantizedAttention {
     pub fn clear_kv_cache(&mut self) {
         self.kv_cache.reset();
     }
+
+    /// Extracts this layer's current KV state (both k and v, cloned) --
+    /// `None` if the cache is empty (nothing forwarded through yet).
+    /// Added for session checkpoint/restore.
+    fn kv_cache_state(&self) -> Option<(Tensor, Tensor)> {
+        match (self.kv_cache.k(), self.kv_cache.v()) {
+            (Some(k), Some(v)) => Some((k.clone(), v.clone())),
+            _ => None,
+        }
+    }
+
+    /// Restores a previously-extracted KV state. `append` on a freshly-reset
+    /// `ConcatKvCache` sets it directly (see `ConcatKvCache::append`'s own
+    /// doc), so reset-then-append-once is the correct full restore, not an
+    /// incremental one.
+    fn set_kv_cache_state(&mut self, state: Option<(Tensor, Tensor)>) -> Result<()> {
+        self.kv_cache.reset();
+        if let Some((k, v)) = state {
+            self.kv_cache.append(&k, &v)?;
+        }
+        Ok(())
+    }
 }
 
 struct LayerWeights {
@@ -239,6 +261,14 @@ impl LayerWeights {
 
     fn clear_kv_cache(&mut self) {
         self.self_attn.clear_kv_cache();
+    }
+
+    fn kv_cache_state(&self) -> Option<(Tensor, Tensor)> {
+        self.self_attn.kv_cache_state()
+    }
+
+    fn set_kv_cache_state(&mut self, state: Option<(Tensor, Tensor)>) -> Result<()> {
+        self.self_attn.set_kv_cache_state(state)
     }
 }
 
@@ -461,12 +491,40 @@ impl GGUFQWenMoE {
 
     /// Resets every layer's KV cache -- for reusing one loaded model across
     /// independent requests without reloading weights. Added for ratatoskr,
-    /// which serializes model access behind a mutex and clears state at the
-    /// start of every request rather than tracking sessions (see
-    /// ratatoskr's src/model/mod.rs).
+    /// which serializes model access behind a mutex (see ratatoskr's
+    /// src/model/mod.rs); ratatoskr now also tracks warm sessions and only
+    /// calls this when actually starting a new/different conversation, not
+    /// unconditionally on every request.
     pub fn clear_kv_cache(&mut self) {
         for layer in self.layers.iter_mut() {
             layer.clear_kv_cache();
         }
+    }
+
+    /// Extracts every layer's current KV cache state, in layer order --
+    /// added for session checkpoint/restore, same shape and pairing
+    /// convention as quantized_qwen2::ModelWeights's own
+    /// kv_cache_state/set_kv_cache_state (kept consistent across both
+    /// standard-KV-cache backends so ratatoskr's session code doesn't need
+    /// per-architecture branching to persist/restore this).
+    pub fn kv_cache_state(&self) -> Vec<Option<(Tensor, Tensor)>> {
+        self.layers.iter().map(|l| l.kv_cache_state()).collect()
+    }
+
+    /// Restores a previously-extracted KV cache state, one entry per layer
+    /// in the same order `kv_cache_state` returned them. Errors rather than
+    /// silently partial-restoring if the layer count doesn't match.
+    pub fn set_kv_cache_state(&mut self, state: Vec<Option<(Tensor, Tensor)>>) -> Result<()> {
+        if state.len() != self.layers.len() {
+            candle::bail!(
+                "kv cache state has {} layers, model has {} -- refusing a partial restore",
+                state.len(),
+                self.layers.len()
+            );
+        }
+        for (layer, s) in self.layers.iter_mut().zip(state) {
+            layer.set_kv_cache_state(s)?;
+        }
+        Ok(())
     }
 }

--- a/candle-transformers/src/models/quantized_qwen3_moe.rs
+++ b/candle-transformers/src/models/quantized_qwen3_moe.rs
@@ -217,6 +217,12 @@ impl QuantizedAttention {
 
         self.attention_wo.forward(&reshaped_ctx.to_dtype(in_dtype)?)
     }
+
+    /// Drops this layer's cached KV state -- for reusing one loaded model
+    /// across independent requests without reloading weights.
+    pub fn clear_kv_cache(&mut self) {
+        self.kv_cache.reset();
+    }
 }
 
 struct LayerWeights {
@@ -229,6 +235,10 @@ struct LayerWeights {
 impl LayerWeights {
     fn forward_attn(&mut self, x: &Tensor, mask: Option<&Tensor>, offset: usize) -> Result<Tensor> {
         self.self_attn.forward(x, mask, offset)
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.self_attn.clear_kv_cache();
     }
 }
 
@@ -447,5 +457,16 @@ impl GGUFQWenMoE {
         let xs = xs.narrow(1, l - 1, 1)?;
         let xs = self.norm.forward(&xs)?;
         self.output.forward(&xs)?.to_dtype(DType::F32)?.squeeze(1)
+    }
+
+    /// Resets every layer's KV cache -- for reusing one loaded model across
+    /// independent requests without reloading weights. Added for ratatoskr,
+    /// which serializes model access behind a mutex and clears state at the
+    /// start of every request rather than tracking sessions (see
+    /// ratatoskr's src/model/mod.rs).
+    pub fn clear_kv_cache(&mut self) {
+        for layer in self.layers.iter_mut() {
+            layer.clear_kv_cache();
+        }
     }
 }

--- a/candle-transformers/src/models/quantized_qwen3_moe.rs
+++ b/candle-transformers/src/models/quantized_qwen3_moe.rs
@@ -218,15 +218,10 @@ impl QuantizedAttention {
         self.attention_wo.forward(&reshaped_ctx.to_dtype(in_dtype)?)
     }
 
-    /// Drops this layer's cached KV state -- for reusing one loaded model
-    /// across independent requests without reloading weights.
     pub fn clear_kv_cache(&mut self) {
         self.kv_cache.reset();
     }
 
-    /// Extracts this layer's current KV state (both k and v, cloned) --
-    /// `None` if the cache is empty (nothing forwarded through yet).
-    /// Added for session checkpoint/restore.
     fn kv_cache_state(&self) -> Option<(Tensor, Tensor)> {
         match (self.kv_cache.k(), self.kv_cache.v()) {
             (Some(k), Some(v)) => Some((k.clone(), v.clone())),
@@ -234,10 +229,6 @@ impl QuantizedAttention {
         }
     }
 
-    /// Restores a previously-extracted KV state. `append` on a freshly-reset
-    /// `ConcatKvCache` sets it directly (see `ConcatKvCache::append`'s own
-    /// doc), so reset-then-append-once is the correct full restore, not an
-    /// incremental one.
     fn set_kv_cache_state(&mut self, state: Option<(Tensor, Tensor)>) -> Result<()> {
         self.kv_cache.reset();
         if let Some((k, v)) = state {
@@ -489,27 +480,16 @@ impl GGUFQWenMoE {
         self.output.forward(&xs)?.to_dtype(DType::F32)?.squeeze(1)
     }
 
-    /// Resets every layer's KV cache -- for reusing one loaded model across
-    /// independent requests without reloading weights.
     pub fn clear_kv_cache(&mut self) {
         for layer in self.layers.iter_mut() {
             layer.clear_kv_cache();
         }
     }
 
-    /// Extracts every layer's current KV cache state, in layer order --
-    /// added for session checkpoint/restore, same shape and pairing
-    /// convention as quantized_qwen2::ModelWeights's own
-    /// kv_cache_state/set_kv_cache_state (kept consistent across both
-    /// standard-KV-cache backends so callers don't need per-architecture
-    /// branching to persist/restore this).
     pub fn kv_cache_state(&self) -> Vec<Option<(Tensor, Tensor)>> {
         self.layers.iter().map(|l| l.kv_cache_state()).collect()
     }
 
-    /// Restores a previously-extracted KV cache state, one entry per layer
-    /// in the same order `kv_cache_state` returned them. Errors rather than
-    /// silently partial-restoring if the layer count doesn't match.
     pub fn set_kv_cache_state(&mut self, state: Vec<Option<(Tensor, Tensor)>>) -> Result<()> {
         if state.len() != self.layers.len() {
             candle::bail!(

--- a/candle-transformers/src/models/quantized_qwen3_moe.rs
+++ b/candle-transformers/src/models/quantized_qwen3_moe.rs
@@ -490,11 +490,7 @@ impl GGUFQWenMoE {
     }
 
     /// Resets every layer's KV cache -- for reusing one loaded model across
-    /// independent requests without reloading weights. Added for ratatoskr,
-    /// which serializes model access behind a mutex (see ratatoskr's
-    /// src/model/mod.rs); ratatoskr now also tracks warm sessions and only
-    /// calls this when actually starting a new/different conversation, not
-    /// unconditionally on every request.
+    /// independent requests without reloading weights.
     pub fn clear_kv_cache(&mut self) {
         for layer in self.layers.iter_mut() {
             layer.clear_kv_cache();
@@ -505,8 +501,8 @@ impl GGUFQWenMoE {
     /// added for session checkpoint/restore, same shape and pairing
     /// convention as quantized_qwen2::ModelWeights's own
     /// kv_cache_state/set_kv_cache_state (kept consistent across both
-    /// standard-KV-cache backends so ratatoskr's session code doesn't need
-    /// per-architecture branching to persist/restore this).
+    /// standard-KV-cache backends so callers don't need per-architecture
+    /// branching to persist/restore this).
     pub fn kv_cache_state(&self) -> Vec<Option<(Tensor, Tensor)>> {
         self.layers.iter().map(|l| l.kv_cache_state()).collect()
     }


### PR DESCRIPTION
Adds explicit KV cache state extraction/restoration to `quantized_qwen2::ModelWeights` and `quantized_qwen3_moe::GGUFQWenMoE`, plus a `clear_kv_cache` on the latter (mirroring the method already present on `quantized_qwen2`/`quantized_qwen3`/`quantized_llama`).

## Why

Both model types previously exposed no way to get attention state out of a live model or put a previously-saved state back in — only an implicit reset via `index_pos == 0` on the next forward. That's enough for the common single-conversation server loop, but not for a caller that needs to persist a session's KV state across process restarts, or swap which conversation a resident model is serving without reprocessing every token from the start of the conversation.

## What

Both new methods share the same shape and pairing convention so callers don't need per-architecture branching:

```rust
pub fn kv_cache_state(&self) -> Vec<Option<(Tensor, Tensor)>>;
pub fn set_kv_cache_state(&mut self, state: Vec<Option<(Tensor, Tensor)>>) -> Result<()>;
```

One entry per layer, in layer order. `None` means that layer hasn't been forwarded through yet. `set_kv_cache_state` errors (rather than silently partial-restoring) on a layer-count mismatch, since mismatched state from a different model/architecture should be rejected loudly.

`GGUFQWenMoE::clear_kv_cache` follows the existing `quantized_qwen2`/`quantized_qwen3` pattern (iterate layers, clear the K/V pair) — it was simply missing for the MoE variant.

No behavior change for existing callers; all three methods are additive.

## Testing

`cargo build -p candle-transformers --features metal` passes clean. This has also been exercised live in downstream code: extracting state after a multi-turn conversation, restoring into a freshly-loaded model, and confirming the restored KV tensors are bit-identical to the originals before continuing generation.
