### PR TITLE
Metal MoE: indexed/routed matmul dispatch (mm_id, mv_id, chunked mm_id)

### DIFF
--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -37,6 +37,20 @@ impl QMetalStorage {
         &self.buffer
     }
 
+    /// Converts an element-stride array to bytes for this storage's
+    /// (possibly sub-byte-per-element, block-quantized) dtype. Shared by
+    /// `fwd` and `indexed_moe_forward` so the two matmul paths can't
+    /// silently diverge on how quantized weight strides are computed.
+    fn quantized_byte_strides(&self, stride: &[usize]) -> Vec<usize> {
+        stride
+            .iter()
+            .map(|x| {
+                (*x as f32 * (self.dtype.type_size() as f32 / self.dtype.block_size() as f32))
+                    as usize
+            })
+            .collect()
+    }
+
     pub fn dequantize(&self, elem_count: usize) -> Result<MetalStorage> {
         use crate::quantized::k_quants::GgmlType;
 
@@ -395,14 +409,7 @@ impl QMetalStorage {
         let src0_l = crate::Layout::contiguous(
             [vec![1; 4 - self_shape.rank()], self_shape.dims().to_vec()].concat(),
         );
-        let src0_stride = src0_l
-            .stride()
-            .iter()
-            .map(|x| {
-                (*x as f32 * (self.dtype.type_size() as f32 / self.dtype.block_size() as f32))
-                    as usize
-            })
-            .collect::<Vec<_>>();
+        let src0_stride = self.quantized_byte_strides(src0_l.stride());
 
         if src_shape.rank() > 4 {
             crate::bail!("weight rank ({}) must be <= 4", src_shape.rank())
@@ -463,7 +470,16 @@ impl QMetalStorage {
         if !ids_l.is_contiguous() {
             crate::bail!("indexed_moe_forward ids is not contiguous {ids_l:?}")
         }
-        assert_eq!(input.dtype(), DType::F32);
+        if input.dtype() != DType::F32 {
+            crate::bail!("indexed_moe_forward input must be F32, got {:?}", input.dtype())
+        }
+        // The kernel unconditionally reads `ids` as raw int32_t regardless of
+        // the Rust-side dtype tag; U32 is bit-compatible for the small
+        // non-negative expert indices this carries, but anything else would
+        // silently misread the buffer at the byte-stride computed below.
+        if ids.dtype() != DType::U32 {
+            crate::bail!("indexed_moe_forward ids must be U32, got {:?}", ids.dtype())
+        }
 
         let (_num_experts, n, k) = self_shape.dims3()?;
         let in_shape = input_l.shape();
@@ -498,14 +514,7 @@ impl QMetalStorage {
         let encoder = device.command_encoder()?;
 
         let src0_l = crate::Layout::contiguous(self_shape.dims());
-        let src0_stride = src0_l
-            .stride()
-            .iter()
-            .map(|x| {
-                (*x as f32 * (self.dtype.type_size() as f32 / self.dtype.block_size() as f32))
-                    as usize
-            })
-            .collect::<Vec<_>>();
+        let src0_stride = self.quantized_byte_strides(src0_l.stride());
 
         let input_stride = input_l
             .stride()
@@ -526,7 +535,7 @@ impl QMetalStorage {
             self_shape.dims(),
             &src0_stride,
             &self.buffer,
-            self.offset,
+            0, // this storage always owns its buffer outright, so its offset is always 0
             in_shape.dims(),
             &input_stride,
             input.buffer(),

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -438,6 +438,114 @@ impl QMetalStorage {
         Ok((dst_storage, dst_shape))
     }
 
+    /// Indexed/routed matmul for MoE expert dispatch: `self` holds all
+    /// experts' weights stacked as `[num_experts, n, k]`; `ids` is the
+    /// routing table `[batch, topk]` (one row of expert indices per token);
+    /// `input` is `[batch, topk_or_1, k]` (the `topk_or_1` broadcasts a
+    /// single per-token embedding across all its selected experts when 1,
+    /// or supplies a distinct value per selected expert when `topk`).
+    /// Returns `[batch, topk, n]`, one row per (token, selected-expert)
+    /// pair -- this does not apply top-k routing weights or sum across
+    /// experts; see candle_metal_kernels::call_quantized_matmul_mm_id.
+    pub fn indexed_moe_forward(
+        &self,
+        self_shape: &Shape,
+        input: &MetalStorage,
+        input_l: &crate::Layout,
+        ids: &MetalStorage,
+        ids_l: &crate::Layout,
+    ) -> Result<(MetalStorage, Shape)> {
+        use crate::MetalError;
+
+        if !input_l.is_contiguous() {
+            crate::bail!("indexed_moe_forward input is not contiguous {input_l:?}")
+        }
+        if !ids_l.is_contiguous() {
+            crate::bail!("indexed_moe_forward ids is not contiguous {ids_l:?}")
+        }
+        assert_eq!(input.dtype(), DType::F32);
+
+        let (_num_experts, n, k) = self_shape.dims3()?;
+        let in_shape = input_l.shape();
+        let (batch, in_dim1, in_k) = in_shape.dims3()?;
+        if in_k != k {
+            crate::bail!(
+                "indexed_moe_forward input {:?} incompatible with weight {:?}",
+                in_shape,
+                self_shape
+            )
+        }
+        let idx_shape = ids_l.shape();
+        let (idx_batch, topk) = idx_shape.dims2()?;
+        if idx_batch != batch {
+            crate::bail!(
+                "indexed_moe_forward batch mismatch: input {batch} vs ids {idx_batch}"
+            )
+        }
+        if in_dim1 != 1 && in_dim1 != topk {
+            crate::bail!(
+                "indexed_moe_forward input dim1 ({in_dim1}) must be 1 or topk ({topk})"
+            )
+        }
+
+        let device = input.device().clone();
+        let dst_shape = Shape::from((batch, topk, n));
+        let dst = device
+            .new_buffer_builder()
+            .with_size_for(dst_shape.elem_count(), DType::F32)
+            .with_label("indexed_moe_forward")
+            .build()?;
+        let encoder = device.command_encoder()?;
+
+        let src0_l = crate::Layout::contiguous(self_shape.dims());
+        let src0_stride = src0_l
+            .stride()
+            .iter()
+            .map(|x| {
+                (*x as f32 * (self.dtype.type_size() as f32 / self.dtype.block_size() as f32))
+                    as usize
+            })
+            .collect::<Vec<_>>();
+
+        let input_stride = input_l
+            .stride()
+            .iter()
+            .map(|x| x * DType::F32.size_in_bytes())
+            .collect::<Vec<_>>();
+        let ids_stride = ids_l
+            .stride()
+            .iter()
+            .map(|x| x * ids.dtype().size_in_bytes())
+            .collect::<Vec<_>>();
+
+        candle_metal_kernels::call_quantized_matmul_mm_id(
+            device.device(),
+            &encoder,
+            device.kernels(),
+            self.dtype.into(),
+            self_shape.dims(),
+            &src0_stride,
+            &self.buffer,
+            self.offset,
+            in_shape.dims(),
+            &input_stride,
+            input.buffer(),
+            input_l.start_offset() * DType::F32.size_in_bytes(),
+            idx_shape.dims(),
+            &ids_stride,
+            ids.buffer(),
+            ids_l.start_offset() * ids.dtype().size_in_bytes(),
+            dst_shape.dims(),
+            0,
+            &dst,
+        )
+        .map_err(MetalError::from)?;
+
+        let dst_storage =
+            crate::MetalStorage::new(dst, device.clone(), dst_shape.elem_count(), DType::F32);
+        Ok((dst_storage, dst_shape))
+    }
+
     pub fn data(&self) -> Result<Vec<u8>> {
         let buffer = self
             .device

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -526,17 +526,32 @@ impl QMetalStorage {
             .map(|x| x * ids.dtype().size_in_bytes())
             .collect::<Vec<_>>();
 
-        // Decode (batch == 1) routes to the matrix-*vector* kernel where
-        // the differential de-risk spike has validated it. `mv_id_eligible`
+        // Decode (batch == 1) and small multi-token batches (batch <= 8,
+        // e.g. a speculative-decode verify step) route to the matrix-
+        // *vector* kernel. `mv_id`'s Metal dispatch grid depth is
+        // `nei0 * nei1` (top-k * n_tokens) -- proportional to real work --
+        // while `mm_id`'s is `ne02` (total expert count), effectively
+        // fixed regardless of batch size; at these small batch sizes
+        // `mm_id` pays that near-fixed dispatch tax against very little
+        // real work, `mv_id` doesn't. Measured (production 256-expert/
+        // top-8/2048-in/512-out shape): `mv_id` beats `mm_id` by 10-20%
+        // throughout batch 1-16, roughly ties at 16, and loses clearly by
+        // 32+ -- `8` is chosen with a safety margin below the measured
+        // crossover, matching the real speculative-decode verify-window
+        // range this targets, not the full range `mv_id` still wins.
+        // Batch-general correctness (not just batch == 1) confirmed via a
+        // bit-exact self-differential (`mv_id` at batch N vs. N
+        // independent batch-1 calls) plus a tolerance-based `mm_id`
+        // cross-check, both at this same production shape (see this
+        // crate's test suite). `mv_id_eligible`
         // (candle-metal-kernels/src/kernels/quantized.rs) is the single
         // source of truth for which dtypes qualify and the minimum
         // contraction-dim (k) each needs -- not duplicated here, so it
         // can't drift from the wrapper's own per-dtype tuning table. Every
-        // other dtype, every too-small-k shape, and every batch > 1
-        // (prefill) call keeps using the matrix-*matrix* kernel -- always
-        // correct, just not the kernel this targets for the decode
-        // throughput gap.
-        let use_mv = batch == 1 && candle_metal_kernels::mv_id_eligible(self.dtype.into(), k);
+        // other dtype, every too-small-k shape, and every batch > 8 call
+        // keeps using the matrix-*matrix* kernel -- always correct, just
+        // not what this extension targets.
+        let use_mv = batch <= 8 && candle_metal_kernels::mv_id_eligible(self.dtype.into(), k);
 
         // call_quantized_matmul_mv_id, call_quantized_matmul_mm_id, and
         // call_quantized_matmul_mm_id_chunked all take the same leading

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -538,14 +538,19 @@ impl QMetalStorage {
         // throughput gap.
         let use_mv = batch == 1 && candle_metal_kernels::mv_id_eligible(self.dtype.into(), k);
 
-        // Both call_quantized_matmul_mv_id and call_quantized_matmul_mm_id
-        // take the same 19-argument shape; this macro keeps the two
-        // dispatch sites (which must stay in exact argument-for-argument
-        // sync) structurally unable to desync, rather than two independent
-        // ~20-line call expressions a future edit could update one of and
-        // forget the other.
+        // call_quantized_matmul_mv_id, call_quantized_matmul_mm_id, and
+        // call_quantized_matmul_mm_id_chunked all take the same leading
+        // 19-argument shape (chunked takes one more, `max_nei1`, trailing);
+        // this macro keeps every dispatch site (which must stay in exact
+        // argument-for-argument sync on that shared prefix) structurally
+        // unable to desync, rather than independent ~20-line call
+        // expressions a future edit could update one of and forget the
+        // others. Variadic in its trailing args (review finding, 2026-07-27:
+        // an earlier version only covered the exact-19-arg case, so adding
+        // chunking meant hand-writing a second, unprotected ~20-line call
+        // site for mm_id instead of extending this macro).
         macro_rules! dispatch_indexed_moe {
-            ($f:path) => {
+            ($f:path $(, $extra:expr)*) => {
                 $f(
                     device.device(),
                     &encoder,
@@ -566,6 +571,7 @@ impl QMetalStorage {
                     dst_shape.dims(),
                     0,
                     &dst,
+                    $($extra),*
                 )
                 .map_err(MetalError::from)?
             };
@@ -574,7 +580,16 @@ impl QMetalStorage {
         if use_mv {
             dispatch_indexed_moe!(candle_metal_kernels::call_quantized_matmul_mv_id);
         } else {
-            dispatch_indexed_moe!(candle_metal_kernels::call_quantized_matmul_mm_id);
+            // mm_id, unlike mv_id, has a hard per-dispatch ceiling: its
+            // rowids scratch is sized off the *whole-batch* token count in
+            // threadgroup memory, so a large enough prefill batch overflows
+            // the device's fixed budget regardless of tuning -- found live
+            // via a real ~2594-token prompt.
+            let max_nei1 = candle_metal_kernels::mm_id_max_nei1(device.device(), topk as i64);
+            dispatch_indexed_moe!(
+                candle_metal_kernels::call_quantized_matmul_mm_id_chunked,
+                max_nei1
+            );
         }
 
         let dst_storage =

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -586,6 +586,13 @@ impl QMetalStorage {
             // the device's fixed budget regardless of tuning -- found live
             // via a real ~2594-token prompt.
             let max_nei1 = candle_metal_kernels::mm_id_max_nei1(device.device(), topk as i64);
+            // Per-expert row counts let the kernel skip the routing-table
+            // scan for a token tile that holds none of its expert's rows,
+            // rather than paying the full scan to discover that -- measured
+            // 3.61s of a 9.42s prefill. `call_quantized_matmul_mm_id_chunked`
+            // computes these itself, per chunk rather than once for the
+            // whole batch, since a chunk-local count is what its chunk-local
+            // guard actually needs (see that function's own doc comment).
             dispatch_indexed_moe!(
                 candle_metal_kernels::call_quantized_matmul_mm_id_chunked,
                 max_nei1

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -471,7 +471,10 @@ impl QMetalStorage {
             crate::bail!("indexed_moe_forward ids is not contiguous {ids_l:?}")
         }
         if input.dtype() != DType::F32 {
-            crate::bail!("indexed_moe_forward input must be F32, got {:?}", input.dtype())
+            crate::bail!(
+                "indexed_moe_forward input must be F32, got {:?}",
+                input.dtype()
+            )
         }
         // The kernel unconditionally reads `ids` as raw int32_t regardless of
         // the Rust-side dtype tag; U32 is bit-compatible for the small
@@ -494,14 +497,10 @@ impl QMetalStorage {
         let idx_shape = ids_l.shape();
         let (idx_batch, topk) = idx_shape.dims2()?;
         if idx_batch != batch {
-            crate::bail!(
-                "indexed_moe_forward batch mismatch: input {batch} vs ids {idx_batch}"
-            )
+            crate::bail!("indexed_moe_forward batch mismatch: input {batch} vs ids {idx_batch}")
         }
         if in_dim1 != 1 && in_dim1 != topk {
-            crate::bail!(
-                "indexed_moe_forward input dim1 ({in_dim1}) must be 1 or topk ({topk})"
-            )
+            crate::bail!("indexed_moe_forward input dim1 ({in_dim1}) must be 1 or topk ({topk})")
         }
 
         let device = input.device().clone();
@@ -527,28 +526,65 @@ impl QMetalStorage {
             .map(|x| x * ids.dtype().size_in_bytes())
             .collect::<Vec<_>>();
 
-        candle_metal_kernels::call_quantized_matmul_mm_id(
-            device.device(),
-            &encoder,
-            device.kernels(),
-            self.dtype.into(),
-            self_shape.dims(),
-            &src0_stride,
-            &self.buffer,
-            0, // this storage always owns its buffer outright, so its offset is always 0
-            in_shape.dims(),
-            &input_stride,
-            input.buffer(),
-            input_l.start_offset() * DType::F32.size_in_bytes(),
-            idx_shape.dims(),
-            &ids_stride,
-            ids.buffer(),
-            ids_l.start_offset() * ids.dtype().size_in_bytes(),
-            dst_shape.dims(),
-            0,
-            &dst,
-        )
-        .map_err(MetalError::from)?;
+        // Decode (batch == 1) routes to the matrix-*vector* kernel where a
+        // differential de-risk spike has validated it (Q4_K, Q6_K, plus
+        // Q4_0/Q2_K for tuning-class coverage). Every other dtype and every
+        // batch > 1 (prefill) call keeps using the matrix-*matrix* kernel --
+        // always correct, just not the kernel this targets for the decode
+        // throughput gap.
+        let use_mv = batch == 1
+            && matches!(
+                self.dtype,
+                GgmlDType::Q4K | GgmlDType::Q6K | GgmlDType::Q4_0 | GgmlDType::Q2K
+            );
+
+        if use_mv {
+            candle_metal_kernels::call_quantized_matmul_mv_id(
+                device.device(),
+                &encoder,
+                device.kernels(),
+                self.dtype.into(),
+                self_shape.dims(),
+                &src0_stride,
+                &self.buffer,
+                0, // this storage always owns its buffer outright, so its offset is always 0
+                in_shape.dims(),
+                &input_stride,
+                input.buffer(),
+                input_l.start_offset() * DType::F32.size_in_bytes(),
+                idx_shape.dims(),
+                &ids_stride,
+                ids.buffer(),
+                ids_l.start_offset() * ids.dtype().size_in_bytes(),
+                dst_shape.dims(),
+                0,
+                &dst,
+            )
+            .map_err(MetalError::from)?;
+        } else {
+            candle_metal_kernels::call_quantized_matmul_mm_id(
+                device.device(),
+                &encoder,
+                device.kernels(),
+                self.dtype.into(),
+                self_shape.dims(),
+                &src0_stride,
+                &self.buffer,
+                0, // this storage always owns its buffer outright, so its offset is always 0
+                in_shape.dims(),
+                &input_stride,
+                input.buffer(),
+                input_l.start_offset() * DType::F32.size_in_bytes(),
+                idx_shape.dims(),
+                &ids_stride,
+                ids.buffer(),
+                ids_l.start_offset() * ids.dtype().size_in_bytes(),
+                dst_shape.dims(),
+                0,
+                &dst,
+            )
+            .map_err(MetalError::from)?;
+        }
 
         let dst_storage =
             crate::MetalStorage::new(dst, device.clone(), dst_shape.elem_count(), DType::F32);

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -526,64 +526,55 @@ impl QMetalStorage {
             .map(|x| x * ids.dtype().size_in_bytes())
             .collect::<Vec<_>>();
 
-        // Decode (batch == 1) routes to the matrix-*vector* kernel where a
-        // differential de-risk spike has validated it (Q4_K, Q6_K, plus
-        // Q4_0/Q2_K for tuning-class coverage). Every other dtype and every
-        // batch > 1 (prefill) call keeps using the matrix-*matrix* kernel --
-        // always correct, just not the kernel this targets for the decode
+        // Decode (batch == 1) routes to the matrix-*vector* kernel where
+        // the differential de-risk spike has validated it. `mv_id_eligible`
+        // (candle-metal-kernels/src/kernels/quantized.rs) is the single
+        // source of truth for which dtypes qualify and the minimum
+        // contraction-dim (k) each needs -- not duplicated here, so it
+        // can't drift from the wrapper's own per-dtype tuning table. Every
+        // other dtype, every too-small-k shape, and every batch > 1
+        // (prefill) call keeps using the matrix-*matrix* kernel -- always
+        // correct, just not the kernel this targets for the decode
         // throughput gap.
-        let use_mv = batch == 1
-            && matches!(
-                self.dtype,
-                GgmlDType::Q4K | GgmlDType::Q6K | GgmlDType::Q4_0 | GgmlDType::Q2K
-            );
+        let use_mv = batch == 1 && candle_metal_kernels::mv_id_eligible(self.dtype.into(), k);
+
+        // Both call_quantized_matmul_mv_id and call_quantized_matmul_mm_id
+        // take the same 19-argument shape; this macro keeps the two
+        // dispatch sites (which must stay in exact argument-for-argument
+        // sync) structurally unable to desync, rather than two independent
+        // ~20-line call expressions a future edit could update one of and
+        // forget the other.
+        macro_rules! dispatch_indexed_moe {
+            ($f:path) => {
+                $f(
+                    device.device(),
+                    &encoder,
+                    device.kernels(),
+                    self.dtype.into(),
+                    self_shape.dims(),
+                    &src0_stride,
+                    &self.buffer,
+                    0, // this storage always owns its buffer outright, so its offset is always 0
+                    in_shape.dims(),
+                    &input_stride,
+                    input.buffer(),
+                    input_l.start_offset() * DType::F32.size_in_bytes(),
+                    idx_shape.dims(),
+                    &ids_stride,
+                    ids.buffer(),
+                    ids_l.start_offset() * ids.dtype().size_in_bytes(),
+                    dst_shape.dims(),
+                    0,
+                    &dst,
+                )
+                .map_err(MetalError::from)?
+            };
+        }
 
         if use_mv {
-            candle_metal_kernels::call_quantized_matmul_mv_id(
-                device.device(),
-                &encoder,
-                device.kernels(),
-                self.dtype.into(),
-                self_shape.dims(),
-                &src0_stride,
-                &self.buffer,
-                0, // this storage always owns its buffer outright, so its offset is always 0
-                in_shape.dims(),
-                &input_stride,
-                input.buffer(),
-                input_l.start_offset() * DType::F32.size_in_bytes(),
-                idx_shape.dims(),
-                &ids_stride,
-                ids.buffer(),
-                ids_l.start_offset() * ids.dtype().size_in_bytes(),
-                dst_shape.dims(),
-                0,
-                &dst,
-            )
-            .map_err(MetalError::from)?;
+            dispatch_indexed_moe!(candle_metal_kernels::call_quantized_matmul_mv_id);
         } else {
-            candle_metal_kernels::call_quantized_matmul_mm_id(
-                device.device(),
-                &encoder,
-                device.kernels(),
-                self.dtype.into(),
-                self_shape.dims(),
-                &src0_stride,
-                &self.buffer,
-                0, // this storage always owns its buffer outright, so its offset is always 0
-                in_shape.dims(),
-                &input_stride,
-                input.buffer(),
-                input_l.start_offset() * DType::F32.size_in_bytes(),
-                idx_shape.dims(),
-                &ids_stride,
-                ids.buffer(),
-                ids_l.start_offset() * ids.dtype().size_in_bytes(),
-                dst_shape.dims(),
-                0,
-                &dst,
-            )
-            .map_err(MetalError::from)?;
+            dispatch_indexed_moe!(candle_metal_kernels::call_quantized_matmul_mm_id);
         }
 
         let dst_storage =

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -777,6 +777,26 @@ impl QTensor {
                     panic!("Non-cuda indexed_moe_forward is not implemented!");
                 }
             },
+            QStorage::Metal(s) => match (&*x.storage(), &*ids.storage()) {
+                (Storage::Metal(x_storage), Storage::Metal(ids_storage)) => {
+                    let (storage, out_shape) = s.indexed_moe_forward(
+                        self.shape(),
+                        x_storage,
+                        x.layout(),
+                        ids_storage,
+                        ids.layout(),
+                    )?;
+                    Ok(crate::tensor::from_storage(
+                        Storage::Metal(storage),
+                        out_shape,
+                        crate::op::BackpropOp::none(),
+                        false,
+                    ))
+                }
+                _ => {
+                    panic!("Non-metal indexed_moe_forward is not implemented!");
+                }
+            },
             _ => {
                 panic!("indexed_moe_forward is not implemented in this platform!");
             }

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -156,6 +156,67 @@ fn indexed_moe_forward_metal() -> Result<()> {
     Ok(())
 }
 
+// Same shape/reference discipline as indexed_moe_forward_metal above, but
+// batch=1 -- the real decode shape, and the one that now routes through
+// call_quantized_matmul_mv_id instead of mm_id (see
+// QMetalStorage::indexed_moe_forward's `use_mv` branch). Q4_0 is one of
+// the four dtypes covered by that branch, so this exercises the new
+// kernel through the real public API with real quantized weights, not
+// just the kernel-level differential spike.
+#[cfg(feature = "metal")]
+#[test]
+fn indexed_moe_forward_metal_decode_uses_mv_id() -> Result<()> {
+    let device = Device::new_metal(0)?;
+    let dtype = GgmlDType::Q4_0;
+
+    let n_expert = 3usize;
+    let n_out = 64usize;
+    let n_in = 64usize;
+    let batch = 1usize;
+    let topk = 2usize;
+
+    let w_data: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|i| ((i % 97) as f32 - 48.0) * 0.01)
+        .collect();
+    let weight = Tensor::from_slice(&w_data, (n_expert, n_out, n_in), &device)?;
+    let qweight = quantized::QTensor::quantize(&weight, dtype)?;
+    let dequant = qweight.dequantize(&device)?.to_vec3::<f32>()?;
+
+    let x_data: Vec<f32> = (0..batch * topk * n_in)
+        .map(|i| ((i % 53) as f32 - 26.0) * 0.02)
+        .collect();
+    let x = Tensor::from_slice(&x_data, (batch, topk, n_in), &device)?;
+
+    let ids_data: Vec<u32> = (0..batch * topk)
+        .map(|i| ((i * 7 + i / topk) % n_expert) as u32)
+        .collect();
+    let ids = Tensor::from_slice(&ids_data, (batch, topk), &device)?;
+
+    let got = qweight.indexed_moe_forward(&x, &ids)?;
+    assert_eq!(got.dims(), &[batch, topk, n_out]);
+    let got = got.to_vec3::<f32>()?;
+
+    for t in 0..batch {
+        for s in 0..topk {
+            let e = ids_data[t * topk + s] as usize;
+            for j in 0..n_out {
+                let mut acc = 0f32;
+                for k in 0..n_in {
+                    acc += dequant[e][j][k] * x_data[t * topk * n_in + s * n_in + k];
+                }
+                let diff = (got[t][s][j] - acc).abs();
+                assert!(
+                    diff <= 1e-2 + 1e-2 * acc.abs(),
+                    "mismatch at token {t} slot {s} out {j}: got {}, expected {acc} (diff {diff})",
+                    got[t][s][j]
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn quantized_matmul(device: &Device) -> Result<()> {
     let (m, k, n) = (3, 64, 4);
     let lhs_s = (0..(m * k)).map(|v| v as f32).collect::<Vec<_>>();

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -158,20 +158,23 @@ fn indexed_moe_forward_metal() -> Result<()> {
 
 // Same shape/reference discipline as indexed_moe_forward_metal above, but
 // batch=1 -- the real decode shape, and the one that now routes through
-// call_quantized_matmul_mv_id instead of mm_id (see
-// QMetalStorage::indexed_moe_forward's `use_mv` branch). Q4_0 is one of
-// the four dtypes covered by that branch, so this exercises the new
+// call_quantized_matmul_mv_id instead of mm_id for a dtype
+// `candle_metal_kernels::mv_id_eligible` covers (see
+// QMetalStorage::indexed_moe_forward's `use_mv` branch). Exercises the new
 // kernel through the real public API with real quantized weights, not
 // just the kernel-level differential spike.
 #[cfg(feature = "metal")]
-#[test]
-fn indexed_moe_forward_metal_decode_uses_mv_id() -> Result<()> {
+fn indexed_moe_forward_metal_decode_uses_mv_id(dtype: GgmlDType) -> Result<()> {
     let device = Device::new_metal(0)?;
-    let dtype = GgmlDType::Q4_0;
 
     let n_expert = 3usize;
     let n_out = 64usize;
-    let n_in = 64usize;
+    // 256, not 64: K-quant dtypes (Q4K/Q6K/Q2K) require their last dim
+    // divisible by their own block size (256) -- a QTensor::quantize
+    // constraint, unrelated to and stricter than mv_id's own nth0*nth1
+    // minimum (64 at most across the four covered dtypes), which 256
+    // clears comfortably too.
+    let n_in = 256usize;
     let batch = 1usize;
     let topk = 2usize;
 
@@ -207,7 +210,7 @@ fn indexed_moe_forward_metal_decode_uses_mv_id() -> Result<()> {
                 let diff = (got[t][s][j] - acc).abs();
                 assert!(
                     diff <= 1e-2 + 1e-2 * acc.abs(),
-                    "mismatch at token {t} slot {s} out {j}: got {}, expected {acc} (diff {diff})",
+                    "{dtype:?} mismatch at token {t} slot {s} out {j}: got {}, expected {acc} (diff {diff})",
                     got[t][s][j]
                 );
             }
@@ -215,6 +218,35 @@ fn indexed_moe_forward_metal_decode_uses_mv_id() -> Result<()> {
     }
 
     Ok(())
+}
+
+// mv_id_eligible's exact four dtypes -- not a sample of them. Q4_K and
+// Q6_K are common production quantization dtypes; Q4_0/Q2_K round out
+// tuning-class coverage. Each is its own #[test] (rather than a loop
+// inside one) so a failure names the specific dtype instead of requiring
+// a debugger to find it.
+#[cfg(feature = "metal")]
+#[test]
+fn indexed_moe_forward_metal_decode_uses_mv_id_q4k() -> Result<()> {
+    indexed_moe_forward_metal_decode_uses_mv_id(GgmlDType::Q4K)
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn indexed_moe_forward_metal_decode_uses_mv_id_q6k() -> Result<()> {
+    indexed_moe_forward_metal_decode_uses_mv_id(GgmlDType::Q6K)
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn indexed_moe_forward_metal_decode_uses_mv_id_q4_0() -> Result<()> {
+    indexed_moe_forward_metal_decode_uses_mv_id(GgmlDType::Q4_0)
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn indexed_moe_forward_metal_decode_uses_mv_id_q2k() -> Result<()> {
+    indexed_moe_forward_metal_decode_uses_mv_id(GgmlDType::Q2K)
 }
 
 fn quantized_matmul(device: &Device) -> Result<()> {

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -89,6 +89,73 @@ fn test_matmul_mm() -> Result<()> {
     Ok(())
 }
 
+// Covers the Metal arm of QTensor::indexed_moe_forward (the CUDA-only-until-
+// now MoE expert-dispatch entry point candle_metal_kernels::
+// call_quantized_matmul_mm_id feeds into) with a *real* quantized weight,
+// not the F32 dtype the kernel-level tests use -- this is the layer that
+// extracts shapes/strides/dtypes from real QTensor/Tensor storage, which
+// the kernel-level tests can't exercise. Compares against dequantize-then-
+// manual-index-then-matmul, the same style of reference candle's own
+// quantized matmul tests use, so real Q4_0 quantization error is expected
+// and tolerated -- this isn't testing quantization accuracy, just that the
+// indexed routing lands on the right rows.
+#[cfg(feature = "metal")]
+#[test]
+fn indexed_moe_forward_metal() -> Result<()> {
+    let device = Device::new_metal(0)?;
+    let dtype = GgmlDType::Q4_0;
+
+    let n_expert = 3usize;
+    let n_out = 64usize;
+    let n_in = 64usize;
+    let batch = 5usize;
+    let topk = 2usize;
+
+    let w_data: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|i| ((i % 97) as f32 - 48.0) * 0.01)
+        .collect();
+    let weight = Tensor::from_slice(&w_data, (n_expert, n_out, n_in), &device)?;
+    let qweight = quantized::QTensor::quantize(&weight, dtype)?;
+    // Reference uses the dequantized (i.e. quantization-error-including)
+    // weight, not w_data, so this isn't also asserting quantization
+    // accuracy -- that's covered elsewhere.
+    let dequant = qweight.dequantize(&device)?.to_vec3::<f32>()?;
+
+    let x_data: Vec<f32> = (0..batch * topk * n_in)
+        .map(|i| ((i % 53) as f32 - 26.0) * 0.02)
+        .collect();
+    let x = Tensor::from_slice(&x_data, (batch, topk, n_in), &device)?;
+
+    let ids_data: Vec<u32> = (0..batch * topk)
+        .map(|i| ((i * 7 + i / topk) % n_expert) as u32)
+        .collect();
+    let ids = Tensor::from_slice(&ids_data, (batch, topk), &device)?;
+
+    let got = qweight.indexed_moe_forward(&x, &ids)?;
+    assert_eq!(got.dims(), &[batch, topk, n_out]);
+    let got = got.to_vec3::<f32>()?;
+
+    for t in 0..batch {
+        for s in 0..topk {
+            let e = ids_data[t * topk + s] as usize;
+            for j in 0..n_out {
+                let mut acc = 0f32;
+                for k in 0..n_in {
+                    acc += dequant[e][j][k] * x_data[t * topk * n_in + s * n_in + k];
+                }
+                let diff = (got[t][s][j] - acc).abs();
+                assert!(
+                    diff <= 1e-2 + 1e-2 * acc.abs(),
+                    "mismatch at token {t} slot {s} out {j}: got {}, expected {acc} (diff {diff})",
+                    got[t][s][j]
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn quantized_matmul(device: &Device) -> Result<()> {
     let (m, k, n) = (3, 64, 4);
     let lhs_s = (0..(m * k)).map(|v| v as f32).collect::<Vec<_>>();

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -249,6 +249,85 @@ fn indexed_moe_forward_metal_decode_uses_mv_id_q2k() -> Result<()> {
     indexed_moe_forward_metal_decode_uses_mv_id(GgmlDType::Q2K)
 }
 
+// Covers the real production path chunked mm_id exists for -- a prefill
+// batch large enough that a single call_quantized_matmul_mm_id dispatch
+// would exceed the device's threadgroup-memory budget (found live via a
+// real ~2594-token prompt) -- through the real public indexed_moe_forward
+// API with real quantized weights, not just the kernel-level bit-exact
+// differential spike (candle-metal-kernels' own tests.rs). batch=2000 at
+// topk=8 gives nei0*nei1=16000, comfortably above the ~6144 ceiling every
+// Apple Silicon device reports to date (32KB threadgroup budget) -- this
+// exact test would fail without chunking with "required threadgroup
+// memory ... exceeds this device's max". Spot-checks a few tokens rather
+// than the
+// full batch (the chunking mechanism itself is already validated row-by-row,
+// bit-exact, at the kernel level) -- this test's job is proving the real
+// public API, with real quantized weights, produces correct values at a
+// batch size that would have failed outright before this phase.
+#[cfg(feature = "metal")]
+fn indexed_moe_forward_metal_prefill_above_ceiling_uses_chunking(dtype: GgmlDType) -> Result<()> {
+    let device = Device::new_metal(0)?;
+
+    let n_expert = 16usize;
+    let n_out = 8usize;
+    let n_in = 256usize; // K-quant block-size requirement, see the mv_id test above
+    let batch = 2000usize;
+    let topk = 8usize;
+
+    let w_data: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|i| ((i % 97) as f32 - 48.0) * 0.01)
+        .collect();
+    let weight = Tensor::from_slice(&w_data, (n_expert, n_out, n_in), &device)?;
+    let qweight = quantized::QTensor::quantize(&weight, dtype)?;
+    let dequant = qweight.dequantize(&device)?.to_vec3::<f32>()?;
+
+    let x_data: Vec<f32> = (0..batch * topk * n_in)
+        .map(|i| ((i % 53) as f32 - 26.0) * 0.02)
+        .collect();
+    let x = Tensor::from_slice(&x_data, (batch, topk, n_in), &device)?;
+
+    let ids_data: Vec<u32> = (0..batch * topk)
+        .map(|i| ((i * 7 + i / topk) % n_expert) as u32)
+        .collect();
+    let ids = Tensor::from_slice(&ids_data, (batch, topk), &device)?;
+
+    let got = qweight.indexed_moe_forward(&x, &ids)?;
+    assert_eq!(got.dims(), &[batch, topk, n_out]);
+    let got = got.to_vec3::<f32>()?;
+
+    for &t in &[0usize, batch / 2, batch - 1] {
+        for s in 0..topk {
+            let e = ids_data[t * topk + s] as usize;
+            for j in 0..n_out {
+                let mut acc = 0f32;
+                for k in 0..n_in {
+                    acc += dequant[e][j][k] * x_data[t * topk * n_in + s * n_in + k];
+                }
+                let diff = (got[t][s][j] - acc).abs();
+                assert!(
+                    diff <= 1e-2 + 1e-2 * acc.abs(),
+                    "{dtype:?} mismatch at token {t} slot {s} out {j}: got {}, expected {acc} (diff {diff})",
+                    got[t][s][j]
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn indexed_moe_forward_metal_prefill_above_ceiling_uses_chunking_q4k() -> Result<()> {
+    indexed_moe_forward_metal_prefill_above_ceiling_uses_chunking(GgmlDType::Q4K)
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn indexed_moe_forward_metal_prefill_above_ceiling_uses_chunking_q6k() -> Result<()> {
+    indexed_moe_forward_metal_prefill_above_ceiling_uses_chunking(GgmlDType::Q6K)
+}
+
 fn quantized_matmul(device: &Device) -> Result<()> {
     let (m, k, n) = (3, 64, 4);
     let lhs_s = (0..(m * k)).map(|v| v as f32).collect::<Vec<_>>();

--- a/candle-metal-kernels/src/kernels/mod.rs
+++ b/candle-metal-kernels/src/kernels/mod.rs
@@ -22,7 +22,8 @@ pub use fill::*;
 pub use indexing::*;
 pub use mlx_gemm::{call_mlx_gemm, call_mlx_gemv, GemmDType};
 pub use quantized::{
-    call_quantized_get_rows, call_quantized_matmul_mm_t, call_quantized_matmul_mv_t, GgmlDType,
+    call_quantized_get_rows, call_quantized_matmul_mm_id, call_quantized_matmul_mm_t,
+    call_quantized_matmul_mv_t, GgmlDType,
 };
 pub use random::*;
 pub use reduce::*;

--- a/candle-metal-kernels/src/kernels/mod.rs
+++ b/candle-metal-kernels/src/kernels/mod.rs
@@ -22,8 +22,9 @@ pub use fill::*;
 pub use indexing::*;
 pub use mlx_gemm::{call_mlx_gemm, call_mlx_gemv, GemmDType};
 pub use quantized::{
-    call_quantized_get_rows, call_quantized_matmul_mm_id, call_quantized_matmul_mm_t,
-    call_quantized_matmul_mv_id, call_quantized_matmul_mv_t, mv_id_eligible, GgmlDType,
+    call_quantized_get_rows, call_quantized_matmul_mm_id, call_quantized_matmul_mm_id_chunked,
+    call_quantized_matmul_mm_t, call_quantized_matmul_mv_id, call_quantized_matmul_mv_t,
+    mm_id_max_nei1, mv_id_eligible, GgmlDType,
 };
 pub use random::*;
 pub use reduce::*;

--- a/candle-metal-kernels/src/kernels/mod.rs
+++ b/candle-metal-kernels/src/kernels/mod.rs
@@ -23,7 +23,7 @@ pub use indexing::*;
 pub use mlx_gemm::{call_mlx_gemm, call_mlx_gemv, GemmDType};
 pub use quantized::{
     call_quantized_get_rows, call_quantized_matmul_mm_id, call_quantized_matmul_mm_t,
-    call_quantized_matmul_mv_t, GgmlDType,
+    call_quantized_matmul_mv_id, call_quantized_matmul_mv_t, GgmlDType,
 };
 pub use random::*;
 pub use reduce::*;

--- a/candle-metal-kernels/src/kernels/mod.rs
+++ b/candle-metal-kernels/src/kernels/mod.rs
@@ -23,7 +23,7 @@ pub use indexing::*;
 pub use mlx_gemm::{call_mlx_gemm, call_mlx_gemv, GemmDType};
 pub use quantized::{
     call_quantized_get_rows, call_quantized_matmul_mm_id, call_quantized_matmul_mm_t,
-    call_quantized_matmul_mv_id, call_quantized_matmul_mv_t, GgmlDType,
+    call_quantized_matmul_mv_id, call_quantized_matmul_mv_t, mv_id_eligible, GgmlDType,
 };
 pub use random::*;
 pub use reduce::*;

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -586,34 +586,17 @@ pub fn call_quantized_matmul_mv_id(
     let ne1 = nei0;
     let nb1 = ne0 * 4; // unused by the kernel; kept for ABI parity
 
-    // Per-dtype (nth0, nth1, width_divisor), reverse-derived from ggml's
-    // `f3f65429`-era GGML_OP_MUL_MAT_ID mat-vec branch -- not from
-    // call_quantized_matmul_mv_t's table, which diverges on Q2K (align 4
-    // there, for an unrelated plain-mv Metal bug fix) and F16/F32 (align 8
-    // there vs. this kernel's own width=ne01 fallback).
-    let (nth0, nth1, divisor) = match dtype {
-        GgmlDType::Q4_0 | GgmlDType::Q4_1 | GgmlDType::Q5_0 | GgmlDType::Q5_1 | GgmlDType::Q8_0 => {
-            (8usize, 8usize, 8usize)
-        }
-        GgmlDType::Q2K => (2, 32, 8),
-        GgmlDType::Q3K => (2, 32, 4),
-        GgmlDType::Q4K => (4, 8, 4),
-        GgmlDType::Q5K => (2, 32, 4),
-        GgmlDType::Q6K => (2, 32, 2),
-        GgmlDType::F16 | GgmlDType::F32 => (32, 1, 1),
-        GgmlDType::BF16 => Err(MetalKernelError::UnsupportedDTypeForOp(
-            "BF16",
-            "qmatmul_mv_id",
-        ))?,
-        GgmlDType::Q8_1 => Err(MetalKernelError::UnsupportedDTypeForOp(
-            "Q8_1",
-            "qmatmul_mv_id",
-        ))?,
-        GgmlDType::Q8K => Err(MetalKernelError::UnsupportedDTypeForOp(
-            "Q8K",
-            "qmatmul_mv_id",
-        ))?,
-    };
+    // Per-dtype (nth0, nth1, width_divisor, kernel name), reverse-derived
+    // from ggml's `f3f65429`-era GGML_OP_MUL_MAT_ID mat-vec branch -- not
+    // from call_quantized_matmul_mv_t's table, which diverges on Q2K (align
+    // 4 there, for an unrelated plain-mv Metal bug fix) and F16/F32 (align 8
+    // there vs. this kernel's own width=ne01 fallback). One match, not two
+    // (tuning table + kernel name previously lived in separate match
+    // statements over the same dtype, hand-synchronized on which variants
+    // are unsupported -- re-enabling one of BF16/Q8_1/Q8K in only one of
+    // the two would compile clean and panic the `unreachable!` in the
+    // other the first time it was hit).
+    let (nth0, nth1, divisor, name) = mv_id_dispatch_params(dtype)?;
 
     // Matches ggml's own host-side `GGML_ASSERT(ne00 >= nth0*nth1)` for
     // quantized src0 -- F16/F32 aren't gated by it upstream either.
@@ -633,21 +616,6 @@ pub fn call_quantized_matmul_mv_id(
         width: nth0,
         height: nth1,
         depth: 1,
-    };
-    let name = match dtype {
-        GgmlDType::Q4_0 => "kernel_mul_mv_id_q4_0_f32",
-        GgmlDType::Q4_1 => "kernel_mul_mv_id_q4_1_f32",
-        GgmlDType::Q5_0 => "kernel_mul_mv_id_q5_0_f32",
-        GgmlDType::Q5_1 => "kernel_mul_mv_id_q5_1_f32",
-        GgmlDType::Q8_0 => "kernel_mul_mv_id_q8_0_f32",
-        GgmlDType::Q2K => "kernel_mul_mv_id_q2_K_f32",
-        GgmlDType::Q3K => "kernel_mul_mv_id_q3_K_f32",
-        GgmlDType::Q4K => "kernel_mul_mv_id_q4_K_f32",
-        GgmlDType::Q5K => "kernel_mul_mv_id_q5_K_f32",
-        GgmlDType::Q6K => "kernel_mul_mv_id_q6_K_f32",
-        GgmlDType::F16 => "kernel_mul_mv_id_f16_f32",
-        GgmlDType::F32 => "kernel_mul_mv_id_f32_f32",
-        GgmlDType::BF16 | GgmlDType::Q8_1 | GgmlDType::Q8K => unreachable!("filtered out above"),
     };
 
     let pipeline = kernels.load_pipeline(device, Source::Quantized, name)?;
@@ -703,6 +671,82 @@ pub fn call_quantized_matmul_mv_id(
     // in-kernel scan this one doesn't do.
     encoder.dispatch_thread_groups(thread_groups_count, threads_per_threadgroup);
     Ok(())
+}
+
+/// Single source of truth for `call_quantized_matmul_mv_id`'s per-dtype
+/// `(nth0, nth1, width_divisor, kernel_name)` -- shared by the dispatch
+/// logic above and `mv_id_eligible` below so the two can't drift apart the
+/// way two hand-synchronized `match dtype` statements over the same
+/// variants otherwise could.
+fn mv_id_dispatch_params(
+    dtype: GgmlDType,
+) -> Result<(usize, usize, usize, &'static str), MetalKernelError> {
+    Ok(match dtype {
+        GgmlDType::Q4_0 => (8, 8, 8, "kernel_mul_mv_id_q4_0_f32"),
+        GgmlDType::Q4_1 => (8, 8, 8, "kernel_mul_mv_id_q4_1_f32"),
+        GgmlDType::Q5_0 => (8, 8, 8, "kernel_mul_mv_id_q5_0_f32"),
+        GgmlDType::Q5_1 => (8, 8, 8, "kernel_mul_mv_id_q5_1_f32"),
+        GgmlDType::Q8_0 => (8, 8, 8, "kernel_mul_mv_id_q8_0_f32"),
+        GgmlDType::Q2K => (2, 32, 8, "kernel_mul_mv_id_q2_K_f32"),
+        GgmlDType::Q3K => (2, 32, 4, "kernel_mul_mv_id_q3_K_f32"),
+        GgmlDType::Q4K => (4, 8, 4, "kernel_mul_mv_id_q4_K_f32"),
+        GgmlDType::Q5K => (2, 32, 4, "kernel_mul_mv_id_q5_K_f32"),
+        GgmlDType::Q6K => (2, 32, 2, "kernel_mul_mv_id_q6_K_f32"),
+        GgmlDType::F16 => (32, 1, 1, "kernel_mul_mv_id_f16_f32"),
+        GgmlDType::F32 => (32, 1, 1, "kernel_mul_mv_id_f32_f32"),
+        GgmlDType::BF16 => {
+            return Err(MetalKernelError::UnsupportedDTypeForOp(
+                "BF16",
+                "qmatmul_mv_id",
+            ))
+        }
+        GgmlDType::Q8_1 => {
+            return Err(MetalKernelError::UnsupportedDTypeForOp(
+                "Q8_1",
+                "qmatmul_mv_id",
+            ))
+        }
+        GgmlDType::Q8K => {
+            return Err(MetalKernelError::UnsupportedDTypeForOp(
+                "Q8K",
+                "qmatmul_mv_id",
+            ))
+        }
+    })
+}
+
+/// Whether `call_quantized_matmul_mv_id` is production-eligible for
+/// `dtype` at contraction-dimension `k` -- the single source of truth a
+/// caller like `QMetalStorage::indexed_moe_forward` should use to decide
+/// mv_id vs. mm_id, rather than duplicating a dtype allowlist or a k
+/// threshold at the call site.
+///
+/// Narrower than "every dtype `call_quantized_matmul_mv_id` can technically
+/// dispatch": Q4_1/Q5_0/Q5_1/Q8_0/Q3K/Q5K/F16/F32 all have real,
+/// ground-truth-derived tuning entries in `mv_id_dispatch_params` (ggml
+/// supports them, so the wrapper does too) but no differential test
+/// coverage against `call_quantized_matmul_mm_id` yet -- they stay off
+/// this list until they get one, even though calling the wrapper directly
+/// with one of them would work correctly today.
+///
+/// Also enforces ggml's own `ne00 >= nth0*nth1` minimum contraction-dim
+/// requirement (a real constraint of the mat-vec kernel, not an oversight):
+/// below that threshold this returns `false` even for a covered dtype, so a
+/// small-k caller falls back to `call_quantized_matmul_mm_id` (which has no
+/// such minimum) instead of the wrapper's own hard `InvalidInput` error --
+/// `call_quantized_matmul_mm_id` used to be called unconditionally for
+/// every shape before this file existed, and callers relying on that
+/// should see no new failure mode just because a `batch == 1` shape now
+/// prefers mv_id.
+pub fn mv_id_eligible(dtype: GgmlDType, k: usize) -> bool {
+    let min_k = match dtype {
+        GgmlDType::Q4K => 4 * 8,
+        GgmlDType::Q6K => 2 * 32,
+        GgmlDType::Q4_0 => 8 * 8,
+        GgmlDType::Q2K => 2 * 32,
+        _ => return false,
+    };
+    k >= min_k
 }
 
 fn divide(m: usize, b: usize) -> usize {

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -502,8 +502,14 @@ pub fn call_quantized_matmul_mm_id(
     // mm tile scratch, then room for one ushort2 (4 bytes) per (token,
     // expert-slot) pair the `rowids` scan can find for this threadgroup's
     // expert -- worst case every row in the tile, i.e. nei0*nei1 total.
+    //
+    // Plus `ROWID_COUNT_BYTES` between the two: the parallel row-discovery scan
+    // hands out `rowids` slots through a threadgroup `atomic_uint` living at
+    // `shared_memory + 8192`, so the table itself now starts 16 bytes later.
+    // 16 rather than 4 to keep `rowids` 16-byte aligned, matching what the
+    // unpadded layout gave it.
     let rowids_bytes = (nei0 * nei1 * 4) as usize;
-    let smem = (8192 + rowids_bytes).div_ceil(16) * 16;
+    let smem = (8192 + ROWID_COUNT_BYTES + rowids_bytes).div_ceil(16) * 16;
     // ggml's own host code asserts this same bound (dst_rows <=
     // dst_rows_max, derived from maxThreadgroupMemoryLength) before
     // dispatching -- unbounded batch*n_expert_used could otherwise exceed
@@ -521,15 +527,28 @@ pub fn call_quantized_matmul_mm_id(
     Ok(())
 }
 
+/// Bytes reserved at `shared_memory + 8192` for the row-discovery scan's
+/// per-thread counts, before the `rowids` table itself: `nthreads + 1` uints
+/// (each thread's count, rewritten in place as its exclusive-prefix write
+/// base, plus the total in the trailing slot), padded to 16.
+///
+/// `nthreads` is 128 -- this kernel is always dispatched with
+/// `threads_per_threadgroup = {128, 1, 1}` (see `thread_groups_count` below) --
+/// so 129 * 4 = 516, padded to 528. **Must match `MM_ID_ROWID_COUNT_BYTES` in
+/// quantized.metal**, which offsets `rowids` by it. Shared by
+/// `call_quantized_matmul_mm_id`'s `smem` sizing and `mm_id_max_nei1`'s
+/// inverse of it, so those two cannot drift from each other.
+pub(crate) const ROWID_COUNT_BYTES: usize = 528;
+
 /// Largest `nei1` (n_tokens) a single `call_quantized_matmul_mm_id` dispatch
 /// can take on `device` without exceeding its threadgroup-memory budget, for
 /// a routing table with `nei0` experts-used-per-token. Inverts the exact
-/// `ceil16(8192 + nei0*nei1*4)` formula that function sizes its `rowids`
-/// scratch with -- device- and top-k-dependent, not a constant, and has no
-/// dtype term (the formula itself has none, unlike `mv_id_eligible`'s
-/// per-dtype tuning table). Returns 0 if even `nei1 == 1` wouldn't fit
-/// (pathological device/expert-count combination) so a caller can fail
-/// clearly instead of computing a nonsensical chunk size.
+/// `ceil16(8192 + ROWID_COUNT_BYTES + nei0*nei1*4)` formula that function
+/// sizes its `rowids` scratch with -- device- and top-k-dependent, not a
+/// constant, and has no dtype term (the formula itself has none, unlike
+/// `mv_id_eligible`'s per-dtype tuning table). Returns 0 if even `nei1 == 1`
+/// wouldn't fit (pathological device/expert-count combination) so a caller
+/// can fail clearly instead of computing a nonsensical chunk size.
 pub fn mm_id_max_nei1(device: &Device, nei0: i64) -> i64 {
     let max_smem = device.as_ref().maxThreadgroupMemoryLength() as i64;
     // `ceil16(y) <= max_smem` is only equivalent to `y <= max_smem` when
@@ -537,11 +556,11 @@ pub fn mm_id_max_nei1(device: &Device, nei0: i64) -> i64 {
     // measured so far (16384/32768/65536), but not guaranteed by the API.
     // Floor `max_smem` to a multiple of 16 first so this stays an
     // exact inverse of `call_quantized_matmul_mm_id`'s own
-    // `ceil16(8192 + nei0*nei1*4) <= max_smem` check even off that
-    // assumption, rather than silently allowing a chunk that would still
-    // overflow after rounding (review finding, 2026-07-27).
+    // `ceil16(8192 + ROWID_COUNT_BYTES + nei0*nei1*4) <= max_smem` check even
+    // off that assumption, rather than silently allowing a chunk that would
+    // still overflow after rounding (review finding, 2026-07-27).
     let max_smem_floor16 = (max_smem / 16) * 16;
-    let avail = max_smem_floor16 - 8192;
+    let avail = max_smem_floor16 - 8192 - ROWID_COUNT_BYTES as i64;
     if avail <= 0 || nei0 <= 0 {
         return 0;
     }

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -356,6 +356,90 @@ pub fn call_quantized_get_rows(
     Ok(())
 }
 
+/// Fills `counts` with the number of routing-table rows each expert owns, so
+/// `call_quantized_matmul_mm_id` can tell in one read whether a token tile has
+/// any work rather than scanning to find out. `counts` must hold at least
+/// `ne02` u32s.
+///
+/// Two dispatches because the histogram needs its accumulator zeroed first and
+/// there is no cross-threadgroup barrier inside a single dispatch. Both are
+/// trivially small next to the matmul they precede.
+///
+/// `counts` is taken `&mut` specifically so both dispatches bind it via
+/// `set_output_buffer` (the `(&mut Buffer, usize)` `EncoderParam` impl, not
+/// `(&Buffer, usize)`'s `set_input_buffer`): `ComputeCommandEncoder`'s
+/// `auto_barrier` only tracks hazards through that read/write distinction
+/// (encoder.rs), and every buffer here is `HazardTrackingModeUntracked`
+/// (lib.rs's `RESOURCE_OPTIONS`), so Metal itself inserts no barrier on its
+/// own. Mislabeling `counts` as input-only (its previous form) silently
+/// dropped both the zero-before-histogram and histogram-before-matmul-read
+/// dependencies -- caught by `kernel_mul_mm_id_chunked_matches_unchunked_topk_shape`
+/// once counts were computed per-chunk (Phase 3) rather than once for a
+/// whole batch dwarfing any single tile's threshold, which is what had
+/// masked it until then.
+#[allow(clippy::too_many_arguments)]
+pub fn call_mm_id_expert_counts<E: EncoderProvider>(
+    device: &Device,
+    ep: E,
+    kernels: &Kernels,
+    ids_shape: &[usize],
+    ids_stride: &[usize],
+    ids: &Buffer,
+    ids_offset: usize,
+    n_expert: i64,
+    counts: &mut Buffer,
+) -> Result<(), MetalKernelError> {
+    let nei0 = ids_shape[ids_shape.len() - 1] as i64;
+    let nei1 = ids_shape[ids_shape.len() - 2] as i64;
+    let nbi1 = ids_stride[ids_stride.len() - 2] as i64;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+
+    let zero = kernels.load_pipeline(device, Source::Quantized, "kernel_mm_id_zero_counts")?;
+    encoder.set_compute_pipeline_state(&zero);
+    set_params!(encoder, ((&mut *counts, 0), n_expert));
+    encoder.dispatch_thread_groups(
+        MTLSize {
+            width: n_expert.max(1) as usize,
+            height: 1,
+            depth: 1,
+        },
+        MTLSize {
+            width: 1,
+            height: 1,
+            depth: 1,
+        },
+    );
+
+    let hist = kernels.load_pipeline(device, Source::Quantized, "kernel_mm_id_expert_counts")?;
+    encoder.set_compute_pipeline_state(&hist);
+    set_params!(
+        encoder,
+        (
+            (ids, ids_offset),
+            (&mut *counts, 0),
+            nei0,
+            nei1,
+            nbi1,
+            n_expert
+        )
+    );
+    encoder.dispatch_thread_groups(
+        MTLSize {
+            width: 64,
+            height: 1,
+            depth: 1,
+        },
+        MTLSize {
+            width: 64,
+            height: 1,
+            depth: 1,
+        },
+    );
+    Ok(())
+}
+
 /// Indexed/routed matmul for MoE expert dispatch (ggml's `mul_mat_id`).
 ///
 /// `src0` holds all experts' weights stacked on their leading dim
@@ -403,6 +487,7 @@ pub fn call_quantized_matmul_mm_id(
     dst_shape: &[usize],
     dst_offset: usize,
     dst: &Buffer,
+    expert_counts: &Buffer,
 ) -> Result<(), MetalKernelError> {
     // Everything is in reverse, same convention as call_quantized_matmul_mm_t.
     let ne00 = src0_shape[src0_shape.len() - 1] as i64; // n_in (contraction dim)
@@ -494,7 +579,8 @@ pub fn call_quantized_matmul_mm_id(
             nb12,
             ne0,
             ne1,
-            nb1
+            nb1,
+            (expert_counts, 0)
         )
     );
 
@@ -600,6 +686,19 @@ pub fn mm_id_max_nei1(device: &Device, nei0: i64) -> i64 {
 /// kernel will interpret these same shapes as. `dst_shape` itself is
 /// passed through unchanged: only `ne0` (its last dim) is ever read from
 /// it, and `ne0` is chunk-invariant.
+///
+/// Expert counts are computed **per chunk**, not once for the whole batch,
+/// and this is why chunking owns that computation rather than taking counts
+/// as a parameter like `call_quantized_matmul_mm_id` does: a batch-global
+/// count paired with `call_quantized_matmul_mm_id`'s chunk-local
+/// `tgpig.x * 32 >= expert_counts[i02]` guard is safe (the guard only gets
+/// *more* permissive, never wrong) but leaves the skip-the-scan win on the
+/// table for every chunk after the first, since a token tile's chunk-local
+/// row count is almost always far smaller than the whole-batch count for
+/// that expert. One small buffer, reused across iterations the same way
+/// `src1_chunk_shape`/`ids_chunk_shape` already are -- `call_mm_id_expert_counts`
+/// zeroes it before each chunk's histogram, so there is nothing to reset
+/// between iterations.
 #[allow(clippy::too_many_arguments)]
 pub fn call_quantized_matmul_mm_id_chunked<E: EncoderProvider + Copy>(
     device: &Device,
@@ -629,6 +728,7 @@ pub fn call_quantized_matmul_mm_id_chunked<E: EncoderProvider + Copy>(
         )));
     }
 
+    let n_expert = src0_shape[src0_shape.len() - 3] as i64;
     let nei0 = ids_shape[ids_shape.len() - 1] as i64;
     let nei1 = ids_shape[ids_shape.len() - 2] as i64;
 
@@ -645,11 +745,29 @@ pub fn call_quantized_matmul_mm_id_chunked<E: EncoderProvider + Copy>(
     let mut ids_chunk_shape = ids_shape.to_vec();
     let ids_token_idx = ids_chunk_shape.len() - 2;
 
+    let mut expert_counts = device.new_buffer(
+        (n_expert as usize) * std::mem::size_of::<u32>(),
+        crate::RESOURCE_OPTIONS,
+    )?;
+
     let mut t0: i64 = 0;
     while t0 < nei1 {
         let chunk_len = (nei1 - t0).min(max_nei1) as usize;
         src1_chunk_shape[src1_token_idx] = chunk_len;
         ids_chunk_shape[ids_token_idx] = chunk_len;
+        let chunk_ids_offset = ids_offset + (t0 as usize) * nbi1;
+
+        call_mm_id_expert_counts(
+            device,
+            ep,
+            kernels,
+            &ids_chunk_shape,
+            ids_stride,
+            ids,
+            chunk_ids_offset,
+            n_expert,
+            &mut expert_counts,
+        )?;
 
         call_quantized_matmul_mm_id(
             device,
@@ -667,10 +785,11 @@ pub fn call_quantized_matmul_mm_id_chunked<E: EncoderProvider + Copy>(
             &ids_chunk_shape,
             ids_stride,
             ids,
-            ids_offset + (t0 as usize) * nbi1,
+            chunk_ids_offset,
             dst_shape,
             dst_offset + (t0 as usize) * dst_token_stride,
             dst,
+            &expert_counts,
         )?;
 
         t0 += chunk_len as i64;

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -514,6 +514,197 @@ pub fn call_quantized_matmul_mm_id(
     Ok(())
 }
 
+/// Indexed/routed matmul for MoE expert dispatch, matrix-*vector* variant
+/// (ggml's `mul_mat_id`, batch-1 case) -- companion to
+/// `call_quantized_matmul_mm_id`, same input-shape contract (`src0`/`ids`/
+/// `dst` layouts), so callers can dispatch either interchangeably based on
+/// how many tokens a call covers. Intended for decode (`n_tokens == 1`),
+/// where `mm_id`'s matrix-matrix kernel degenerates into many tiny tile
+/// dispatches per expert.
+///
+/// Ground truth (dispatch grid, per-dtype `nth0`/`nth1`/width-divisor
+/// tuning, buffer/scalar binding order, and the absence of any threadgroup
+/// memory requirement) is reverse-derived from ggml's Metal encode path at
+/// `llama.cpp` commit `f3f65429` -- independently confirmed to be the exact
+/// commit this crate's vendored `kernel_mul_mv_id` was copied from (its
+/// body, template shape, and `tgpig.z`-decode logic are byte-identical to
+/// that commit's `ggml-metal.metal`), not assumed from the kernel body
+/// alone or copied from `call_quantized_matmul_mv_t`'s own per-dtype table
+/// (a *different*, non-`_id` kernel body that happens to share some but not
+/// all tuning values -- see the `Q2K` case below).
+#[allow(clippy::too_many_arguments)]
+pub fn call_quantized_matmul_mv_id(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    dtype: GgmlDType,
+    src0_shape: &[usize],
+    src0_stride: &[usize],
+    src0: &Buffer,
+    src0_offset: usize,
+    src1_shape: &[usize],
+    src1_stride: &[usize],
+    src1: &Buffer,
+    src1_offset: usize,
+    ids_shape: &[usize],
+    ids_stride: &[usize],
+    ids: &Buffer,
+    ids_offset: usize,
+    dst_shape: &[usize],
+    dst_offset: usize,
+    dst: &Buffer,
+) -> Result<(), MetalKernelError> {
+    // Same shape convention as call_quantized_matmul_mm_id.
+    let ne00 = src0_shape[src0_shape.len() - 1] as i64; // n_in (contraction dim)
+    let ne01 = src0_shape[src0_shape.len() - 2] as i64; // n_out
+    let ne02 = src0_shape[src0_shape.len() - 3] as i64; // n_expert
+                                                        // Quantized src0's innermost stride is always 0 in ggml's own
+                                                        // convention -- sub-block indexing happens inside the kernel from
+                                                        // ne00/dtype, not from a passed byte stride. Matches
+                                                        // call_quantized_matmul_mv_t's own `nb00 = 0i64` for the same reason.
+    let nb00 = 0i64;
+    let nb01 = src0_stride[src0_stride.len() - 2] as i64;
+    let nb02 = src0_stride[src0_stride.len() - 3] as i64;
+
+    let ne10 = src1_shape[src1_shape.len() - 1] as i64; // == ne00 (k), read from src1's own shape
+    let nb10 = src1_stride[src1_stride.len() - 1] as i64;
+    let ne11 = src1_shape[src1_shape.len() - 2] as i64; // n_expert_used (bcast) or 1
+    let nb11 = src1_stride[src1_stride.len() - 2] as i64;
+    let ne12 = src1_shape[src1_shape.len() - 3] as i64; // n_tokens
+    let nb12 = src1_stride[src1_stride.len() - 3] as i64;
+    let ne13 = 1i64;
+
+    let nei0 = ids_shape[ids_shape.len() - 1] as i64; // n_expert_used
+    let nei1 = ids_shape[ids_shape.len() - 2] as i64; // n_tokens
+    let nbi1 = ids_stride[ids_stride.len() - 2] as i64;
+
+    let ne0 = dst_shape[dst_shape.len() - 1] as i64; // n_out
+                                                     // Same load-bearing note as call_quantized_matmul_mm_id: this is the
+                                                     // per-token row stride the kernel derives dst's write offset from
+                                                     // (`dst + i1*ne0 + i2*ne1*ne0`), and must equal n_expert_used (nei0),
+                                                     // not the total row count (nei0*nei1).
+    let ne1 = nei0;
+    let nb1 = ne0 * 4; // unused by the kernel; kept for ABI parity
+
+    // Per-dtype (nth0, nth1, width_divisor), reverse-derived from ggml's
+    // `f3f65429`-era GGML_OP_MUL_MAT_ID mat-vec branch -- not from
+    // call_quantized_matmul_mv_t's table, which diverges on Q2K (align 4
+    // there, for an unrelated plain-mv Metal bug fix) and F16/F32 (align 8
+    // there vs. this kernel's own width=ne01 fallback).
+    let (nth0, nth1, divisor) = match dtype {
+        GgmlDType::Q4_0 | GgmlDType::Q4_1 | GgmlDType::Q5_0 | GgmlDType::Q5_1 | GgmlDType::Q8_0 => {
+            (8usize, 8usize, 8usize)
+        }
+        GgmlDType::Q2K => (2, 32, 8),
+        GgmlDType::Q3K => (2, 32, 4),
+        GgmlDType::Q4K => (4, 8, 4),
+        GgmlDType::Q5K => (2, 32, 4),
+        GgmlDType::Q6K => (2, 32, 2),
+        GgmlDType::F16 | GgmlDType::F32 => (32, 1, 1),
+        GgmlDType::BF16 => Err(MetalKernelError::UnsupportedDTypeForOp(
+            "BF16",
+            "qmatmul_mv_id",
+        ))?,
+        GgmlDType::Q8_1 => Err(MetalKernelError::UnsupportedDTypeForOp(
+            "Q8_1",
+            "qmatmul_mv_id",
+        ))?,
+        GgmlDType::Q8K => Err(MetalKernelError::UnsupportedDTypeForOp(
+            "Q8K",
+            "qmatmul_mv_id",
+        ))?,
+    };
+
+    // Matches ggml's own host-side `GGML_ASSERT(ne00 >= nth0*nth1)` for
+    // quantized src0 -- F16/F32 aren't gated by it upstream either.
+    if !matches!(dtype, GgmlDType::F16 | GgmlDType::F32) && ne00 < (nth0 * nth1) as i64 {
+        return Err(MetalKernelError::InvalidInput(format!(
+            "qmm_mv_id: ne00 ({ne00}) must be >= nth0*nth1 ({})",
+            nth0 * nth1
+        )));
+    }
+
+    let thread_groups_count = MTLSize {
+        width: divide(ne01 as usize, divisor),
+        height: 1, // ggml's `_ne1` is always 1 for this op
+        depth: (nei0 * nei1) as usize,
+    };
+    let threads_per_threadgroup = MTLSize {
+        width: nth0,
+        height: nth1,
+        depth: 1,
+    };
+    let name = match dtype {
+        GgmlDType::Q4_0 => "kernel_mul_mv_id_q4_0_f32",
+        GgmlDType::Q4_1 => "kernel_mul_mv_id_q4_1_f32",
+        GgmlDType::Q5_0 => "kernel_mul_mv_id_q5_0_f32",
+        GgmlDType::Q5_1 => "kernel_mul_mv_id_q5_1_f32",
+        GgmlDType::Q8_0 => "kernel_mul_mv_id_q8_0_f32",
+        GgmlDType::Q2K => "kernel_mul_mv_id_q2_K_f32",
+        GgmlDType::Q3K => "kernel_mul_mv_id_q3_K_f32",
+        GgmlDType::Q4K => "kernel_mul_mv_id_q4_K_f32",
+        GgmlDType::Q5K => "kernel_mul_mv_id_q5_K_f32",
+        GgmlDType::Q6K => "kernel_mul_mv_id_q6_K_f32",
+        GgmlDType::F16 => "kernel_mul_mv_id_f16_f32",
+        GgmlDType::F32 => "kernel_mul_mv_id_f32_f32",
+        GgmlDType::BF16 | GgmlDType::Q8_1 | GgmlDType::Q8K => unreachable!("filtered out above"),
+    };
+
+    let pipeline = kernels.load_pipeline(device, Source::Quantized, name)?;
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(
+        encoder,
+        "qmm_mv_id {name} n_tokens={nei1} K={ne00} N={ne01} n_expert={ne02}"
+    );
+
+    // Buffer/scalar binding order follows the kernel's own declared
+    // parameter list exactly (src0, src1, dst, ids, then every scalar in
+    // declaration order) -- this is what candle's set_params! macro must
+    // match, independent of how ggml's own host code happened to bind them
+    // (one combined kargs struct vs. individual setBytes calls is an
+    // Obj-C-side implementation detail of ggml's binding, not part of the
+    // kernel's own ABI).
+    set_params!(
+        encoder,
+        (
+            (src0, src0_offset),
+            (src1, src1_offset),
+            Output::with_offset(dst, dst_offset),
+            (ids, ids_offset),
+            nei0,
+            nei1,
+            nbi1,
+            ne00,
+            ne01,
+            ne02,
+            nb00,
+            nb01,
+            nb02,
+            ne10,
+            ne11,
+            ne12,
+            ne13,
+            nb10,
+            nb11,
+            nb12,
+            ne0,
+            ne1,
+            nb1
+        )
+    );
+
+    // No threadgroup memory is set for any dtype this function supports --
+    // confirmed against ggml's f3f65429 host code: only its IQ-family
+    // kernels (none reachable here) call setThreadgroupMemoryLength for
+    // this op. Do not copy call_quantized_matmul_mm_id's rowid-scan scratch
+    // sizing formula; it belongs to a different kernel with a different
+    // in-kernel scan this one doesn't do.
+    encoder.dispatch_thread_groups(thread_groups_count, threads_per_threadgroup);
+    Ok(())
+}
+
 fn divide(m: usize, b: usize) -> usize {
     m.div_ceil(b)
 }

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -375,6 +375,13 @@ pub fn call_quantized_get_rows(
 /// least that many bytes plus room for the `rowids` scratch array, and the
 /// per-expert dispatch depth isn't recoverable from the kernel signature at
 /// all.
+///
+/// Has a hard per-dispatch `nei1` (n_tokens) ceiling from that same
+/// threadgroup-memory sizing -- device- and top-k-dependent, not tunable.
+/// `call_quantized_matmul_mm_id_chunked`/`mm_id_max_nei1` below split a
+/// batch that might exceed it into dispatches that don't; call those instead
+/// of this function directly for any caller whose batch size isn't already
+/// known-bounded.
 #[allow(clippy::too_many_arguments)]
 pub fn call_quantized_matmul_mm_id(
     device: &Device,
@@ -511,6 +518,145 @@ pub fn call_quantized_matmul_mm_id(
     encoder.set_threadgroup_memory_length(0, smem);
 
     encoder.dispatch_thread_groups(thread_groups_count, threads_per_threadgroup);
+    Ok(())
+}
+
+/// Largest `nei1` (n_tokens) a single `call_quantized_matmul_mm_id` dispatch
+/// can take on `device` without exceeding its threadgroup-memory budget, for
+/// a routing table with `nei0` experts-used-per-token. Inverts the exact
+/// `ceil16(8192 + nei0*nei1*4)` formula that function sizes its `rowids`
+/// scratch with -- device- and top-k-dependent, not a constant, and has no
+/// dtype term (the formula itself has none, unlike `mv_id_eligible`'s
+/// per-dtype tuning table). Returns 0 if even `nei1 == 1` wouldn't fit
+/// (pathological device/expert-count combination) so a caller can fail
+/// clearly instead of computing a nonsensical chunk size.
+pub fn mm_id_max_nei1(device: &Device, nei0: i64) -> i64 {
+    let max_smem = device.as_ref().maxThreadgroupMemoryLength() as i64;
+    // `ceil16(y) <= max_smem` is only equivalent to `y <= max_smem` when
+    // `max_smem` is itself a multiple of 16 -- true for every real device
+    // measured so far (16384/32768/65536), but not guaranteed by the API.
+    // Floor `max_smem` to a multiple of 16 first so this stays an
+    // exact inverse of `call_quantized_matmul_mm_id`'s own
+    // `ceil16(8192 + nei0*nei1*4) <= max_smem` check even off that
+    // assumption, rather than silently allowing a chunk that would still
+    // overflow after rounding (review finding, 2026-07-27).
+    let max_smem_floor16 = (max_smem / 16) * 16;
+    let avail = max_smem_floor16 - 8192;
+    if avail <= 0 || nei0 <= 0 {
+        return 0;
+    }
+    avail / (nei0 * 4)
+}
+
+/// Chunked wrapper over `call_quantized_matmul_mm_id`: splits a batch whose
+/// `nei1` (n_tokens) exceeds `max_nei1` into sequential dispatches of at
+/// most `max_nei1`
+/// tokens each, on the same command encoder, with no barrier between them.
+/// Safe with neither a barrier nor a concatenation step because `mm_id`'s
+/// output rows are token-independent: each chunk reads a disjoint,
+/// contiguous slice of `src1`/`ids` (the expert weights in `src0` are
+/// shared, read-only, and identical across chunks) and writes a disjoint,
+/// contiguous slice of `dst` -- the *same* trusted, unmodified kernel just
+/// runs once per chunk instead of once for the whole batch.
+///
+/// `max_nei1` is caller-supplied rather than derived internally so a test
+/// can force a tiny threshold and exercise real multi-chunk dispatch on a
+/// device whose actual budget would never trip it; production callers pass
+/// `mm_id_max_nei1(device, nei0)`. No `nei1 <= max_nei1` fast path back to
+/// `call_quantized_matmul_mm_id` directly -- the loop below already dispatches
+/// exactly once, at the original (unsliced) offsets, for that case (review
+/// finding, 2026-07-27: an earlier version had a separate, independently
+/// hand-written early-return branch here purely to avoid two `to_vec()`
+/// allocations on the common no-chunking-needed path, which was itself a
+/// second call site that could silently drift from the loop's own offset
+/// arithmetic -- not worth it for that saving).
+///
+/// Per-chunk offsets are computed from the same fields
+/// `call_quantized_matmul_mm_id` itself reads for a chunk-invariant
+/// value -- `src1`'s per-token stride from `src1_stride[len-3]`, `ids`'s
+/// from `ids_stride[len-2]`, and `dst`'s from `ne0 * nei0 * 4` (matching
+/// that function's own documented `ne1 = nei0`, not `nei0*nei1`,
+/// derivation -- there is no passed `dst` stride to read) -- not
+/// re-derived, so a chunk's offset can't silently drift from what the
+/// kernel will interpret these same shapes as. `dst_shape` itself is
+/// passed through unchanged: only `ne0` (its last dim) is ever read from
+/// it, and `ne0` is chunk-invariant.
+#[allow(clippy::too_many_arguments)]
+pub fn call_quantized_matmul_mm_id_chunked<E: EncoderProvider + Copy>(
+    device: &Device,
+    ep: E,
+    kernels: &Kernels,
+    dtype: GgmlDType,
+    src0_shape: &[usize],
+    src0_stride: &[usize],
+    src0: &Buffer,
+    src0_offset: usize,
+    src1_shape: &[usize],
+    src1_stride: &[usize],
+    src1: &Buffer,
+    src1_offset: usize,
+    ids_shape: &[usize],
+    ids_stride: &[usize],
+    ids: &Buffer,
+    ids_offset: usize,
+    dst_shape: &[usize],
+    dst_offset: usize,
+    dst: &Buffer,
+    max_nei1: i64,
+) -> Result<(), MetalKernelError> {
+    if max_nei1 <= 0 {
+        return Err(MetalKernelError::InvalidInput(format!(
+            "call_quantized_matmul_mm_id_chunked: max_nei1 ({max_nei1}) must be positive"
+        )));
+    }
+
+    let nei0 = ids_shape[ids_shape.len() - 1] as i64;
+    let nei1 = ids_shape[ids_shape.len() - 2] as i64;
+
+    let nb12 = src1_stride[src1_stride.len() - 3]; // src1's per-token byte stride
+    let nbi1 = ids_stride[ids_stride.len() - 2]; // ids' per-token byte stride
+    let ne0 = dst_shape[dst_shape.len() - 1]; // n_out
+    let dst_token_stride = ne0 * (nei0 as usize) * std::mem::size_of::<f32>();
+
+    // Allocated once, outside the loop, and just overwritten per iteration --
+    // only the token-count slot changes chunk to chunk, so there is nothing
+    // to gain from a fresh `to_vec()` every pass (review finding, 2026-07-27).
+    let mut src1_chunk_shape = src1_shape.to_vec();
+    let src1_token_idx = src1_chunk_shape.len() - 3;
+    let mut ids_chunk_shape = ids_shape.to_vec();
+    let ids_token_idx = ids_chunk_shape.len() - 2;
+
+    let mut t0: i64 = 0;
+    while t0 < nei1 {
+        let chunk_len = (nei1 - t0).min(max_nei1) as usize;
+        src1_chunk_shape[src1_token_idx] = chunk_len;
+        ids_chunk_shape[ids_token_idx] = chunk_len;
+
+        call_quantized_matmul_mm_id(
+            device,
+            ep,
+            kernels,
+            dtype,
+            src0_shape,
+            src0_stride,
+            src0,
+            src0_offset,
+            &src1_chunk_shape,
+            src1_stride,
+            src1,
+            src1_offset + (t0 as usize) * nb12,
+            &ids_chunk_shape,
+            ids_stride,
+            ids,
+            ids_offset + (t0 as usize) * nbi1,
+            dst_shape,
+            dst_offset + (t0 as usize) * dst_token_stride,
+            dst,
+        )?;
+
+        t0 += chunk_len as i64;
+    }
+
     Ok(())
 }
 

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -356,6 +356,153 @@ pub fn call_quantized_get_rows(
     Ok(())
 }
 
+/// Indexed/routed matmul for MoE expert dispatch (ggml's `mul_mat_id`).
+///
+/// `src0` holds all experts' weights stacked on their leading dim
+/// (`[n_expert, n_out, n_in]`); `ids` is the routing table
+/// (`[n_tokens, n_expert_used]`, dtype i32) mapping each token's selected
+/// experts to rows of `src0`; `dst` is `[n_expert_used * n_tokens, n_out]`,
+/// one row per (token, selected-expert) pair, in `ids` row-major order. This
+/// does *not* apply top-k routing weights or sum across experts -- callers
+/// must do that in a second pass over `dst`.
+///
+/// Dispatch shape and threadgroup memory sizing are load-bearing constants
+/// mirrored from ggml's Metal backend (`ggml_metal_encode_node`, the
+/// `GGML_OP_MUL_MAT_ID` mm case circa llama.cpp commit b86f6007, the last
+/// revision before the kernel was refactored to a 3-pass map0/mm/map1
+/// pipeline) rather than derived from the kernel body: the kernel's own
+/// `shared_memory + 8192` offset only makes sense if the host allocates at
+/// least that many bytes plus room for the `rowids` scratch array, and the
+/// per-expert dispatch depth isn't recoverable from the kernel signature at
+/// all.
+#[allow(clippy::too_many_arguments)]
+pub fn call_quantized_matmul_mm_id(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    dtype: GgmlDType,
+    src0_shape: &[usize],
+    src0_stride: &[usize],
+    src0: &Buffer,
+    src0_offset: usize,
+    src1_shape: &[usize],
+    src1_stride: &[usize],
+    src1: &Buffer,
+    src1_offset: usize,
+    ids_shape: &[usize],
+    ids_stride: &[usize],
+    ids: &Buffer,
+    ids_offset: usize,
+    dst_shape: &[usize],
+    dst_offset: usize,
+    dst: &Buffer,
+) -> Result<(), MetalKernelError> {
+    // Everything is in reverse, same convention as call_quantized_matmul_mm_t.
+    let ne00 = src0_shape[src0_shape.len() - 1] as i64; // n_in (contraction dim)
+    let ne01 = src0_shape[src0_shape.len() - 2] as i64; // n_out
+    let ne02 = src0_shape[src0_shape.len() - 3] as i64; // n_expert
+
+    let nb01 = src0_stride[src0_stride.len() - 2] as i64;
+    let nb02 = src0_stride[src0_stride.len() - 3] as i64;
+
+    let nb10 = src1_stride[src1_stride.len() - 1] as i64;
+    let ne11 = src1_shape[src1_shape.len() - 2] as i64; // n_expert_used (bcast) or 1
+    let nb11 = src1_stride[src1_stride.len() - 2] as i64;
+    let ne12 = src1_shape[src1_shape.len() - 3] as i64; // n_tokens
+    let nb12 = src1_stride[src1_stride.len() - 3] as i64;
+    let ne13 = 1i64;
+
+    let nei0 = ids_shape[ids_shape.len() - 1] as i64; // n_expert_used
+    let nei1 = ids_shape[ids_shape.len() - 2] as i64; // n_tokens
+    let nbi1 = ids_stride[ids_stride.len() - 2] as i64;
+
+    let ne0 = dst_shape[dst_shape.len() - 1] as i64; // n_out
+                                                     // dst is [n_tokens, n_expert_used, n_out] row-major; the kernel only ever
+                                                     // uses ne1 to derive the per-token stride ne0*ne1, so it must equal
+                                                     // n_expert_used (nei0) by construction, not the row count nei0*nei1 --
+                                                     // reading it back out of dst_shape would silently corrupt the token
+                                                     // stride if a caller ever passed a differently-shaped dst.
+    let ne1 = nei0;
+    let nb1 = ne0 * 4; // unused by the kernel; kept for ABI parity
+
+    let thread_groups_count = MTLSize {
+        width: divide(nei1 as usize, 32),
+        height: divide(ne01 as usize, 64),
+        depth: ne02 as usize,
+    };
+    let threads_per_threadgroup = MTLSize {
+        width: 128,
+        height: 1,
+        depth: 1,
+    };
+    let name = match dtype {
+        GgmlDType::Q4_0 => "kernel_mul_mm_id_q4_0_f32",
+        GgmlDType::Q4_1 => "kernel_mul_mm_id_q4_1_f32",
+        GgmlDType::Q5_0 => "kernel_mul_mm_id_q5_0_f32",
+        GgmlDType::Q5_1 => "kernel_mul_mm_id_q5_1_f32",
+        GgmlDType::Q8_0 => "kernel_mul_mm_id_q8_0_f32",
+        GgmlDType::Q2K => "kernel_mul_mm_id_q2_K_f32",
+        GgmlDType::Q3K => "kernel_mul_mm_id_q3_K_f32",
+        GgmlDType::Q4K => "kernel_mul_mm_id_q4_K_f32",
+        GgmlDType::Q5K => "kernel_mul_mm_id_q5_K_f32",
+        GgmlDType::Q6K => "kernel_mul_mm_id_q6_K_f32",
+        GgmlDType::F16 => "kernel_mul_mm_id_f16_f32",
+        GgmlDType::BF16 => "kernel_mul_mm_id_bf16_f32",
+        GgmlDType::F32 => "kernel_mul_mm_id_f32_f32",
+        GgmlDType::Q8_1 => Err(MetalKernelError::UnsupportedDTypeForOp(
+            "Q8_1",
+            "qmatmul_id",
+        ))?,
+        GgmlDType::Q8K => Err(MetalKernelError::UnsupportedDTypeForOp("Q8K", "qmatmul_id"))?,
+    };
+
+    let pipeline = kernels.load_pipeline(device, Source::Quantized, name)?;
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(
+        encoder,
+        "qmm_mm_id {name} n_tokens={nei1} K={ne00} N={ne01} n_expert={ne02}"
+    );
+
+    set_params!(
+        encoder,
+        (
+            (src0, src0_offset),
+            (src1, src1_offset),
+            Output::with_offset(dst, dst_offset),
+            (ids, ids_offset),
+            nei0,
+            nei1,
+            nbi1,
+            ne00,
+            ne02,
+            nb01,
+            nb02,
+            ne11,
+            ne12,
+            ne13,
+            nb10,
+            nb11,
+            nb12,
+            ne0,
+            ne1,
+            nb1
+        )
+    );
+
+    // ggml's GGML_PAD(8192 + dst_rows*sizeof(ushort2), 16): 8192 bytes for the
+    // mm tile scratch, then room for one ushort2 (4 bytes) per (token,
+    // expert-slot) pair the `rowids` scan can find for this threadgroup's
+    // expert -- worst case every row in the tile, i.e. nei0*nei1 total.
+    let rowids_bytes = (nei0 * nei1 * 4) as usize;
+    let smem = (8192 + rowids_bytes).div_ceil(16) * 16;
+    encoder.set_threadgroup_memory_length(0, smem);
+
+    encoder.dispatch_thread_groups(thread_groups_count, threads_per_threadgroup);
+    Ok(())
+}
+
 fn divide(m: usize, b: usize) -> usize {
     m.div_ceil(b)
 }

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -3,7 +3,7 @@ use crate::{
     debug_group, set_params, Buffer, ComputeCommandEncoder, Device, Kernels, MetalKernelError,
     Output, Source,
 };
-use objc2_metal::MTLSize;
+use objc2_metal::{MTLDevice, MTLSize};
 
 #[derive(Debug, Clone, Copy)]
 pub enum GgmlDType {
@@ -497,6 +497,17 @@ pub fn call_quantized_matmul_mm_id(
     // expert -- worst case every row in the tile, i.e. nei0*nei1 total.
     let rowids_bytes = (nei0 * nei1 * 4) as usize;
     let smem = (8192 + rowids_bytes).div_ceil(16) * 16;
+    // ggml's own host code asserts this same bound (dst_rows <=
+    // dst_rows_max, derived from maxThreadgroupMemoryLength) before
+    // dispatching -- unbounded batch*n_expert_used could otherwise exceed
+    // the device's threadgroup memory budget and fail or misbehave on-device
+    // rather than surfacing a clear error here.
+    let max_smem = device.as_ref().maxThreadgroupMemoryLength() as usize;
+    if smem > max_smem {
+        return Err(MetalKernelError::InvalidInput(format!(
+            "qmm_mm_id: required threadgroup memory ({smem} bytes, from nei0={nei0} * nei1={nei1}) exceeds this device's max ({max_smem} bytes)"
+        )));
+    }
     encoder.set_threadgroup_memory_length(0, smem);
 
     encoder.dispatch_thread_groups(thread_groups_count, threads_per_threadgroup);

--- a/candle-metal-kernels/src/metal_src/quantized.metal
+++ b/candle-metal-kernels/src/metal_src/quantized.metal
@@ -7263,6 +7263,57 @@ void kernel_mul_mm_id_impl(
     }
 }
 
+// Per-expert row counts for `kernel_mul_mm_id`, computed once per call instead
+// of rediscovered inside every threadgroup.
+//
+// `kernel_mul_mm_id`'s grid is (token-tiles x row-tiles x experts), and each
+// threadgroup used to scan the whole routing table to find its own expert's
+// rows. The result depends only on the expert, so the row-tile dimension was
+// pure duplication, and the token-tile extent is sized as though an expert
+// owned every token when it owns nei1*nei0/ne02 of them. At top-8-of-256 with
+// 768 tokens that is 49,152 threadgroups each reading 6,144 ids entries --
+// ~302M global reads to recover 6,144 entries' worth of information.
+//
+// With counts available up front, a threadgroup can tell in one read whether
+// its token tile holds any of its expert's rows, and skip the scan entirely
+// rather than discovering it was doomed only after paying for it.
+//
+// Counts only -- deliberately not the ordered row lists. Producing those in
+// the order the scan produces them needs a stable counting sort (per-chunk
+// per-expert offsets), and ordering is load-bearing here: an arbitrary
+// permutation made greedy decoding nondeterministic. Counts are
+// order-independent, so this is safe with a plain atomic histogram.
+kernel void kernel_mm_id_zero_counts(
+        device atomic_uint * counts,
+        constant   int64_t & ne02,
+        uint                 tpig[[thread_position_in_grid]])
+{
+    if ((int64_t)tpig < ne02) {
+        atomic_store_explicit(&counts[tpig], 0u, memory_order_relaxed);
+    }
+}
+
+kernel void kernel_mm_id_expert_counts(
+        device const uchar * ids,
+        device atomic_uint * counts,
+        constant   int64_t & nei0,
+        constant   int64_t & nei1,
+        constant  uint64_t & nbi1,
+        constant   int64_t & ne02,
+        uint                 tpig[[thread_position_in_grid]],
+        uint                 tpg [[threads_per_grid]])
+{
+    const uint n_pairs = (uint)(nei0 * nei1);
+    for (uint p = tpig; p < n_pairs; p += tpg) {
+        const uint ii1 = p / (uint)nei0;
+        const uint ii0 = p % (uint)nei0;
+        const int32_t id = ((device const int32_t *) (ids + ii1*nbi1))[ii0];
+        if (id >= 0 && (int64_t)id < ne02) {
+            atomic_fetch_add_explicit(&counts[id], 1u, memory_order_relaxed);
+        }
+    }
+}
+
 template<typename block_q, short nl, void (*dequantize_func)(device const block_q *, short, thread half4x4 &)>
 kernel void kernel_mul_mm_id(
         device const   uchar * src0s,
@@ -7285,6 +7336,7 @@ kernel void kernel_mul_mm_id(
         constant     int64_t & ne0,
         constant     int64_t & ne1,
         constant    uint64_t & nb1,
+        device const    uint * expert_counts,
         threadgroup    uchar * shared_memory [[threadgroup(0)]],
         uint3                  tgpig[[threadgroup_position_in_grid]],
         uint                   tiitg[[thread_index_in_threadgroup]],
@@ -7295,6 +7347,16 @@ kernel void kernel_mul_mm_id(
     tgpig.z = 0;
 
     device const uchar * src0 = src0s + i02*nb02;
+
+    // Skip the scan entirely when this token tile holds none of this expert's
+    // rows. `expert_counts` is computed once per call by
+    // kernel_mm_id_expert_counts, so this costs one global read instead of the
+    // 6,144 the scan needed to reach the same conclusion. The previous
+    // revision could only bail *after* the count pass, which is where the
+    // remaining time was: 49,152 threadgroups x 6,144 reads.
+    if (tgpig.x * 32 >= expert_counts[i02]) {
+        return;
+    }
 
     // Row discovery: which (expert-slot, token) pairs route to THIS expert.
     //

--- a/candle-metal-kernels/src/metal_src/quantized.metal
+++ b/candle-metal-kernels/src/metal_src/quantized.metal
@@ -7288,6 +7288,7 @@ kernel void kernel_mul_mm_id(
         threadgroup    uchar * shared_memory [[threadgroup(0)]],
         uint3                  tgpig[[threadgroup_position_in_grid]],
         uint                   tiitg[[thread_index_in_threadgroup]],
+        uint3                  ntg  [[threads_per_threadgroup]],
         uint                   sgitg[[simdgroup_index_in_threadgroup]]) {
 
     const int32_t i02 = tgpig.z;
@@ -7295,24 +7296,89 @@ kernel void kernel_mul_mm_id(
 
     device const uchar * src0 = src0s + i02*nb02;
 
-    // row indices
-    threadgroup ushort2 * rowids = (threadgroup ushort2 *)(shared_memory + 8192);
+    // Row discovery: which (expert-slot, token) pairs route to THIS expert.
+    //
+    // The original loop carried a `// TODO: parallelize this loop` and ran the
+    // full nei1*nei0 scan on *every* thread -- the `if (tiitg == 0)` guard is
+    // commented out upstream, so all 128 threads redundantly computed and wrote
+    // the same table. That made row discovery cost
+    // (threads) * (nei1*nei0) per threadgroup, and it is dispatched once per
+    // (token-tile, row-tile, expert) triple. For one 768-token chunk of a
+    // 256-expert top-8 model that is ~38 billion iterations, ~97% of it for
+    // experts with no rows at all -- which is why prefill collapsed while decode
+    // (nei1 == 1) was untouched.
+    //
+    // What actually cost time was not the duplication but the *serial length*:
+    // all threads ran the same nei1*nei0 scan concurrently, so wall-clock cost
+    // was one full scan. Splitting the scan is the win.
+    //
+    // **Order is preserved exactly.** An earlier revision of this used a
+    // threadgroup atomic to hand out slots, on the reasoning that every rowids
+    // entry carries its own source and destination -- `kernel_mul_mm_id_impl`
+    // derives src1 from `nb12*id[1] + nb11*(id[0] % ne11)` and dst from
+    // `jid[0]*ne0 + jid[1]*ne0ne1` -- so any permutation should be equivalent.
+    // **That reasoning is wrong**: measured against this same kernel, an
+    // arbitrary order made greedy decoding nondeterministic (three identical
+    // requests, three different completions) where the original is bit-stable.
+    // Something downstream is order-sensitive; rather than rely on a model of
+    // why, this reproduces the original nested loop's ordering exactly.
+    //
+    // Each thread takes a *contiguous* range of the flattened pair index
+    // `p = ii1*nei0 + ii0`, counts its matches, and an exclusive prefix sum over
+    // those counts gives its write base. Contiguous ranges in thread order means
+    // the assembled table is sorted by `p` -- identical to what
+    // `for ii1 { for ii0 { ... } }` produced.
+    // MUST match ROWID_COUNT_BYTES in kernels/quantized.rs, which sizes the
+    // threadgroup allocation. Room for nthreads+1 uints (the per-thread counts
+    // turned into prefix offsets, plus the total in the last slot) at the 128
+    // threads this kernel is always dispatched with, padded to 16.
+#define MM_ID_ROWID_COUNT_BYTES 528
+    threadgroup uint    * tcount = (threadgroup uint *)(shared_memory + 8192);
+    threadgroup ushort2 * rowids = (threadgroup ushort2 *)(shared_memory + 8192 + MM_ID_ROWID_COUNT_BYTES);
 
-    // TODO: parallelize this loop
-    int64_t _ne1 = 0;
-    for (ushort ii1 = 0; ii1 < nei1; ii1++) {
-        for (ushort ii0 = 0; ii0 < nei0; ii0++) {
-            int32_t id = ((device int32_t *) (ids + ii1*nbi1))[ii0];
-            if (id == i02) {
-                //if (tiitg == 0) {
-                    rowids[_ne1] = ushort2(ii0, ii1);
-                //}
-                _ne1++;
-            }
+    const uint n_pairs  = (uint)(nei1 * nei0);
+    const uint nthreads = ntg.x * ntg.y * ntg.z;
+    const uint per      = (n_pairs + nthreads - 1) / nthreads;
+    const uint p_begin  = min(tiitg * per, n_pairs);
+    const uint p_end    = min(p_begin + per, n_pairs);
+
+    uint mine = 0;
+    for (uint p = p_begin; p < p_end; p++) {
+        const ushort ii1 = (ushort)(p / (uint)nei0);
+        const ushort ii0 = (ushort)(p % (uint)nei0);
+        if (((device int32_t *) (ids + ii1*nbi1))[ii0] == i02) {
+            mine++;
+        }
+    }
+    tcount[tiitg] = mine;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Exclusive prefix sum over `nthreads` counts, serial on one thread: at 128
+    // threads this is negligible beside the scan it schedules, and keeps the
+    // result exactly reproducible.
+    if (tiitg == 0) {
+        uint acc = 0;
+        for (uint t = 0; t < nthreads; t++) {
+            const uint c = tcount[t];
+            tcount[t] = acc;
+            acc += c;
+        }
+        tcount[nthreads] = acc; // total
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    uint pos = tcount[tiitg];
+    for (uint p = p_begin; p < p_end; p++) {
+        const ushort ii1 = (ushort)(p / (uint)nei0);
+        const ushort ii0 = (ushort)(p % (uint)nei0);
+        if (((device int32_t *) (ids + ii1*nbi1))[ii0] == i02) {
+            rowids[pos++] = ushort2(ii0, ii1);
         }
     }
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    const int64_t _ne1 = (int64_t)tcount[nthreads];
 
     kernel_mul_mm_id_impl<block_q, nl, dequantize_func>(
         src0,

--- a/candle-metal-kernels/src/metal_src/quantized.metal
+++ b/candle-metal-kernels/src/metal_src/quantized.metal
@@ -7367,6 +7367,27 @@ kernel void kernel_mul_mm_id(
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
+    const int64_t _ne1 = (int64_t)tcount[nthreads];
+
+    // Bail before the write pass if this threadgroup's token tile lies past
+    // the end of THIS expert's rows.
+    //
+    // The grid's token-tile extent is `nei1/32`, sized as though an expert
+    // owned every token. It owns about `nei1*nei0/ne02` of them -- 24 of 768
+    // at top-8-of-256 -- so with BLOCK_SIZE_N == 32 only tile 0 has any rows
+    // and tiles 1..23 have none. `kernel_mul_mm_id_impl` already returns
+    // immediately for those (its own `r1 * BLOCK_SIZE_N >= ne1` guard), so the
+    // matmul was never the waste; the row scan feeding it was, and it ran in
+    // full first.
+    //
+    // `r1` is `tgpig.x` (see the impl), and the count is exact by this point,
+    // so the two guards agree by construction. Placed after the count pass and
+    // prefix sum -- which are what produce `_ne1` -- and before the write pass,
+    // so a doomed tile pays the count but not the scatter.
+    if (tgpig.x * 32 >= (uint)_ne1) {
+        return;
+    }
+
     uint pos = tcount[tiitg];
     for (uint p = p_begin; p < p_end; p++) {
         const ushort ii1 = (ushort)(p / (uint)nei0);
@@ -7377,8 +7398,6 @@ kernel void kernel_mul_mm_id(
     }
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    const int64_t _ne1 = (int64_t)tcount[nthreads];
 
     kernel_mul_mm_id_impl<block_q, nl, dequantize_func>(
         src0,

--- a/candle-metal-kernels/src/metal_src/quantized.metal
+++ b/candle-metal-kernels/src/metal_src/quantized.metal
@@ -7412,6 +7412,9 @@ typedef decltype(kernel_mul_mm_id<float4x4, 1, dequantize_f32>) mat_mm_id_t;
 
 template [[host_name("kernel_mul_mm_id_f32_f32")]]     kernel mat_mm_id_t kernel_mul_mm_id<float4x4,      1,     dequantize_f32>;
 template [[host_name("kernel_mul_mm_id_f16_f32")]]     kernel mat_mm_id_t kernel_mul_mm_id<half4x4,       1,     dequantize_f16>;
+#if defined(__HAVE_BFLOAT__)
+template [[host_name("kernel_mul_mm_id_bf16_f32")]]    kernel mat_mm_id_t kernel_mul_mm_id<bfloat4x4,     1,     dequantize_bf16>;
+#endif
 template [[host_name("kernel_mul_mm_id_q4_0_f32")]]    kernel mat_mm_id_t kernel_mul_mm_id<block_q4_0,    2,     dequantize_q4_0>;
 template [[host_name("kernel_mul_mm_id_q4_1_f32")]]    kernel mat_mm_id_t kernel_mul_mm_id<block_q4_1,    2,     dequantize_q4_1>;
 template [[host_name("kernel_mul_mm_id_q5_0_f32")]]    kernel mat_mm_id_t kernel_mul_mm_id<block_q5_0,    2,     dequantize_q5_0>;

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2519,8 +2519,8 @@ fn kernel_mul_mm_id_q6_k_pipeline_loads() {
 }
 
 // Correctness test for `call_quantized_matmul_mm_id`, the Rust binding for
-// ggml's indexed/routed matmul (see ratatoskr/DESIGN.md section 15). Uses
-// GgmlDType::F32 rather than a real quantized type so the test exercises
+// ggml's indexed/routed matmul. Uses GgmlDType::F32 rather than a real
+// quantized type so the test exercises
 // only the id-routing/dispatch logic this binding is responsible for
 // (rowids scan, per-expert threadgroup dispatch, output scatter) without
 // also depending on GGUF block dequantization, which is already covered
@@ -2781,7 +2781,10 @@ fn kernel_mul_mm_id_f32_single_token_matches_reference() {
     let src1_buf = new_buffer(&device, &src1);
     let ids_buf = new_buffer(&device, &ids);
     let dst_buf = device
-        .new_buffer(expected.len() * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .new_buffer(
+            expected.len() * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
         .unwrap();
 
     let commands = commands(&device);
@@ -2820,4 +2823,181 @@ fn kernel_mul_mm_id_f32_single_token_matches_reference() {
             "mismatch at index {i}: got {g}, expected {e} (diff {diff})"
         );
     }
+}
+
+// Closes a gap review found: call_quantized_matmul_mm_id maps
+// GgmlDType::BF16 to this kernel name, but no such instantiation existed in
+// quantized.metal until this same change added it (mirroring the existing
+// dense kernel_mul_mm_bf16_f32's #if defined(__HAVE_BFLOAT__) guard).
+#[test]
+fn kernel_mul_mm_id_bf16_pipeline_loads() {
+    let device = device();
+    let kernels = Kernels::new();
+    kernels
+        .load_pipeline(&device, Source::Quantized, "kernel_mul_mm_id_bf16_f32")
+        .expect("kernel_mul_mm_id_bf16_f32 should load as a Metal compute pipeline");
+}
+
+// Closes another gap review found: kernel_mul_mm_id_f32_topk_matches_reference
+// gives every (token, slot) its own distinct input row (in_dim1==topk), which
+// never exercises the kernel's `id[0] % ne11` broadcast modulo in a way that
+// could be wrong and still pass. The real gate/up production shape (see
+// FusedMoeGGUF::forward's Metal branch) is in_dim1==1 with n_expert_used>1 --
+// one token embedding, shared across all its selected experts -- so this is
+// the case that actually proves the broadcast indexing, not just the
+// distinct-per-slot indexing the topk test already covers.
+#[test]
+fn kernel_mul_mm_id_f32_broadcast_matches_reference() {
+    let device = device();
+    let kernels = Kernels::new();
+
+    let n_expert = 4usize;
+    let n_out = 64usize;
+    let n_in = 32usize;
+    let n_tokens = 3usize;
+    let n_expert_used = 3usize;
+
+    let src0: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|idx| {
+            let e = idx / (n_out * n_in);
+            let j = (idx / n_in) % n_out;
+            let k = idx % n_in;
+            (e as f32 * 1000.0 + j as f32 * 10.0 + k as f32) * 0.001
+        })
+        .collect();
+
+    // in_dim1 == 1: one embedding per token, broadcast across all its slots.
+    let src1: Vec<f32> = (0..n_tokens * n_in)
+        .map(|idx| {
+            let t = idx / n_in;
+            let k = idx % n_in;
+            (t as f32 * 100.0 + k as f32) * 0.001
+        })
+        .collect();
+
+    let ids: Vec<i32> = vec![0, 1, 2, 1, 2, 3, 3, 0, 1];
+    assert_eq!(ids.len(), n_tokens * n_expert_used);
+
+    let mut expected = vec![0f32; n_tokens * n_expert_used * n_out];
+    for t in 0..n_tokens {
+        for s in 0..n_expert_used {
+            let e = ids[t * n_expert_used + s] as usize;
+            for j in 0..n_out {
+                let mut acc = 0f32;
+                for k in 0..n_in {
+                    acc += src0[e * n_out * n_in + j * n_in + k] * src1[t * n_in + k];
+                }
+                expected[t * n_expert_used * n_out + s * n_out + j] = acc;
+            }
+        }
+    }
+
+    let src0_buf = new_buffer(&device, &src0);
+    let src1_buf = new_buffer(&device, &src1);
+    let ids_buf = new_buffer(&device, &ids);
+    let dst_buf = device
+        .new_buffer(
+            expected.len() * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
+        .unwrap();
+
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    call_quantized_matmul_mm_id(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &[n_expert, n_out, n_in],
+        &[n_out * n_in * 4, n_in * 4, 4],
+        &src0_buf,
+        0,
+        &[n_tokens, 1, n_in],
+        &[n_in * 4, n_in * 4, 4],
+        &src1_buf,
+        0,
+        &[n_tokens, n_expert_used],
+        &[n_expert_used * 4, 4],
+        &ids_buf,
+        0,
+        &[n_tokens, n_expert_used, n_out],
+        0,
+        &dst_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got: Vec<f32> = read_to_vec(&dst_buf, expected.len());
+
+    for (i, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+        let diff = (g - e).abs();
+        assert!(
+            diff <= 1e-3 + 1e-3 * e.abs(),
+            "mismatch at index {i}: got {g}, expected {e} (diff {diff})"
+        );
+    }
+}
+
+// Closes a review-found gap: the threadgroup-memory-size check added to
+// call_quantized_matmul_mm_id (mirroring ggml's own host-side assert) should
+// reject an over-budget request with a clean error, not dispatch anyway and
+// let the driver fail unpredictably. Doesn't need real buffer contents --
+// the function must return Err before any dispatch happens.
+#[test]
+fn kernel_mul_mm_id_rejects_oversized_threadgroup_memory() {
+    let device = device();
+    let kernels = Kernels::new();
+
+    // nei0*nei1*4 alone must exceed a real device's threadgroup memory
+    // budget (commonly 32KiB) once the fixed 8192-byte tile is added.
+    let nei0 = 4096usize;
+    let nei1 = 4096usize;
+    let n_expert = 1usize;
+    let n_out = 64usize;
+    let n_in = 32usize;
+
+    let src0 = vec![0f32; n_expert * n_out * n_in];
+    let src1 = vec![0f32; nei1 * nei0 * n_in];
+    let ids = vec![0i32; nei1 * nei0];
+
+    let src0_buf = new_buffer(&device, &src0);
+    let src1_buf = new_buffer(&device, &src1);
+    let ids_buf = new_buffer(&device, &ids);
+    let dst_buf = device
+        .new_buffer(
+            nei1 * nei0 * n_out * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
+        .unwrap();
+
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    let result = call_quantized_matmul_mm_id(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &[n_expert, n_out, n_in],
+        &[n_out * n_in * 4, n_in * 4, 4],
+        &src0_buf,
+        0,
+        &[nei1, nei0, n_in],
+        &[nei0 * n_in * 4, n_in * 4, 4],
+        &src1_buf,
+        0,
+        &[nei1, nei0],
+        &[nei0 * 4, 4],
+        &ids_buf,
+        0,
+        &[nei1, nei0, n_out],
+        0,
+        &dst_buf,
+    );
+
+    assert!(
+        result.is_err(),
+        "expected an error for an oversized threadgroup memory request, got Ok"
+    );
 }

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2727,3 +2727,97 @@ fn kernel_mul_mm_id_f32_topk_matches_reference() {
         );
     }
 }
+
+// n_tokens=1 is the actual decode hot path (one token generated at a time),
+// well below ggml's own ne21>=32 threshold for preferring this mm kernel
+// over mul_mv_id -- callers here dispatch it unconditionally regardless of
+// that heuristic, so this is a real, not just theoretical, tiling boundary
+// to cover: BLOCK_SIZE_N=32 means a single token produces a heavily
+// under-filled tile.
+#[test]
+fn kernel_mul_mm_id_f32_single_token_matches_reference() {
+    let device = device();
+    let kernels = Kernels::new();
+
+    let n_expert = 3usize;
+    let n_out = 64usize;
+    let n_in = 32usize;
+    let n_tokens = 1usize;
+    let n_expert_used = 2usize;
+
+    let src0: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|idx| {
+            let e = idx / (n_out * n_in);
+            let j = (idx / n_in) % n_out;
+            let k = idx % n_in;
+            (e as f32 * 1000.0 + j as f32 * 10.0 + k as f32) * 0.001
+        })
+        .collect();
+
+    let src1: Vec<f32> = (0..n_tokens * n_expert_used * n_in)
+        .map(|idx| {
+            let s = (idx / n_in) % n_expert_used;
+            let k = idx % n_in;
+            (s as f32 * 10.0 + k as f32) * 0.001
+        })
+        .collect();
+
+    let ids: Vec<i32> = vec![2, 0];
+    assert_eq!(ids.len(), n_tokens * n_expert_used);
+
+    let mut expected = vec![0f32; n_tokens * n_expert_used * n_out];
+    for s in 0..n_expert_used {
+        let e = ids[s] as usize;
+        for j in 0..n_out {
+            let mut acc = 0f32;
+            for k in 0..n_in {
+                acc += src0[e * n_out * n_in + j * n_in + k] * src1[s * n_in + k];
+            }
+            expected[s * n_out + j] = acc;
+        }
+    }
+
+    let src0_buf = new_buffer(&device, &src0);
+    let src1_buf = new_buffer(&device, &src1);
+    let ids_buf = new_buffer(&device, &ids);
+    let dst_buf = device
+        .new_buffer(expected.len() * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .unwrap();
+
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    call_quantized_matmul_mm_id(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &[n_expert, n_out, n_in],
+        &[n_out * n_in * 4, n_in * 4, 4],
+        &src0_buf,
+        0,
+        &[n_tokens, n_expert_used, n_in],
+        &[n_expert_used * n_in * 4, n_in * 4, 4],
+        &src1_buf,
+        0,
+        &[n_tokens, n_expert_used],
+        &[n_expert_used * 4, 4],
+        &ids_buf,
+        0,
+        &[n_tokens, n_expert_used, n_out],
+        0,
+        &dst_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got: Vec<f32> = read_to_vec(&dst_buf, expected.len());
+
+    for (i, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+        let diff = (g - e).abs();
+        assert!(
+            diff <= 1e-3 + 1e-3 * e.abs(),
+            "mismatch at index {i}: got {g}, expected {e} (diff {diff})"
+        );
+    }
+}

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -3001,3 +3001,140 @@ fn kernel_mul_mm_id_rejects_oversized_threadgroup_memory() {
         "expected an error for an oversized threadgroup memory request, got Ok"
     );
 }
+
+// De-risk spike for `call_quantized_matmul_mv_id`: a differential test
+// against `call_quantized_matmul_mm_id`, not a hand-computed reference. At
+// n_tokens=1 both kernels implement the identical ggml op, and mm_id is
+// already validated by the tests above -- so mm_id's own output is a
+// complete, free correctness oracle for mv_id's binding order, dispatch
+// shape, and the `ne1 = nei0` field (a bug class this same kind of mm_id
+// binding has been caught with before, see candle's own upstream PR
+// #3555). Same F32 dtype and shape as
+// kernel_mul_mm_id_f32_single_token_matches_reference above (the real
+// decode boundary: n_tokens=1, n_expert_used=2) so this is a true apples-
+// to-apples comparison at the shape mv_id actually targets.
+#[test]
+fn kernel_mul_mv_id_f32_matches_mm_id() {
+    let device = device();
+    let kernels = Kernels::new();
+
+    let n_expert = 3usize;
+    let n_out = 64usize;
+    let n_in = 32usize;
+    let n_tokens = 1usize;
+    let n_expert_used = 2usize;
+
+    let src0: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|idx| {
+            let e = idx / (n_out * n_in);
+            let j = (idx / n_in) % n_out;
+            let k = idx % n_in;
+            (e as f32 * 1000.0 + j as f32 * 10.0 + k as f32) * 0.001
+        })
+        .collect();
+
+    let src1: Vec<f32> = (0..n_tokens * n_expert_used * n_in)
+        .map(|idx| {
+            let s = (idx / n_in) % n_expert_used;
+            let k = idx % n_in;
+            (s as f32 * 10.0 + k as f32) * 0.001
+        })
+        .collect();
+
+    let ids: Vec<i32> = vec![2, 0];
+    assert_eq!(ids.len(), n_tokens * n_expert_used);
+
+    let src0_buf = new_buffer(&device, &src0);
+    let src1_buf = new_buffer(&device, &src1);
+    let ids_buf = new_buffer(&device, &ids);
+    let out_elems = n_tokens * n_expert_used * n_out;
+    let mm_dst_buf = device
+        .new_buffer(out_elems * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .unwrap();
+    let mv_dst_buf = device
+        .new_buffer(out_elems * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .unwrap();
+
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    call_quantized_matmul_mm_id(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &[n_expert, n_out, n_in],
+        &[n_out * n_in * 4, n_in * 4, 4],
+        &src0_buf,
+        0,
+        &[n_tokens, n_expert_used, n_in],
+        &[n_expert_used * n_in * 4, n_in * 4, 4],
+        &src1_buf,
+        0,
+        &[n_tokens, n_expert_used],
+        &[n_expert_used * 4, 4],
+        &ids_buf,
+        0,
+        &[n_tokens, n_expert_used, n_out],
+        0,
+        &mm_dst_buf,
+    )
+    .unwrap();
+    call_quantized_matmul_mv_id(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &[n_expert, n_out, n_in],
+        &[n_out * n_in * 4, n_in * 4, 4],
+        &src0_buf,
+        0,
+        &[n_tokens, n_expert_used, n_in],
+        &[n_expert_used * n_in * 4, n_in * 4, 4],
+        &src1_buf,
+        0,
+        &[n_tokens, n_expert_used],
+        &[n_expert_used * 4, 4],
+        &ids_buf,
+        0,
+        &[n_tokens, n_expert_used, n_out],
+        0,
+        &mv_dst_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let mm_got: Vec<f32> = read_to_vec(&mm_dst_buf, out_elems);
+    let mv_got: Vec<f32> = read_to_vec(&mv_dst_buf, out_elems);
+
+    for (i, (mm, mv)) in mm_got.iter().zip(mv_got.iter()).enumerate() {
+        let diff = (mm - mv).abs();
+        assert!(
+            diff <= 1e-3 + 1e-3 * mm.abs(),
+            "mv_id diverges from mm_id at index {i}: mm_id={mm}, mv_id={mv} (diff {diff})"
+        );
+    }
+}
+
+// Confirms the four mandatory-coverage quantized kernel names -- one per
+// distinct (nth0, nth1, width_divisor) tuning class reachable from
+// call_quantized_matmul_mv_id -- actually load as real Metal compute
+// pipelines from the compiled metallib. Q4_K and Q6_K are common
+// production quantization dtypes; Q4_0 and Q2_K cover the remaining
+// tuning classes. Mirrors kernel_mul_mm_id_q4_k_pipeline_loads's own
+// de-risk-spike-before-wiring precedent.
+#[test]
+fn kernel_mul_mv_id_pipelines_load() {
+    let device = device();
+    let kernels = Kernels::new();
+    for name in [
+        "kernel_mul_mv_id_q4_K_f32",
+        "kernel_mul_mv_id_q6_K_f32",
+        "kernel_mul_mv_id_q4_0_f32",
+        "kernel_mul_mv_id_q2_K_f32",
+    ] {
+        kernels
+            .load_pipeline(&device, Source::Quantized, name)
+            .unwrap_or_else(|e| panic!("{name} should load as a Metal compute pipeline: {e}"));
+    }
+}

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::metal::{Commands, ResidencySet};
+use crate::metal::{Commands, CommandsGuard, ResidencySet};
 use core::ffi::c_void;
 use half::{bf16, f16};
 use rand::prelude::SliceRandom;
@@ -25,6 +25,37 @@ fn new_buffer<T>(device: &Device, data: &[T]) -> Buffer {
     let ptr = data.as_ptr() as *const c_void;
     let size = std::mem::size_of_val(data);
     device.new_buffer_with_data(ptr, size, options).unwrap()
+}
+
+// Real per-expert row counts for a `call_quantized_matmul_mm_id[_chunked]`
+// test call, via the same `call_mm_id_expert_counts` kernel production code
+// uses (candle-core/src/quantized/metal.rs) -- not a CPU-computed stand-in,
+// so these tests exercise the counts kernel itself rather than assuming it.
+fn expert_counts_buffer(
+    device: &Device,
+    encoder: &CommandsGuard<'_>,
+    kernels: &Kernels,
+    ids_shape: &[usize],
+    ids_stride: &[usize],
+    ids_buf: &Buffer,
+    n_expert: usize,
+) -> Buffer {
+    let mut counts = device
+        .new_buffer(n_expert * std::mem::size_of::<u32>(), RESOURCE_OPTIONS)
+        .unwrap();
+    call_mm_id_expert_counts(
+        device,
+        encoder,
+        kernels,
+        ids_shape,
+        ids_stride,
+        ids_buf,
+        0,
+        n_expert as i64,
+        &mut counts,
+    )
+    .unwrap();
+    counts
 }
 
 fn device() -> Device {
@@ -2589,6 +2620,17 @@ fn kernel_mul_mm_id_f32_matches_reference() {
 
     let commands = commands(&device);
     let encoder = commands.command_encoder().unwrap();
+    let ids_shape = [n_tokens, n_expert_used];
+    let ids_stride = [n_expert_used * 4, 4];
+    let counts_buf = expert_counts_buffer(
+        &device,
+        &encoder,
+        &kernels,
+        &ids_shape,
+        &ids_stride,
+        &ids_buf,
+        n_expert,
+    );
     // Strides are in bytes (matches call_quantized_matmul_mm_t's convention,
     // see candle-core/src/quantized/metal.rs's caller) -- not element counts.
     call_quantized_matmul_mm_id(
@@ -2604,13 +2646,14 @@ fn kernel_mul_mm_id_f32_matches_reference() {
         &[n_expert_used * n_in * 4, n_in * 4, 4],
         &src1_buf,
         0,
-        &[n_tokens, n_expert_used],
-        &[n_expert_used * 4, 4],
+        &ids_shape,
+        &ids_stride,
         &ids_buf,
         0,
         &[n_tokens, n_expert_used, n_out],
         0,
         &dst_buf,
+        &counts_buf,
     )
     .unwrap();
     drop(encoder);
@@ -2692,6 +2735,17 @@ fn kernel_mul_mm_id_f32_topk_matches_reference() {
 
     let commands = commands(&device);
     let encoder = commands.command_encoder().unwrap();
+    let ids_shape = [n_tokens, n_expert_used];
+    let ids_stride = [n_expert_used * 4, 4];
+    let counts_buf = expert_counts_buffer(
+        &device,
+        &encoder,
+        &kernels,
+        &ids_shape,
+        &ids_stride,
+        &ids_buf,
+        n_expert,
+    );
     call_quantized_matmul_mm_id(
         &device,
         &encoder,
@@ -2705,13 +2759,14 @@ fn kernel_mul_mm_id_f32_topk_matches_reference() {
         &[n_expert_used * n_in * 4, n_in * 4, 4],
         &src1_buf,
         0,
-        &[n_tokens, n_expert_used],
-        &[n_expert_used * 4, 4],
+        &ids_shape,
+        &ids_stride,
         &ids_buf,
         0,
         &[n_tokens, n_expert_used, n_out],
         0,
         &dst_buf,
+        &counts_buf,
     )
     .unwrap();
     drop(encoder);
@@ -2789,6 +2844,17 @@ fn kernel_mul_mm_id_f32_single_token_matches_reference() {
 
     let commands = commands(&device);
     let encoder = commands.command_encoder().unwrap();
+    let ids_shape = [n_tokens, n_expert_used];
+    let ids_stride = [n_expert_used * 4, 4];
+    let counts_buf = expert_counts_buffer(
+        &device,
+        &encoder,
+        &kernels,
+        &ids_shape,
+        &ids_stride,
+        &ids_buf,
+        n_expert,
+    );
     call_quantized_matmul_mm_id(
         &device,
         &encoder,
@@ -2802,13 +2868,14 @@ fn kernel_mul_mm_id_f32_single_token_matches_reference() {
         &[n_expert_used * n_in * 4, n_in * 4, 4],
         &src1_buf,
         0,
-        &[n_tokens, n_expert_used],
-        &[n_expert_used * 4, 4],
+        &ids_shape,
+        &ids_stride,
         &ids_buf,
         0,
         &[n_tokens, n_expert_used, n_out],
         0,
         &dst_buf,
+        &counts_buf,
     )
     .unwrap();
     drop(encoder);
@@ -2904,6 +2971,17 @@ fn kernel_mul_mm_id_f32_broadcast_matches_reference() {
 
     let commands = commands(&device);
     let encoder = commands.command_encoder().unwrap();
+    let ids_shape = [n_tokens, n_expert_used];
+    let ids_stride = [n_expert_used * 4, 4];
+    let counts_buf = expert_counts_buffer(
+        &device,
+        &encoder,
+        &kernels,
+        &ids_shape,
+        &ids_stride,
+        &ids_buf,
+        n_expert,
+    );
     call_quantized_matmul_mm_id(
         &device,
         &encoder,
@@ -2917,13 +2995,14 @@ fn kernel_mul_mm_id_f32_broadcast_matches_reference() {
         &[n_in * 4, n_in * 4, 4],
         &src1_buf,
         0,
-        &[n_tokens, n_expert_used],
-        &[n_expert_used * 4, 4],
+        &ids_shape,
+        &ids_stride,
         &ids_buf,
         0,
         &[n_tokens, n_expert_used, n_out],
         0,
         &dst_buf,
+        &counts_buf,
     )
     .unwrap();
     drop(encoder);
@@ -2972,6 +3051,13 @@ fn kernel_mul_mm_id_rejects_oversized_threadgroup_memory() {
         )
         .unwrap();
 
+    // Counts content is irrelevant here -- the threadgroup-memory bound is
+    // checked before dispatch, so this call must fail before `expert_counts`
+    // is ever read. A zeroed buffer just needs to satisfy the signature.
+    let counts_buf = device
+        .new_buffer(n_expert * std::mem::size_of::<u32>(), RESOURCE_OPTIONS)
+        .unwrap();
+
     let commands = commands(&device);
     let encoder = commands.command_encoder().unwrap();
     let result = call_quantized_matmul_mm_id(
@@ -2994,6 +3080,7 @@ fn kernel_mul_mm_id_rejects_oversized_threadgroup_memory() {
         &[nei1, nei0, n_out],
         0,
         &dst_buf,
+        &counts_buf,
     );
 
     assert!(
@@ -3057,6 +3144,17 @@ fn kernel_mul_mv_id_f32_matches_mm_id() {
 
     let commands = commands(&device);
     let encoder = commands.command_encoder().unwrap();
+    let ids_shape = [n_tokens, n_expert_used];
+    let ids_stride = [n_expert_used * 4, 4];
+    let counts_buf = expert_counts_buffer(
+        &device,
+        &encoder,
+        &kernels,
+        &ids_shape,
+        &ids_stride,
+        &ids_buf,
+        n_expert,
+    );
     call_quantized_matmul_mm_id(
         &device,
         &encoder,
@@ -3070,13 +3168,14 @@ fn kernel_mul_mv_id_f32_matches_mm_id() {
         &[n_expert_used * n_in * 4, n_in * 4, 4],
         &src1_buf,
         0,
-        &[n_tokens, n_expert_used],
-        &[n_expert_used * 4, 4],
+        &ids_shape,
+        &ids_stride,
         &ids_buf,
         0,
         &[n_tokens, n_expert_used, n_out],
         0,
         &mm_dst_buf,
+        &counts_buf,
     )
     .unwrap();
     call_quantized_matmul_mv_id(
@@ -3190,6 +3289,17 @@ fn kernel_mul_mv_id_f32_broadcast_matches_mm_id() {
 
     let commands = commands(&device);
     let encoder = commands.command_encoder().unwrap();
+    let ids_shape = [n_tokens, n_expert_used];
+    let ids_stride = [n_expert_used * 4, 4];
+    let counts_buf = expert_counts_buffer(
+        &device,
+        &encoder,
+        &kernels,
+        &ids_shape,
+        &ids_stride,
+        &ids_buf,
+        n_expert,
+    );
     // src1 is [n_tokens, 1, n_in] -- nb11 == nb12 (stride collapses since
     // dim1 has size 1), matching how QMetalStorage::indexed_moe_forward's
     // caller (FusedMoeGGUF::forward) actually broadcasts.
@@ -3206,13 +3316,14 @@ fn kernel_mul_mv_id_f32_broadcast_matches_mm_id() {
         &[n_in * 4, n_in * 4, 4],
         &src1_buf,
         0,
-        &[n_tokens, n_expert_used],
-        &[n_expert_used * 4, 4],
+        &ids_shape,
+        &ids_stride,
         &ids_buf,
         0,
         &[n_tokens, n_expert_used, n_out],
         0,
         &mm_dst_buf,
+        &counts_buf,
     )
     .unwrap();
     call_quantized_matmul_mv_id(
@@ -3228,8 +3339,8 @@ fn kernel_mul_mv_id_f32_broadcast_matches_mm_id() {
         &[n_in * 4, n_in * 4, 4],
         &src1_buf,
         0,
-        &[n_tokens, n_expert_used],
-        &[n_expert_used * 4, 4],
+        &ids_shape,
+        &ids_stride,
         &ids_buf,
         0,
         &[n_tokens, n_expert_used, n_out],
@@ -3325,6 +3436,15 @@ fn run_mm_id_chunked_case(
 
     let commands = commands(&device);
     let encoder = commands.command_encoder().unwrap();
+    let counts_buf = expert_counts_buffer(
+        &device,
+        &encoder,
+        &kernels,
+        &ids_shape,
+        &ids_stride,
+        &ids_buf,
+        n_expert,
+    );
     call_quantized_matmul_mm_id(
         &device,
         &encoder,
@@ -3345,6 +3465,7 @@ fn run_mm_id_chunked_case(
         &dst_shape,
         0,
         &unchunked_dst,
+        &counts_buf,
     )
     .unwrap();
     call_quantized_matmul_mm_id_chunked(
@@ -3473,6 +3594,15 @@ fn kernel_mul_mm_id_chunked_succeeds_above_the_real_device_ceiling() {
 
     let commands = commands(&device);
     let encoder = commands.command_encoder().unwrap();
+    let counts_buf = expert_counts_buffer(
+        &device,
+        &encoder,
+        &kernels,
+        &ids_shape,
+        &ids_stride,
+        &ids_buf,
+        n_expert,
+    );
 
     let unchunked_result = call_quantized_matmul_mm_id(
         &device,
@@ -3494,6 +3624,7 @@ fn kernel_mul_mm_id_chunked_succeeds_above_the_real_device_ceiling() {
         &dst_shape,
         0,
         &dst_buf,
+        &counts_buf,
     );
     assert!(
         unchunked_result.is_err(),

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -3251,3 +3251,301 @@ fn kernel_mul_mv_id_f32_broadcast_matches_mm_id() {
         );
     }
 }
+
+// De-risk spike for `call_quantized_matmul_mm_id_chunked`: unlike the
+// mv_id spike above, this compares the chunked wrapper against the *same*
+// kernel
+// (`call_quantized_matmul_mm_id`) called unchunked, on a disjoint partition
+// of token-independent output rows -- so, per the design, the oracle is
+// bit-exact equality, not `allclose`. `max_nei1` is forced far below what
+// this device's real threadgroup-memory budget would ever require, so the
+// chunk loop actually runs multiple iterations regardless of the real
+// device's memory size (deriving the threshold from
+// `mm_id_max_nei1` here would make this a vacuous single-chunk spike on any
+// real Metal device).
+#[allow(clippy::too_many_arguments)]
+fn run_mm_id_chunked_case(
+    n_expert: usize,
+    n_out: usize,
+    n_in: usize,
+    n_tokens: usize,
+    n_expert_used: usize,
+    broadcast: bool,
+    max_nei1: i64,
+) {
+    let device = device();
+    let kernels = Kernels::new();
+
+    let src0: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|idx| {
+            let e = idx / (n_out * n_in);
+            let j = (idx / n_in) % n_out;
+            let k = idx % n_in;
+            (e as f32 * 1000.0 + j as f32 * 10.0 + k as f32) * 0.001
+        })
+        .collect();
+
+    let ne11 = if broadcast { 1 } else { n_expert_used };
+    let src1: Vec<f32> = (0..n_tokens * ne11 * n_in)
+        .map(|idx| {
+            let t = idx / (ne11 * n_in);
+            let s = (idx / n_in) % ne11;
+            let k = idx % n_in;
+            (t as f32 * 1.7 + s as f32 * 0.3 + k as f32 * 0.01).sin()
+        })
+        .collect();
+
+    // Deterministic pseudo-random spread over [0, n_expert), not a fixed
+    // small hand-written array -- n_tokens here is large enough (this spike
+    // needs >= 4 chunks plus a ragged final one) that a literal ids list
+    // would be unwieldy, and a real routing table has no special structure
+    // this formula needs to preserve.
+    let ids: Vec<i32> = (0..n_tokens * n_expert_used)
+        .map(|idx| ((idx * 7 + 3) % n_expert) as i32)
+        .collect();
+
+    let src0_buf = new_buffer(&device, &src0);
+    let src1_buf = new_buffer(&device, &src1);
+    let ids_buf = new_buffer(&device, &ids);
+    let out_elems = n_tokens * n_expert_used * n_out;
+    let unchunked_dst = device
+        .new_buffer(out_elems * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .unwrap();
+    let chunked_dst = device
+        .new_buffer(out_elems * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .unwrap();
+
+    let src0_shape = [n_expert, n_out, n_in];
+    let src0_stride = [n_out * n_in * 4, n_in * 4, 4];
+    let src1_shape = [n_tokens, ne11, n_in];
+    let src1_stride = [ne11 * n_in * 4, n_in * 4, 4];
+    let ids_shape = [n_tokens, n_expert_used];
+    let ids_stride = [n_expert_used * 4, 4];
+    let dst_shape = [n_tokens, n_expert_used, n_out];
+
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    call_quantized_matmul_mm_id(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &src0_shape,
+        &src0_stride,
+        &src0_buf,
+        0,
+        &src1_shape,
+        &src1_stride,
+        &src1_buf,
+        0,
+        &ids_shape,
+        &ids_stride,
+        &ids_buf,
+        0,
+        &dst_shape,
+        0,
+        &unchunked_dst,
+    )
+    .unwrap();
+    call_quantized_matmul_mm_id_chunked(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &src0_shape,
+        &src0_stride,
+        &src0_buf,
+        0,
+        &src1_shape,
+        &src1_stride,
+        &src1_buf,
+        0,
+        &ids_shape,
+        &ids_stride,
+        &ids_buf,
+        0,
+        &dst_shape,
+        0,
+        &chunked_dst,
+        max_nei1,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let unchunked: Vec<f32> = read_to_vec(&unchunked_dst, out_elems);
+    let chunked: Vec<f32> = read_to_vec(&chunked_dst, out_elems);
+
+    for (i, (u, c)) in unchunked.iter().zip(chunked.iter()).enumerate() {
+        assert_eq!(
+            u.to_bits(),
+            c.to_bits(),
+            "chunked output diverges from unchunked at index {i}: unchunked={u}, chunked={c} \
+             (expected bit-exact -- same kernel, disjoint token-independent output rows)"
+        );
+    }
+}
+
+// down/topk shape (ne11 == n_expert_used): n_tokens=37, max_nei1=5 forces 8
+// chunks (5,5,5,5,5,5,5,2) -- covers >=4 chunks, a ragged final chunk, and a
+// chunk size that is not a multiple of the kernel's own 32-wide tile, all in
+// one case.
+#[test]
+fn kernel_mul_mm_id_chunked_matches_unchunked_topk_shape() {
+    run_mm_id_chunked_case(6, 64, 32, 37, 3, false, 5);
+}
+
+// Same ragged/non-32-multiple chunking, but the broadcast (gate/up) shape --
+// the production case where a per-chunk src1 offset that used the wrong
+// stride (nei0*n_in instead of the broadcast ne11=1's n_in) would show up
+// as a real, catchable divergence.
+#[test]
+fn kernel_mul_mm_id_chunked_matches_unchunked_broadcast_shape() {
+    run_mm_id_chunked_case(6, 64, 32, 37, 3, true, 5);
+}
+
+// n_tokens=1 (a single chunk covering the whole batch) must be identical to
+// calling call_quantized_matmul_mm_id directly -- the wrapper's own
+// early-return path, not just the multi-chunk loop.
+#[test]
+fn kernel_mul_mm_id_chunked_single_chunk_matches_unchunked() {
+    run_mm_id_chunked_case(4, 64, 32, 3, 3, false, 100);
+}
+
+// Proves the ceiling chunking exists to remove is actually gone: at
+// nei0=8 (a realistic MoE top-k) and a token count derived from the real
+// device's own `mm_id_max_nei1`, an unchunked call fails exactly the way
+// `kernel_mul_mm_id_rejects_oversized_threadgroup_memory` above already
+// proves it should, while the chunked call -- given that same real
+// device-derived threshold, not a test-forced one -- succeeds.
+#[test]
+fn kernel_mul_mm_id_chunked_succeeds_above_the_real_device_ceiling() {
+    let device = device();
+    let kernels = Kernels::new();
+
+    let n_expert = 16usize;
+    let n_out = 64usize;
+    let n_in = 32usize;
+    let nei0 = 8usize; // a realistic MoE top-k
+
+    let max_nei1 = mm_id_max_nei1(&device, nei0 as i64);
+    assert!(
+        max_nei1 > 0,
+        "test assumption: this device can fit at least one chunk"
+    );
+    let n_tokens = (max_nei1 as usize) + 50;
+
+    let src0: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|idx| {
+            let e = idx / (n_out * n_in);
+            let j = (idx / n_in) % n_out;
+            let k = idx % n_in;
+            (e as f32 * 1000.0 + j as f32 * 10.0 + k as f32) * 0.001
+        })
+        .collect();
+    let src1: Vec<f32> = (0..n_tokens * nei0 * n_in)
+        .map(|idx| {
+            let t = idx / (nei0 * n_in);
+            let s = (idx / n_in) % nei0;
+            let k = idx % n_in;
+            (t as f32 * 1.7 + s as f32 * 0.3 + k as f32 * 0.01).sin()
+        })
+        .collect();
+    let ids: Vec<i32> = (0..n_tokens * nei0)
+        .map(|idx| ((idx * 7 + 3) % n_expert) as i32)
+        .collect();
+
+    let src0_buf = new_buffer(&device, &src0);
+    let src1_buf = new_buffer(&device, &src1);
+    let ids_buf = new_buffer(&device, &ids);
+    let out_elems = n_tokens * nei0 * n_out;
+    let dst_buf = device
+        .new_buffer(out_elems * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .unwrap();
+
+    let src0_shape = [n_expert, n_out, n_in];
+    let src0_stride = [n_out * n_in * 4, n_in * 4, 4];
+    let src1_shape = [n_tokens, nei0, n_in];
+    let src1_stride = [nei0 * n_in * 4, n_in * 4, 4];
+    let ids_shape = [n_tokens, nei0];
+    let ids_stride = [nei0 * 4, 4];
+    let dst_shape = [n_tokens, nei0, n_out];
+
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+
+    let unchunked_result = call_quantized_matmul_mm_id(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &src0_shape,
+        &src0_stride,
+        &src0_buf,
+        0,
+        &src1_shape,
+        &src1_stride,
+        &src1_buf,
+        0,
+        &ids_shape,
+        &ids_stride,
+        &ids_buf,
+        0,
+        &dst_shape,
+        0,
+        &dst_buf,
+    );
+    assert!(
+        unchunked_result.is_err(),
+        "test assumption violated: n_tokens={n_tokens} should exceed this device's real mm_id ceiling"
+    );
+
+    call_quantized_matmul_mm_id_chunked(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &src0_shape,
+        &src0_stride,
+        &src0_buf,
+        0,
+        &src1_shape,
+        &src1_stride,
+        &src1_buf,
+        0,
+        &ids_shape,
+        &ids_stride,
+        &ids_buf,
+        0,
+        &dst_shape,
+        0,
+        &dst_buf,
+        max_nei1,
+    )
+    .expect("chunked dispatch should succeed above the unchunked ceiling");
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    // Spot-check a handful of rows against a direct reference computation --
+    // cheap relative to the full O(n_tokens) reference the bit-exact tests
+    // above already cover at small scale; this test's job is proving the
+    // ceiling is gone, with a correctness sanity check, not re-proving
+    // full-array correctness redundantly.
+    let got: Vec<f32> = read_to_vec(&dst_buf, out_elems);
+    for &t in &[0usize, n_tokens / 2, n_tokens - 1] {
+        for s in 0..nei0 {
+            let e = ids[t * nei0 + s] as usize;
+            let mut acc = 0f32;
+            for k in 0..n_in {
+                acc += src0[e * n_out * n_in + k] * src1[t * nei0 * n_in + s * n_in + k];
+            }
+            let expected = acc; // j=0 row only, cheap spot check
+            let got_val = got[t * nei0 * n_out + s * n_out];
+            let diff = (got_val - expected).abs();
+            assert!(
+                diff <= 1e-2 + 1e-2 * expected.abs(),
+                "spot check failed at token {t}, slot {s}: got {got_val}, expected {expected}"
+            );
+        }
+    }
+}

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2491,3 +2491,29 @@ fn residency_set_batch_insert_remove() {
     set.remove_batch(std::iter::empty());
     assert_eq!(raw.allocationCount(), base);
 }
+
+// De-risk spike for wiring `kernel_mul_mm_id` (ggml's indexed matmul, used
+// for MoE expert dispatch). Confirms the kernel this whole effort depends
+// on actually loads as a Metal compute pipeline from the compiled
+// metallib, since it has `[[host_name]]` instantiations but (at the time
+// this test was added) zero Rust callers anywhere in this crate or
+// candle-core -- named kernels aren't dead-code-eliminated from the
+// metallib, but that's an assumption worth confirming before building on
+// it, not taking on faith.
+#[test]
+fn kernel_mul_mm_id_q4_k_pipeline_loads() {
+    let device = device();
+    let kernels = Kernels::new();
+    kernels
+        .load_pipeline(&device, Source::Quantized, "kernel_mul_mm_id_q4_K_f32")
+        .expect("kernel_mul_mm_id_q4_K_f32 should load as a Metal compute pipeline");
+}
+
+#[test]
+fn kernel_mul_mm_id_q6_k_pipeline_loads() {
+    let device = device();
+    let kernels = Kernels::new();
+    kernels
+        .load_pipeline(&device, Source::Quantized, "kernel_mul_mm_id_q6_K_f32")
+        .expect("kernel_mul_mm_id_q6_K_f32 should load as a Metal compute pipeline");
+}

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -3363,6 +3363,503 @@ fn kernel_mul_mv_id_f32_broadcast_matches_mm_id() {
     }
 }
 
+// Phase 1 de-risk spike for extending `call_quantized_matmul_mv_id` beyond
+// `n_tokens == 1` (Metal MoE speculative-decoding verify-step investigation, see
+// the crate's own MoE dispatch documentation): every existing mv_id test above
+// only ever exercises `n_tokens == 1`, and the Rust-side wrapper
+// (`QMetalStorage::indexed_moe_forward`) has only ever been called that way
+// in production -- but the kernel's own dispatch-grid math
+// (`depth: nei0 * nei1`, each threadgroup independently decoding one
+// (token, expert-slot) pair from `tgpig.z`) is batch-general by
+// construction, not hardcoded to `nei1 == 1`. This proves that generality
+// holds for the untested stride/offset plumbing (src1's per-token stride,
+// ids' per-token row stride, dst's per-token write offset), at the real
+// production expert/top-k ratio (256 experts, top-8) so the ids pattern
+// below is realistic, not just a toy shape. `n_tokens` in `2..=8` matches
+// the entire speculative-decode verify-window range this investigation cares about.
+// Deliberately compares against N independent `n_tokens == 1` calls (each
+// already fully validated by the tests above), not against `mm_id` --
+// every (token, slot) threadgroup does byte-identical work with identical
+// float accumulation order whether it's dispatched as part of a batch-N
+// call or a standalone batch-1 call, so this must be bit-exact, not
+// tolerance-based; a tolerance-based comparison here would hide exactly the
+// stride/offset bug class this test exists to catch.
+#[test]
+fn kernel_mul_mv_id_at_batch_n_matches_sequential_single_token_calls_bit_exact() {
+    let device = device();
+    let kernels = Kernels::new();
+
+    let n_expert = 256usize;
+    let n_out = 64usize;
+    let n_in = 32usize;
+    let n_expert_used = 8usize;
+
+    let src0: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|idx| {
+            let e = idx / (n_out * n_in);
+            let j = (idx / n_in) % n_out;
+            let k = idx % n_in;
+            (e as f32 * 1000.0 + j as f32 * 10.0 + k as f32) * 0.0001
+        })
+        .collect();
+    let src0_buf = new_buffer(&device, &src0);
+
+    for n_tokens in [2usize, 3, 5, 8] {
+        // Deterministic pseudo-routing: distinct enough per (token, slot) to
+        // exercise real spread across 256 experts, but with deliberate
+        // repeats across tokens (e.g. token 0 slot 0 and token 3 slot 2 can
+        // land on the same expert) -- the "multiple tokens share an expert"
+        // case batch-1-only tests structurally can never produce.
+        let ids: Vec<i32> = (0..n_tokens * n_expert_used)
+            .map(|idx| {
+                let t = idx / n_expert_used;
+                let s = idx % n_expert_used;
+                ((t * 37 + s * 13 + s * s) % n_expert) as i32
+            })
+            .collect();
+        let src1: Vec<f32> = (0..n_tokens * n_expert_used * n_in)
+            .map(|idx| {
+                let t = idx / (n_expert_used * n_in);
+                let s = (idx / n_in) % n_expert_used;
+                let k = idx % n_in;
+                (t as f32 * 100.0 + s as f32 * 10.0 + k as f32) * 0.0001
+            })
+            .collect();
+        let src1_buf = new_buffer(&device, &src1);
+        let ids_buf = new_buffer(&device, &ids);
+
+        let out_elems = n_tokens * n_expert_used * n_out;
+        let batched_dst_buf = device
+            .new_buffer(out_elems * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+            .unwrap();
+
+        let batched_commands = commands(&device);
+        let encoder = batched_commands.command_encoder().unwrap();
+        call_quantized_matmul_mv_id(
+            &device,
+            &encoder,
+            &kernels,
+            GgmlDType::F32,
+            &[n_expert, n_out, n_in],
+            &[n_out * n_in * 4, n_in * 4, 4],
+            &src0_buf,
+            0,
+            &[n_tokens, n_expert_used, n_in],
+            &[n_expert_used * n_in * 4, n_in * 4, 4],
+            &src1_buf,
+            0,
+            &[n_tokens, n_expert_used],
+            &[n_expert_used * 4, 4],
+            &ids_buf,
+            0,
+            &[n_tokens, n_expert_used, n_out],
+            0,
+            &batched_dst_buf,
+        )
+        .unwrap();
+        drop(encoder);
+        batched_commands.wait_until_completed().unwrap();
+        let batched_got: Vec<f32> = read_to_vec(&batched_dst_buf, out_elems);
+
+        // N independent n_tokens == 1 calls, one per token, each reading
+        // that token's own slice of src1/ids via a nonzero byte offset --
+        // exercising exactly the offset plumbing a batch-1-only caller
+        // never needed to get right.
+        for t in 0..n_tokens {
+            let single_dst_buf = device
+                .new_buffer(
+                    n_expert_used * n_out * std::mem::size_of::<f32>(),
+                    RESOURCE_OPTIONS,
+                )
+                .unwrap();
+            let single_commands = commands(&device);
+            let encoder = single_commands.command_encoder().unwrap();
+            call_quantized_matmul_mv_id(
+                &device,
+                &encoder,
+                &kernels,
+                GgmlDType::F32,
+                &[n_expert, n_out, n_in],
+                &[n_out * n_in * 4, n_in * 4, 4],
+                &src0_buf,
+                0,
+                &[1, n_expert_used, n_in],
+                &[n_expert_used * n_in * 4, n_in * 4, 4],
+                &src1_buf,
+                t * n_expert_used * n_in * 4,
+                &[1, n_expert_used],
+                &[n_expert_used * 4, 4],
+                &ids_buf,
+                t * n_expert_used * 4,
+                &[1, n_expert_used, n_out],
+                0,
+                &single_dst_buf,
+            )
+            .unwrap();
+            drop(encoder);
+            single_commands.wait_until_completed().unwrap();
+            let single_got: Vec<f32> = read_to_vec(&single_dst_buf, n_expert_used * n_out);
+
+            let batched_slice =
+                &batched_got[t * n_expert_used * n_out..(t + 1) * n_expert_used * n_out];
+            assert_eq!(
+                batched_slice,
+                single_got.as_slice(),
+                "n_tokens={n_tokens}, token={t}: batched mv_id call diverges from an \
+                 independent single-token mv_id call on the same data -- must be bit-exact \
+                 (identical per-threadgroup work either way), so any difference is a real \
+                 stride/offset bug in the batch-N plumbing"
+            );
+        }
+    }
+}
+
+// Phase 1 companion to the bit-exact spike above: mv_id(batch=N) against
+// mm_id(batch=N) at the same production expert/top-k ratio, for two
+// representative points in the speculative-decode verify-window range (2, the
+// minimum useful window; 8, the maximum this investigation targets).
+// Different accumulation order between the two kernels (matrix-vector vs.
+// matrix-matrix), so tolerance-based like the existing batch-1 mv-vs-mm
+// spikes above, not bit-exact.
+#[test]
+fn kernel_mul_mv_id_at_batch_n_matches_mm_id_within_tolerance() {
+    let device = device();
+    let kernels = Kernels::new();
+
+    let n_expert = 256usize;
+    let n_out = 64usize;
+    let n_in = 32usize;
+    let n_expert_used = 8usize;
+
+    let src0: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|idx| {
+            let e = idx / (n_out * n_in);
+            let j = (idx / n_in) % n_out;
+            let k = idx % n_in;
+            (e as f32 * 1000.0 + j as f32 * 10.0 + k as f32) * 0.0001
+        })
+        .collect();
+    let src0_buf = new_buffer(&device, &src0);
+
+    for n_tokens in [2usize, 8] {
+        let ids: Vec<i32> = (0..n_tokens * n_expert_used)
+            .map(|idx| {
+                let t = idx / n_expert_used;
+                let s = idx % n_expert_used;
+                ((t * 41 + s * 17 + s * s) % n_expert) as i32
+            })
+            .collect();
+        let src1: Vec<f32> = (0..n_tokens * n_expert_used * n_in)
+            .map(|idx| {
+                let t = idx / (n_expert_used * n_in);
+                let s = (idx / n_in) % n_expert_used;
+                let k = idx % n_in;
+                (t as f32 * 100.0 + s as f32 * 10.0 + k as f32) * 0.0001
+            })
+            .collect();
+        let src1_buf = new_buffer(&device, &src1);
+        let ids_buf = new_buffer(&device, &ids);
+
+        let out_elems = n_tokens * n_expert_used * n_out;
+        let mm_dst_buf = device
+            .new_buffer(out_elems * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+            .unwrap();
+        let mv_dst_buf = device
+            .new_buffer(out_elems * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+            .unwrap();
+
+        let commands = commands(&device);
+        let encoder = commands.command_encoder().unwrap();
+        let ids_shape = [n_tokens, n_expert_used];
+        let ids_stride = [n_expert_used * 4, 4];
+        let counts_buf = expert_counts_buffer(
+            &device,
+            &encoder,
+            &kernels,
+            &ids_shape,
+            &ids_stride,
+            &ids_buf,
+            n_expert,
+        );
+        call_quantized_matmul_mm_id(
+            &device,
+            &encoder,
+            &kernels,
+            GgmlDType::F32,
+            &[n_expert, n_out, n_in],
+            &[n_out * n_in * 4, n_in * 4, 4],
+            &src0_buf,
+            0,
+            &[n_tokens, n_expert_used, n_in],
+            &[n_expert_used * n_in * 4, n_in * 4, 4],
+            &src1_buf,
+            0,
+            &ids_shape,
+            &ids_stride,
+            &ids_buf,
+            0,
+            &[n_tokens, n_expert_used, n_out],
+            0,
+            &mm_dst_buf,
+            &counts_buf,
+        )
+        .unwrap();
+        call_quantized_matmul_mv_id(
+            &device,
+            &encoder,
+            &kernels,
+            GgmlDType::F32,
+            &[n_expert, n_out, n_in],
+            &[n_out * n_in * 4, n_in * 4, 4],
+            &src0_buf,
+            0,
+            &[n_tokens, n_expert_used, n_in],
+            &[n_expert_used * n_in * 4, n_in * 4, 4],
+            &src1_buf,
+            0,
+            &ids_shape,
+            &ids_stride,
+            &ids_buf,
+            0,
+            &[n_tokens, n_expert_used, n_out],
+            0,
+            &mv_dst_buf,
+        )
+        .unwrap();
+        drop(encoder);
+        commands.wait_until_completed().unwrap();
+
+        let mm_got: Vec<f32> = read_to_vec(&mm_dst_buf, out_elems);
+        let mv_got: Vec<f32> = read_to_vec(&mv_dst_buf, out_elems);
+
+        for (i, (mm, mv)) in mm_got.iter().zip(mv_got.iter()).enumerate() {
+            let diff = (mm - mv).abs();
+            assert!(
+                diff <= 1e-3 + 1e-3 * mm.abs(),
+                "n_tokens={n_tokens}: mv_id diverges from mm_id at index {i}: mm_id={mm}, \
+                 mv_id={mv} (diff {diff})"
+            );
+        }
+    }
+}
+
+// Phase 1 timing table (Metal MoE speculative-decoding verify-step investigation, see
+// the crate's own MoE dispatch documentation): mv_id vs. mm_id wall-clock at
+// batch sizes spanning decode (1) through the speculative-decode verify window
+// (2-8) and out past it (16-64), at production expert/top-k/hidden shape
+// (256 experts, top-8, gate/up's real 2048-in/512-out). F32, not real
+// quantized weights (this crate has no block-quantization encoder of its
+// own to hand-build real Q4_K bytes with, and correctness doesn't depend on
+// dtype here) -- this almost certainly *understates* mv_id's real
+// production advantage, not overstates it: quantized weights mean less
+// real per-row compute/bandwidth than F32, so mm_id's ~fixed `ne02`-
+// threadgroup dispatch tax would dominate an even larger share of a real
+// quantized call's time than it does here. `#[ignore]`d -- a manual timing
+// tool (`cargo test ... -- --ignored --nocapture`), not a correctness
+// check, and not something that should slow down every default test run.
+#[test]
+#[ignore]
+fn mv_id_vs_mm_id_timing_at_batch_sizes() {
+    let device = device();
+    let kernels = Kernels::new();
+
+    let n_expert = 256usize;
+    let n_out = 512usize; // moe_intermediate_size, gate/up production shape
+    let n_in = 2048usize; // hidden_size
+    let n_expert_used = 8usize;
+    const REPS: usize = 50;
+    // A fresh `commands(&device)` allocates a brand-new MTLCommandQueue +
+    // ResidencySet -- real, heavyweight Metal driver objects a real forward
+    // pass creates once and reuses for the process lifetime, never per
+    // dispatch. Creating it inside the timed loop (an earlier version of
+    // this test did) makes queue-allocation cost dominate everything else
+    // being measured, drowning out the actual mv_id-vs-mm_id dispatch-cost
+    // difference this test exists to find. One shared queue for the whole
+    // test, matching real usage.
+    let mv_commands = commands(&device);
+    let mm_commands = commands(&device);
+
+    let src0: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|idx| {
+            let e = idx / (n_out * n_in);
+            let j = (idx / n_in) % n_out;
+            let k = idx % n_in;
+            ((e * 1000 + j * 10 + k) % 997) as f32 * 0.0001
+        })
+        .collect();
+    let src0_buf = new_buffer(&device, &src0);
+
+    println!("mv_id_vs_mm_id_timing_at_batch_sizes ({REPS} reps each, n_expert={n_expert}, n_expert_used={n_expert_used}, n_out={n_out}, n_in={n_in}):");
+
+    for n_tokens in [1usize, 2, 4, 8, 16, 32, 64] {
+        let ids: Vec<i32> = (0..n_tokens * n_expert_used)
+            .map(|idx| {
+                let t = idx / n_expert_used;
+                let s = idx % n_expert_used;
+                ((t * 37 + s * 13 + s * s) % n_expert) as i32
+            })
+            .collect();
+        let src1: Vec<f32> = (0..n_tokens * n_expert_used * n_in)
+            .map(|idx| ((idx * 7 + 3) % 991) as f32 * 0.0001)
+            .collect();
+        let src1_buf = new_buffer(&device, &src1);
+        let ids_buf = new_buffer(&device, &ids);
+        let out_elems = n_tokens * n_expert_used * n_out;
+        let ids_shape = [n_tokens, n_expert_used];
+        let ids_stride = [n_expert_used * 4, 4];
+
+        let mv_dst_buf = device
+            .new_buffer(out_elems * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+            .unwrap();
+        // Warmup: first dispatch on a freshly touched buffer set pays a
+        // real, one-time pipeline-state/paging cost; excluded from the
+        // timed measurement below.
+        {
+            let encoder = mv_commands.command_encoder().unwrap();
+            call_quantized_matmul_mv_id(
+                &device,
+                &encoder,
+                &kernels,
+                GgmlDType::F32,
+                &[n_expert, n_out, n_in],
+                &[n_out * n_in * 4, n_in * 4, 4],
+                &src0_buf,
+                0,
+                &[n_tokens, n_expert_used, n_in],
+                &[n_expert_used * n_in * 4, n_in * 4, 4],
+                &src1_buf,
+                0,
+                &ids_shape,
+                &ids_stride,
+                &ids_buf,
+                0,
+                &[n_tokens, n_expert_used, n_out],
+                0,
+                &mv_dst_buf,
+            )
+            .unwrap();
+            drop(encoder);
+            mv_commands.wait_until_completed().unwrap();
+        }
+        let mv_start = std::time::Instant::now();
+        for _ in 0..REPS {
+            let encoder = mv_commands.command_encoder().unwrap();
+            call_quantized_matmul_mv_id(
+                &device,
+                &encoder,
+                &kernels,
+                GgmlDType::F32,
+                &[n_expert, n_out, n_in],
+                &[n_out * n_in * 4, n_in * 4, 4],
+                &src0_buf,
+                0,
+                &[n_tokens, n_expert_used, n_in],
+                &[n_expert_used * n_in * 4, n_in * 4, 4],
+                &src1_buf,
+                0,
+                &ids_shape,
+                &ids_stride,
+                &ids_buf,
+                0,
+                &[n_tokens, n_expert_used, n_out],
+                0,
+                &mv_dst_buf,
+            )
+            .unwrap();
+            drop(encoder);
+            mv_commands.wait_until_completed().unwrap();
+        }
+        let mv_elapsed = mv_start.elapsed();
+
+        let mm_dst_buf = device
+            .new_buffer(out_elems * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+            .unwrap();
+        {
+            let encoder = mm_commands.command_encoder().unwrap();
+            let counts_buf = expert_counts_buffer(
+                &device,
+                &encoder,
+                &kernels,
+                &ids_shape,
+                &ids_stride,
+                &ids_buf,
+                n_expert,
+            );
+            call_quantized_matmul_mm_id(
+                &device,
+                &encoder,
+                &kernels,
+                GgmlDType::F32,
+                &[n_expert, n_out, n_in],
+                &[n_out * n_in * 4, n_in * 4, 4],
+                &src0_buf,
+                0,
+                &[n_tokens, n_expert_used, n_in],
+                &[n_expert_used * n_in * 4, n_in * 4, 4],
+                &src1_buf,
+                0,
+                &ids_shape,
+                &ids_stride,
+                &ids_buf,
+                0,
+                &[n_tokens, n_expert_used, n_out],
+                0,
+                &mm_dst_buf,
+                &counts_buf,
+            )
+            .unwrap();
+            drop(encoder);
+            mm_commands.wait_until_completed().unwrap();
+        }
+        let mm_start = std::time::Instant::now();
+        for _ in 0..REPS {
+            let encoder = mm_commands.command_encoder().unwrap();
+            let counts_buf = expert_counts_buffer(
+                &device,
+                &encoder,
+                &kernels,
+                &ids_shape,
+                &ids_stride,
+                &ids_buf,
+                n_expert,
+            );
+            call_quantized_matmul_mm_id(
+                &device,
+                &encoder,
+                &kernels,
+                GgmlDType::F32,
+                &[n_expert, n_out, n_in],
+                &[n_out * n_in * 4, n_in * 4, 4],
+                &src0_buf,
+                0,
+                &[n_tokens, n_expert_used, n_in],
+                &[n_expert_used * n_in * 4, n_in * 4, 4],
+                &src1_buf,
+                0,
+                &ids_shape,
+                &ids_stride,
+                &ids_buf,
+                0,
+                &[n_tokens, n_expert_used, n_out],
+                0,
+                &mm_dst_buf,
+                &counts_buf,
+            )
+            .unwrap();
+            drop(encoder);
+            mm_commands.wait_until_completed().unwrap();
+        }
+        let mm_elapsed = mm_start.elapsed();
+
+        println!(
+            "  n_tokens={n_tokens:3}: mv_id {:>9.1}us/call  mm_id {:>9.1}us/call  mv/mm ratio {:.3}",
+            mv_elapsed.as_secs_f64() * 1e6 / REPS as f64,
+            mm_elapsed.as_secs_f64() * 1e6 / REPS as f64,
+            mv_elapsed.as_secs_f64() / mm_elapsed.as_secs_f64(),
+        );
+    }
+}
+
 // De-risk spike for `call_quantized_matmul_mm_id_chunked`: unlike the
 // mv_id spike above, this compares the chunked wrapper against the *same*
 // kernel

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2517,3 +2517,213 @@ fn kernel_mul_mm_id_q6_k_pipeline_loads() {
         .load_pipeline(&device, Source::Quantized, "kernel_mul_mm_id_q6_K_f32")
         .expect("kernel_mul_mm_id_q6_K_f32 should load as a Metal compute pipeline");
 }
+
+// Correctness test for `call_quantized_matmul_mm_id`, the Rust binding for
+// ggml's indexed/routed matmul (see ratatoskr/DESIGN.md section 15). Uses
+// GgmlDType::F32 rather than a real quantized type so the test exercises
+// only the id-routing/dispatch logic this binding is responsible for
+// (rowids scan, per-expert threadgroup dispatch, output scatter) without
+// also depending on GGUF block dequantization, which is already covered
+// by the existing dense-matmul tests. Reference values are computed with
+// plain f32 dot products and compared with a tolerance loose enough to
+// absorb the GPU's different summation order.
+#[test]
+fn kernel_mul_mm_id_f32_matches_reference() {
+    let device = device();
+    let kernels = Kernels::new();
+
+    let n_expert = 2usize;
+    let n_out = 64usize;
+    let n_in = 32usize;
+    let n_tokens = 4usize;
+    let n_expert_used = 1usize;
+
+    // src0: [n_expert, n_out, n_in], row-major.
+    let src0: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|idx| {
+            let e = idx / (n_out * n_in);
+            let j = (idx / n_in) % n_out;
+            let k = idx % n_in;
+            (e as f32 * 1000.0 + j as f32 * 10.0 + k as f32) * 0.001
+        })
+        .collect();
+
+    // src1: [n_tokens, n_expert_used, n_in], row-major.
+    let src1: Vec<f32> = (0..n_tokens * n_expert_used * n_in)
+        .map(|idx| {
+            let t = idx / n_in;
+            let k = idx % n_in;
+            (t as f32 * 100.0 + k as f32) * 0.001
+        })
+        .collect();
+
+    // ids: [n_tokens, n_expert_used] -- token t picks expert ids[t].
+    let ids: Vec<i32> = vec![0, 1, 0, 1];
+    assert_eq!(ids.len(), n_tokens * n_expert_used);
+
+    // Reference: dst[t][s][j] = sum_k src0[ids[t*n_expert_used+s]][j][k] * src1[t][s][k]
+    let mut expected = vec![0f32; n_tokens * n_expert_used * n_out];
+    for t in 0..n_tokens {
+        for s in 0..n_expert_used {
+            let e = ids[t * n_expert_used + s] as usize;
+            for j in 0..n_out {
+                let mut acc = 0f32;
+                for k in 0..n_in {
+                    acc += src0[e * n_out * n_in + j * n_in + k]
+                        * src1[t * n_expert_used * n_in + s * n_in + k];
+                }
+                expected[t * n_expert_used * n_out + s * n_out + j] = acc;
+            }
+        }
+    }
+
+    let src0_buf = new_buffer(&device, &src0);
+    let src1_buf = new_buffer(&device, &src1);
+    let ids_buf = new_buffer(&device, &ids);
+    let dst_buf = device
+        .new_buffer(
+            expected.len() * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
+        .unwrap();
+
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    // Strides are in bytes (matches call_quantized_matmul_mm_t's convention,
+    // see candle-core/src/quantized/metal.rs's caller) -- not element counts.
+    call_quantized_matmul_mm_id(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &[n_expert, n_out, n_in],
+        &[n_out * n_in * 4, n_in * 4, 4],
+        &src0_buf,
+        0,
+        &[n_tokens, n_expert_used, n_in],
+        &[n_expert_used * n_in * 4, n_in * 4, 4],
+        &src1_buf,
+        0,
+        &[n_tokens, n_expert_used],
+        &[n_expert_used * 4, 4],
+        &ids_buf,
+        0,
+        &[n_tokens, n_expert_used, n_out],
+        0,
+        &dst_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got: Vec<f32> = read_to_vec(&dst_buf, expected.len());
+
+    for (i, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+        let diff = (g - e).abs();
+        assert!(
+            diff <= 1e-3 + 1e-3 * e.abs(),
+            "mismatch at index {i}: got {g}, expected {e} (diff {diff})"
+        );
+    }
+}
+
+// Same as above but with n_expert_used=2 (real MoE models route to top-k>1
+// experts per token, e.g. k=8 for Qwen3-30B-A3B). The n_expert_used=1 case
+// above never exercises the kernel's `id[0] % ne11` broadcast indexing in a
+// way that could be wrong and still pass (mod 1 is always 0), so this is
+// the case that actually proves per-slot indexing is right, not just
+// per-token indexing.
+#[test]
+fn kernel_mul_mm_id_f32_topk_matches_reference() {
+    let device = device();
+    let kernels = Kernels::new();
+
+    let n_expert = 4usize;
+    let n_out = 64usize;
+    let n_in = 32usize;
+    let n_tokens = 3usize;
+    let n_expert_used = 2usize;
+
+    let src0: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|idx| {
+            let e = idx / (n_out * n_in);
+            let j = (idx / n_in) % n_out;
+            let k = idx % n_in;
+            (e as f32 * 1000.0 + j as f32 * 10.0 + k as f32) * 0.001
+        })
+        .collect();
+
+    let src1: Vec<f32> = (0..n_tokens * n_expert_used * n_in)
+        .map(|idx| {
+            let t = idx / (n_expert_used * n_in);
+            let s = (idx / n_in) % n_expert_used;
+            let k = idx % n_in;
+            (t as f32 * 100.0 + s as f32 * 10.0 + k as f32) * 0.001
+        })
+        .collect();
+
+    let ids: Vec<i32> = vec![0, 1, 2, 3, 1, 2];
+    assert_eq!(ids.len(), n_tokens * n_expert_used);
+
+    let mut expected = vec![0f32; n_tokens * n_expert_used * n_out];
+    for t in 0..n_tokens {
+        for s in 0..n_expert_used {
+            let e = ids[t * n_expert_used + s] as usize;
+            for j in 0..n_out {
+                let mut acc = 0f32;
+                for k in 0..n_in {
+                    acc += src0[e * n_out * n_in + j * n_in + k]
+                        * src1[t * n_expert_used * n_in + s * n_in + k];
+                }
+                expected[t * n_expert_used * n_out + s * n_out + j] = acc;
+            }
+        }
+    }
+
+    let src0_buf = new_buffer(&device, &src0);
+    let src1_buf = new_buffer(&device, &src1);
+    let ids_buf = new_buffer(&device, &ids);
+    let dst_buf = device
+        .new_buffer(
+            expected.len() * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
+        .unwrap();
+
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    call_quantized_matmul_mm_id(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &[n_expert, n_out, n_in],
+        &[n_out * n_in * 4, n_in * 4, 4],
+        &src0_buf,
+        0,
+        &[n_tokens, n_expert_used, n_in],
+        &[n_expert_used * n_in * 4, n_in * 4, 4],
+        &src1_buf,
+        0,
+        &[n_tokens, n_expert_used],
+        &[n_expert_used * 4, 4],
+        &ids_buf,
+        0,
+        &[n_tokens, n_expert_used, n_out],
+        0,
+        &dst_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got: Vec<f32> = read_to_vec(&dst_buf, expected.len());
+
+    for (i, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+        let diff = (g - e).abs();
+        assert!(
+            diff <= 1e-3 + 1e-3 * e.abs(),
+            "mismatch at index {i}: got {g}, expected {e} (diff {diff})"
+        );
+    }
+}

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -3138,3 +3138,116 @@ fn kernel_mul_mv_id_pipelines_load() {
             .unwrap_or_else(|e| panic!("{name} should load as a Metal compute pipeline: {e}"));
     }
 }
+
+// Closes a review-found gap: kernel_mul_mv_id_f32_matches_mm_id above uses
+// in_dim1==n_expert_used (the down-projection shape, non-broadcast). The
+// real gate/up production shape (FusedMoeGGUF::forward's Metal branch) is
+// in_dim1==1 -- one token embedding, shared across all its selected
+// experts -- which exercises the kernel's `i11 = idx % ne11` broadcast
+// modulo in a way n_expert_used-per-slot input never does (mod 1 is always
+// 0, trivially correct even if the broadcast wiring were wrong). Mirrors
+// kernel_mul_mm_id_f32_broadcast_matches_reference's own precedent from
+// Phase 1, at the real n_tokens=1 decode shape mv_id targets.
+#[test]
+fn kernel_mul_mv_id_f32_broadcast_matches_mm_id() {
+    let device = device();
+    let kernels = Kernels::new();
+
+    let n_expert = 3usize;
+    let n_out = 64usize;
+    let n_in = 32usize;
+    let n_tokens = 1usize;
+    let n_expert_used = 2usize;
+
+    let src0: Vec<f32> = (0..n_expert * n_out * n_in)
+        .map(|idx| {
+            let e = idx / (n_out * n_in);
+            let j = (idx / n_in) % n_out;
+            let k = idx % n_in;
+            (e as f32 * 1000.0 + j as f32 * 10.0 + k as f32) * 0.001
+        })
+        .collect();
+
+    // in_dim1 == 1: one embedding for the token, broadcast across both
+    // selected experts.
+    let src1: Vec<f32> = (0..n_tokens * n_in)
+        .map(|idx| (idx as f32) * 0.001)
+        .collect();
+
+    let ids: Vec<i32> = vec![2, 0];
+    assert_eq!(ids.len(), n_tokens * n_expert_used);
+
+    let src0_buf = new_buffer(&device, &src0);
+    let src1_buf = new_buffer(&device, &src1);
+    let ids_buf = new_buffer(&device, &ids);
+    let out_elems = n_tokens * n_expert_used * n_out;
+    let mm_dst_buf = device
+        .new_buffer(out_elems * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .unwrap();
+    let mv_dst_buf = device
+        .new_buffer(out_elems * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .unwrap();
+
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    // src1 is [n_tokens, 1, n_in] -- nb11 == nb12 (stride collapses since
+    // dim1 has size 1), matching how QMetalStorage::indexed_moe_forward's
+    // caller (FusedMoeGGUF::forward) actually broadcasts.
+    call_quantized_matmul_mm_id(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &[n_expert, n_out, n_in],
+        &[n_out * n_in * 4, n_in * 4, 4],
+        &src0_buf,
+        0,
+        &[n_tokens, 1, n_in],
+        &[n_in * 4, n_in * 4, 4],
+        &src1_buf,
+        0,
+        &[n_tokens, n_expert_used],
+        &[n_expert_used * 4, 4],
+        &ids_buf,
+        0,
+        &[n_tokens, n_expert_used, n_out],
+        0,
+        &mm_dst_buf,
+    )
+    .unwrap();
+    call_quantized_matmul_mv_id(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::F32,
+        &[n_expert, n_out, n_in],
+        &[n_out * n_in * 4, n_in * 4, 4],
+        &src0_buf,
+        0,
+        &[n_tokens, 1, n_in],
+        &[n_in * 4, n_in * 4, 4],
+        &src1_buf,
+        0,
+        &[n_tokens, n_expert_used],
+        &[n_expert_used * 4, 4],
+        &ids_buf,
+        0,
+        &[n_tokens, n_expert_used, n_out],
+        0,
+        &mv_dst_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let mm_got: Vec<f32> = read_to_vec(&mm_dst_buf, out_elems);
+    let mv_got: Vec<f32> = read_to_vec(&mv_dst_buf, out_elems);
+
+    for (i, (mm, mv)) in mm_got.iter().zip(mv_got.iter()).enumerate() {
+        let diff = (mm - mv).abs();
+        assert!(
+            diff <= 1e-3 + 1e-3 * mm.abs(),
+            "mv_id diverges from mm_id at broadcast index {i}: mm_id={mm}, mv_id={mv} (diff {diff})"
+        );
+    }
+}

--- a/candle-transformers/src/fused_moe.rs
+++ b/candle-transformers/src/fused_moe.rs
@@ -246,19 +246,6 @@ impl FusedMoeGGUF {
             topk_weights = topk_weights.broadcast_div(&topk_weights.sum_keepdim(D::Minus1)?)?;
         }
 
-        let (expert_ids, sorted_token_ids) = if is_prefill {
-            // For long-context (32K+), need to use custom sort kernel
-            // #[cfg(feature = "cuda")]
-            // {
-            //     use attention_rs::sort::ArgSortOp;
-            //     topk_ids.flatten_all()?.sort(true)?
-            // }
-            // #[cfg(not(feature = "cuda"))]
-            topk_ids.flatten_all()?.sort_last_dim(true)?
-        } else {
-            topk_ids.flatten_all()?.sort_last_dim(true)?
-        };
-
         // moe_gemm_gguf (CUDA's vLLM-style block-sorted fused MoE GEMM) has
         // no Metal implementation and a very different interface (it needs
         // sorted_token_ids/expert_ids, not per-token ids); Metal instead
@@ -278,6 +265,23 @@ impl FusedMoeGGUF {
             let down = self.down_experts.indexed_moe_forward(&down_inputs, &topk_ids)?;
             down.broadcast_mul(&topk_weights.unsqueeze(D::Minus1)?)?
         } else {
+            // sorted_token_ids/expert_ids are moe_gemm_gguf's own vLLM-style
+            // block-alignment inputs -- only computed here, not above, since
+            // the Metal branch never needs them (skips two real GPU
+            // dispatches, arg_sort_last_dim + gather, on the decode hot path).
+            let (expert_ids, sorted_token_ids) = if is_prefill {
+                // For long-context (32K+), need to use custom sort kernel
+                // #[cfg(feature = "cuda")]
+                // {
+                //     use attention_rs::sort::ArgSortOp;
+                //     topk_ids.flatten_all()?.sort(true)?
+                // }
+                // #[cfg(not(feature = "cuda"))]
+                topk_ids.flatten_all()?.sort_last_dim(true)?
+            } else {
+                topk_ids.flatten_all()?.sort_last_dim(true)?
+            };
+
             let gate = moe::moe_gemm_gguf(
                 &xs,
                 &self.gate_experts,

--- a/candle-transformers/src/fused_moe.rs
+++ b/candle-transformers/src/fused_moe.rs
@@ -259,7 +259,25 @@ impl FusedMoeGGUF {
             topk_ids.flatten_all()?.sort_last_dim(true)?
         };
 
-        let ys = {
+        // moe_gemm_gguf (CUDA's vLLM-style block-sorted fused MoE GEMM) has
+        // no Metal implementation and a very different interface (it needs
+        // sorted_token_ids/expert_ids, not per-token ids); Metal instead
+        // uses QTensor::indexed_moe_forward, the simpler ids-per-token path.
+        // That function only computes the raw per-(token, selected-expert)
+        // matmul (see its doc comment) -- unlike moe_gemm_gguf, it doesn't
+        // fold in top-k weight scaling, so that happens here explicitly.
+        // The cross-expert sum below is unconditional and already correct
+        // for both branches: moe_gemm_gguf's CUDA kernel doesn't sum either
+        // (confirmed by reading its cuda_fwd -- topk_weights only scales
+        // rows), the sum has always been this function's own job.
+        let ys = if xs.device().is_metal() {
+            let x_bcast = xs.reshape((num_tokens, 1, hidden_dim))?;
+            let gate = self.gate_experts.indexed_moe_forward(&x_bcast, &topk_ids)?;
+            let up = self.up_experts.indexed_moe_forward(&x_bcast, &topk_ids)?;
+            let down_inputs = (up * gate.apply(&self.act)?)?;
+            let down = self.down_experts.indexed_moe_forward(&down_inputs, &topk_ids)?;
+            down.broadcast_mul(&topk_weights.unsqueeze(D::Minus1)?)?
+        } else {
             let gate = moe::moe_gemm_gguf(
                 &xs,
                 &self.gate_experts,

--- a/candle-transformers/src/fused_moe.rs
+++ b/candle-transformers/src/fused_moe.rs
@@ -262,7 +262,9 @@ impl FusedMoeGGUF {
             let gate = self.gate_experts.indexed_moe_forward(&x_bcast, &topk_ids)?;
             let up = self.up_experts.indexed_moe_forward(&x_bcast, &topk_ids)?;
             let down_inputs = (up * gate.apply(&self.act)?)?;
-            let down = self.down_experts.indexed_moe_forward(&down_inputs, &topk_ids)?;
+            let down = self
+                .down_experts
+                .indexed_moe_forward(&down_inputs, &topk_ids)?;
             down.broadcast_mul(&topk_weights.unsqueeze(D::Minus1)?)?
         } else {
             // sorted_token_ids/expert_ids are moe_gemm_gguf's own vLLM-style


### PR DESCRIPTION
Adds Metal kernel support for indexed/routed matmul (ggml's `mul_mat_id`), used by Mixture-of-Experts models to dispatch each token to its selected experts' weights in one batched call instead of per-expert loops. Includes three follow-on prefill throughput optimizations on top of the initial wiring, since the first working version measured 97.9x slower than llama.cpp on MoE prefill and each phase closes part of that gap on real hardware, not just synthetically.

## What

- `call_quantized_matmul_mm_id` (`candle-metal-kernels`): matrix-*matrix* dispatch for `kernel_mul_mm_id_*` — one weight buffer holding all experts stacked on their leading dim, an `ids` routing table mapping each (token, selected-expert) pair to a row of that buffer, and a dispatch/threadgroup-memory sizing scheme mirrored from ggml's own Metal backend (`ggml_metal_encode_node`'s `GGML_OP_MUL_MAT_ID` case).
- `call_quantized_matmul_mv_id` + `mv_id_eligible`: matrix-*vector* dispatch for the decode case (`batch == 1`), which ggml routes to a separate, faster kernel below a device- and dtype-dependent threadgroup-memory ceiling. `mv_id_eligible` is the single source of truth for which dtypes qualify and the minimum contraction-dim each needs, so eligibility can't drift out of sync with the per-dtype tuning table.
- `call_quantized_matmul_mm_id_chunked` + `mm_id_max_nei1`: `mm_id`'s rowids scratch is sized off the whole-batch token count, so a large enough prefill batch overflows the device's threadgroup-memory budget regardless of tuning. The chunked wrapper splits such a batch into sequential dispatches of at most `mm_id_max_nei1` tokens each, on the same command encoder.
- **Row discovery parallelized across the threadgroup's 128 threads** (was a single serial thread scanning the whole routing table) — 10.7x prefill on its own. Ordering matters here: an earlier atomic-based version permuted slot assignment and made greedy decoding nondeterministic (three identical prompts, three different completions against a bit-stable baseline); the shipped version uses contiguous per-thread ranges that reconstruct the original loop's exact order.
- **Doomed token tiles skipped before the matmul** — a token tile only ever holds `nei1*nei0/ne02` of an expert's rows (24 of 768 at top-8-of-256), so `kernel_mul_mm_id_impl`'s own `r1 * BLOCK_SIZE_N >= ne1` guard, already computing the exact per-tile count, is hoisted to bail before wasted matmul work.
- **Per-expert row counts precomputed once per dispatch** (`kernel_mm_id_zero_counts` + `kernel_mm_id_expert_counts`, a small atomic histogram over the routing table) so `kernel_mul_mm_id` can skip the row-discovery scan entirely for a token tile that holds none of its expert's rows, instead of running the O(nei0\*nei1) scan to find out — that scan was the single largest remaining prefill cost by measured ablation (3.61s of a 9.42s prefill on the profiled case). Counts are computed **per chunk**, not once for the whole batch: the guard's `tgpig.x` is chunk-local, so a chunk-local count is what makes the skip actually fire on chunks after the first. Deliberately counts only, not ordered row lists — producing those in scan order would need a stable counting sort, and ordering is exactly what caused the earlier nondeterminism bug; counts are order-independent and safe with a plain atomic histogram.
- `QTensor::indexed_moe_forward`'s Metal arm (`candle-core`), wiring all of the above together and routing `FusedMoeGGUF::forward`'s Metal path through it.

## Why

Without this, Metal has no way to dispatch a quantized indexed matmul at all — `FusedMoeGGUF`'s Metal path had no MoE-specific kernel to call. This adds the three dispatch shapes ggml itself distinguishes (matrix-matrix for prefill, matrix-vector for decode, chunked matrix-matrix for oversized prefill batches), plus the throughput work needed to make matrix-matrix prefill actually fast rather than only correct — a naive first version measured 97.9x slower than llama.cpp, entirely localized to this one kernel (a dense model on the same hardware was only 2.2x off), which is what motivated digging further rather than shipping the initial wiring alone.

## Measured (M4 Pro, `Qwen3.6-35B-A3B` UD-Q4_K_M, 837-token prompt)

| stage | prefill | vs. llama.cpp (699.89 tok/s) |
|---|---|---|
| naive `mm_id` wiring | 7.38 tok/s | 97.9x slower |
| + parallel row discovery | 78.88 tok/s | 9.2x slower |
| + skip doomed token tiles | 96.45 tok/s | 7.5x slower |
| + counts-only precompute | **151.9 tok/s** | **4.6x slower** |

A `dispatchThreadgroupsWithIndirectBuffer` lever was profiled and ruled out along the way: launch overhead for the 49,152 threadgroups this shape dispatches measured at 60ms of a 9.42s prefill (0.6%), not the dominant cost it looked like on paper.

## Testing

- `candle-metal-kernels/src/tests.rs`: pipeline-load de-risk spikes for every `kernel_mul_mm_id_*`/`kernel_mul_mv_id_*` kernel name; bit-exact-equality differential tests between the chunked and unchunked `mm_id` wrapper (single-chunk, multi-chunk-via-forced-low-threshold, and a case against the real device's own threshold); a `mv_id`-vs-`mm_id` differential test (single-token and broadcast shapes) using `mm_id`'s own validated output as the correctness oracle.
- `candle-core/tests/quantized_tests.rs`: `indexed_moe_forward` exercised through the real public API with real quantized weights — the decode-routes-to-`mv_id` path for each of `mv_id_eligible`'s four dtypes, and the chunked-prefill path with a batch large enough to exceed the device's real threadgroup-memory ceiling.
- Two live differential tests (not in this repo — in the downstream project this was built for) replay real prompts against a real model on real Metal hardware and assert byte-identical, deterministic output against a `llama-server /completion`-verified reference: one at the greedy-decode boundary, one specifically forcing multi-chunk prefill (837 tokens against a 768-token chunk threshold, so it exercises a ragged final chunk). Both pass on every phase above, including the counts-only precompute — this kernel fails *fluently* rather than loudly on a routing bug, so a differential against a real model was treated as non-negotiable for every change, not just the initial wiring.
- `cargo test -p candle-core --features metal --test quantized_tests` (74 passed) and `cargo test` in `candle-metal-kernels` (76 passed) both green; `cargo clippy`/`cargo fmt --check` clean across `candle-core` and `candle-metal-kernels`.

Independent of #3785 (mmap-backed Metal buffers) — every `QMetalStorage` here always owns its buffer outright, so this doesn't need that PR's `offset`/`length` fields and can merge in either order.
