### PR TITLE
Fix duplicated words in documentation

### DIFF
--- a/candle-core/src/lib.rs
+++ b/candle-core/src/lib.rs
@@ -166,7 +166,7 @@ impl<M: Module> Module for Option<&M> {
     }
 }
 
-/// A single forward method using a single single tensor argument and a flag to
+/// A single forward method using a single tensor argument and a flag to
 /// separate the training and evaluation behaviors.
 pub trait ModuleT {
     fn forward_t(&self, xs: &Tensor, train: bool) -> Result<Tensor>;

--- a/candle-examples/examples/stella-en-v5/README.md
+++ b/candle-examples/examples/stella-en-v5/README.md
@@ -6,7 +6,7 @@ As of 7th Oct 2024, *Stella_en_1.5B_v5* is one of the top ranking model on `retr
 
 ## Running the example
 
-Stella_en_1.5B_v5 is used to generate text embeddings embeddings for a prompt. The model weights
+Stella_en_1.5B_v5 is used to generate text embeddings for a prompt. The model weights
 are downloaded from the hub on the first run.
 
 ```bash


### PR DESCRIPTION
Fixes two duplicated words in user-facing documentation:

- `embeddings embeddings` in the Stella embedding example
- `single single tensor` in the `ModuleT` trait documentation

No APIs or runtime behavior change. Validated with exact text assertions and `git diff --check`.