### PR TITLE
Add unit tests for candle-transformers (#3286)

### DIFF
--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -159,3 +159,66 @@ impl LogitsProcessor {
         Ok(next_token)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::{Device, Result, Tensor};
+
+    #[test]
+    fn sample_with_topk_then_topp() -> Result<()> {
+        let mut lp = LogitsProcessor::from_sampling(
+            42,
+            Sampling::TopKThenTopP {
+                k: 2,
+                p: 0.9,
+                temperature: 1.0,
+            },
+        );
+        let logits = Tensor::new(&[0.1, 0.2, 0.3, 0.4], &Device::Cpu)?;
+        let token = lp.sample(&logits)?;
+        assert!(token == 2 || token == 3);
+        Ok(())
+    }
+
+    #[test]
+    fn sample_with_very_low_temperature_maps_to_argmax() -> Result<()> {
+        let mut lp = LogitsProcessor::new(42, Some(1e-8), Some(0.5));
+        let logits = Tensor::new(&[0.1, 0.4, 0.2, 0.3], &Device::Cpu)?;
+        let token = lp.sample(&logits)?;
+        assert_eq!(token, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn sample_f_with_modifier() -> Result<()> {
+        let mut lp = LogitsProcessor::from_sampling(42, Sampling::All { temperature: 1.0 });
+        let logits = Tensor::new(&[0.0f64, 0.0, 0.0, 100.0], &Device::Cpu)?;
+        let token = lp.sample_f(&logits, |prs| {
+            prs[3] = 0.0;
+        })?;
+        assert_ne!(token, 3);
+        Ok(())
+    }
+
+    #[test]
+    fn sample_with_single_logit() -> Result<()> {
+        let logits = Tensor::new(&[5.0], &Device::Cpu)?;
+
+        let mut lp = LogitsProcessor::new(42, None, None);
+        assert_eq!(lp.sample(&logits)?, 0);
+
+        let mut lp = LogitsProcessor::from_sampling(42, Sampling::All { temperature: 1.0 });
+        assert_eq!(lp.sample(&logits)?, 0);
+
+        let mut lp =
+            LogitsProcessor::from_sampling(42, Sampling::TopK { k: 1, temperature: 1.0 });
+        assert_eq!(lp.sample(&logits)?, 0);
+
+        let mut lp =
+            LogitsProcessor::from_sampling(42, Sampling::TopP { p: 0.5, temperature: 1.0 });
+        assert_eq!(lp.sample(&logits)?, 0);
+
+        Ok(())
+    }
+}

--- a/candle-transformers/src/models/mamba2.rs
+++ b/candle-transformers/src/models/mamba2.rs
@@ -645,3 +645,153 @@ impl Model {
         self.dtype
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::{Device, Result, Tensor};
+
+    fn test_config() -> Config {
+        Config {
+            d_model: 128,
+            n_layer: 2,
+            vocab_size: 1000,
+            d_state: 64,
+            expand: 2,
+            headdim: 64,
+            ngroups: 1,
+            pad_vocab_size_multiple: 16,
+        }
+    }
+
+    #[test]
+    fn test_config_vocab_size_padding() {
+        let mut cfg = test_config();
+        cfg.vocab_size = 1000;
+        cfg.pad_vocab_size_multiple = 16;
+        assert_eq!(cfg.vocab_size(), 1008);
+
+        cfg.vocab_size = 1024;
+        assert_eq!(cfg.vocab_size(), 1024);
+
+        cfg.vocab_size = 1;
+        assert_eq!(cfg.vocab_size(), 16);
+    }
+
+    #[test]
+    fn test_config_derived_dimensions() {
+        let cfg = test_config();
+        assert_eq!(cfg.d_inner(), 256);
+        assert_eq!(cfg.nheads(), 4);
+        assert_eq!(cfg.d_xbc(), 256 + 2 * 1 * 64);
+    }
+
+    #[test]
+    fn test_config_json_deserialization() -> Result<()> {
+        let json = r#"{
+            "hidden_size": 768,
+            "num_hidden_layers": 24,
+            "vocab_size": 50280,
+            "state_size": 128,
+            "expand": 2,
+            "head_dim": 64,
+            "n_groups": 1,
+            "pad_vocab_size_multiple": 8
+        }"#;
+        let cfg: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.d_model, 768);
+        assert_eq!(cfg.n_layer, 24);
+        assert_eq!(cfg.vocab_size, 50280);
+        assert_eq!(cfg.d_state, 128);
+        assert_eq!(cfg.headdim, 64);
+        assert_eq!(cfg.ngroups, 1);
+        assert_eq!(cfg.d_inner(), 1536);
+        assert_eq!(cfg.nheads(), 24);
+        Ok(())
+    }
+
+    #[test]
+    fn test_config_default_values() {
+        let json = r#"{
+            "d_model": 128,
+            "n_layer": 2,
+            "vocab_size": 1000
+        }"#;
+        let cfg: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.d_state, 64);
+        assert_eq!(cfg.expand, 2);
+        assert_eq!(cfg.headdim, 64);
+        assert_eq!(cfg.ngroups, 1);
+        assert_eq!(cfg.pad_vocab_size_multiple, 16);
+    }
+
+    #[test]
+    fn test_state_new() -> Result<()> {
+        let cfg = test_config();
+        let state = State::new(2, &cfg, DType::F32, &Device::Cpu)?;
+        assert_eq!(state.hs.len(), cfg.n_layer);
+        assert_eq!(state.conv_states.len(), cfg.n_layer);
+        assert_eq!(state.pos, 0);
+        assert_eq!(
+            state.hs[0].dims(),
+            [2, cfg.nheads(), cfg.headdim, cfg.d_state]
+        );
+        assert_eq!(state.conv_states[0].dims(), [2, cfg.d_xbc(), D_CONV]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_segsum_basic() -> Result<()> {
+        let x = Tensor::new(&[1.0f32, 2.0, 3.0], &Device::Cpu)?;
+        let result = segsum(&x)?;
+        assert_eq!(result.dims(), [3, 3]);
+
+        let vals = result.to_vec2::<f32>()?;
+        assert_eq!(vals[0][0], 0.0);
+        assert_eq!(vals[1][1], 0.0);
+        assert_eq!(vals[2][2], 0.0);
+        assert_eq!(vals[1][0], 2.0);
+        assert_eq!(vals[2][0], 5.0);
+        assert_eq!(vals[2][1], 3.0);
+        assert!(vals[0][1].is_infinite() && vals[0][1] < 0.0);
+        assert!(vals[0][2].is_infinite() && vals[0][2] < 0.0);
+        assert!(vals[1][2].is_infinite() && vals[1][2] < 0.0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_pad_to_chunk_size_no_padding_needed() -> Result<()> {
+        let x = Tensor::zeros((2, 8, 4), DType::F32, &Device::Cpu)?;
+        let (padded, pad_len) = pad_to_chunk_size(&x, 4)?;
+        assert_eq!(pad_len, 0);
+        assert_eq!(padded.dims(), [2, 8, 4]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_pad_to_chunk_size_with_padding() -> Result<()> {
+        let x = Tensor::ones((2, 5, 4), DType::F32, &Device::Cpu)?;
+        let (padded, pad_len) = pad_to_chunk_size(&x, 4)?;
+        assert_eq!(pad_len, 3);
+        assert_eq!(padded.dims(), [2, 8, 4]);
+        let orig = padded.narrow(1, 0, 5)?.flatten_all()?.to_vec1::<f32>()?;
+        assert!(orig.iter().all(|&v| v == 1.0));
+        let pad = padded.narrow(1, 5, 3)?.flatten_all()?.to_vec1::<f32>()?;
+        assert!(pad.iter().all(|&v| v == 0.0));
+        Ok(())
+    }
+
+    #[test]
+    fn test_reshape_into_and_from_chunks_roundtrip() -> Result<()> {
+        let x = Tensor::arange(0f32, 24., &Device::Cpu)?.reshape((1, 12, 2))?;
+        let chunked = reshape_into_chunks(&x, 4)?;
+        assert_eq!(chunked.dims(), [1, 3, 4, 2]);
+        let restored = reshape_from_chunks(&chunked)?;
+        assert_eq!(restored.dims(), [1, 12, 2]);
+        assert_eq!(
+            x.flatten_all()?.to_vec1::<f32>()?,
+            restored.flatten_all()?.to_vec1::<f32>()?
+        );
+        Ok(())
+    }
+}

--- a/candle-transformers/src/object_detection.rs
+++ b/candle-transformers/src/object_detection.rs
@@ -114,3 +114,55 @@ pub fn soft_non_maximum_suppression<D>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bbox(xmin: f32, ymin: f32, xmax: f32, ymax: f32) -> Bbox<()> {
+        Bbox {
+            xmin,
+            ymin,
+            xmax,
+            ymax,
+            confidence: 1.0,
+            data: (),
+        }
+    }
+
+    #[test]
+    fn test_iou_identical_boxes() {
+        let b = bbox(0.0, 0.0, 10.0, 10.0);
+        assert_eq!(iou(&b, &b), 1.0);
+    }
+
+    #[test]
+    fn test_iou_no_overlap() {
+        let b1 = bbox(0.0, 0.0, 1.0, 1.0);
+        let b2 = bbox(5.0, 5.0, 6.0, 6.0);
+        assert_eq!(iou(&b1, &b2), 0.0);
+    }
+
+    #[test]
+    fn test_iou_partial_overlap() {
+        let b1 = bbox(0.0, 0.0, 2.0, 2.0);
+        let b2 = bbox(1.0, 1.0, 3.0, 3.0);
+        let result = iou(&b1, &b2);
+        assert!((result - 4.0 / 14.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_iou_containment() {
+        let outer = bbox(0.0, 0.0, 4.0, 4.0);
+        let inner = bbox(1.0, 1.0, 3.0, 3.0);
+        let result = iou(&outer, &inner);
+        assert!((result - 9.0 / 25.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_iou_touching_edges() {
+        let b1 = bbox(0.0, 0.0, 1.0, 1.0);
+        let b2 = bbox(2.0, 0.0, 3.0, 1.0);
+        assert_eq!(iou(&b1, &b2), 0.0);
+    }
+}

--- a/candle-transformers/src/utils.rs
+++ b/candle-transformers/src/utils.rs
@@ -56,3 +56,96 @@ pub fn repeat_kv(xs: Tensor, n_rep: usize) -> Result<Tensor> {
         Tensor::cat(&vec![&xs; n_rep], 2)?.reshape((b_sz, n_kv_head * n_rep, seq_len, head_dim))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::{Device, IndexOp};
+
+    #[test]
+    fn test_build_causal_mask_square() -> Result<()> {
+        let mask = build_causal_mask(4, 0, &Device::Cpu)?;
+        assert_eq!(mask.dims(), [4, 4]);
+        assert_eq!(
+            mask.to_vec2::<u8>()?,
+            [[0, 1, 1, 1], [0, 0, 1, 1], [0, 0, 0, 1], [0, 0, 0, 0],]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_build_causal_mask_with_index_pos() -> Result<()> {
+        let mask = build_causal_mask(2, 3, &Device::Cpu)?;
+        assert_eq!(mask.dims(), [2, 5]);
+        assert_eq!(mask.to_vec2::<u8>()?, [[0, 0, 0, 0, 1], [0, 0, 0, 0, 0],]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_build_causal_mask_single_token() -> Result<()> {
+        let mask = build_causal_mask(1, 0, &Device::Cpu)?;
+        assert_eq!(mask.dims(), [1, 1]);
+        assert_eq!(mask.to_vec2::<u8>()?, [[0]]);
+
+        let mask = build_causal_mask(1, 5, &Device::Cpu)?;
+        assert_eq!(mask.dims(), [1, 6]);
+        assert_eq!(mask.to_vec2::<u8>()?, [[0, 0, 0, 0, 0, 0]]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_apply_repeat_penalty_positive_logits() -> Result<()> {
+        let logits = Tensor::new(&[1.0f32, 2.0, 3.0, 4.0], &Device::Cpu)?;
+        let result = apply_repeat_penalty(&logits, 2.0, &[1, 3])?;
+        assert_eq!(result.to_vec1::<f32>()?, [1.0, 1.0, 3.0, 2.0]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_apply_repeat_penalty_negative_logits() -> Result<()> {
+        let logits = Tensor::new(&[-1.0f32, 2.0, -3.0, 4.0], &Device::Cpu)?;
+        let result = apply_repeat_penalty(&logits, 2.0, &[0, 2])?;
+        assert_eq!(result.to_vec1::<f32>()?, [-2.0, 2.0, -6.0, 4.0]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_apply_repeat_penalty_no_op_cases() -> Result<()> {
+        let logits = Tensor::new(&[1.0f32, 2.0, 3.0], &Device::Cpu)?;
+
+        let result = apply_repeat_penalty(&logits, 2.0, &[])?;
+        assert_eq!(result.to_vec1::<f32>()?, [1.0, 2.0, 3.0]);
+
+        let result = apply_repeat_penalty(&logits, 1.0, &[0, 1, 2])?;
+        assert_eq!(result.to_vec1::<f32>()?, [1.0, 2.0, 3.0]);
+
+        let result = apply_repeat_penalty(&logits, 2.0, &[1, 1, 1])?;
+        assert_eq!(result.to_vec1::<f32>()?, [1.0, 1.0, 3.0]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_repeat_kv() -> Result<()> {
+        let t = Tensor::arange(0f32, 24., &Device::Cpu)?.reshape((1, 2, 3, 4))?;
+
+        let out = repeat_kv(t.clone(), 1)?;
+        assert_eq!(out.dims(), [1, 2, 3, 4]);
+        assert_eq!(
+            out.flatten_all()?.to_vec1::<f32>()?,
+            t.flatten_all()?.to_vec1::<f32>()?
+        );
+
+        let out = repeat_kv(t, 2)?;
+        assert_eq!(out.dims(), [1, 4, 3, 4]);
+        let head0 = out.i((0, 0))?.to_vec2::<f32>()?;
+        let head1 = out.i((0, 1))?.to_vec2::<f32>()?;
+        let head2 = out.i((0, 2))?.to_vec2::<f32>()?;
+        let head3 = out.i((0, 3))?.to_vec2::<f32>()?;
+        assert_eq!(head0, head1);
+        assert_eq!(head2, head3);
+        assert_ne!(head0, head2);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add inline unit tests for mamba2, utils, object_detection, and generation modules. Tests cover causal mask construction, repeat penalty, GQA head expansion, IoU computation, TopKThenTopP sampling, sample_f, Mamba2 segsum, chunk padding/reshaping, config deserialization, and state initialization.