### PR TITLE
Add `IncrementalDecoder` to `candle-transformers::generation`

### DIFF
--- a/candle-examples/src/token_output_stream.rs
+++ b/candle-examples/src/token_output_stream.rs
@@ -1,86 +1,69 @@
 use candle::Result;
+use candle_transformers::generation::IncrementalDecoder;
 
 /// This is a wrapper around a tokenizer to ensure that tokens can be returned to the user in a
 /// streaming way rather than having to wait for the full decoding.
+///
+/// It is a thin adapter over [`IncrementalDecoder`], which does the actual work; new code is
+/// better off using that directly.
 pub struct TokenOutputStream {
-    tokenizer: tokenizers::Tokenizer,
-    tokens: Vec<u32>,
-    prev_index: usize,
-    current_index: usize,
+    decoder: IncrementalDecoder,
 }
 
 impl TokenOutputStream {
     pub fn new(tokenizer: tokenizers::Tokenizer) -> Self {
         Self {
-            tokenizer,
-            tokens: Vec::new(),
-            prev_index: 0,
-            current_index: 0,
+            decoder: IncrementalDecoder::from_tokenizer(tokenizer),
         }
     }
 
     pub fn into_inner(self) -> tokenizers::Tokenizer {
-        self.tokenizer
+        self.decoder.into_tokenizer()
     }
 
-    fn decode(&self, tokens: &[u32]) -> Result<String> {
-        match self.tokenizer.decode(tokens, true) {
-            Ok(str) => Ok(str),
-            Err(err) => candle::bail!("cannot decode: {err}"),
-        }
-    }
-
-    // https://github.com/huggingface/text-generation-inference/blob/5ba53d44a18983a4de32d122f4cb46f4a17d9ef6/server/text_generation_server/models/model.py#L68
+    /// Returns the text that this token made available, if any. `None` means the token did not
+    /// settle any new text yet, e.g. it carries the first byte of a multi-byte character.
+    ///
+    /// The output is append-only: [`IncrementalDecoder::push`] only ever hands out text it has
+    /// shown cannot be rewritten, so what this returns is always safe to print or append. For a
+    /// tokenizer whose decoder can rewrite text it already produced, that means nothing is
+    /// streamed at all and the whole text arrives through [`Self::decode_rest`].
     pub fn next_token(&mut self, token: u32) -> Result<Option<String>> {
-        let prev_text = if self.tokens.is_empty() {
-            String::new()
-        } else {
-            let tokens = &self.tokens[self.prev_index..self.current_index];
-            self.decode(tokens)?
-        };
-        self.tokens.push(token);
-        let text = self.decode(&self.tokens[self.prev_index..])?;
-        if text.len() > prev_text.len() && text.chars().last().unwrap().is_alphanumeric() {
-            let text = text.split_at(prev_text.len());
-            self.prev_index = self.current_index;
-            self.current_index = self.tokens.len();
-            Ok(Some(text.1.to_string()))
-        } else {
+        let text = self.decoder.push(token)?;
+        if text.is_empty() {
             Ok(None)
+        } else {
+            Ok(Some(text.to_string()))
         }
     }
 
+    /// The text held back by [`Self::next_token`], to be printed once generation is over.
     pub fn decode_rest(&self) -> Result<Option<String>> {
-        let prev_text = if self.tokens.is_empty() {
-            String::new()
-        } else {
-            let tokens = &self.tokens[self.prev_index..self.current_index];
-            self.decode(tokens)?
-        };
-        let text = self.decode(&self.tokens[self.prev_index..])?;
-        if text.len() > prev_text.len() {
-            let text = text.split_at(prev_text.len());
-            Ok(Some(text.1.to_string()))
-        } else {
+        let rest = self.decoder.pending();
+        if rest.is_empty() {
             Ok(None)
+        } else {
+            Ok(Some(rest.to_string()))
         }
     }
 
     pub fn decode_all(&self) -> Result<String> {
-        self.decode(&self.tokens)
+        Ok(self.decoder.text().to_string())
     }
 
     pub fn get_token(&self, token_s: &str) -> Option<u32> {
-        self.tokenizer.get_vocab(true).get(token_s).copied()
+        self.decoder
+            .tokenizer()
+            .get_vocab(true)
+            .get(token_s)
+            .copied()
     }
 
     pub fn tokenizer(&self) -> &tokenizers::Tokenizer {
-        &self.tokenizer
+        self.decoder.tokenizer()
     }
 
     pub fn clear(&mut self) {
-        self.tokens.clear();
-        self.prev_index = 0;
-        self.current_index = 0;
+        self.decoder.clear()
     }
 }

--- a/candle-transformers/Cargo.toml
+++ b/candle-transformers/Cargo.toml
@@ -23,6 +23,7 @@ rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_plain = { workspace = true }
+tokenizers = { workspace = true }
 tracing = { workspace = true }
 
 [features]

--- a/candle-transformers/src/generation/incremental_decoder.rs
+++ b/candle-transformers/src/generation/incremental_decoder.rs
@@ -1,0 +1,651 @@
+//! Incremental detokenization for autoregressive decode loops.
+//!
+//! An autoregressive loop needs the text produced so far on every step, both to match stop
+//! sequences and to stream deltas back to the caller. Re-decoding the whole token sequence on
+//! every step is correct but quadratic in the generated length. Appending the decode of each
+//! token is linear but wrong: a BPE/SentencePiece decode is *not* the concatenation of its
+//! tokens' decodes. A multi-byte character can span several tokens (the prefix decodes to
+//! U+FFFD, and a later token retroactively replaces it), and decoding a sub-sequence can gain
+//! or lose a leading space.
+//!
+//! [`IncrementalDecoder`] keeps a bounded trailing window of tokens, re-decodes only that
+//! window, and appends the difference against the *previous* window decode, so any artifact
+//! caused by decoding a sub-sequence appears in both decodes and cancels out. The window is
+//! only moved forward when the shorter decode is provably a suffix of the current one, and
+//! only when the tokenizer's decoder has been shown to have a bounded context; otherwise the
+//! decoder degrades to whole-sequence decoding rather than corrupting the output.
+//!
+//! The invariant is that [`IncrementalDecoder::text`] equals a whole-sequence decode of every
+//! token pushed so far, at every step.
+//!
+//! ```no_run
+//! use candle_transformers::generation::IncrementalDecoder;
+//!
+//! # fn main() -> candle::Result<()> {
+//! # let tokenizer: tokenizers::Tokenizer = unimplemented!();
+//! # let next_token = |_: &[u32]| -> candle::Result<u32> { unimplemented!() };
+//! let mut decoder = IncrementalDecoder::new(&tokenizer);
+//! let mut tokens = vec![1u32];
+//! for _ in 0..128 {
+//!     let token = next_token(&tokens)?;
+//!     tokens.push(token);
+//!     let delta = decoder.push(token)?;
+//!     print!("{delta}");
+//!     if decoder.text().ends_with("</s>") {
+//!         break;
+//!     }
+//! }
+//! print!("{}", decoder.finish());
+//! # Ok(())
+//! # }
+//! ```
+
+use candle::{Error, Result};
+use serde_json::Value;
+use std::collections::HashSet;
+use tokenizers::Tokenizer;
+
+/// The character `String::from_utf8_lossy` (and `ByteFallback`) emits for bytes that do not
+/// form a valid UTF-8 sequence yet. A trailing run of these is never emitted, as a later token
+/// may complete the sequence and replace them.
+const REPLACEMENT: char = '\u{FFFD}';
+
+/// Number of trailing tokens kept in the window after a successful re-anchor.
+const MIN_WINDOW_TOKENS: usize = 8;
+
+/// Window length that triggers a re-anchoring attempt. Re-anchoring costs one extra decode of
+/// `MIN_WINDOW_TOKENS` tokens and happens at most once every
+/// `MAX_WINDOW_TOKENS - MIN_WINDOW_TOKENS` pushes, so the amortized cost per token is constant.
+const MAX_WINDOW_TOKENS: usize = 64;
+
+/// Longest pattern rewritten by `tokenizers`' wordpiece `cleanup` helper (`" do not"`).
+const CLEANUP_PATTERN_LEN: usize = 7;
+
+/// What could be established about the tokenizer's decoder by inspecting its serialized form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DecoderContext {
+    /// Whether the decode of a token depends only on a bounded amount of surrounding context.
+    /// When false, windowing is unsound and the whole sequence is re-decoded on every step.
+    bounded: bool,
+    /// Number of trailing bytes of the decoded text that a future token may still rewrite.
+    unstable_tail: usize,
+    /// Whether the decode of the last token depends on it being last, so that text only
+    /// becomes stable once a further token has been pushed.
+    lag_one_step: bool,
+    /// Whether a `ByteFallback` renders the tokens. It groups a run of `<0xXX>` markers and
+    /// converts the run as a whole, so an open run's text is not settled until a non-marker
+    /// token closes it - one invalid byte turns the entire run into replacement characters,
+    /// including the part that already decoded cleanly.
+    byte_fallback: bool,
+}
+
+impl DecoderContext {
+    const UNBOUNDED: Self = Self {
+        bounded: false,
+        unstable_tail: 0,
+        lag_one_step: false,
+        byte_fallback: false,
+    };
+
+    /// Resolve the bounded-context property of a tokenizer's decoder.
+    ///
+    /// `tokenizers` keeps the decoder fields private, so the decoder is inspected through its
+    /// serialized form. Anything unrecognized is treated as unbounded.
+    fn resolve(tokenizer: &Tokenizer) -> Self {
+        let decoder = match tokenizer.get_decoder() {
+            // Without a decoder `Tokenizer::decode` joins the tokens with a space, which is
+            // strictly per-token.
+            None => {
+                return Self {
+                    bounded: true,
+                    unstable_tail: 0,
+                    lag_one_step: false,
+                    byte_fallback: false,
+                }
+            }
+            Some(decoder) => decoder,
+        };
+        let value = match serde_json::to_value(decoder) {
+            Ok(value) => value,
+            Err(_) => return Self::UNBOUNDED,
+        };
+        let mut ctx = Self {
+            bounded: true,
+            unstable_tail: 0,
+            lag_one_step: false,
+            byte_fallback: false,
+        };
+        let mut scan = Scan::default();
+        if !scan_decoder(&value, &mut scan, &mut ctx) {
+            return Self::UNBOUNDED;
+        }
+        ctx
+    }
+}
+
+/// What the decoders seen so far in the chain have done to the token list, which decides how
+/// the ones after them have to be read.
+#[derive(Debug, Clone, Copy, Default)]
+struct Scan {
+    /// The list has been collapsed into a single string. Before that point a decoder only ever
+    /// sees one token at a time and cannot rewrite across token boundaries; after it, string
+    /// rewrites apply to the whole decoded text and their reach has to be accounted for.
+    fused: bool,
+    /// The list can lose entries, so pushing a token does not necessarily hand the decoders
+    /// after this one an extra element.
+    suppresses: bool,
+    /// A token's string can be rewritten into something that is not what the vocabulary holds,
+    /// so whether a `<0xXX>` marker reaches `ByteFallback` can no longer be told from the raw
+    /// id. Forging a marker where the vocabulary has none would let already-emitted text be
+    /// re-rendered; destroying one would leave a run open that never closes.
+    alters_markers: bool,
+}
+
+/// Characters that can appear in a `<0xXX>` byte marker.
+///
+/// A marker is made of these characters and nothing else, which cuts both ways. A rewrite whose
+/// output holds none of them cannot forge a marker, since its result always carries a character
+/// no marker has; and one whose input pattern holds none of them cannot match inside a marker,
+/// so it cannot destroy one either.
+fn in_marker_alphabet(c: char) -> bool {
+    matches!(c, '<' | '>' | 'x' | 'X' | '0'..='9' | 'a'..='f' | 'A'..='F')
+}
+
+/// Whether a rewrite of `pattern` into `content`, applied to a token, can leave it a marker when
+/// it was not one or stop it being one when it was.
+fn alters_markers(pattern: &str, content: &str) -> bool {
+    // An empty replacement shortens the token, which can expose a marker hidden behind a prefix.
+    content.is_empty()
+        || content.chars().any(in_marker_alphabet)
+        || pattern.chars().any(in_marker_alphabet)
+}
+
+/// Walk a serialized decoder, accumulating how far a future token can reach back into the text
+/// already produced. Returns false as soon as the reach cannot be bounded.
+fn scan_decoder(value: &Value, scan: &mut Scan, ctx: &mut DecoderContext) -> bool {
+    let ty = match value.get("type").and_then(Value::as_str) {
+        Some(ty) => ty,
+        None => return false,
+    };
+    match ty {
+        "Sequence" => match value.get("decoders").and_then(Value::as_array) {
+            Some(decoders) => decoders.iter().all(|d| scan_decoder(d, scan, ctx)),
+            None => false,
+        },
+        // Joins the token list into a single string.
+        "Fuse" => {
+            scan.fused = true;
+            true
+        }
+        // Concatenates every token's bytes before a single lossy UTF-8 conversion, which is what
+        // lets a multi-byte character span tokens and be fixed up retroactively. It also
+        // collapses the list into one string.
+        //
+        // Applied to an already fused string it is unbounded: a token whose characters are not
+        // all in the byte-level alphabet falls back to that token's raw UTF-8 bytes, so one
+        // appended character can flip the whole accumulated string onto the fallback path and
+        // rewrite the entire prefix.
+        "ByteLevel" => {
+            if scan.fused {
+                return false;
+            }
+            scan.fused = true;
+            true
+        }
+        // Groups runs of `<0xXX>` tokens before converting them to text, so an incomplete run
+        // shows up as a trailing run of U+FFFD which a later token replaces.
+        //
+        // Applied to an already fused string it is unbounded: the `<0xXX>` shape is matched
+        // against the whole accumulated string, so appending anything can retroactively turn a
+        // decoded byte back into its literal marker.
+        "ByteFallback" => {
+            // Recognizing an open marker run means testing the shape of each pushed token, which
+            // is only meaningful against the string the vocabulary holds. A decoder ahead of this
+            // one that can change whether a token is a marker defeats that.
+            if scan.fused || scan.alters_markers {
+                return false;
+            }
+            // Merges a run of markers into one entry, so the list can shrink.
+            scan.suppresses = true;
+            ctx.byte_fallback = true;
+            true
+        }
+        // Per-token, apart from the prepend scheme which only affects the first token, i.e. the
+        // start of the text.
+        "Metaspace" => {
+            let replacement = value
+                .get("replacement")
+                .and_then(Value::as_str)
+                .unwrap_or("\u{2581}");
+            let prepend = value
+                .get("prepend_scheme")
+                .and_then(Value::as_str)
+                .unwrap_or("always");
+            if prepend == "never" {
+                // Every occurrence becomes a space, so this is the ordinary rewrite test.
+                scan.alters_markers |= alters_markers(replacement, " ");
+            } else {
+                // On the first token the replacement is *dropped* rather than turned into a
+                // space, so `\u{2581}<0x61>` comes out as a marker the vocabulary never had.
+                scan.alters_markers = true;
+            }
+            true
+        }
+        "WordPiece" => {
+            // Strips a `##` prefix, which can expose a marker underneath it.
+            scan.alters_markers = true;
+            if scan.fused
+                && value
+                    .get("cleanup")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true)
+            {
+                ctx.unstable_tail += CLEANUP_PATTERN_LEN;
+            }
+            true
+        }
+        "CTC" => {
+            // Deduplicates and drops entries that decode to nothing, and deleting the pad token
+            // from a string can expose a marker underneath it.
+            scan.suppresses = true;
+            scan.alters_markers = true;
+            if scan.fused {
+                // The pad token is stripped from the string whatever `cleanup` says, so its
+                // reach counts even when the cleanup patterns do not.
+                let pad = value.get("pad_token").and_then(Value::as_str).unwrap_or("");
+                ctx.unstable_tail += pad.len();
+                if value
+                    .get("cleanup")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true)
+                {
+                    ctx.unstable_tail += CLEANUP_PATTERN_LEN;
+                }
+                let delimiter = value
+                    .get("word_delimiter_token")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                ctx.unstable_tail += delimiter.len();
+            }
+            true
+        }
+        "BPEDecoder" => {
+            // Replacing the suffix with nothing can expose a marker underneath it.
+            scan.alters_markers = true;
+            if scan.fused {
+                // On a fused string every occurrence of the suffix is dropped, wherever it is,
+                // so a suffix completed across pushes rewrites up to its own length of text.
+                let suffix = value.get("suffix").and_then(Value::as_str).unwrap_or("");
+                ctx.unstable_tail += suffix.len();
+            } else {
+                // The end-of-word suffix of the *last* token is dropped rather than turned into
+                // a space, so the tail of the text changes as soon as another token is pushed.
+                // The lag that compensates for it assumes each push hands this decoder one more
+                // entry, which an upstream decoder that drops entries breaks.
+                if scan.suppresses {
+                    return false;
+                }
+                ctx.lag_one_step = true;
+            }
+            true
+        }
+        "Strip" => {
+            // Trims characters off either end, which can expose a marker underneath them.
+            scan.alters_markers = true;
+            if scan.fused {
+                let stop = value.get("stop").and_then(Value::as_u64).unwrap_or(0) as usize;
+                let content = value.get("content").and_then(Value::as_str).unwrap_or("");
+                ctx.unstable_tail += stop * content.len();
+            }
+            true
+        }
+        "Replace" => {
+            let content = value.get("content").and_then(Value::as_str).unwrap_or("");
+            let literal = value
+                .get("pattern")
+                .and_then(|p| p.get("String"))
+                .and_then(Value::as_str);
+            // A regex pattern cannot be reasoned about at all; a literal one is judged on both
+            // what it can spell and what it can match.
+            match literal {
+                Some(pattern) => scan.alters_markers |= alters_markers(pattern, content),
+                None => scan.alters_markers = true,
+            }
+            if !scan.fused {
+                // Applied to each token independently, so it cannot reach across tokens.
+                return true;
+            }
+            // Applied to the whole text: appending bytes can create a match straddling the
+            // boundary, rewriting up to `pattern.len()` bytes already emitted. A regex pattern
+            // can match arbitrarily far back, which is exactly the unbounded case.
+            match value.get("pattern").and_then(|p| p.get("String")) {
+                Some(Value::String(pattern)) => {
+                    ctx.unstable_tail += pattern.len();
+                    true
+                }
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+/// An open run of `<0xXX>` byte markers. `ByteFallback` converts such a run as a whole, so none
+/// of its text is settled until a non-marker token closes it, and the window may not start
+/// inside it.
+#[derive(Debug, Clone, Copy)]
+struct ByteRun {
+    /// Offset in `text` where the run's output begins.
+    text_start: usize,
+    /// How many entries at the end of `window` the run spans.
+    tokens: usize,
+}
+
+/// A detokenizer that turns a stream of token ids into a stream of text deltas in amortized
+/// constant time per token.
+///
+/// See the [module documentation](self) for the approach.
+pub struct IncrementalDecoder {
+    tokenizer: Tokenizer,
+    skip_special_tokens: bool,
+    ctx: DecoderContext,
+    /// Special ids that `Tokenizer::decode` filters out before the decoder ever sees them.
+    /// Not the whole set it drops - see [`IncrementalDecoder::is_dropped`].
+    dropped: HashSet<u32>,
+    /// Every token pushed so far.
+    tokens: Vec<u32>,
+    /// The tokens the next decode runs over: a trailing slice of `tokens`, with the ids that
+    /// `decode` filters out left out. Dropping those is a no-op on the decode - the decoder is
+    /// handed the exact same input either way - and it keeps a run of skipped special tokens
+    /// from growing the window, since such a run offers no tail long enough to re-anchor on.
+    window: Vec<u32>,
+    /// Decode of `window`; always a suffix of `text`.
+    window_text: String,
+    /// Decode of the whole token sequence.
+    text: String,
+    /// Number of bytes of `text` already returned by `push`.
+    emitted: usize,
+    /// The currently open run of `<0xXX>` byte markers, if one is open.
+    open_byte_run: Option<ByteRun>,
+    /// Bytes of previously returned text invalidated by the last `push`.
+    retracted: usize,
+}
+
+impl IncrementalDecoder {
+    /// Create a decoder for `tokenizer`, resolving the bounded-context property of its decoder.
+    ///
+    /// The tokenizer is cloned; use [`IncrementalDecoder::from_tokenizer`] to avoid the clone.
+    pub fn new(tokenizer: &Tokenizer) -> Self {
+        Self::from_tokenizer(tokenizer.clone())
+    }
+
+    /// Create a decoder taking ownership of `tokenizer`.
+    pub fn from_tokenizer(tokenizer: Tokenizer) -> Self {
+        let ctx = DecoderContext::resolve(&tokenizer);
+        let dropped = dropped_ids(&tokenizer, true);
+        Self {
+            tokenizer,
+            skip_special_tokens: true,
+            ctx,
+            dropped,
+            tokens: Vec::new(),
+            window: Vec::new(),
+            window_text: String::new(),
+            text: String::new(),
+            emitted: 0,
+            open_byte_run: None,
+            retracted: 0,
+        }
+    }
+
+    /// Whether special tokens are dropped from the decoded text, `true` by default.
+    pub fn with_skip_special_tokens(mut self, skip_special_tokens: bool) -> Self {
+        self.skip_special_tokens = skip_special_tokens;
+        self.dropped = dropped_ids(&self.tokenizer, skip_special_tokens);
+        self.clear();
+        self
+    }
+
+    /// Whether the tokenizer's decoder was shown to have a bounded context.
+    ///
+    /// When false the decoder is still correct, but it re-decodes the whole sequence on every
+    /// push - quadratic in the number of generated tokens - and [`IncrementalDecoder::push`]
+    /// streams nothing, since no part of the text can be shown to be settled. Use
+    /// [`IncrementalDecoder::text`] to observe it as it grows, and
+    /// [`IncrementalDecoder::finish`] to collect it at the end.
+    pub fn is_windowed(&self) -> bool {
+        self.ctx.bounded
+    }
+
+    /// Push a token and return the text that became available because of it.
+    ///
+    /// The returned slice may be empty: text that a further token could still rewrite is held
+    /// back until it is settled - a trailing run of U+FFFD from an incomplete multi-byte
+    /// character, an open run of `ByteFallback` byte markers, the reach of a rewriting decoder,
+    /// or, for a decoder that is not [windowed](IncrementalDecoder::is_windowed), all of it.
+    ///
+    /// Emission is append-only: concatenating every value returned by `push`, followed by
+    /// [`IncrementalDecoder::finish`], reproduces [`IncrementalDecoder::text`] exactly.
+    pub fn push(&mut self, token: u32) -> Result<&str> {
+        self.retracted = 0;
+        self.tokens.push(token);
+        if !self.is_dropped(token) {
+            self.window.push(token);
+        }
+
+        let new_window = self.decode(&self.window)?;
+        let committed = self.text.len() - self.window_text.len();
+        // The delta is taken against the *previous* decode of the same window, so a leading
+        // space gained or lost by decoding a sub-sequence is present in both and cancels.
+        let common = committed + common_prefix_len(&self.window_text, &new_window);
+        self.text.truncate(committed);
+        self.text.push_str(&new_window);
+        self.window_text = new_window;
+
+        // Before re-anchoring, which needs to know how far back the open run reaches.
+        self.track_byte_run(token, common);
+        if self.ctx.bounded && self.window.len() >= MAX_WINDOW_TOKENS {
+            self.reanchor()?;
+        }
+
+        if common < self.emitted {
+            self.retracted = self.emitted - common;
+            self.emitted = common;
+        }
+        let start = self.emitted;
+        self.emitted = self.emission_limit(common);
+        Ok(&self.text[start..self.emitted])
+    }
+
+    /// The whole text decoded so far.
+    ///
+    /// This is always equal to decoding every pushed token in one go.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// The text held back by [`IncrementalDecoder::push`] because a future token could still
+    /// rewrite it.
+    pub fn pending(&self) -> &str {
+        &self.text[self.emitted..]
+    }
+
+    /// Release the text held back by [`IncrementalDecoder::push`], for use once generation is
+    /// over. Any trailing U+FFFD is genuinely undecodable at that point.
+    pub fn finish(&mut self) -> &str {
+        let start = self.emitted;
+        self.emitted = self.text.len();
+        &self.text[start..]
+    }
+
+    /// Number of bytes of previously returned text invalidated by the last
+    /// [`IncrementalDecoder::push`].
+    ///
+    /// This is a diagnostic, and is always zero: text is only ever emitted once it has been
+    /// shown to be settled. A non-zero value means the rewrite reach of some decoder was
+    /// under-estimated, i.e. a bug here rather than something a caller has to handle.
+    pub fn retracted(&self) -> usize {
+        self.retracted
+    }
+
+    /// The tokens pushed so far.
+    pub fn tokens(&self) -> &[u32] {
+        &self.tokens
+    }
+
+    /// Number of tokens re-decoded by the next [`IncrementalDecoder::push`].
+    ///
+    /// This stays bounded for a windowed decoder, and grows with the sequence otherwise.
+    pub fn window_len(&self) -> usize {
+        self.window.len()
+    }
+
+    /// The underlying tokenizer.
+    pub fn tokenizer(&self) -> &Tokenizer {
+        &self.tokenizer
+    }
+
+    /// Consume the decoder, returning the underlying tokenizer.
+    pub fn into_tokenizer(self) -> Tokenizer {
+        self.tokenizer
+    }
+
+    /// Reset the decoder, keeping the tokenizer and its resolved decoder context.
+    pub fn clear(&mut self) {
+        self.tokens.clear();
+        self.window.clear();
+        self.window_text.clear();
+        self.text.clear();
+        self.emitted = 0;
+        self.open_byte_run = None;
+        self.retracted = 0;
+    }
+
+    fn decode(&self, tokens: &[u32]) -> Result<String> {
+        if tokens.is_empty() {
+            // Some decoders (`BPEDecoder`) index the last token unconditionally.
+            return Ok(String::new());
+        }
+        self.tokenizer
+            .decode(tokens, self.skip_special_tokens)
+            .map_err(|err| Error::Msg(format!("cannot decode: {err}")))
+    }
+
+    /// Try to move the window forward, keeping the text unchanged.
+    ///
+    /// The window is only moved when the shorter decode is provably a suffix of the current
+    /// window decode, and long enough that a rewriting decoder cannot reach past it. When no
+    /// split is acceptable the window simply keeps growing, degrading towards whole-sequence
+    /// decoding rather than dropping or duplicating text.
+    fn reanchor(&mut self) -> Result<()> {
+        let min_tail = self.ctx.unstable_tail.max(1);
+        // `ByteFallback` converts a marker run as a whole, so a window that starts inside an
+        // open one renders it differently from the full sequence: the shorter decode is a
+        // suffix *now*, but the next marker re-renders the part left outside the window.
+        let mut keep = MIN_WINDOW_TOKENS.max(self.open_byte_run.map_or(0, |run| run.tokens));
+        while keep < self.window.len() {
+            let start = self.window.len() - keep;
+            let tail = self.decode(&self.window[start..])?;
+            if tail.len() >= min_tail && self.window_text.ends_with(&tail) {
+                self.window.drain(..start);
+                self.window_text = tail;
+                return Ok(());
+            }
+            keep *= 2;
+        }
+        Ok(())
+    }
+
+    /// Note which tokens are still inside an open `ByteFallback` run, so their text can be held
+    /// back: the run is converted as a whole, so a later marker can re-render all of it.
+    fn track_byte_run(&mut self, token: u32, common: usize) {
+        // A dropped id never reaches the decoder, so it neither opens nor closes a run.
+        if !self.ctx.byte_fallback || self.is_dropped(token) {
+            return;
+        }
+        match (self.is_byte_marker(token), self.open_byte_run.as_mut()) {
+            (false, _) => self.open_byte_run = None,
+            (true, Some(run)) => run.tokens += 1,
+            (true, None) => {
+                self.open_byte_run = Some(ByteRun {
+                    text_start: common,
+                    tokens: 1,
+                })
+            }
+        }
+    }
+
+    /// Whether `Tokenizer::decode` drops this id before the decoder runs: a special token being
+    /// skipped, or an id the vocabulary has no token for at all.
+    fn is_dropped(&self, token: u32) -> bool {
+        self.dropped.contains(&token) || self.tokenizer.id_to_token(token).is_none()
+    }
+
+    /// Whether an id decodes to a `<0xXX>` marker, matching `ByteFallback`'s own test.
+    fn is_byte_marker(&self, token: u32) -> bool {
+        match self.tokenizer.id_to_token(token) {
+            Some(t) => {
+                t.len() == 6
+                    && t.starts_with("<0x")
+                    && t.ends_with('>')
+                    && t.get(3..5)
+                        .is_some_and(|hex| u8::from_str_radix(hex, 16).is_ok())
+            }
+            None => false,
+        }
+    }
+
+    /// Largest prefix of `text` that no future token can rewrite.
+    fn emission_limit(&self, common: usize) -> usize {
+        // Nothing can be proven about an unbounded decoder, so nothing is emitted until
+        // `finish`: this type never hands out text it may have to take back.
+        if !self.ctx.bounded {
+            return self.emitted;
+        }
+        let mut limit = self.text.len();
+        // An incomplete multi-byte character decodes to U+FFFD, which a later token replaces.
+        while limit > 0 && self.text[..limit].ends_with(REPLACEMENT) {
+            limit -= REPLACEMENT.len_utf8();
+        }
+        limit = limit.saturating_sub(self.ctx.unstable_tail);
+        while limit > 0 && !self.text.is_char_boundary(limit) {
+            limit -= 1;
+        }
+        if self.ctx.lag_one_step {
+            limit = limit.min(common);
+        }
+        if let Some(run) = self.open_byte_run {
+            limit = limit.min(run.text_start);
+        }
+        limit.max(self.emitted)
+    }
+}
+
+/// Ids that `Tokenizer::decode` drops before running the decoder: special tokens when they are
+/// being skipped, and ids that map to no token at all.
+///
+/// Conservative on purpose - an id missing from this set only means the window advances less
+/// eagerly, never that it advances when it should not.
+fn dropped_ids(tokenizer: &Tokenizer, skip_special_tokens: bool) -> HashSet<u32> {
+    if !skip_special_tokens {
+        return HashSet::new();
+    }
+    tokenizer
+        .get_added_tokens_decoder()
+        .into_iter()
+        .filter(|(_, token)| token.special)
+        .map(|(id, _)| id)
+        .collect()
+}
+
+/// Length in bytes of the longest common prefix of `a` and `b`, on a character boundary.
+fn common_prefix_len(a: &str, b: &str) -> usize {
+    let mut len = 0;
+    for (ca, cb) in a.chars().zip(b.chars()) {
+        if ca != cb {
+            break;
+        }
+        len += ca.len_utf8();
+    }
+    len
+}

--- a/candle-transformers/src/generation/incremental_decoder.rs
+++ b/candle-transformers/src/generation/incremental_decoder.rs
@@ -39,9 +39,27 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! The decoder only ever reads the tokenizer, and is generic over how it holds it, so a loop
+//! that runs one decoder per row does not have to clone the vocabulary per row:
+//!
+//! ```no_run
+//! use candle_transformers::generation::IncrementalDecoder;
+//! use std::sync::Arc;
+//!
+//! # fn main() {
+//! # let tokenizer: Arc<tokenizers::Tokenizer> = unimplemented!();
+//! # let batch_size = 8;
+//! let decoders: Vec<_> = (0..batch_size)
+//!     .map(|_| IncrementalDecoder::from_tokenizer(Arc::clone(&tokenizer)))
+//!     .collect();
+//! # let _ = decoders;
+//! # }
+//! ```
 
 use candle::{Error, Result};
 use serde_json::Value;
+use std::borrow::Borrow;
 use std::collections::HashSet;
 use tokenizers::Tokenizer;
 
@@ -363,8 +381,17 @@ struct ByteRun {
 /// constant time per token.
 ///
 /// See the [module documentation](self) for the approach.
-pub struct IncrementalDecoder {
-    tokenizer: Tokenizer,
+///
+/// `T` is how the decoder holds the tokenizer, which it only ever reads: `Tokenizer` to own it,
+/// `&Tokenizer` to borrow it, or `Arc<Tokenizer>` to share one across the decoders of a batch
+/// without cloning the vocabulary per row. It defaults to `Tokenizer`, so `IncrementalDecoder`
+/// on its own still names the owning form.
+///
+/// Cloning a decoder carries over the tokenizer and its resolved decoder context, so a batch
+/// loop can resolve both once and clone a decoder per row rather than rebuilding one.
+#[derive(Clone)]
+pub struct IncrementalDecoder<T = Tokenizer> {
+    tokenizer: T,
     skip_special_tokens: bool,
     ctx: DecoderContext,
     /// Special ids that `Tokenizer::decode` filters out before the decoder ever sees them.
@@ -393,18 +420,33 @@ pub struct IncrementalDecoder {
     retracted: usize,
 }
 
-impl IncrementalDecoder {
-    /// Create a decoder for `tokenizer`, resolving the bounded-context property of its decoder.
+impl IncrementalDecoder<Tokenizer> {
+    /// Create a decoder owning a clone of `tokenizer`, resolving the bounded-context property
+    /// of its decoder.
     ///
-    /// The tokenizer is cloned; use [`IncrementalDecoder::from_tokenizer`] to avoid the clone.
+    /// The clone deep-copies the vocabulary. Use [`IncrementalDecoder::from_tokenizer`] to hold
+    /// the tokenizer by reference or by `Arc` instead, which matters for a batched loop that
+    /// needs one decoder per row.
     pub fn new(tokenizer: &Tokenizer) -> Self {
         Self::from_tokenizer(tokenizer.clone())
     }
+}
 
-    /// Create a decoder taking ownership of `tokenizer`.
-    pub fn from_tokenizer(tokenizer: Tokenizer) -> Self {
-        let ctx = DecoderContext::resolve(&tokenizer);
-        let dropped = dropped_ids(&tokenizer, true);
+impl<T: Borrow<Tokenizer>> IncrementalDecoder<T> {
+    /// Create a decoder holding `tokenizer` however the caller has it: by value, by reference,
+    /// or behind an `Arc` shared with the rest of a batch.
+    ///
+    /// ```no_run
+    /// # use candle_transformers::generation::IncrementalDecoder;
+    /// # use std::sync::Arc;
+    /// # let tokenizer: tokenizers::Tokenizer = unimplemented!();
+    /// let owning = IncrementalDecoder::from_tokenizer(tokenizer.clone());
+    /// let borrowing = IncrementalDecoder::from_tokenizer(&tokenizer);
+    /// let sharing = IncrementalDecoder::from_tokenizer(Arc::new(tokenizer));
+    /// ```
+    pub fn from_tokenizer(tokenizer: T) -> Self {
+        let ctx = DecoderContext::resolve(tokenizer.borrow());
+        let dropped = dropped_ids(tokenizer.borrow(), true);
         Self {
             tokenizer,
             skip_special_tokens: true,
@@ -424,7 +466,7 @@ impl IncrementalDecoder {
     /// Whether special tokens are dropped from the decoded text, `true` by default.
     pub fn with_skip_special_tokens(mut self, skip_special_tokens: bool) -> Self {
         self.skip_special_tokens = skip_special_tokens;
-        self.dropped = dropped_ids(&self.tokenizer, skip_special_tokens);
+        self.dropped = dropped_ids(self.tokenizer.borrow(), skip_special_tokens);
         self.clear();
         self
     }
@@ -529,11 +571,11 @@ impl IncrementalDecoder {
 
     /// The underlying tokenizer.
     pub fn tokenizer(&self) -> &Tokenizer {
-        &self.tokenizer
+        self.tokenizer.borrow()
     }
 
-    /// Consume the decoder, returning the underlying tokenizer.
-    pub fn into_tokenizer(self) -> Tokenizer {
+    /// Consume the decoder, returning however the tokenizer was handed to it.
+    pub fn into_tokenizer(self) -> T {
         self.tokenizer
     }
 
@@ -554,7 +596,7 @@ impl IncrementalDecoder {
             // Some decoders (`BPEDecoder`) index the last token unconditionally.
             return Ok(String::new());
         }
-        self.tokenizer
+        self.tokenizer()
             .decode(tokens, self.skip_special_tokens)
             .map_err(|err| Error::Msg(format!("cannot decode: {err}")))
     }
@@ -611,12 +653,12 @@ impl IncrementalDecoder {
     /// Whether `Tokenizer::decode` drops this id before the decoder runs: a special token being
     /// skipped, or an id the vocabulary has no token for at all.
     fn is_dropped(&self, token: u32) -> bool {
-        self.dropped.contains(&token) || self.tokenizer.id_to_token(token).is_none()
+        self.dropped.contains(&token) || self.tokenizer().id_to_token(token).is_none()
     }
 
     /// Whether an id decodes to a `<0xXX>` marker, matching `ByteFallback`'s own test.
     fn is_byte_marker(&self, token: u32) -> bool {
-        match self.tokenizer.id_to_token(token) {
+        match self.tokenizer().id_to_token(token) {
             Some(t) => {
                 t.len() == 6
                     && t.starts_with("<0x")

--- a/candle-transformers/src/generation/incremental_decoder.rs
+++ b/candle-transformers/src/generation/incremental_decoder.rs
@@ -58,6 +58,9 @@ const MIN_WINDOW_TOKENS: usize = 8;
 /// `MAX_WINDOW_TOKENS - MIN_WINDOW_TOKENS` pushes, so the amortized cost per token is constant.
 const MAX_WINDOW_TOKENS: usize = 64;
 
+/// How many window lengths to try around each re-anchoring candidate before doubling.
+const ANCHOR_CANDIDATES: usize = 3;
+
 /// Longest pattern rewritten by `tokenizers`' wordpiece `cleanup` helper (`" do not"`).
 const CLEANUP_PATTERN_LEN: usize = 7;
 
@@ -151,6 +154,24 @@ fn in_marker_alphabet(c: char) -> bool {
     matches!(c, '<' | '>' | 'x' | 'X' | '0'..='9' | 'a'..='f' | 'A'..='F')
 }
 
+/// Record that a fused decoder can reach `reach` bytes back into the text it produces.
+///
+/// Returns false when reach is already pending from an earlier decoder in the chain. That reach
+/// was measured against the string this decoder takes as *input*, and a rewrite that changes
+/// lengths moves the boundary it refers to, so the two cannot simply be added: with
+/// `Fuse -> Replace("ab", "q") -> Replace("a", "xxxxxxxxxx")`, two bytes of pending reach cover
+/// ten bytes of output.
+fn add_fused_reach(ctx: &mut DecoderContext, reach: usize) -> bool {
+    if reach == 0 {
+        return true;
+    }
+    if ctx.unstable_tail != 0 {
+        return false;
+    }
+    ctx.unstable_tail = reach;
+    true
+}
+
 /// Whether a rewrite of `pattern` into `content`, applied to a token, can leave it a marker when
 /// it was not one or stop it being one when it was.
 fn alters_markers(pattern: &str, content: &str) -> bool {
@@ -240,7 +261,7 @@ fn scan_decoder(value: &Value, scan: &mut Scan, ctx: &mut DecoderContext) -> boo
                     .and_then(Value::as_bool)
                     .unwrap_or(true)
             {
-                ctx.unstable_tail += CLEANUP_PATTERN_LEN;
+                return add_fused_reach(ctx, CLEANUP_PATTERN_LEN);
             }
             true
         }
@@ -253,19 +274,17 @@ fn scan_decoder(value: &Value, scan: &mut Scan, ctx: &mut DecoderContext) -> boo
                 // The pad token is stripped from the string whatever `cleanup` says, so its
                 // reach counts even when the cleanup patterns do not.
                 let pad = value.get("pad_token").and_then(Value::as_str).unwrap_or("");
-                ctx.unstable_tail += pad.len();
-                if value
+                let cleanup = value
                     .get("cleanup")
                     .and_then(Value::as_bool)
-                    .unwrap_or(true)
-                {
-                    ctx.unstable_tail += CLEANUP_PATTERN_LEN;
-                }
+                    .unwrap_or(true);
                 let delimiter = value
                     .get("word_delimiter_token")
                     .and_then(Value::as_str)
                     .unwrap_or("");
-                ctx.unstable_tail += delimiter.len();
+                let reach =
+                    pad.len() + delimiter.len() + if cleanup { CLEANUP_PATTERN_LEN } else { 0 };
+                return add_fused_reach(ctx, reach);
             }
             true
         }
@@ -276,7 +295,9 @@ fn scan_decoder(value: &Value, scan: &mut Scan, ctx: &mut DecoderContext) -> boo
                 // On a fused string every occurrence of the suffix is dropped, wherever it is,
                 // so a suffix completed across pushes rewrites up to its own length of text.
                 let suffix = value.get("suffix").and_then(Value::as_str).unwrap_or("");
-                ctx.unstable_tail += suffix.len();
+                if !add_fused_reach(ctx, suffix.len()) {
+                    return false;
+                }
             } else {
                 // The end-of-word suffix of the *last* token is dropped rather than turned into
                 // a space, so the tail of the text changes as soon as another token is pushed.
@@ -295,7 +316,7 @@ fn scan_decoder(value: &Value, scan: &mut Scan, ctx: &mut DecoderContext) -> boo
             if scan.fused {
                 let stop = value.get("stop").and_then(Value::as_u64).unwrap_or(0) as usize;
                 let content = value.get("content").and_then(Value::as_str).unwrap_or("");
-                ctx.unstable_tail += stop * content.len();
+                return add_fused_reach(ctx, stop * content.len());
             }
             true
         }
@@ -318,12 +339,9 @@ fn scan_decoder(value: &Value, scan: &mut Scan, ctx: &mut DecoderContext) -> boo
             // Applied to the whole text: appending bytes can create a match straddling the
             // boundary, rewriting up to `pattern.len()` bytes already emitted. A regex pattern
             // can match arbitrarily far back, which is exactly the unbounded case.
-            match value.get("pattern").and_then(|p| p.get("String")) {
-                Some(Value::String(pattern)) => {
-                    ctx.unstable_tail += pattern.len();
-                    true
-                }
-                _ => false,
+            match literal {
+                Some(pattern) => add_fused_reach(ctx, pattern.len()),
+                None => false,
             }
         }
         _ => false,
@@ -367,6 +385,10 @@ pub struct IncrementalDecoder {
     emitted: usize,
     /// The currently open run of `<0xXX>` byte markers, if one is open.
     open_byte_run: Option<ByteRun>,
+    /// How far emission may go while `lag_one_step` holds. It only advances on a push the
+    /// decoder actually sees: an id `decode` filters out leaves the text alone, so treating it
+    /// as a step would release the previous token's text a step early.
+    lag_limit: usize,
     /// Bytes of previously returned text invalidated by the last `push`.
     retracted: usize,
 }
@@ -394,6 +416,7 @@ impl IncrementalDecoder {
             text: String::new(),
             emitted: 0,
             open_byte_run: None,
+            lag_limit: 0,
             retracted: 0,
         }
     }
@@ -429,7 +452,8 @@ impl IncrementalDecoder {
     pub fn push(&mut self, token: u32) -> Result<&str> {
         self.retracted = 0;
         self.tokens.push(token);
-        if !self.is_dropped(token) {
+        let dropped = self.is_dropped(token);
+        if !dropped {
             self.window.push(token);
         }
 
@@ -442,6 +466,9 @@ impl IncrementalDecoder {
         self.text.push_str(&new_window);
         self.window_text = new_window;
 
+        if !dropped {
+            self.lag_limit = common;
+        }
         // Before re-anchoring, which needs to know how far back the open run reaches.
         self.track_byte_run(token, common);
         if self.ctx.bounded && self.window.len() >= MAX_WINDOW_TOKENS {
@@ -453,7 +480,7 @@ impl IncrementalDecoder {
             self.emitted = common;
         }
         let start = self.emitted;
-        self.emitted = self.emission_limit(common);
+        self.emitted = self.emission_limit();
         Ok(&self.text[start..self.emitted])
     }
 
@@ -518,6 +545,7 @@ impl IncrementalDecoder {
         self.text.clear();
         self.emitted = 0;
         self.open_byte_run = None;
+        self.lag_limit = 0;
         self.retracted = 0;
     }
 
@@ -544,12 +572,17 @@ impl IncrementalDecoder {
         // suffix *now*, but the next marker re-renders the part left outside the window.
         let mut keep = MIN_WINDOW_TOKENS.max(self.open_byte_run.map_or(0, |run| run.tokens));
         while keep < self.window.len() {
-            let start = self.window.len() - keep;
-            let tail = self.decode(&self.window[start..])?;
-            if tail.len() >= min_tail && self.window_text.ends_with(&tail) {
-                self.window.drain(..start);
-                self.window_text = tail;
-                return Ok(());
+            // A candidate can fail purely because of what its own first token turns into - a
+            // `WordPiece` continuation piece keeps its `##` when it leads, a `Metaspace` token
+            // loses its space - so try the neighbouring lengths before doubling away from them.
+            for candidate in keep..(keep + ANCHOR_CANDIDATES).min(self.window.len()) {
+                let start = self.window.len() - candidate;
+                let tail = self.decode(&self.window[start..])?;
+                if tail.len() >= min_tail && self.window_text.ends_with(&tail) {
+                    self.window.drain(..start);
+                    self.window_text = tail;
+                    return Ok(());
+                }
             }
             keep *= 2;
         }
@@ -596,7 +629,7 @@ impl IncrementalDecoder {
     }
 
     /// Largest prefix of `text` that no future token can rewrite.
-    fn emission_limit(&self, common: usize) -> usize {
+    fn emission_limit(&self) -> usize {
         // Nothing can be proven about an unbounded decoder, so nothing is emitted until
         // `finish`: this type never hands out text it may have to take back.
         if !self.ctx.bounded {
@@ -612,7 +645,7 @@ impl IncrementalDecoder {
             limit -= 1;
         }
         if self.ctx.lag_one_step {
-            limit = limit.min(common);
+            limit = limit.min(self.lag_limit);
         }
         if let Some(run) = self.open_byte_run {
             limit = limit.min(run.text_start);

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -3,8 +3,14 @@
 //! Functionality for modeling sampling strategies and logits processing in text generation
 //! with support for temperature-based sampling, top-k filtering, nucleus sampling (top-p),
 //! and combinations thereof.
+//!
+//! This module also provides [`IncrementalDecoder`], a detokenizer for streaming the text
+//! produced by a decode loop.
 use candle::{DType, Error, Result, Tensor};
 use rand::{distr::Distribution, SeedableRng};
+
+mod incremental_decoder;
+pub use incremental_decoder::IncrementalDecoder;
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum Sampling {

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -10,7 +10,9 @@ use candle::{DType, Error, Result, Tensor};
 use rand::{distr::Distribution, SeedableRng};
 
 mod incremental_decoder;
+mod stop_criteria;
 pub use incremental_decoder::IncrementalDecoder;
+pub use stop_criteria::{FinishReason, StopCriteria};
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum Sampling {

--- a/candle-transformers/src/generation/stop_criteria.rs
+++ b/candle-transformers/src/generation/stop_criteria.rs
@@ -1,0 +1,97 @@
+//! Stop-sequence matching and finish reasons for autoregressive decode loops.
+//!
+//! Stop sequences are strings, rather than token ids: a sequence can span token boundaries or
+//! use a tokenization different from the one that produced the completion.  [`StopCriteria`]
+//! therefore operates on the text maintained by [`super::IncrementalDecoder`].
+
+/// Why a generation finished.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FinishReason {
+    /// The model produced an EOS token or a configured stop sequence.
+    Stop,
+    /// The configured token budget was spent before the model stopped.
+    Length,
+}
+
+/// Text and token conditions that end an autoregressive generation.
+///
+/// A decode loop should retain [`Self::hold`] bytes of its decoded text before streaming it.
+/// [`Self::safe_emit_end`] returns the corresponding character-boundary offset, and accounts
+/// for an already matched stop sequence.  This lets a stop sequence spanning two tokens be
+/// detected without sending any part of it to the consumer.
+#[derive(Clone, Debug)]
+pub struct StopCriteria {
+    stop: Vec<String>,
+    eos: Vec<u32>,
+    hold: usize,
+}
+
+impl StopCriteria {
+    /// Creates criteria from text stop sequences and EOS token ids.
+    ///
+    /// Empty stop sequences are ignored: they would match before any generated text and do not
+    /// describe a useful stopping condition.
+    pub fn new(stop: impl IntoIterator<Item = String>, eos: Vec<u32>) -> Self {
+        let stop: Vec<_> = stop.into_iter().filter(|stop| !stop.is_empty()).collect();
+        let hold = stop
+            .iter()
+            .map(|stop| stop.len().saturating_sub(1))
+            .max()
+            .unwrap_or(0);
+        Self { stop, eos, hold }
+    }
+
+    /// Number of trailing bytes that must be retained while looking for a stop sequence.
+    pub fn hold(&self) -> usize {
+        self.hold
+    }
+
+    /// Returns whether `token` is an EOS token configured for this generation.
+    pub fn is_eos(&self, token: u32) -> bool {
+        self.eos.contains(&token)
+    }
+
+    /// Returns the byte offset of the earliest configured stop sequence in `text`.
+    ///
+    /// When several sequences match, position wins over configuration order.  This avoids
+    /// truncating at a later stop merely because it appeared earlier in the configuration.
+    pub fn matched(&self, text: &str) -> Option<usize> {
+        self.stop.iter().filter_map(|stop| text.find(stop)).min()
+    }
+
+    /// Returns the largest character-boundary offset that may be streamed from `text` now.
+    ///
+    /// If a stop sequence has matched, its beginning is returned so that the sequence itself is
+    /// not emitted.  Otherwise this retains [`Self::hold`] trailing bytes, rounded down to a
+    /// UTF-8 character boundary.
+    pub fn safe_emit_end(&self, text: &str) -> usize {
+        if let Some(matched) = self.matched(text) {
+            return matched;
+        }
+        let mut end = text.len().saturating_sub(self.hold);
+        while !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        end
+    }
+
+    /// Determines a known finish reason after a token has been decoded.
+    ///
+    /// Model-controlled endings win when they land on the last allowed token: an EOS token or a
+    /// stop sequence at that boundary is [`FinishReason::Stop`], not `Length`.  If the loop
+    /// ended for a reason outside these criteria, do not call this method and report no reason.
+    pub fn finish_reason(
+        &self,
+        token: u32,
+        text: &str,
+        budget_exhausted: bool,
+    ) -> Option<FinishReason> {
+        if self.is_eos(token) || self.matched(text).is_some() {
+            Some(FinishReason::Stop)
+        } else if budget_exhausted {
+            Some(FinishReason::Length)
+        } else {
+            None
+        }
+    }
+}

--- a/candle-transformers/tests/incremental_decoder_tests.rs
+++ b/candle-transformers/tests/incremental_decoder_tests.rs
@@ -536,3 +536,68 @@ fn clear_resets_the_stream() {
     assert!(decoder.tokens().is_empty());
     assert_eq!(decoder.push(1).unwrap(), " world");
 }
+
+#[test]
+fn a_borrowed_or_shared_tokenizer_decodes_identically() {
+    // The tokenizer is only ever read, so how the decoder holds it must not change what it
+    // produces: owned, borrowed and shared have to agree step by step.
+    let tokenizer = tokenizer(&["Hello", "Ġworld", "Ã", "©"], byte_level());
+    let ids = [0u32, 1, 2, 3, 1];
+
+    let owning = IncrementalDecoder::new(&tokenizer);
+    let borrowing = IncrementalDecoder::from_tokenizer(&tokenizer);
+    let sharing = IncrementalDecoder::from_tokenizer(std::sync::Arc::new(tokenizer.clone()));
+
+    let mut owning = owning;
+    let mut borrowing = borrowing;
+    let mut sharing = sharing;
+    for &id in ids.iter() {
+        let expected = owning.push(id).unwrap().to_string();
+        assert_eq!(borrowing.push(id).unwrap(), expected);
+        assert_eq!(sharing.push(id).unwrap(), expected);
+        assert_eq!(borrowing.text(), owning.text());
+        assert_eq!(sharing.text(), owning.text());
+    }
+    assert_eq!(owning.is_windowed(), sharing.is_windowed());
+    assert_eq!(borrowing.finish(), owning.finish());
+    assert_eq!(sharing.finish(), "");
+}
+
+#[test]
+fn a_batch_of_decoders_shares_one_tokenizer() {
+    // What a continuous-batching loop needs: one decoder per row, without a vocabulary clone or
+    // a re-resolution of the decoder context per row. Cloning a decoder carries both over, so
+    // the shared tokenizer is only ever pointed at, never copied.
+    let shared = std::sync::Arc::new(tokenizer(&["Hello", "Ġworld"], byte_level()));
+    let row = IncrementalDecoder::from_tokenizer(std::sync::Arc::clone(&shared));
+    let mut rows: Vec<_> = (0..4).map(|_| row.clone()).collect();
+    assert_eq!(std::sync::Arc::strong_count(&shared), 6);
+
+    // Each row is an independent stream over the same tokenizer.
+    for (i, decoder) in rows.iter_mut().enumerate() {
+        let expected = if i % 2 == 0 { "Hello" } else { " world" };
+        assert_eq!(decoder.push(i as u32 % 2).unwrap(), expected);
+        assert_eq!(decoder.text(), expected);
+    }
+
+    // And the tokenizer can be handed back in the form it came in.
+    let returned = row.into_tokenizer();
+    assert!(std::sync::Arc::ptr_eq(&returned, &shared));
+}
+
+#[test]
+fn cloning_a_decoder_forks_its_stream() {
+    let tokenizer = tokenizer(&["Hello", "Ġworld", "Ã", "©"], byte_level());
+    let mut decoder = IncrementalDecoder::from_tokenizer(&tokenizer);
+    decoder.push(0).unwrap();
+    // Fork with a multi-byte character still open, so the pending state has to come along too.
+    decoder.push(2).unwrap();
+
+    let mut fork = decoder.clone();
+    assert_eq!(fork.text(), decoder.text());
+    // The fork completes the character; the original leaves it undecodable and moves on.
+    assert_eq!(fork.push(3).unwrap(), "é");
+    assert_eq!(decoder.push(1).unwrap(), "\u{fffd} world");
+    assert_eq!(decoder.text(), tokenizer.decode(&[0, 2, 1], true).unwrap());
+    assert_eq!(fork.text(), tokenizer.decode(&[0, 2, 3], true).unwrap());
+}

--- a/candle-transformers/tests/incremental_decoder_tests.rs
+++ b/candle-transformers/tests/incremental_decoder_tests.rs
@@ -1,0 +1,466 @@
+use candle_transformers::generation::IncrementalDecoder;
+use serde_json::{json, Value};
+use tokenizers::Tokenizer;
+
+/// Build a tokenizer from an explicit vocabulary and decoder, so the tests exercise decoder
+/// behaviour without downloading anything.
+fn tokenizer(vocab: &[&str], decoder: Value) -> Tokenizer {
+    tokenizer_with_added(vocab, decoder, json!([]))
+}
+
+fn tokenizer_with_added(vocab: &[&str], decoder: Value, added_tokens: Value) -> Tokenizer {
+    let vocab: serde_json::Map<String, Value> = vocab
+        .iter()
+        .enumerate()
+        .map(|(i, token)| ((*token).to_string(), json!(i)))
+        .collect();
+    let spec = json!({
+        "version": "1.0",
+        "truncation": null,
+        "padding": null,
+        "added_tokens": added_tokens,
+        "normalizer": null,
+        "pre_tokenizer": null,
+        "post_processor": null,
+        "decoder": decoder,
+        "model": {
+            "type": "BPE",
+            "dropout": null,
+            "unk_token": null,
+            "continuing_subword_prefix": null,
+            "end_of_word_suffix": null,
+            "fuse_unk": false,
+            "byte_fallback": false,
+            "ignore_merges": false,
+            "vocab": vocab,
+            "merges": [],
+        },
+    });
+    Tokenizer::from_bytes(serde_json::to_vec(&spec).unwrap()).unwrap()
+}
+
+fn byte_level() -> Value {
+    json!({"type": "ByteLevel", "add_prefix_space": false, "trim_offsets": true, "use_regex": true})
+}
+
+/// The invariant from the issue: the incremental text equals a whole-sequence decode at every
+/// step, and the concatenation of the emitted deltas reproduces it exactly.
+fn check_stream(tokenizer: &Tokenizer, ids: &[u32]) -> String {
+    let mut decoder = IncrementalDecoder::new(tokenizer);
+    let mut streamed = String::new();
+    for (i, &id) in ids.iter().enumerate() {
+        let delta = decoder.push(id).unwrap().to_string();
+        assert_eq!(decoder.retracted(), 0, "unexpected retraction at step {i}");
+        streamed.push_str(&delta);
+        let expected = tokenizer.decode(&ids[..=i], true).unwrap();
+        assert_eq!(decoder.text(), expected, "diverged at step {i}");
+        assert!(
+            expected.starts_with(&streamed),
+            "emitted text is not a prefix of the decode at step {i}: {streamed:?} vs {expected:?}"
+        );
+    }
+    streamed.push_str(decoder.finish());
+    assert_eq!(streamed, decoder.text());
+    streamed
+}
+
+#[test]
+fn multi_byte_char_spanning_tokens() {
+    // "Ã" and "©" are the byte-level spellings of 0xC3 and 0xA9, the two bytes of "é".
+    let tokenizer = tokenizer(&["Hello", "Ġworld", "Ã", "©"], byte_level());
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    assert!(decoder.is_windowed());
+
+    assert_eq!(decoder.push(0).unwrap(), "Hello");
+    assert_eq!(decoder.push(1).unwrap(), " world");
+    // The lone 0xC3 decodes to U+FFFD, which the next token replaces, so nothing is emitted.
+    assert_eq!(decoder.push(2).unwrap(), "");
+    assert_eq!(decoder.text(), "Hello world\u{FFFD}");
+    assert_eq!(decoder.push(3).unwrap(), "é");
+    assert_eq!(decoder.text(), "Hello worldé");
+
+    check_stream(&tokenizer, &[0, 1, 2, 3]);
+}
+
+#[test]
+fn undecodable_bytes_are_released_by_finish() {
+    let tokenizer = tokenizer(&["Hello", "Ã"], byte_level());
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    assert_eq!(decoder.push(0).unwrap(), "Hello");
+    assert_eq!(decoder.push(1).unwrap(), "");
+    assert_eq!(decoder.finish(), "\u{FFFD}");
+    assert_eq!(decoder.finish(), "");
+}
+
+#[test]
+fn sentencepiece_leading_space() {
+    // The decoder shipped by the Llama-style tokenizers: a per-token replace, byte fallback,
+    // a fuse, then a strip of the leading space introduced by the first "▁".
+    let decoder = json!({"type": "Sequence", "decoders": [
+        {"type": "Replace", "pattern": {"String": "▁"}, "content": " "},
+        {"type": "ByteFallback"},
+        {"type": "Fuse"},
+        {"type": "Strip", "content": " ", "start": 1, "stop": 0},
+    ]});
+    let tokenizer = tokenizer(&["▁Hello", "▁world", "<0xE5>", "<0x8f>", "<0xab>"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(incremental.is_windowed());
+
+    // The leading space is stripped from the first token but not from the second, so a naive
+    // per-token decode would produce "HelloWorld".
+    assert_eq!(incremental.push(0).unwrap(), "Hello");
+    assert_eq!(incremental.push(1).unwrap(), " world");
+    // 叫 is three byte-fallback tokens. The run stays open until a non-marker token closes it,
+    // since one more marker could re-render the whole of it, so it lands with `finish`.
+    assert_eq!(incremental.push(2).unwrap(), "");
+    assert_eq!(incremental.push(3).unwrap(), "");
+    assert_eq!(incremental.push(4).unwrap(), "");
+    assert_eq!(incremental.text(), "Hello world叫");
+    assert_eq!(incremental.finish(), "叫");
+
+    check_stream(&tokenizer, &[0, 1, 2, 3, 4]);
+}
+
+#[test]
+fn wordpiece_decoder() {
+    let decoder = json!({"type": "WordPiece", "prefix": "##", "cleanup": true});
+    let tokenizer = tokenizer(&["Ara", "##új", "##o", "No", "##guera"], decoder);
+    let streamed = check_stream(&tokenizer, &[0, 1, 2, 3, 4]);
+    assert_eq!(streamed, "Araújo Noguera");
+}
+
+#[test]
+fn no_decoder_joins_with_spaces() {
+    let tokenizer = tokenizer(&["a", "b", "c"], Value::Null);
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    assert!(decoder.is_windowed());
+    assert_eq!(decoder.push(0).unwrap(), "a");
+    assert_eq!(decoder.push(1).unwrap(), " b");
+    assert_eq!(check_stream(&tokenizer, &[0, 1, 2]), "a b c");
+}
+
+#[test]
+fn bpe_decoder_defers_the_last_token() {
+    // `BPEDecoder` drops the end-of-word suffix of the last token instead of turning it into a
+    // space, so the tail of the text is rewritten by the next push and must not be emitted yet.
+    let decoder = json!({"type": "BPEDecoder", "suffix": "</w>"});
+    let tokenizer = tokenizer(&["ab</w>", "cd</w>"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert_eq!(incremental.push(0).unwrap(), "");
+    assert_eq!(incremental.text(), "ab");
+    assert_eq!(incremental.push(1).unwrap(), "ab");
+    assert_eq!(incremental.text(), "ab cd");
+    assert_eq!(incremental.finish(), " cd");
+
+    check_stream(&tokenizer, &[0, 1, 0, 1, 0]);
+}
+
+#[test]
+fn window_stays_bounded_over_a_long_run() {
+    let tokenizer = tokenizer(
+        &["Hello", "Ġworld", "Ã", "©", "Ġthe", "Ġquick", "."],
+        byte_level(),
+    );
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    let mut ids = Vec::new();
+    // A cheap deterministic shuffle, so the run mixes plain tokens with byte pairs.
+    let mut state = 12345u64;
+    for _ in 0..2000 {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let id = (state >> 33) as u32 % 7;
+        ids.push(id);
+        decoder.push(id).unwrap();
+        assert_eq!(decoder.text(), tokenizer.decode(&ids, true).unwrap());
+        // A window that fails to re-anchor keeps growing until the next attempt, so the bound
+        // is on the order of the re-anchoring threshold rather than exactly it.
+        assert!(
+            decoder.window_len() <= 128,
+            "window grew to {} tokens",
+            decoder.window_len()
+        );
+    }
+}
+
+#[test]
+fn unbounded_decoder_falls_back_to_whole_sequence() {
+    // A `Replace` with a regex pattern, applied after the tokens have been fused, can rewrite
+    // text arbitrarily far back: windowing has to be disabled for it.
+    let decoder = json!({"type": "Sequence", "decoders": [
+        byte_level(),
+        {"type": "Replace", "pattern": {"Regex": "\\s+"}, "content": " "},
+    ]});
+    let tokenizer = tokenizer(&["Hello", "Ġworld", "Ġ", "Ġthe"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(!incremental.is_windowed());
+
+    let mut ids = Vec::new();
+    for id in [0, 1, 2, 2, 3, 2, 0] {
+        ids.push(id);
+        incremental.push(id).unwrap();
+        assert_eq!(incremental.text(), tokenizer.decode(&ids, true).unwrap());
+    }
+    assert_eq!(incremental.window_len(), ids.len());
+}
+
+#[test]
+fn fused_bpe_decoder_accounts_for_its_suffix() {
+    // After a `Fuse` the decoder sees one string, so every occurrence of the suffix is dropped
+    // wherever it lands - including one assembled across several pushed tokens, which rewrites
+    // text that a per-token reading would have considered settled.
+    let decoder = json!({"type": "Sequence", "decoders": [
+        {"type": "Fuse"},
+        {"type": "BPEDecoder", "suffix": "abc"},
+    ]});
+    let tokenizer = tokenizer(&["a", "b", "c", "x"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(incremental.is_windowed());
+
+    // "a", then "ab", then the suffix completes and the text collapses to "".
+    for (i, id) in [0, 1, 2].into_iter().enumerate() {
+        assert_eq!(incremental.push(id).unwrap(), "");
+        assert_eq!(incremental.retracted(), 0, "retraction at step {i}");
+    }
+    assert_eq!(incremental.text(), "");
+    check_stream(&tokenizer, &[3, 0, 1, 2, 3]);
+}
+
+#[test]
+fn fused_ctc_accounts_for_its_pad_token() {
+    // The pad token is stripped from the fused string whether or not `cleanup` is set.
+    let decoder = json!({"type": "Sequence", "decoders": [
+        {"type": "Fuse"},
+        {"type": "CTC", "pad_token": "<pad>", "word_delimiter_token": "|", "cleanup": false},
+    ]});
+    let tokenizer = tokenizer(&["<", "p", "a", "d", ">"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(incremental.is_windowed());
+
+    for (i, id) in [0, 1, 2, 3, 4].into_iter().enumerate() {
+        assert_eq!(incremental.push(id).unwrap(), "");
+        assert_eq!(incremental.retracted(), 0, "retraction at step {i}");
+    }
+    assert_eq!(incremental.text(), "");
+}
+
+#[test]
+fn byte_decoders_after_a_fuse_are_unbounded() {
+    // Both match a shape against the whole accumulated string, so appending one token can
+    // rewrite the entire prefix; neither may be windowed once the tokens have been fused.
+    for inner in [byte_level(), json!({"type": "ByteFallback"})] {
+        let fused = json!({"type": "Sequence", "decoders": [{"type": "Fuse"}, inner.clone()]});
+        let after_fuse = tokenizer(&["<0x61>", "Hello", "Ã"], fused);
+        assert!(
+            !IncrementalDecoder::new(&after_fuse).is_windowed(),
+            "{inner} after a Fuse must not be windowed"
+        );
+        // On its own it stays windowed.
+        let alone = tokenizer(&["<0x61>", "Hello", "Ã"], inner);
+        assert!(IncrementalDecoder::new(&alone).is_windowed());
+    }
+}
+
+#[test]
+fn a_run_of_special_tokens_keeps_the_window_bounded() {
+    // Skipped special tokens decode to nothing, so no candidate tail is ever long enough to
+    // re-anchor on. They never reach the decoder either, so the window can simply skip them.
+    let added = json!([{
+        "id": 2, "content": "<eos>", "single_word": false,
+        "lstrip": false, "rstrip": false, "normalized": false, "special": true,
+    }]);
+    let tokenizer = tokenizer_with_added(&["Hello", "Ġworld", "<eos>"], byte_level(), added);
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    decoder.push(0).unwrap();
+
+    let mut ids = vec![0];
+    for _ in 0..500 {
+        ids.push(2);
+        decoder.push(2).unwrap();
+        assert_eq!(decoder.text(), tokenizer.decode(&ids, true).unwrap());
+        // The skipped tokens never enter the window at all.
+        assert_eq!(decoder.window_len(), 1);
+    }
+    ids.push(1);
+    assert_eq!(decoder.push(1).unwrap(), " world");
+    assert_eq!(decoder.text(), tokenizer.decode(&ids, true).unwrap());
+}
+
+#[test]
+fn byte_fallback_run_is_withheld_until_it_closes() {
+    // `ByteFallback` converts a run of `<0xXX>` markers as a whole: `String::from_utf8` is
+    // applied to every byte accumulated so far, so a single invalid byte re-renders the entire
+    // run as replacement characters - including the part that had already decoded cleanly.
+    let decoder = json!({"type": "ByteFallback"});
+    let tokenizer = tokenizer(&["<0x61>", "<0xFF>", "z"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(incremental.is_windowed());
+
+    // "a" on its own, but nothing is emitted: the run is still open.
+    assert_eq!(incremental.push(0).unwrap(), "");
+    assert_eq!(incremental.text(), "a");
+    // The invalid byte turns the whole run into replacement characters.
+    assert_eq!(incremental.push(1).unwrap(), "");
+    assert_eq!(incremental.text(), "\u{FFFD}\u{FFFD}");
+    assert_eq!(incremental.retracted(), 0);
+    // A non-marker token closes the run, settling it.
+    assert_eq!(incremental.push(2).unwrap(), "\u{FFFD}\u{FFFD}z");
+
+    check_stream(&tokenizer, &[0, 1, 2, 0, 2, 1]);
+}
+
+#[test]
+fn unbounded_decoder_emits_nothing_until_finish() {
+    // A fused regex `Replace` rewriting a trailing "!" into "?": the first token decodes to
+    // "?", and the second rewrites it back to "!". Nothing may be streamed from a decoder that
+    // can do that, or a caller appending the deltas would print "?!a" instead of "!a".
+    let decoder = json!({"type": "Sequence", "decoders": [
+        {"type": "Fuse"},
+        {"type": "Replace", "pattern": {"Regex": "!$"}, "content": "?"},
+    ]});
+    let tokenizer = tokenizer(&["!", "a"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(!incremental.is_windowed());
+
+    assert_eq!(incremental.push(0).unwrap(), "");
+    assert_eq!(incremental.text(), "?");
+    assert_eq!(incremental.push(1).unwrap(), "");
+    assert_eq!(incremental.text(), "!a");
+    assert_eq!(incremental.retracted(), 0);
+    assert_eq!(incremental.finish(), "!a");
+}
+
+#[test]
+fn ctc_before_bpe_is_unbounded() {
+    // `BPEDecoder`'s one-step lag assumes every push hands it one more entry. `CTC` dedups and
+    // drops entries that decode to nothing, so a pushed pad token settles nothing, yet the lag
+    // would treat it as if it had.
+    let decoder = json!({"type": "Sequence", "decoders": [
+        {"type": "CTC", "pad_token": "<pad>", "word_delimiter_token": "|", "cleanup": false},
+        {"type": "BPEDecoder", "suffix": "</w>"},
+    ]});
+    let tokenizer = tokenizer(&["ab</w>z", "<pad>", "cd</w>"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(!incremental.is_windowed());
+
+    // The pad token leaves the text alone; only the third token settles anything.
+    for id in [0, 1, 2] {
+        assert_eq!(incremental.push(id).unwrap(), "");
+        assert_eq!(incremental.retracted(), 0);
+    }
+    assert_eq!(incremental.text(), "ab zcd");
+    assert_eq!(incremental.finish(), "ab zcd");
+
+    check_stream(&tokenizer, &[0, 1, 2]);
+}
+
+#[test]
+fn reanchoring_keeps_an_open_byte_run_whole() {
+    // A window starting inside an open marker run renders it differently from the full
+    // sequence: the shorter decode is a suffix at that moment, but the next marker re-renders
+    // the part left outside the window.
+    let decoder = json!({"type": "ByteFallback"});
+    let tokenizer = tokenizer(&["<0x61>", "<0xFF>", "z"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+
+    let mut ids = Vec::new();
+    for _ in 0..80 {
+        ids.push(0);
+        incremental.push(0).unwrap();
+        assert_eq!(incremental.text(), tokenizer.decode(&ids, true).unwrap());
+    }
+    // The whole run must still be in the window, so this re-renders all of it.
+    ids.push(1);
+    incremental.push(1).unwrap();
+    assert_eq!(incremental.text(), tokenizer.decode(&ids, true).unwrap());
+    assert_eq!(incremental.retracted(), 0);
+    assert_eq!(incremental.text().chars().count(), 81);
+    assert!(incremental.text().chars().all(|c| c == '\u{FFFD}'));
+}
+
+#[test]
+fn a_decoder_that_can_forge_byte_markers_is_unbounded() {
+    // Marker runs are recognized from the id's vocabulary token, so a decoder ahead of the
+    // `ByteFallback` that can turn something else into a marker defeats the tracking.
+    let forging = json!({"type": "Sequence", "decoders": [
+        {"type": "Replace", "pattern": {"String": "A"}, "content": "<0x61>"},
+        {"type": "ByteFallback"},
+    ]});
+    let forged = tokenizer(&["A", "<0xFF>"], forging);
+    assert!(!IncrementalDecoder::new(&forged).is_windowed());
+
+    // The SentencePiece chain replaces "▁" with a space, which cannot spell a marker, so it
+    // keeps the fast path.
+    let sentencepiece = json!({"type": "Sequence", "decoders": [
+        {"type": "Replace", "pattern": {"String": "▁"}, "content": " "},
+        {"type": "ByteFallback"},
+        {"type": "Fuse"},
+        {"type": "Strip", "content": " ", "start": 1, "stop": 0},
+    ]});
+    let tokenizer = tokenizer(&["▁Hello", "<0xE5>"], sentencepiece);
+    assert!(IncrementalDecoder::new(&tokenizer).is_windowed());
+}
+
+#[test]
+fn metaspace_before_byte_fallback_is_unbounded() {
+    // At the first token, a prepend scheme other than `Never` *drops* the replacement character
+    // rather than turning it into a space, so "▁<0x61>" comes out as a marker the vocabulary
+    // never had.
+    let prepending = json!({"type": "Sequence", "decoders": [
+        {"type": "Metaspace", "replacement": "▁", "prepend_scheme": "always", "split": true},
+        {"type": "ByteFallback"},
+    ]});
+    let forged = tokenizer(&["▁<0x61>", "<0xFF>"], prepending);
+    assert!(!IncrementalDecoder::new(&forged).is_windowed());
+
+    // With `never` every occurrence becomes a space, which spells no part of a marker.
+    let never = json!({"type": "Sequence", "decoders": [
+        {"type": "Metaspace", "replacement": "▁", "prepend_scheme": "never", "split": true},
+        {"type": "ByteFallback"},
+    ]});
+    let plain = tokenizer(&["▁<0x61>", "<0xFF>"], never);
+    assert!(IncrementalDecoder::new(&plain).is_windowed());
+}
+
+#[test]
+fn a_replace_that_destroys_byte_markers_is_unbounded() {
+    // Marker runs are recognized from the id's vocabulary token, so a rewrite that can match
+    // *inside* a marker leaves the tracking believing in runs the decoder never sees.
+    let destroying = json!({"type": "Sequence", "decoders": [
+        {"type": "Replace", "pattern": {"String": "<"}, "content": "_"},
+        {"type": "ByteFallback"},
+    ]});
+    let destroyed = tokenizer(&["<0x61>", "z"], destroying);
+    assert!(!IncrementalDecoder::new(&destroyed).is_windowed());
+}
+
+#[test]
+fn unknown_ids_stay_out_of_the_window() {
+    // `Tokenizer::decode` drops ids the vocabulary has no token for, so they never reach the
+    // decoder and must not hold the window open either.
+    let tokenizer = tokenizer(&["Hello", "Ġworld"], byte_level());
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    decoder.push(0).unwrap();
+
+    let mut ids = vec![0];
+    for _ in 0..500 {
+        ids.push(9999);
+        decoder.push(9999).unwrap();
+        assert_eq!(decoder.text(), tokenizer.decode(&ids, true).unwrap());
+        assert_eq!(decoder.window_len(), 1);
+    }
+    ids.push(1);
+    assert_eq!(decoder.push(1).unwrap(), " world");
+    assert_eq!(decoder.text(), tokenizer.decode(&ids, true).unwrap());
+}
+
+#[test]
+fn clear_resets_the_stream() {
+    let tokenizer = tokenizer(&["Hello", "Ġworld"], byte_level());
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    decoder.push(0).unwrap();
+    decoder.clear();
+    assert_eq!(decoder.text(), "");
+    assert!(decoder.tokens().is_empty());
+    assert_eq!(decoder.push(1).unwrap(), " world");
+}

--- a/candle-transformers/tests/incremental_decoder_tests.rs
+++ b/candle-transformers/tests/incremental_decoder_tests.rs
@@ -455,6 +455,78 @@ fn unknown_ids_stay_out_of_the_window() {
 }
 
 #[test]
+fn bpe_lag_survives_a_skipped_token() {
+    // The one-step lag assumes each push hands `BPEDecoder` one more entry. A skipped special
+    // token never reaches the decoder, so the text does not move and the lag must not treat it
+    // as a step - otherwise the previous token's text is released one push early.
+    let added = json!([{
+        "id": 1, "content": "<eos>", "single_word": false,
+        "lstrip": false, "rstrip": false, "normalized": false, "special": true,
+    }]);
+    let decoder = json!({"type": "BPEDecoder", "suffix": "</w>"});
+    let tokenizer = tokenizer_with_added(&["a</w>b", "<eos>", "c"], decoder, added);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+
+    assert_eq!(incremental.push(0).unwrap(), "");
+    assert_eq!(incremental.text(), "ab");
+    // The skipped token settles nothing.
+    assert_eq!(incremental.push(1).unwrap(), "");
+    assert_eq!(incremental.retracted(), 0);
+    assert_eq!(incremental.push(2).unwrap(), "a");
+    assert_eq!(incremental.text(), "a bc");
+    assert_eq!(incremental.retracted(), 0);
+
+    check_stream(&tokenizer, &[0, 1, 2]);
+}
+
+#[test]
+fn two_fused_rewrites_are_unbounded() {
+    // The first replace's reach is measured against the string the second one takes as input,
+    // and a length-changing rewrite moves the boundary it refers to: two bytes of pending reach
+    // end up covering ten bytes of output, so the reaches cannot simply be summed.
+    let decoder = json!({"type": "Sequence", "decoders": [
+        {"type": "Fuse"},
+        {"type": "Replace", "pattern": {"String": "ab"}, "content": "q"},
+        {"type": "Replace", "pattern": {"String": "a"}, "content": "xxxxxxxxxx"},
+    ]});
+    let tokenizer = tokenizer(&["a", "b"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(!incremental.is_windowed());
+
+    assert_eq!(incremental.push(0).unwrap(), "");
+    assert_eq!(incremental.text(), "xxxxxxxxxx");
+    assert_eq!(incremental.push(1).unwrap(), "");
+    assert_eq!(incremental.text(), "q");
+    assert_eq!(incremental.retracted(), 0);
+    assert_eq!(incremental.finish(), "q");
+}
+
+#[test]
+fn wordpiece_reanchors_around_continuation_pieces() {
+    // A candidate window starting on a `##` piece keeps the prefix that the full decode strips,
+    // so it can never be a suffix. Trying the neighbouring lengths finds a boundary that works.
+    let decoder = json!({"type": "WordPiece", "prefix": "##", "cleanup": true});
+    let tokenizer = tokenizer(&["Ara", "##új", "##o", "No", "##guera"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    let mut ids = Vec::new();
+    let mut state = 999u64;
+    for _ in 0..600 {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let id = (state >> 33) as u32 % 5;
+        ids.push(id);
+        incremental.push(id).unwrap();
+        assert_eq!(incremental.text(), tokenizer.decode(&ids, true).unwrap());
+    }
+    assert!(
+        incremental.window_len() <= 128,
+        "window grew to {} tokens",
+        incremental.window_len()
+    );
+}
+
+#[test]
 fn clear_resets_the_stream() {
     let tokenizer = tokenizer(&["Hello", "Ġworld"], byte_level());
     let mut decoder = IncrementalDecoder::new(&tokenizer);

--- a/candle-transformers/tests/stop_criteria_tests.rs
+++ b/candle-transformers/tests/stop_criteria_tests.rs
@@ -1,0 +1,54 @@
+use candle_transformers::generation::{FinishReason, StopCriteria};
+
+#[test]
+fn holds_back_the_longest_stop_sequence_on_a_char_boundary() {
+    let criteria = StopCriteria::new(["<end>".to_owned(), "éx".to_owned()], vec![]);
+    assert_eq!(criteria.hold(), 4);
+
+    // The byte cut is in the middle of `é`; retain that whole character instead.
+    assert_eq!(criteria.safe_emit_end("aéxyz"), 1);
+    assert_eq!(criteria.safe_emit_end("hello"), 1);
+}
+
+#[test]
+fn finds_the_earliest_stop_regardless_of_configuration_order() {
+    let criteria = StopCriteria::new(["later".to_owned(), "first".to_owned()], vec![]);
+    let text = "first, then later";
+    assert_eq!(criteria.matched(text), Some(0));
+    assert_eq!(criteria.safe_emit_end(text), 0);
+
+    // A stop that completes across token boundaries must not be streamed.
+    let split = StopCriteria::new(["<stop>".to_owned()], vec![]);
+    assert_eq!(split.safe_emit_end("answer<st"), 4);
+    assert_eq!(split.matched("answer<stop>"), Some(6));
+    assert_eq!(split.safe_emit_end("answer<stop>"), 6);
+}
+
+#[test]
+fn reports_model_stop_before_budget_exhaustion() {
+    let criteria = StopCriteria::new(["<stop>".to_owned()], vec![2]);
+    assert!(criteria.is_eos(2));
+    assert!(!criteria.is_eos(3));
+
+    assert_eq!(
+        criteria.finish_reason(2, "answer", true),
+        Some(FinishReason::Stop)
+    );
+    assert_eq!(
+        criteria.finish_reason(3, "answer<stop>", true),
+        Some(FinishReason::Stop)
+    );
+    assert_eq!(
+        criteria.finish_reason(3, "answer", true),
+        Some(FinishReason::Length)
+    );
+    assert_eq!(criteria.finish_reason(3, "answer", false), None);
+}
+
+#[test]
+fn ignores_empty_stop_sequences() {
+    let criteria = StopCriteria::new([String::new()], vec![]);
+    assert_eq!(criteria.hold(), 0);
+    assert_eq!(criteria.matched("answer"), None);
+    assert_eq!(criteria.safe_emit_end("answer"), 6);
+}


### PR DESCRIPTION
Implements the incremental detokenizer requested in #3782.

## Problem

Every autoregressive decode loop needs the text generated so far on each step, for
stop-sequence matching and for streaming deltas. Today there are two options and both are
unsatisfying:

1. Re-decode the whole token sequence each step — correct, but O(n²) in the generated
   length.
2. `candle-examples`'s `TokenOutputStream` — O(1) amortised, but its `is_alphanumeric`
   heuristic changes emission timing and can hold text back indefinitely; it is an
   example, not a supported API.

The naive fix does not work, which is what makes this worth having in the library. A
BPE/SentencePiece decode is not the concatenation of its tokens' decodes: a multi-byte
character can span several tokens (the prefix decodes to U+FFFD, which a later token
retroactively replaces), and decoding a sub-sequence can gain or lose a leading space.

## API

```rust
// candle-transformers::generation, next to LogitsProcessor
pub struct IncrementalDecoder { /* … */ }

impl IncrementalDecoder {
    pub fn new(tokenizer: &Tokenizer) -> Self;        // clones
    pub fn from_tokenizer(tokenizer: Tokenizer) -> Self;
    pub fn with_skip_special_tokens(self, skip: bool) -> Self;

    pub fn push(&mut self, token: u32) -> Result<&str>;  // newly settled text
    pub fn text(&self) -> &str;                          // whole decoded text
    pub fn finish(&mut self) -> &str;                    // release what is held back
    pub fn pending(&self) -> &str;                       // held back, without consuming

    pub fn is_windowed(&self) -> bool;
    pub fn window_len(&self) -> usize;
    pub fn retracted(&self) -> usize;
    pub fn tokens(&self) -> &[u32];
    pub fn tokenizer(&self) -> &Tokenizer;
    pub fn into_tokenizer(self) -> Tokenizer;
    pub fn clear(&mut self);
}
```

Two invariants:

- **`text()` equals a whole-sequence decode of every token pushed so far, at every step** —
  the one the issue asks to assert in tests.
- **Emission is append-only**: concatenating every `push()` result, then `finish()`,
  reproduces `text()` exactly. `push` never returns text it has to take back.

Typical use:

```rust
let mut decoder = IncrementalDecoder::new(&tokenizer);
for _ in 0..max_tokens {
    let token = logits_processor.sample(&logits)?;
    print!("{}", decoder.push(token)?);
    if decoder.text().ends_with(stop_sequence) {
        break;
    }
}
print!("{}", decoder.finish());
```

## How it works

- **Window + delta, not append.** A bounded trailing window of tokens (re-anchored to 8,
  re-anchoring attempted at 64) is re-decoded on each push, and the delta is taken against
  the *previous* decode of the same window — so a sub-sequence artifact appears in both
  decodes and cancels.
- **Revision, not just extension.** Text a future token could still rewrite is withheld
  rather than emitted and later corrected.
- **Verified re-anchoring.** The window only moves forward when the shorter decode is
  provably a suffix of the current window decode, is long enough that a rewriting decoder
  cannot reach past it, and does not start inside an open `ByteFallback` marker run. When
  no split qualifies the window keeps growing, degrading towards whole-sequence decoding
  rather than dropping or duplicating text.
- **Bounded decoder context.** The suffix check proves the shortened decode matches *now*;
  it does not prove a future token cannot rewrite text before the anchor. Since
  `tokenizers` keeps the decoder fields private, the decoder is inspected through its
  serialized form, and anything unrecognized is treated as unbounded.

The decoder scan is **order-aware**, which is the part that is easy to get wrong. It tracks
three properties of the decoders seen so far, and reads each subsequent decoder against
them:

| Scan state | Meaning |
| --- | --- |
| `fused` | The token list has been collapsed into one string, so later string rewrites apply to the whole text instead of one token. |
| `suppresses` | The list can lose entries, so a push does not necessarily hand later decoders one more element. |
| `alters_markers` | A token's string can be rewritten, so whether a `<0xXX>` byte marker reaches `ByteFallback` can no longer be told from the raw id. |

| Serialized decoder | Verdict |
| --- | --- |
| *(none)* — tokens joined with a space | bounded |
| `Fuse` | bounded; sets `fused` |
| `ByteLevel` | bounded and sets `fused`; **unbounded** if already `fused` |
| `ByteFallback` | bounded, enables run tracking, sets `suppresses`; **unbounded** if `fused` or `alters_markers` |
| `Metaspace` | bounded; sets `alters_markers` unless `prepend_scheme` is `never` and its replacement is marker-neutral |
| `WordPiece` | bounded, sets `alters_markers`; if `fused` and `cleanup`, tail += longest cleanup pattern |
| `CTC` | bounded, sets `suppresses` and `alters_markers`; if `fused`, tail += `pad_token` + cleanup pattern + `word_delimiter_token` |
| `BPEDecoder` | sets `alters_markers`; if `fused`, tail += `suffix`; else one-step lag, or **unbounded** if `suppresses` |
| `Strip` | bounded, sets `alters_markers`; if `fused`, tail += `stop` × `content` |
| `Replace`, literal pattern | bounded; sets `alters_markers` unless marker-neutral; if `fused`, tail += `pattern` |
| `Replace`, regex pattern | sets `alters_markers`; **unbounded** if `fused` |
| `Sequence` | recurse in order, threading the scan state |
| anything else | **unbounded** |

"Marker-neutral" is decided by the alphabet a `<0xXX>` marker is made of — `<`, `>`, `x`
and hex digits. A rewrite whose *output* holds none of those characters cannot forge a
marker, since its result always carries a character no marker has; and one whose *input
pattern* holds none of them cannot match inside a marker, so it cannot destroy one either.
Both halves have to hold. The SentencePiece chain replaces `▁` with a space and satisfies
both, so it keeps the fast path.

`push` withholds text that is not yet settled: a trailing run of U+FFFD from an incomplete
multi-byte character, an open `ByteFallback` marker run (the run is converted as a whole,
so one invalid byte re-renders all of it), the reach of a rewriting decoder, the last token
of an unfused `BPEDecoder`, and — for a decoder that is not windowed — everything, since
nothing about it can be shown to be settled.

`retracted()` is a diagnostic that is always zero. A non-zero value means some decoder's
rewrite reach was under-estimated in the scan, i.e. a bug here rather than something a
caller has to handle.

## Dependency

`candle-transformers` gains a direct dependency on `tokenizers`, but **no crate is added to
the dependency graph**: `candle-core` already depends on `tokenizers` unconditionally
(`candle-core/Cargo.toml:38`, used by `candle-core/src/quantized/tokenizer.rs` for GGUF
tokenizer support), and `candle-transformers` depends on `candle-core` through `candle-nn`.
Every `candle-transformers` user compiles it today.

A feature gate was considered and dropped for that reason: it would have bought nothing in
compile time or graph size, while making the API harder to discover, hiding it from
docs.rs by default, and leaving the tests reachable only through feature unification. No
`tokenizers` feature is requested here, so the workspace's `default-features = false`
applies — the decoder introspection only uses `serde_json` on the serialized form and never
touches the regex engine.

Happy to put it behind a feature instead if you would rather `candle-transformers` not name
`tokenizers` directly, or if that `candle-core` dependency is something you plan to remove.

## `TokenOutputStream`

`candle-examples`'s `TokenOutputStream` becomes a thin adapter over `IncrementalDecoder`,
with its public API unchanged, so no example needed touching. Behaviour change: the
`is_alphanumeric` heuristic is gone, so text streams as soon as it is provably settled
instead of waiting for the next alphanumeric character, and nothing is held back
indefinitely. `decode_all()` returns the maintained text rather than re-decoding.

## Testing

`candle-transformers/tests/incremental_decoder_tests.rs` — 21 tests, each building a
tokenizer from an explicit vocabulary and decoder so nothing is downloaded. They cover the
base behaviour (multi-byte characters spanning tokens, the SentencePiece chain and its
leading-space strip, `WordPiece`, no decoder, `BPEDecoder`'s deferred last token, window
boundedness over a 2000-token run) and one regression test per composition that was found
to break the invariants.

Separately, not in the test suite since it needs network, the invariants were checked
against four real `tokenizer.json` files — GPT-2, Qwen2.5-0.5B, bert-base-uncased and
Mistral-7B-Instruct-v0.3 — over 3000 random tokens each. In every case `text()` matched a
whole-sequence decode at every step, the emitted text was always a prefix of it, there were
no retractions, the window stayed at or below 64 tokens, and nothing was left held back at
the end.

`cargo fmt --check`, `cargo clippy --tests -- -D warnings` and the test suite pass.

## Notes for reviewers

The decoder scan started out considerably more permissive, and review hardened it through
thirteen findings. Two of them broke `text()` itself rather than just emission, and are
worth knowing about if you review this area:

- Re-anchoring could start the window inside an open `ByteFallback` marker run. The shorter
  decode is a genuine suffix at that moment, but the next marker re-renders the part left
  outside the window, so 65 markers decoded as 56 characters plus 9 replacements.
- `ByteLevel` and `ByteFallback` placed after a `Fuse` match a shape against the whole
  accumulated string, so appending a single token can rewrite the entire prefix.

That rate is itself the strongest argument for the point the issue raises: this logic would
be far more robust inside `tokenizers`, where the decoders' behaviour is readable directly
rather than inferred from their serialized form. Every one of those defects came from a
subtlety only visible in a `decode_chain` implementation. Filing here because that is where
the decode loops live; happy to move it upstream if you prefer.

## Note on prior art

`tokenizers` 0.22 ships `Tokenizer::decode_stream` / `DecodeStream`, which solves the same
problem with an unverified re-anchor: it drains to the previous prefix index and returns a
`DecodeStreamError::InvalidPrefix` when the assumption breaks, with no gate on the
decoder's context. This implementation differs in verifying the re-anchor before taking it,
degrading to whole-sequence decoding instead of erroring, and exposing the full text so
stop-sequence matching does not need a second buffer.

Closes #3782