### PR TITLE
Add a GGUF architecture dispatcher to `candle-transformers`

### DIFF
--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -10,6 +10,8 @@
 //!  - Computer vision models: [`dinov2`], [`convmixer`], [`efficientnet`], ...
 //!  
 //! Some of the models also have quantized variants, e.g.  [`quantized_blip`], [`quantized_llama`] and  [`quantized_qwen2`].
+//! [`quantized_lm`] loads any of the quantized language models from a GGUF file by dispatching on
+//! its `general.architecture`.
 //!
 //! The implementations aim to be readable while maintaining good performance. For more information
 //! on each model see the model's module docs in the links below.
@@ -92,6 +94,7 @@ pub mod quantized_glm4;
 pub mod quantized_lfm2;
 pub mod quantized_llama;
 pub mod quantized_llama2_c;
+pub mod quantized_lm;
 pub mod quantized_metavoice;
 pub mod quantized_mistral;
 pub mod quantized_mixformer;

--- a/candle-transformers/src/models/quantized_lm.rs
+++ b/candle-transformers/src/models/quantized_lm.rs
@@ -160,12 +160,49 @@ impl Architecture {
         }
         Ok(())
     }
+
+    /// Whether this backend reads [`Options::use_flash_attn`].
+    ///
+    /// The flag is ignored by every other family, so a generic loader can leave it set.
+    pub fn supports_flash_attn(&self) -> bool {
+        *self == Self::Phi3
+    }
+
+    /// Reject a flash-attention request this build or device cannot honor.
+    ///
+    /// Only checked for the backends that read the flag; see
+    /// [`Architecture::supports_flash_attn`]. `quantized_phi3` calls a `flash_attn` shim that is
+    /// `unimplemented!()` without the `flash-attn` feature, so an unhonorable request would
+    /// otherwise panic at the first attention layer rather than fail at load.
+    pub fn check_flash_attn_support(&self, device: &Device, use_flash_attn: bool) -> Result<()> {
+        if !use_flash_attn || !self.supports_flash_attn() {
+            return Ok(());
+        }
+        if !cfg!(feature = "flash-attn") {
+            candle::bail!(
+                "the {} backend cannot use flash-attention: build candle-transformers with \
+                 --features flash-attn",
+                self.name()
+            )
+        }
+        if !device.is_cuda() {
+            candle::bail!(
+                "the {} backend can only use flash-attention on a cuda device",
+                self.name()
+            )
+        }
+        Ok(())
+    }
 }
 
 /// Per-family construction extras, with defaults that suit every backend.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Options {
-    /// Use flash-attention where the backend supports it. Only `phi3` reads this today.
+    /// Use flash-attention where the backend supports it. Only `phi3` reads this today; the
+    /// other families ignore it, so a generic loader can leave it set.
+    ///
+    /// Setting it for a backend that does read it requires the `flash-attn` feature and a CUDA
+    /// device — see [`Architecture::check_flash_attn_support`].
     pub use_flash_attn: bool,
     /// Working dtype for the backends that take one (`glm4`, `qwen3moe`).
     ///
