### PR TITLE
feat(nix): Add reproducible Nix dev shells for `Rust`, `PyO3`, and `Wasm`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - flake.nix
+      - flake.lock
+      - .github/workflows/nix.yml
+  pull_request:
+    paths:
+      - flake.nix
+      - flake.lock
+      - .github/workflows/nix.yml
+
+name: Nix
+
+jobs:
+  flake-check:
+    name: Flake check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - name: Check flake outputs
+        run: nix flake check --all-systems --no-build --no-update-lock-file

--- a/README.md
+++ b/README.md
@@ -150,6 +150,26 @@ cargo run --example quantized --release
 In order to use **CUDA** add `--features cuda` to the example command line. If
 you have cuDNN installed, use `--features cudnn` for even more speedups.
 
+### Nix development shell
+
+If you use Nix with flakes enabled, you can enter a CPU-focused Rust
+development environment with the tooling used by common Candle workflows:
+
+```bash
+nix develop
+cargo check --workspace
+```
+
+Additional shells are available for optional workflows:
+
+```bash
+nix develop .#pyo3
+nix develop .#wasm
+```
+
+The Nix shell is intended for local development and CI parity. CUDA and NCCL
+setups still depend on your system driver/toolkit installation.
+
 There are also some wasm examples for whisper and
 [llama2.c](https://github.com/karpathy/llama2.c). You can either build them with
 `trunk` or try them online:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,62 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785318670,
+        "narHash": "sha256-dN6Ou5x/+23FZLEpYP3IffO+NyJFzUlGumt1uu3MMaY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0954f7ee2f6bb3dc7d4e3d0d8bcb8fd4bde4cfc5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1785302874,
+        "narHash": "sha256-fpKEww3TJoo1ANHO2q918ei+ayOrp0YEQAO1DuBLOB4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b99d48435bc3e34309d2c7ae6f7d45e77a156c38",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,117 @@
+{
+  description = "Development environment for Candle";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
+
+  outputs =
+    {
+      nixpkgs,
+      rust-overlay,
+      ...
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forEachSystem = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forEachSystem (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ rust-overlay.overlays.default ];
+          };
+          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "clippy"
+              "rustfmt"
+            ];
+          };
+          rustWasmToolchain = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "clippy"
+              "rustfmt"
+            ];
+            targets = [ "wasm32-unknown-unknown" ];
+          };
+          darwinFrameworks = pkgs.lib.optionals pkgs.stdenv.isDarwin (
+            with pkgs.darwin.apple_sdk.frameworks;
+            [
+              Accelerate
+              Foundation
+              Metal
+              MetalPerformanceShaders
+              Security
+            ]
+          );
+        in
+        {
+          default = pkgs.mkShell {
+            packages =
+              with pkgs;
+              [
+                rustToolchain
+                pkg-config
+                openssl
+                protobuf
+                cmake
+              ]
+              ++ lib.optionals stdenv.isLinux [
+                lld
+              ]
+              ++ lib.optionals stdenv.isDarwin [
+                libiconv
+              ]
+              ++ darwinFrameworks;
+
+            shellHook = ''
+              echo "Candle development shell"
+              echo "Common checks: cargo check --workspace, cargo test --workspace, cargo fmt --all -- --check"
+            '';
+          };
+
+          pyo3 = pkgs.mkShell {
+            packages =
+              with pkgs;
+              [
+                rustToolchain
+                pkg-config
+                openssl
+                protobuf
+                python313
+                maturin
+                python313Packages.pytest
+                python313Packages.black
+              ]
+              ++ lib.optionals stdenv.isDarwin [
+                libiconv
+              ];
+
+            shellHook = ''
+              echo "Candle PyO3 development shell"
+              echo "Example: cd candle-pyo3 && python -m maturin develop -r --features onnx"
+            '';
+          };
+
+          wasm = pkgs.mkShell {
+            packages = with pkgs; [
+              rustWasmToolchain
+              trunk
+              wasm-pack
+              wasm-bindgen-cli
+            ];
+
+            shellHook = ''
+              echo "Candle WASM development shell"
+              echo "The Rust toolchain includes the wasm32-unknown-unknown target"
+            '';
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION

This pr adds Nix dev shells for Rust, PyO3, and WASM development, plus CI to validate the flake.

  ## Why

  This gives Nix/NixOS contributors a reproducible setup without manually installing Rust tools, protobuf, OpenSSL/pkg-config,
  Python tooling, or the WASM target.

  The default shell stays focused on common Rust work, while optional shells cover PyO3 and WASM workflows.

  ## tests

  ```bash
  nix develop .#wasm --command rustc --print target-libdir --target wasm32-unknown-unknown
  nix develop --command cargo check -p candle-core
```