### PR TITLE
Add zero-copy (mmap-backed) Metal buffer support for quantized weights

### DIFF
--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -8,6 +8,16 @@ pub struct QMetalStorage {
     dtype: GgmlDType,
     device: MetalDevice,
     buffer: Arc<Buffer>,
+    /// Byte offset of this tensor's data within `buffer`. Nonzero when
+    /// `buffer` is shared across several tensors (e.g. one no-copy buffer
+    /// wrapping an entire mmap'd file) via `from_buffer`; zero for every
+    /// storage that owns its buffer outright.
+    offset: usize,
+    /// This tensor's own byte length -- may be smaller than `buffer.length()`
+    /// when `buffer` is shared. Every read/blit against `buffer` must use
+    /// this, not `buffer.length()`, or it silently reads past this tensor's
+    /// data into a neighboring one.
+    length: usize,
 }
 
 impl QMetalStorage {
@@ -19,10 +29,32 @@ impl QMetalStorage {
             .with_label("qstorage_zeros")
             .build()?;
         Ok(Self {
+            length: buffer.length(),
             buffer,
             device: device.clone(),
             dtype,
+            offset: 0,
         })
+    }
+
+    /// Wraps an existing, externally-created buffer -- e.g. a no-copy Metal
+    /// buffer over an mmap'd region -- as this tensor's storage, with no
+    /// allocation and no copy. `offset`/`length` locate this tensor's bytes
+    /// within `buffer`, which may be shared with other tensors.
+    pub fn from_buffer(
+        buffer: Arc<Buffer>,
+        offset: usize,
+        length: usize,
+        device: MetalDevice,
+        dtype: GgmlDType,
+    ) -> Self {
+        Self {
+            buffer,
+            offset,
+            length,
+            device,
+            dtype,
+        }
     }
 
     pub fn dtype(&self) -> GgmlDType {
@@ -37,19 +69,31 @@ impl QMetalStorage {
         &self.buffer
     }
 
+    /// Byte offset of this tensor's data within `buffer()`. Zero unless this
+    /// storage was built via `from_buffer` over a shared buffer.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// This tensor's own byte length -- use this, not `buffer().length()`,
+    /// when `buffer()` may be shared with other tensors.
+    pub fn length(&self) -> usize {
+        self.length
+    }
+
     pub fn dequantize(&self, elem_count: usize) -> Result<MetalStorage> {
         use crate::quantized::k_quants::GgmlType;
 
         let buffer = self
             .device
             .new_buffer_builder()
-            .with_size(self.buffer.length())
+            .with_size(self.length)
             .with_label("qstorage_dequantize_blit")
             .build()?;
         {
             let mut blit = self.device.blit_command_encoder()?;
             blit.set_label("blit_to_cpu");
-            blit.copy_from_buffer(&self.buffer, 0, &buffer, 0, self.buffer.length());
+            blit.copy_from_buffer(&self.buffer, self.offset, &buffer, 0, self.length);
         }
         self.device.flush_and_wait_current()?;
         let mut out = vec![0.0; elem_count];
@@ -144,7 +188,13 @@ impl QMetalStorage {
             .with_data(&qcpu_storage.data()?)
             .with_label("qstorage_quantized")
             .build()?;
+        // A fresh full-ownership allocation replaces whatever view (offset,
+        // length) this storage previously had -- reset both, or a
+        // quantize-after-from_buffer would keep stale view metadata pointing
+        // into a buffer this storage no longer shares.
+        self.length = buffer.length();
         self.buffer = buffer;
+        self.offset = 0;
         Ok(())
     }
 
@@ -166,7 +216,13 @@ impl QMetalStorage {
             .with_data(&qcpu_storage.data()?)
             .with_label("qstorage_quantize_imatrix")
             .build()?;
+        // A fresh full-ownership allocation replaces whatever view (offset,
+        // length) this storage previously had -- reset both, or a
+        // quantize-after-from_buffer would keep stale view metadata pointing
+        // into a buffer this storage no longer shares.
+        self.length = buffer.length();
         self.buffer = buffer;
+        self.offset = 0;
         Ok(())
     }
 
@@ -192,7 +248,13 @@ impl QMetalStorage {
             .with_data(&qcpu_storage.data()?)
             .with_label("qstorage_quantize_imatrix_onto")
             .build()?;
+        // A fresh full-ownership allocation replaces whatever view (offset,
+        // length) this storage previously had -- reset both, or a
+        // quantize-after-from_buffer would keep stale view metadata pointing
+        // into a buffer this storage no longer shares.
+        self.length = buffer.length();
         self.buffer = buffer;
+        self.offset = 0;
         Ok(())
     }
 
@@ -213,12 +275,18 @@ impl QMetalStorage {
             .with_data(&qcpu_storage.data()?)
             .with_label("qstorage_quantize_onto")
             .build()?;
+        // A fresh full-ownership allocation replaces whatever view (offset,
+        // length) this storage previously had -- reset both, or a
+        // quantize-after-from_buffer would keep stale view metadata pointing
+        // into a buffer this storage no longer shares.
+        self.length = buffer.length();
         self.buffer = buffer;
+        self.offset = 0;
         Ok(())
     }
 
     pub fn storage_size_in_bytes(&self) -> usize {
-        self.buffer.length()
+        self.length
     }
 
     pub fn embedding(
@@ -331,6 +399,7 @@ impl QMetalStorage {
                 storage.buffer(),
                 (layout.start_offset() + batch_id * k) * storage.dtype().size_in_bytes(),
                 &self.buffer,
+                self.offset,
                 batch_id * n * DType::F32.size_in_bytes(),
                 &dst,
             )
@@ -419,6 +488,7 @@ impl QMetalStorage {
             src0_l.dims(),
             &src0_stride,
             &self.buffer,
+            self.offset,
             src1_l.dims(),
             &src1_l
                 .stride()
@@ -442,13 +512,13 @@ impl QMetalStorage {
         let buffer = self
             .device
             .new_buffer_builder()
-            .with_size(self.buffer.length())
+            .with_size(self.length)
             .with_label("qstorage_data_blit")
             .build()?;
         {
             let mut blit = self.device.blit_command_encoder()?;
             blit.set_label("blit_to_cpu");
-            blit.copy_from_buffer(&self.buffer, 0, &buffer, 0, self.buffer.length());
+            blit.copy_from_buffer(&self.buffer, self.offset, &buffer, 0, self.length);
         }
         self.device.flush_and_wait_current()?;
         Ok(read_to_vec::<u8>(&buffer, self.storage_size_in_bytes()))
@@ -465,10 +535,13 @@ pub fn load_quantized<T: super::GgmlType + Send + Sync + 'static>(
         .with_label("qstorage_load_quantized")
         .build()?;
     let device = device.clone();
+    let length = buffer.length();
     Ok(QStorage::Metal(QMetalStorage {
         dtype: T::DTYPE,
         device,
         buffer,
+        offset: 0,
+        length,
     }))
 }
 

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -8,15 +8,13 @@ pub struct QMetalStorage {
     dtype: GgmlDType,
     device: MetalDevice,
     buffer: Arc<Buffer>,
-    /// Byte offset of this tensor's data within `buffer`. Nonzero when
-    /// `buffer` is shared across several tensors (e.g. one no-copy buffer
-    /// wrapping an entire mmap'd file) via `from_buffer`; zero for every
-    /// storage that owns its buffer outright.
+    /// Byte offset of this tensor's data within `buffer`.
+    /// Allows multiple quantized tensors to be backed by the same underlying metal buffer.
     offset: usize,
-    /// This tensor's own byte length -- may be smaller than `buffer.length()`
-    /// when `buffer` is shared. Every read/blit against `buffer` must use
-    /// this, not `buffer.length()`, or it silently reads past this tensor's
-    /// data into a neighboring one.
+    /// This tensor's own byte length. May be smaller than `buffer.length()`
+    /// when `buffer` is shared. All uses of `buffer` must use this, and not
+    /// `buffer.length()`, or risk silently reading past this tensor's data
+    /// into a neighboring one.
     length: usize,
 }
 
@@ -37,10 +35,9 @@ impl QMetalStorage {
         })
     }
 
-    /// Wraps an existing, externally-created buffer -- e.g. a no-copy Metal
-    /// buffer over an mmap'd region -- as this tensor's storage, with no
-    /// allocation and no copy. `offset`/`length` locate this tensor's bytes
-    /// within `buffer`, which may be shared with other tensors.
+    /// Wraps an existing buffer as this tensor's storage.
+    /// The buffer may be used as the shared underlying buffer of several tensors,
+    /// so `offset` and `length` define the specific bytes that make up this tensor.
     pub fn from_buffer(
         buffer: Arc<Buffer>,
         offset: usize,
@@ -55,6 +52,19 @@ impl QMetalStorage {
             device,
             dtype,
         }
+    }
+
+    /// Replaces this storage's buffer with a freshly-allocated one it owns
+    /// outright, resetting `offset`/`length` to match it. A fresh allocation
+    /// replaces whatever view (offset, length) this storage previously had,
+    /// so all three fields must change together -- doing this by hand at
+    /// each call site risks a quantize-after-from_buffer leaving stale view
+    /// metadata pointing into a buffer this storage no longer shares.
+    fn replace_with_owned_buffer(&mut self, buffer: Arc<Buffer>) {
+        // New backing allocation
+        self.buffer = buffer;
+        self.offset = 0;
+        self.length = self.buffer.length();
     }
 
     pub fn dtype(&self) -> GgmlDType {
@@ -75,8 +85,8 @@ impl QMetalStorage {
         self.offset
     }
 
-    /// This tensor's own byte length -- use this, not `buffer().length()`,
-    /// when `buffer()` may be shared with other tensors.
+    /// Byte length of the tensor. Use this, not `buffer().length()`,
+    /// as the underlying buffer may be shared with other tensors.
     pub fn length(&self) -> usize {
         self.length
     }
@@ -188,13 +198,7 @@ impl QMetalStorage {
             .with_data(&qcpu_storage.data()?)
             .with_label("qstorage_quantized")
             .build()?;
-        // A fresh full-ownership allocation replaces whatever view (offset,
-        // length) this storage previously had -- reset both, or a
-        // quantize-after-from_buffer would keep stale view metadata pointing
-        // into a buffer this storage no longer shares.
-        self.length = buffer.length();
-        self.buffer = buffer;
-        self.offset = 0;
+        self.replace_with_owned_buffer(buffer);
         Ok(())
     }
 
@@ -216,13 +220,7 @@ impl QMetalStorage {
             .with_data(&qcpu_storage.data()?)
             .with_label("qstorage_quantize_imatrix")
             .build()?;
-        // A fresh full-ownership allocation replaces whatever view (offset,
-        // length) this storage previously had -- reset both, or a
-        // quantize-after-from_buffer would keep stale view metadata pointing
-        // into a buffer this storage no longer shares.
-        self.length = buffer.length();
-        self.buffer = buffer;
-        self.offset = 0;
+        self.replace_with_owned_buffer(buffer);
         Ok(())
     }
 
@@ -248,13 +246,7 @@ impl QMetalStorage {
             .with_data(&qcpu_storage.data()?)
             .with_label("qstorage_quantize_imatrix_onto")
             .build()?;
-        // A fresh full-ownership allocation replaces whatever view (offset,
-        // length) this storage previously had -- reset both, or a
-        // quantize-after-from_buffer would keep stale view metadata pointing
-        // into a buffer this storage no longer shares.
-        self.length = buffer.length();
-        self.buffer = buffer;
-        self.offset = 0;
+        self.replace_with_owned_buffer(buffer);
         Ok(())
     }
 
@@ -275,13 +267,7 @@ impl QMetalStorage {
             .with_data(&qcpu_storage.data()?)
             .with_label("qstorage_quantize_onto")
             .build()?;
-        // A fresh full-ownership allocation replaces whatever view (offset,
-        // length) this storage previously had -- reset both, or a
-        // quantize-after-from_buffer would keep stale view metadata pointing
-        // into a buffer this storage no longer shares.
-        self.length = buffer.length();
-        self.buffer = buffer;
-        self.offset = 0;
+        self.replace_with_owned_buffer(buffer);
         Ok(())
     }
 

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -1514,13 +1514,6 @@ test_device!(
     from_data_dequant_matches_canonical_when_caller_passes_cow_owned_metal
 );
 
-/// `QMetalStorage::from_buffer` is how a zero-copy (e.g. mmap-backed) loader
-/// wires a tensor's storage to a *view* -- possibly at a nonzero offset --
-/// into a buffer shared with other tensors, instead of a buffer this storage
-/// owns outright. This must produce identical dequantize and matmul output
-/// to the normal owned-buffer path, at both a zero and a nonzero offset --
-/// an offset-arithmetic bug here would silently corrupt weights rather than
-/// crash.
 #[cfg(feature = "metal")]
 #[test]
 fn qmetalstorage_from_buffer_view_matches_owned_buffer() -> Result<()> {
@@ -1544,9 +1537,6 @@ fn qmetalstorage_from_buffer_view_matches_owned_buffer() -> Result<()> {
     let canonical_dequant = canonical.dequantize(&device)?.to_vec2::<f32>()?;
     let raw_bytes: Vec<u8> = canonical.data()?.to_vec();
 
-    // QTensor isn't Clone and QMatMul::from_qtensor takes it by value, so
-    // compute the canonical matmul reference once, up front -- it doesn't
-    // depend on front_padding, only `view` needs rebuilding per iteration.
     let activation = Tensor::ones((1, k), DType::F32, &device)?;
     let canonical_matmul = quantized::QMatMul::from_qtensor(canonical)?;
     let canonical_out = canonical_matmul.forward(&activation)?.to_vec2::<f32>()?;
@@ -1578,8 +1568,7 @@ fn qmetalstorage_from_buffer_view_matches_owned_buffer() -> Result<()> {
             "from_buffer view (offset={front_padding}) dequant must be bit-identical to the owned-buffer path"
         );
 
-        // Exercise the offset-aware matmul path (call_quantized_matmul_mv_t),
-        // not just dequantize -- these are two independent call sites.
+        // Also test matmul as it is a separate code path
         let view_matmul = quantized::QMatMul::from_qtensor(view)?;
         let view_out = view_matmul.forward(&activation)?.to_vec2::<f32>()?;
         let mm_max_diff = canonical_out

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -1513,3 +1513,86 @@ test_device!(
     from_data_dequant_matches_canonical_when_caller_passes_cow_owned_cuda,
     from_data_dequant_matches_canonical_when_caller_passes_cow_owned_metal
 );
+
+/// `QMetalStorage::from_buffer` is how a zero-copy (e.g. mmap-backed) loader
+/// wires a tensor's storage to a *view* -- possibly at a nonzero offset --
+/// into a buffer shared with other tensors, instead of a buffer this storage
+/// owns outright. This must produce identical dequantize and matmul output
+/// to the normal owned-buffer path, at both a zero and a nonzero offset --
+/// an offset-arithmetic bug here would silently corrupt weights rather than
+/// crash.
+#[cfg(feature = "metal")]
+#[test]
+fn qmetalstorage_from_buffer_view_matches_owned_buffer() -> Result<()> {
+    use candle_core::quantized::{metal::QMetalStorage, QStorage, QTensor};
+
+    let device = Device::new_metal(0)?;
+    let metal_device = match &device {
+        Device::Metal(d) => d.clone(),
+        _ => unreachable!(),
+    };
+    let dtype = GgmlDType::Q4K;
+    // A (n_out, k) weight, matching quantized_matmul's own convention
+    // (quantize a (n,k)-shaped tensor, matmul against a (m,k) activation).
+    let k = dtype.block_size();
+    let n_out = 4usize;
+    let n = n_out * k;
+
+    let src_data: Vec<f32> = (0..n).map(|i| ((i as f32) * 0.013).sin()).collect();
+    let src = Tensor::from_vec(src_data, (n_out, k), &device)?;
+    let canonical = QTensor::quantize(&src, dtype)?;
+    let canonical_dequant = canonical.dequantize(&device)?.to_vec2::<f32>()?;
+    let raw_bytes: Vec<u8> = canonical.data()?.to_vec();
+
+    // QTensor isn't Clone and QMatMul::from_qtensor takes it by value, so
+    // compute the canonical matmul reference once, up front -- it doesn't
+    // depend on front_padding, only `view` needs rebuilding per iteration.
+    let activation = Tensor::ones((1, k), DType::F32, &device)?;
+    let canonical_matmul = quantized::QMatMul::from_qtensor(canonical)?;
+    let canonical_out = canonical_matmul.forward(&activation)?.to_vec2::<f32>()?;
+
+    for front_padding in [0usize, 4096] {
+        let mut combined = vec![0xABu8; front_padding];
+        combined.extend_from_slice(&raw_bytes);
+        combined.extend_from_slice(&[0xCDu8; 4096]); // trailing padding, must never be read
+
+        let shared_buffer = metal_device.new_buffer_with_data(&combined)?;
+        let storage = QMetalStorage::from_buffer(
+            shared_buffer,
+            front_padding,
+            raw_bytes.len(),
+            metal_device.clone(),
+            dtype,
+        );
+        let view = QTensor::new(QStorage::Metal(storage), (n_out, k))?;
+
+        let view_dequant = view.dequantize(&device)?.to_vec2::<f32>()?;
+        let max_diff = canonical_dequant
+            .iter()
+            .flatten()
+            .zip(view_dequant.iter().flatten())
+            .map(|(a, b): (&f32, &f32)| (a - b).abs())
+            .fold(0f32, f32::max);
+        assert_eq!(
+            max_diff, 0.0,
+            "from_buffer view (offset={front_padding}) dequant must be bit-identical to the owned-buffer path"
+        );
+
+        // Exercise the offset-aware matmul path (call_quantized_matmul_mv_t),
+        // not just dequantize -- these are two independent call sites.
+        let view_matmul = quantized::QMatMul::from_qtensor(view)?;
+        let view_out = view_matmul.forward(&activation)?.to_vec2::<f32>()?;
+        let mm_max_diff = canonical_out
+            .iter()
+            .flatten()
+            .zip(view_out.iter().flatten())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0f32, f32::max);
+        assert_eq!(
+            mm_max_diff, 0.0,
+            "from_buffer view (offset={front_padding}) matmul must be bit-identical to the owned-buffer path"
+        );
+    }
+
+    Ok(())
+}

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -34,6 +34,7 @@ pub fn call_quantized_matmul_mv_t(
     lhs: &Buffer,
     lhs_offset: usize,
     rhs: &Buffer,
+    rhs_offset: usize,
     dst_offset: usize,
     dst: &Buffer,
 ) -> Result<(), MetalKernelError> {
@@ -150,7 +151,7 @@ pub fn call_quantized_matmul_mv_t(
     set_params!(
         encoder,
         (
-            rhs,
+            (rhs, rhs_offset),
             (lhs, lhs_offset),
             Output::with_offset(dst, dst_offset),
             ne00,
@@ -187,6 +188,7 @@ pub fn call_quantized_matmul_mm_t(
     src0_shape: &[usize],
     src0_stride: &[usize],
     src0: &Buffer,
+    src0_offset: usize,
     src1_shape: &[usize],
     src1_stride: &[usize],
     src1: &Buffer,
@@ -256,7 +258,7 @@ pub fn call_quantized_matmul_mm_t(
     set_params!(
         encoder,
         (
-            src0,
+            (src0, src0_offset),
             (src1, src1_offset),
             Output::with_offset(dst, dst_offset),
             ne00,

--- a/candle-metal-kernels/src/metal/device.rs
+++ b/candle-metal-kernels/src/metal/device.rs
@@ -101,6 +101,42 @@ impl Device {
         }
     }
 
+    /// Wraps existing memory as a Metal buffer with no copy -- the buffer's
+    /// contents alias `pointer`'s memory for as long as the returned
+    /// `Buffer` (and anything holding it) is alive. Intended for a no-copy
+    /// view over mmap'd memory (e.g. GGUF model weights): the caller must
+    /// keep that mapping alive for at least as long as the returned buffer.
+    ///
+    /// Per Apple's documented constraint on `newBufferWithBytesNoCopy:...`,
+    /// `pointer` must be page-aligned and `length` a multiple of the page
+    /// size -- this method does not adjust either; the caller is
+    /// responsible (an mmap's own base pointer already satisfies this by
+    /// construction, so wrapping a whole mapping from its start needs no
+    /// adjustment).
+    ///
+    /// No deallocator is registered: nothing needs to be freed on this
+    /// side when the buffer is released, since the backing memory is
+    /// owned and will be unmapped by the caller, not by this buffer.
+    ///
+    /// # Safety
+    /// `pointer` must be valid for reads for `length` bytes for at least as
+    /// long as the returned `Buffer` is alive.
+    pub unsafe fn new_buffer_with_bytes_no_copy(
+        &self,
+        pointer: *const c_void,
+        length: usize,
+        options: MTLResourceOptions,
+    ) -> Result<Buffer, MetalKernelError> {
+        let pointer = ptr::NonNull::new(pointer as *mut c_void)
+            .ok_or_else(|| MetalKernelError::InvalidInput("Null pointer".to_string()))?;
+        self.as_ref()
+            .newBufferWithBytesNoCopy_length_options_deallocator(pointer, length, options, None)
+            .map(Buffer::new)
+            .ok_or(MetalKernelError::FailedToCreateResource(
+                "Buffer".to_string(),
+            ))
+    }
+
     pub fn new_library_with_source(
         &self,
         source: &str,

--- a/candle-metal-kernels/src/metal/device.rs
+++ b/candle-metal-kernels/src/metal/device.rs
@@ -101,26 +101,6 @@ impl Device {
         }
     }
 
-    /// Wraps existing memory as a Metal buffer with no copy -- the buffer's
-    /// contents alias `pointer`'s memory for as long as the returned
-    /// `Buffer` (and anything holding it) is alive. Intended for a no-copy
-    /// view over mmap'd memory (e.g. GGUF model weights): the caller must
-    /// keep that mapping alive for at least as long as the returned buffer.
-    ///
-    /// Per Apple's documented constraint on `newBufferWithBytesNoCopy:...`,
-    /// `pointer` must be page-aligned and `length` a multiple of the page
-    /// size -- this method does not adjust either; the caller is
-    /// responsible (an mmap's own base pointer already satisfies this by
-    /// construction, so wrapping a whole mapping from its start needs no
-    /// adjustment).
-    ///
-    /// No deallocator is registered: nothing needs to be freed on this
-    /// side when the buffer is released, since the backing memory is
-    /// owned and will be unmapped by the caller, not by this buffer.
-    ///
-    /// # Safety
-    /// `pointer` must be valid for reads for `length` bytes for at least as
-    /// long as the returned `Buffer` is alive.
     pub unsafe fn new_buffer_with_bytes_no_copy(
         &self,
         pointer: *const c_void,


### PR DESCRIPTION
Adds a zero-copy path for loading quantized weights into Metal buffers, for the llama.cpp-style mmap-backed loading case: view an mmap'd GGUF file as a Metal buffer directly, instead of allocating a new buffer and copying the file's bytes into it.

## What

- `Device::new_buffer_with_bytes_no_copy` (`candle-metal-kernels`): a thin wrapper around `newBufferWithBytesNoCopy:length:options:deallocator:`, taking a raw pointer + length (e.g. an mmap'd region's base and size) and returning a `Buffer` that aliases that memory rather than copying it. No deallocator is registered — the caller owns the mapping and is responsible for keeping it alive at least as long as the buffer.
- `QMetalStorage::from_buffer` (`candle-core`): wraps an existing (possibly externally-created, possibly shared) buffer as a tensor's quantized storage, at a given `offset`/`length` within that buffer — the shape needed when one no-copy buffer backs an entire mmap'd file and many tensors are views into different offsets of it.
- `src0_offset`/`rhs_offset` parameters added to `call_quantized_matmul_mm_t`/`call_quantized_matmul_mv_t` so a matmul can read directly from such an offset view without a separate per-tensor buffer.

## Why

Without this, loading a GGUF's weights onto Metal means allocating a fresh buffer per tensor (or per file) and copying bytes in — for large quantized MoE models that's real load-time and peak-memory cost that llama.cpp's own mmap-based Metal loader avoids entirely by aliasing the OS page cache. This gives `candle-core` callers the same option: mmap the file, wrap the mapping in one `Buffer` via `new_buffer_with_bytes_no_copy`, then hand out `QMetalStorage::from_buffer` views into it per-tensor at zero additional copies.

This is the buffer-creation half of the mmap story; #3771 (residency-set batch registration for externally-created buffers) is the complementary keep-it-GPU-resident half — a caller using both would create the no-copy buffer here, then register it via `Device::register_buffers` there.

## Testing

`qmetalstorage_from_buffer_view_matches_owned_buffer` (`candle-core/tests/quantized_tests.rs`) validates that a tensor backed by a `from_buffer` view — at both a zero and a nonzero offset into a buffer shared with other tensors — produces identical dequantize and matmul output to the normal owned-buffer path. `cargo build -p candle-core --features metal` passes clean.