@@ -253,6 +290,7 @@ pub fn from_gguf_with<R: Read + Seek>(
     let arch = Architecture::from_content(&ct)?;
     let dtype = options.dtype_for(device);
     arch.check_device_support(device, dtype)?;
+    arch.check_flash_attn_support(device, options.use_flash_attn)?;
     let model: Box<dyn QuantizedLm> = match arch {
         Architecture::Llama => Box::new(quantized_llama::ModelWeights::from_gguf(
             ct, reader, device,
@@ -462,6 +500,47 @@ mod tests {
         for arch in [Architecture::Llama, Architecture::Glm4, Architecture::Qwen3] {
             arch.check_device_support(&Device::Cpu, DType::F32).unwrap();
         }
+    }
+
+    #[test]
+    fn unhonorable_flash_attn_is_rejected_before_any_read() {
+        // quantized_phi3's flash_attn shim is `unimplemented!()` without the feature, so an
+        // unhonorable request must fail at load rather than panic mid-forward.
+        let ct = content(&[("general.architecture", Value::String("phi3".to_string()))]);
+        let options = Options::new().with_flash_attn(true);
+        let mut reader = Cursor::new(Vec::new());
+        let err = match from_gguf_with(ct, &mut reader, &Device::Cpu, &options) {
+            Ok(_) => panic!("phi3 loaded with an unhonorable flash-attn request"),
+            Err(err) => err.to_string(),
+        };
+        if cfg!(feature = "flash-attn") {
+            assert!(err.contains("cuda device"), "{err}");
+        } else {
+            assert!(err.contains("--features flash-attn"), "{err}");
+        }
+    }
+
+    #[test]
+    fn flash_attn_is_ignored_by_the_families_that_do_not_read_it() {
+        assert!(Architecture::Phi3.supports_flash_attn());
+        for arch in [
+            Architecture::Llama,
+            Architecture::Gemma3,
+            Architecture::Glm4,
+            Architecture::Lfm2,
+            Architecture::Phi2,
+            Architecture::Qwen2,
+            Architecture::Qwen3,
+            Architecture::Qwen3Moe,
+        ] {
+            assert!(!arch.supports_flash_attn(), "{}", arch.name());
+            // The flag is inert for them, so a generic loader can leave it set.
+            arch.check_flash_attn_support(&Device::Cpu, true).unwrap();
+        }
+        // And an unset flag never trips the check.
+        Architecture::Phi3
+            .check_flash_attn_support(&Device::Cpu, false)
+            .unwrap();
     }
 
     #[test]

--- a/candle-transformers/src/models/quantized_lm.rs
+++ b/candle-transformers/src/models/quantized_lm.rs
@@ -7,7 +7,8 @@
 //! both once:
 //!
 //! - [`QuantizedLm`] is the decoder interface every family already implements, so a loaded
-//!   model can be used behind a `Box<dyn QuantizedLm>` without a wrapper enum.
+//!   model can be used behind a `Box<dyn QuantizedLm>` without a wrapper enum — including from
+//!   a worker pool, since the trait requires `Send`.
 //! - [`from_gguf`] reads `general.architecture` and constructs the matching backend,
 //!   normalizing the per-family extras (`use_flash_attn`, working `dtype`) into [`Options`].
 //! - [`context_length`] and [`arch_metadata`] read architecture-prefixed metadata through the
@@ -44,7 +45,14 @@ use super::{
 ///
 /// `index_pos` is the number of tokens already in the KV cache, i.e. the position of the first
 /// token of `input` in the sequence.
-pub trait QuantizedLm {
+///
+/// `Send` is a supertrait so that a loaded model can be moved into a worker pool, e.g. held as
+/// `Mutex<Box<dyn QuantizedLm>>` in a model registry. Every backend already satisfies it, but
+/// type erasure drops auto traits and `Box<dyn QuantizedLm>` would not coerce to
+/// `Box<dyn QuantizedLm + Send>` after the fact — a consumer would be forced back to the
+/// per-family enum this module exists to delete. `Sync` is deliberately not required: `forward`
+/// takes `&mut self`, so callers serialize access anyway.
+pub trait QuantizedLm: Send {
     fn forward(&mut self, input: &Tensor, index_pos: usize) -> Result<Tensor>;
 }
 
@@ -362,6 +370,17 @@ mod tests {
             tensor_infos: HashMap::new(),
             tensor_data_offset: 0,
         }
+    }
+
+    #[test]
+    fn a_loaded_model_can_be_moved_into_a_worker_pool() {
+        // Checked at compile time. A registry holds the model behind a mutex and hands it to a
+        // worker, which needs `Send` through the erased type — and an auto trait dropped by
+        // erasure cannot be recovered afterwards. `Sync` is not required: `forward` takes
+        // `&mut self`, so access is serialized regardless.
+        fn assert_send<T: Send>() {}
+        assert_send::<Box<dyn QuantizedLm>>();
+        assert_send::<std::sync::Mutex<Box<dyn QuantizedLm>>>();
     }
 
     #[test]

--- a/candle-transformers/src/models/quantized_lm.rs
+++ b/candle-transformers/src/models/quantized_lm.rs
@@ -1,0 +1,478 @@
+//! Architecture dispatch for quantized (GGUF) language models.
+//!
+//! `candle-transformers` ships one `quantized_*` module per model family, each with its
+//! own constructor and its own metadata namespace. Loading "whatever GGUF this is" therefore
+//! means writing a dispatcher on `general.architecture`, plus remembering that
+//! `llama.context_length` and `qwen3.context_length` are different keys. This module does
+//! both once:
+//!
+//! - [`QuantizedLm`] is the decoder interface every family already implements, so a loaded
+//!   model can be used behind a `Box<dyn QuantizedLm>` without a wrapper enum.
+//! - [`from_gguf`] reads `general.architecture` and constructs the matching backend,
+//!   normalizing the per-family extras (`use_flash_attn`, working `dtype`) into [`Options`].
+//! - [`context_length`] and [`arch_metadata`] read architecture-prefixed metadata through the
+//!   file's own namespace, so a consumer cannot silently read `llama.*` out of a Qwen file.
+//!
+//! Unsupported `(architecture, device, dtype)` combinations are rejected before any tensor is
+//! read — see [`Architecture::check_device_support`].
+//!
+//! ```no_run
+//! use candle::{Device, quantized::gguf_file};
+//! use candle_transformers::models::quantized_lm;
+//!
+//! # fn main() -> candle::Result<()> {
+//! let device = Device::Cpu;
+//! let mut file = std::fs::File::open("model.gguf")?;
+//! let content = gguf_file::Content::read(&mut file)?;
+//! let ctx = quantized_lm::context_length(&content);
+//! let mut model = quantized_lm::from_gguf(content, &mut file, &device)?;
+//! # let _ = (ctx, &mut model);
+//! # Ok(())
+//! # }
+//! ```
+
+use candle::quantized::gguf_file;
+use candle::{DType, Device, Result, Tensor};
+use std::io::{Read, Seek};
+
+use super::{
+    quantized_gemma3, quantized_glm4, quantized_lfm2, quantized_llama, quantized_phi,
+    quantized_phi3, quantized_qwen2, quantized_qwen3, quantized_qwen3_moe,
+};
+
+/// The decoder interface shared by the quantized model families.
+///
+/// `index_pos` is the number of tokens already in the KV cache, i.e. the position of the first
+/// token of `input` in the sequence.
+pub trait QuantizedLm {
+    fn forward(&mut self, input: &Tensor, index_pos: usize) -> Result<Tensor>;
+}
+
+/// A model family with a quantized GGUF backend in this crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Architecture {
+    /// [`quantized_llama`], `general.architecture = "llama"`.
+    Llama,
+    /// [`quantized_gemma3`], covers the whole gemma line.
+    Gemma3,
+    /// [`quantized_glm4`], `general.architecture = "glm4"`.
+    Glm4,
+    /// [`quantized_lfm2`], `general.architecture = "lfm2"`.
+    Lfm2,
+    /// [`quantized_phi`], `general.architecture = "phi2"`.
+    Phi2,
+    /// [`quantized_phi3`], `general.architecture = "phi3"`.
+    Phi3,
+    /// [`quantized_qwen2`], `general.architecture = "qwen2"`.
+    Qwen2,
+    /// [`quantized_qwen3`], `general.architecture = "qwen3"`.
+    Qwen3,
+    /// [`quantized_qwen3_moe`], `general.architecture = "qwen3moe"`. CUDA only.
+    Qwen3Moe,
+}
+
+/// Every `general.architecture` value [`from_gguf`] accepts, in dispatch order.
+pub const SUPPORTED_ARCHITECTURES: &[&str] = &[
+    "llama",
+    "gemma",
+    "gemma2",
+    "gemma3",
+    "gemma-embedding",
+    "glm4",
+    "lfm2",
+    "phi2",
+    "phi3",
+    "qwen2",
+    "qwen3",
+    "qwen3moe",
+];
+
+impl Architecture {
+    /// Map a `general.architecture` value onto the backend that handles it.
+    ///
+    /// The gemma backend reads several prefixes, so `gemma`, `gemma2`, `gemma3` and
+    /// `gemma-embedding` all map to [`Architecture::Gemma3`].
+    pub fn from_name(name: &str) -> Option<Self> {
+        let arch = match name {
+            "llama" => Self::Llama,
+            "gemma" | "gemma2" | "gemma3" | "gemma-embedding" => Self::Gemma3,
+            "glm4" => Self::Glm4,
+            "lfm2" => Self::Lfm2,
+            "phi2" => Self::Phi2,
+            "phi3" => Self::Phi3,
+            "qwen2" => Self::Qwen2,
+            "qwen3" => Self::Qwen3,
+            "qwen3moe" => Self::Qwen3Moe,
+            _ => return None,
+        };
+        Some(arch)
+    }
+
+    /// Read `general.architecture` from `ct` and resolve it to a backend.
+    pub fn from_content(ct: &gguf_file::Content) -> Result<Self> {
+        let name = architecture_name(ct)?;
+        match Self::from_name(name) {
+            Some(arch) => Ok(arch),
+            None => candle::bail!(
+                "unsupported gguf architecture {name:?}, expected one of {SUPPORTED_ARCHITECTURES:?}"
+            ),
+        }
+    }
+
+    /// The canonical `general.architecture` value for this backend.
+    ///
+    /// This is not a round-trip of [`Architecture::from_name`] for the aliased families:
+    /// a `gemma2` file resolves to [`Architecture::Gemma3`], whose name is `"gemma3"`.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Llama => "llama",
+            Self::Gemma3 => "gemma3",
+            Self::Glm4 => "glm4",
+            Self::Lfm2 => "lfm2",
+            Self::Phi2 => "phi2",
+            Self::Phi3 => "phi3",
+            Self::Qwen2 => "qwen2",
+            Self::Qwen3 => "qwen3",
+            Self::Qwen3Moe => "qwen3moe",
+        }
+    }
+
+    /// Reject a `(device, dtype)` combination this backend cannot run on.
+    ///
+    /// [`from_gguf`] calls this before reading any tensor, so an unusable combination fails at
+    /// load time rather than in the middle of the first forward pass.
+    ///
+    /// `qwen3moe` routes its experts through `candle_nn::moe_gemm_gguf`, which is implemented
+    /// for CUDA only and whose prefill kernel takes an F16 or BF16 working dtype.
+    pub fn check_device_support(&self, device: &Device, dtype: DType) -> Result<()> {
+        if *self == Self::Qwen3Moe {
+            if !device.is_cuda() {
+                candle::bail!(
+                    "the qwen3moe backend requires a cuda device: \
+                     candle_nn::moe_gemm_gguf is only implemented for the cuda backend"
+                )
+            }
+            if !matches!(dtype, DType::F16 | DType::BF16) {
+                candle::bail!(
+                    "the qwen3moe backend requires a f16 or bf16 working dtype, got {dtype:?}"
+                )
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Per-family construction extras, with defaults that suit every backend.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Options {
+    /// Use flash-attention where the backend supports it. Only `phi3` reads this today.
+    pub use_flash_attn: bool,
+    /// Working dtype for the backends that take one (`glm4`, `qwen3moe`).
+    ///
+    /// `None` resolves to BF16 on CUDA and Metal, F32 elsewhere. Note that `qwen3moe` rejects
+    /// F32, so a CPU load of that family fails on the device check first either way.
+    pub dtype: Option<DType>,
+}
+
+impl Options {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_flash_attn(mut self, use_flash_attn: bool) -> Self {
+        self.use_flash_attn = use_flash_attn;
+        self
+    }
+
+    pub fn with_dtype(mut self, dtype: DType) -> Self {
+        self.dtype = Some(dtype);
+        self
+    }
+
+    /// The working dtype to use on `device`, resolving the `None` default.
+    pub fn dtype_for(&self, device: &Device) -> DType {
+        self.dtype.unwrap_or({
+            if device.is_cuda() || device.is_metal() {
+                DType::BF16
+            } else {
+                DType::F32
+            }
+        })
+    }
+}
+
+/// The raw `general.architecture` value, e.g. `"qwen3"`.
+pub fn architecture_name(ct: &gguf_file::Content) -> Result<&str> {
+    match ct.metadata.get("general.architecture") {
+        None => candle::bail!("cannot find general.architecture in metadata"),
+        Some(v) => Ok(v.to_string()?.as_str()),
+    }
+}
+
+/// Read a metadata entry from the file's own architecture namespace.
+///
+/// `arch_metadata(ct, "context_length")` reads `qwen3.context_length` out of a Qwen3 file and
+/// `llama.context_length` out of a llama one, which is what consumers hardcoding a single
+/// prefix get wrong. Returns `None` when `general.architecture` or the entry is missing.
+pub fn arch_metadata<'a>(ct: &'a gguf_file::Content, suffix: &str) -> Option<&'a gguf_file::Value> {
+    let arch = architecture_name(ct).ok()?;
+    ct.metadata.get(&format!("{arch}.{suffix}"))
+}
+
+/// The training context window of the checkpoint, read from `{architecture}.context_length`.
+///
+/// Returns `None` when the key is absent or not an integer — callers should fall back to their
+/// own default rather than to another family's namespace.
+pub fn context_length(ct: &gguf_file::Content) -> Option<usize> {
+    let v = arch_metadata(ct, "context_length")?;
+    v.to_u64().ok().map(|v| v as usize)
+}
+
+/// Load a GGUF checkpoint with the backend registered for its `general.architecture`.
+///
+/// Uses [`Options::default`]; see [`from_gguf_with`] to pass a working dtype or enable
+/// flash-attention.
+pub fn from_gguf<R: Read + Seek>(
+    ct: gguf_file::Content,
+    reader: &mut R,
+    device: &Device,
+) -> Result<Box<dyn QuantizedLm>> {
+    from_gguf_with(ct, reader, device, &Options::default())
+}
+
+/// Load a GGUF checkpoint with the backend registered for its `general.architecture`.
+///
+/// Fails before reading any tensor when the architecture is unknown, or when the backend
+/// cannot run on `device` with the resolved working dtype.
+pub fn from_gguf_with<R: Read + Seek>(
+    ct: gguf_file::Content,
+    reader: &mut R,
+    device: &Device,
+    options: &Options,
+) -> Result<Box<dyn QuantizedLm>> {
+    let arch = Architecture::from_content(&ct)?;
+    let dtype = options.dtype_for(device);
+    arch.check_device_support(device, dtype)?;
+    let model: Box<dyn QuantizedLm> = match arch {
+        Architecture::Llama => Box::new(quantized_llama::ModelWeights::from_gguf(
+            ct, reader, device,
+        )?),
+        Architecture::Gemma3 => Box::new(quantized_gemma3::ModelWeights::from_gguf(
+            ct, reader, device,
+        )?),
+        Architecture::Glm4 => Box::new(quantized_glm4::ModelWeights::from_gguf(
+            ct, reader, device, dtype,
+        )?),
+        Architecture::Lfm2 => {
+            Box::new(quantized_lfm2::ModelWeights::from_gguf(ct, reader, device)?)
+        }
+        Architecture::Phi2 => Box::new(quantized_phi::ModelWeights::from_gguf(ct, reader, device)?),
+        Architecture::Phi3 => Box::new(quantized_phi3::ModelWeights::from_gguf(
+            options.use_flash_attn,
+            ct,
+            reader,
+            device,
+        )?),
+        Architecture::Qwen2 => Box::new(quantized_qwen2::ModelWeights::from_gguf(
+            ct, reader, device,
+        )?),
+        Architecture::Qwen3 => Box::new(quantized_qwen3::ModelWeights::from_gguf(
+            ct, reader, device,
+        )?),
+        Architecture::Qwen3Moe => Box::new(quantized_qwen3_moe::GGUFQWenMoE::from_gguf(
+            ct, reader, device, dtype,
+        )?),
+    };
+    Ok(model)
+}
+
+macro_rules! impl_quantized_lm {
+    ($ty:ty) => {
+        impl QuantizedLm for $ty {
+            fn forward(&mut self, input: &Tensor, index_pos: usize) -> Result<Tensor> {
+                <$ty>::forward(self, input, index_pos)
+            }
+        }
+    };
+}
+
+impl_quantized_lm!(quantized_llama::ModelWeights);
+impl_quantized_lm!(quantized_gemma3::ModelWeights);
+impl_quantized_lm!(quantized_glm4::ModelWeights);
+impl_quantized_lm!(quantized_lfm2::ModelWeights);
+impl_quantized_lm!(quantized_phi::ModelWeights);
+impl_quantized_lm!(quantized_phi3::ModelWeights);
+impl_quantized_lm!(quantized_qwen2::ModelWeights);
+impl_quantized_lm!(quantized_qwen3::ModelWeights);
+impl_quantized_lm!(quantized_qwen3_moe::GGUFQWenMoE);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::quantized::gguf_file::{Content, Value, VersionedMagic};
+    use std::collections::HashMap;
+    use std::io::Cursor;
+
+    fn content(entries: &[(&str, Value)]) -> Content {
+        let metadata = entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect::<HashMap<_, _>>();
+        Content {
+            magic: VersionedMagic::GgufV3,
+            metadata,
+            tensor_infos: HashMap::new(),
+            tensor_data_offset: 0,
+        }
+    }
+
+    #[test]
+    fn architecture_names_resolve() {
+        for name in SUPPORTED_ARCHITECTURES {
+            assert!(
+                Architecture::from_name(name).is_some(),
+                "{name} is advertised but does not dispatch"
+            );
+        }
+        assert_eq!(Architecture::from_name("qwen3"), Some(Architecture::Qwen3));
+        assert_eq!(
+            Architecture::from_name("qwen3moe"),
+            Some(Architecture::Qwen3Moe)
+        );
+        // The gemma backend probes several prefixes, they share one entry point.
+        for name in ["gemma", "gemma2", "gemma3", "gemma-embedding"] {
+            assert_eq!(Architecture::from_name(name), Some(Architecture::Gemma3));
+        }
+        assert_eq!(Architecture::from_name("qwen"), None);
+        assert_eq!(Architecture::from_name("mamba"), None);
+        assert_eq!(Architecture::from_name(""), None);
+    }
+
+    #[test]
+    fn canonical_names_dispatch_back_to_themselves() {
+        for arch in [
+            Architecture::Llama,
+            Architecture::Gemma3,
+            Architecture::Glm4,
+            Architecture::Lfm2,
+            Architecture::Phi2,
+            Architecture::Phi3,
+            Architecture::Qwen2,
+            Architecture::Qwen3,
+            Architecture::Qwen3Moe,
+        ] {
+            assert_eq!(Architecture::from_name(arch.name()), Some(arch));
+            assert!(SUPPORTED_ARCHITECTURES.contains(&arch.name()));
+        }
+    }
+
+    #[test]
+    fn missing_architecture_is_an_error() {
+        let ct = content(&[("qwen3.context_length", Value::U32(40960))]);
+        assert!(architecture_name(&ct).is_err());
+        assert!(Architecture::from_content(&ct).is_err());
+        assert_eq!(context_length(&ct), None);
+    }
+
+    #[test]
+    fn unknown_architecture_lists_the_supported_ones() {
+        let ct = content(&[("general.architecture", Value::String("mamba".to_string()))]);
+        let err = Architecture::from_content(&ct).unwrap_err().to_string();
+        assert!(err.contains("mamba"), "{err}");
+        assert!(err.contains("qwen3moe"), "{err}");
+    }
+
+    #[test]
+    fn context_length_follows_the_files_own_namespace() {
+        let qwen = content(&[
+            ("general.architecture", Value::String("qwen3".to_string())),
+            ("qwen3.context_length", Value::U32(40960)),
+            // A llama-prefixed key must not leak into a qwen file.
+            ("llama.context_length", Value::U32(2048)),
+        ]);
+        assert_eq!(context_length(&qwen), Some(40960));
+
+        let llama = content(&[
+            ("general.architecture", Value::String("llama".to_string())),
+            ("llama.context_length", Value::U32(2048)),
+        ]);
+        assert_eq!(context_length(&llama), Some(2048));
+
+        // The footgun: a qwen file carrying no llama namespace yields None rather than a
+        // silently wrong default.
+        let bare = content(&[
+            ("general.architecture", Value::String("qwen3".to_string())),
+            ("llama.context_length", Value::U32(2048)),
+        ]);
+        assert_eq!(context_length(&bare), None);
+    }
+
+    #[test]
+    fn context_length_upcasts_integer_widths() {
+        let ct = content(&[
+            ("general.architecture", Value::String("llama".to_string())),
+            ("llama.context_length", Value::U64(131072)),
+        ]);
+        assert_eq!(context_length(&ct), Some(131072));
+
+        let bad = content(&[
+            ("general.architecture", Value::String("llama".to_string())),
+            ("llama.context_length", Value::String("4096".to_string())),
+        ]);
+        assert_eq!(context_length(&bad), None);
+    }
+
+    #[test]
+    fn arch_metadata_reads_arbitrary_suffixes() {
+        let ct = content(&[
+            ("general.architecture", Value::String("phi3".to_string())),
+            ("phi3.block_count", Value::U32(32)),
+        ]);
+        assert_eq!(
+            arch_metadata(&ct, "block_count").and_then(|v| v.to_u64().ok()),
+            Some(32)
+        );
+        assert!(arch_metadata(&ct, "expert_count").is_none());
+    }
+
+    #[test]
+    fn qwen3moe_is_rejected_off_cuda_before_any_read() {
+        let ct = content(&[(
+            "general.architecture",
+            Value::String("qwen3moe".to_string()),
+        )]);
+        // An empty reader: the load must fail on the device check, not on a short read.
+        let mut reader = Cursor::new(Vec::new());
+        let err = match from_gguf(ct, &mut reader, &Device::Cpu) {
+            Ok(_) => panic!("qwen3moe loaded on the cpu"),
+            Err(err) => err.to_string(),
+        };
+        assert!(err.contains("cuda"), "{err}");
+    }
+
+    #[test]
+    fn only_qwen3moe_constrains_the_device() {
+        // Even the dtype qwen3moe wants is not enough off cuda.
+        let err = Architecture::Qwen3Moe
+            .check_device_support(&Device::Cpu, DType::F16)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("cuda"), "{err}");
+        // Every other family is device and dtype agnostic here.
+        for arch in [Architecture::Llama, Architecture::Glm4, Architecture::Qwen3] {
+            arch.check_device_support(&Device::Cpu, DType::F32).unwrap();
+        }
+    }
+
+    #[test]
+    fn default_options_resolve_a_cpu_dtype() {
+        let options = Options::default();
+        assert!(!options.use_flash_attn);
+        assert_eq!(options.dtype, None);
+        assert_eq!(options.dtype_for(&Device::Cpu), DType::F32);
+
+        let options = Options::new().with_dtype(DType::BF16).with_flash_attn(true);
+        assert!(options.use_flash_attn);
+        assert_eq!(options.dtype_for(&Device::Cpu), DType::BF16);
+    }
+}

--- a/candle-transformers/src/models/quantized_lm.rs
+++ b/candle-transformers/src/models/quantized_lm.rs
@@ -544,6 +544,30 @@ mod tests {
     }
 
     #[test]
+    fn cuda_accepts_what_the_cpu_cannot_reach() {
+        // No-op without a GPU. On the cuda runner this covers the branches a cpu-only run can
+        // never take: the qwen3moe accept path, its dtype rejection, and the cuda default.
+        let Ok(device) = Device::new_cuda(0) else {
+            return;
+        };
+        assert_eq!(Options::default().dtype_for(&device), DType::BF16);
+        for dtype in [DType::BF16, DType::F16] {
+            Architecture::Qwen3Moe
+                .check_device_support(&device, dtype)
+                .unwrap();
+        }
+        let err = match Architecture::Qwen3Moe.check_device_support(&device, DType::F32) {
+            Ok(()) => panic!("qwen3moe accepted an f32 working dtype"),
+            Err(err) => err.to_string(),
+        };
+        assert!(err.contains("f16"), "{err}");
+        // Every family stays loadable on cuda under the resolved default.
+        for arch in [Architecture::Llama, Architecture::Glm4, Architecture::Qwen3] {
+            arch.check_device_support(&device, DType::BF16).unwrap();
+        }
+    }
+
+    #[test]
     fn default_options_resolve_a_cpu_dtype() {
         let options = Options::default();
         assert!(!options.use_flash_attn);


### PR DESCRIPTION
Closes #3783.

`candle-transformers` ships one `quantized_*` module per model family but no way to
load "whatever GGUF this is", so every consumer ends up writing the same dispatcher.
This adds `models::quantized_lm`, which does it once.

## API

```rust
pub trait QuantizedLm {
    fn forward(&mut self, input: &Tensor, index_pos: usize) -> Result<Tensor>;
}

pub fn from_gguf<R: Read + Seek>(
    ct: gguf_file::Content,
    reader: &mut R,
    device: &Device,
) -> Result<Box<dyn QuantizedLm>>;

pub fn from_gguf_with<R: Read + Seek>(
    ct: gguf_file::Content,
    reader: &mut R,
    device: &Device,
    options: &Options,
) -> Result<Box<dyn QuantizedLm>>;

pub fn context_length(ct: &gguf_file::Content) -> Option<usize>;
pub fn arch_metadata<'a>(ct: &'a gguf_file::Content, suffix: &str) -> Option<&'a gguf_file::Value>;
```

Usage:

```rust
let content = gguf_file::Content::read(&mut file)?;
let ctx = quantized_lm::context_length(&content);
let mut model = quantized_lm::from_gguf(content, &mut file, &device)?;
let logits = model.forward(&input, 0)?;
```

## Divergent signatures

The trait costs nothing to implement: every dispatched family already exposes
`forward(&mut self, input, index_pos) -> Result<Tensor>` inherently, so the impls are
one-line delegations. The constructor extras move into an `Options` struct rather than
into the trait:

```rust
pub struct Options {
    pub use_flash_attn: bool,   // read by quantized_phi3 only
    pub dtype: Option<DType>,   // read by quantized_glm4 and quantized_qwen3_moe
}
```

`dtype: None` resolves to BF16 on CUDA and Metal, F32 elsewhere — the same choice the
`quantized-glm4` example already makes by hand. `use_flash_attn` stays inert for the
families that don't read it, so a generic loader can set it once and load anything.

## Dispatch table

| `general.architecture` | backend |
| --- | --- |
| `llama` | `quantized_llama::ModelWeights` |
| `gemma`, `gemma2`, `gemma3`, `gemma-embedding` | `quantized_gemma3::ModelWeights` |
| `glm4` | `quantized_glm4::ModelWeights` |
| `lfm2` | `quantized_lfm2::ModelWeights` |
| `phi2` | `quantized_phi::ModelWeights` |
| `phi3` | `quantized_phi3::ModelWeights` |
| `qwen2` | `quantized_qwen2::ModelWeights` |
| `qwen3` | `quantized_qwen3::ModelWeights` |
| `qwen3moe` | `quantized_qwen3_moe::GGUFQWenMoE` |

The four gemma names share one entry point because `quantized_gemma3::from_gguf` already
probes those metadata prefixes itself. `Architecture` and `SUPPORTED_ARCHITECTURES` are
public so callers can probe support without opening a file, and an unknown architecture
fails with the supported list rather than a metadata-key error.

## Architecture-prefixed metadata

`arch_metadata` reads through the file's own namespace instead of a hardcoded prefix, and
`context_length` is built on it. A Qwen3 file with no `qwen3.context_length` now yields
`None` — a caller falls back to its own default instead of silently picking up a
`llama.context_length` that happens to be present. There is a test pinning exactly that.

## Pre-flight validation

Both checks run before a single tensor is read, addressing the "Related" section of the
issue:

- **`qwen3moe` off CUDA.** `candle_nn::moe_gemm_gguf` is CUDA-only and its prefill kernel
  casts the input to F16 or BF16, so the family is rejected on a non-CUDA device or a
  non-F16/BF16 working dtype. Previously this only surfaced once the first expert layer
  ran.
- **Unhonorable flash-attention.** `quantized_phi3`'s `flash_attn` shim is
  `unimplemented!()` without the `flash-attn` feature, so `use_flash_attn: true` on such a
  build used to panic at the first attention layer. It is now a load-time error, and
  requires a CUDA device.

Both are exposed as `Architecture::check_device_support` and
`Architecture::check_flash_attn_support` so a caller can pre-flight a combination without
attempting a load.

## Tests

13 unit tests, all CPU-only and requiring no weights — they build `gguf_file::Content`
in memory. They cover name resolution and the gemma aliases, the missing- and
unknown-architecture errors, `context_length` namespacing and integer-width upcasting,
and that both pre-flight checks fire before any read. One further test is gated on an
available CUDA device and no-ops otherwise; it covers the `qwen3moe` accept path, its
dtype rejection, and the BF16 default, none of which a CPU-only run can reach.

## Notes for reviewers

- Additive only: no existing module is modified, and no existing signature changes. The
  per-family constructors stay public and usable directly.
- `QuantizedLm` requires `Send`, so a loaded model can be held as
  `Mutex<Box<dyn QuantizedLm>>` and handed to a worker pool. All nine backends already
  satisfied it — type erasure was the only thing dropping it, and `Box<dyn QuantizedLm>`
  cannot be widened to `Box<dyn QuantizedLm + Send>` after the fact. `Sync` is not
  required, since `forward` takes `&mut self`.
- `Architecture::name()` is deliberately not a round-trip of `from_name` for the aliased
  gemma family — a `gemma2` file resolves to `Architecture::Gemma3`, whose name is
  `"gemma3"`. Documented on the method.
- No end-to-end load of a real GGUF is covered, as there are no checkpoint fixtures in
  the repo for these families. Happy to add an example wiring if useful.
