### PR TITLE
Avoid input repack in tiled CPU conv2d

### DIFF
--- a/candle-core/src/cpu_backend/conv2d.rs
+++ b/candle-core/src/cpu_backend/conv2d.rs
@@ -139,23 +139,6 @@ fn conv2d_tiled<T: WithDType + num_traits::Num + Copy + 'static>(
     // Output shape: [b_size, c_out, out_h, out_w].
     let dst = vec![T::zero(); p.b_size * p.c_out * out_h * out_w];
 
-    // Convert NCHW input to NHWC layout for tiled im2col.
-    let cont_s0 = p.i_h * p.i_w * p.c_in;
-    let cont_s1 = p.i_w * p.c_in;
-    let cont_s2 = p.c_in;
-    let mut inp_cont = vec![T::zero(); p.b_size * p.c_in * p.i_h * p.i_w];
-    for b_idx in 0..p.b_size {
-        for h_idx in 0..p.i_h {
-            for w_idx in 0..p.i_w {
-                for c_idx in 0..p.c_in {
-                    let src_idx = b_idx * inp_s0 + c_idx * inp_s1 + h_idx * inp_s2 + w_idx * inp_s3;
-                    let dst_idx = b_idx * cont_s0 + h_idx * cont_s1 + w_idx * cont_s2 + c_idx;
-                    inp_cont[dst_idx] = inp[src_idx]
-                }
-            }
-        }
-    }
-
     // shape of k: [c_out, c_in, k_h, k_w]
     // strides of k: [k_s0, k_s1, k_s2, k_s3]
     // For matmul, we need flattened k in shape [c_out, k_h * k_w * c_in]
@@ -185,7 +168,7 @@ fn conv2d_tiled<T: WithDType + num_traits::Num + Copy + 'static>(
 
     // Process batches and tiles in parallel using rayon.
     (0..p.b_size).into_par_iter().try_for_each(|b_idx| {
-        let inp_offset = b_idx * cont_s0;
+        let inp_offset = b_idx * inp_s0;
         let out_batch_offset = b_idx * (p.c_out * out_h * out_w);
 
         let num_tiles = total_out_pixels.div_ceil(TILE_SIZE);
@@ -195,17 +178,13 @@ fn conv2d_tiled<T: WithDType + num_traits::Num + Copy + 'static>(
             let tile_end = (tile_start + TILE_SIZE).min(total_out_pixels);
             let tile_size = tile_end - tile_start;
 
-            // Precompute output coordinates.
-            // Used in both im2col extraction and writing output.
-            let out_coords: Vec<_> = (tile_start..tile_end)
-                .map(|idx| (idx / out_w, idx % out_w))
-                .collect();
-
             // Build im2col tile: [k_size, tile_size]
             // This represents the input patches needed for this tile of outputs
             let mut col_tile = vec![T::zero(); k_size * tile_size];
 
-            for (tile_idx, (out_y, out_x)) in out_coords.iter().enumerate() {
+            for (tile_idx, out_idx) in (tile_start..tile_end).enumerate() {
+                let out_y = out_idx / out_w;
+                let out_x = out_idx % out_w;
                 // Extract the im2col patch for this output position
                 for c_in in 0..p.c_in {
                     let mut patch_offset = c_in;
@@ -224,9 +203,10 @@ fn conv2d_tiled<T: WithDType + num_traits::Num + Copy + 'static>(
                             if in_x >= 0 && in_x < p.i_w as isize {
                                 let in_y = in_y as usize;
                                 let in_x = in_x as usize;
-                                let inp_idx = inp_offset + in_y * cont_s1 + in_x * cont_s2 + c_in;
+                                let inp_idx =
+                                    inp_offset + c_in * inp_s1 + in_y * inp_s2 + in_x * inp_s3;
                                 let col_idx = patch_offset * tile_size + tile_idx;
-                                col_tile[col_idx] = inp_cont[inp_idx];
+                                col_tile[col_idx] = inp[inp_idx];
                             }
                             // Move to next position (skip c_in channels)
                             patch_offset += p.c_in;
@@ -247,7 +227,9 @@ fn conv2d_tiled<T: WithDType + num_traits::Num + Copy + 'static>(
             let result = matmul.f(&k_flat, &k_layout, &col_tile, &col_layout)?;
 
             // Copy results to output: result is [c_out, tile_size]
-            for (tile_idx, (out_y, out_x)) in out_coords.iter().enumerate() {
+            for (tile_idx, out_idx) in (tile_start..tile_end).enumerate() {
+                let out_y = out_idx / out_w;
+                let out_x = out_idx % out_w;
                 let dst_base = out_batch_offset + out_y * out_w + out_x;
 
                 for c_out_idx in 0..p.c_out {

--- a/candle-core/tests/conv_tests.rs
+++ b/candle-core/tests/conv_tests.rs
@@ -975,6 +975,34 @@ fn conv2d_grad_noncontiguous_kernel(dev: &Device) -> Result<()> {
     Ok(())
 }
 
+// A non-contiguous input view and its contiguous copy must produce identical
+// results through the general tiled conv2d path.
+fn conv2d_noncontiguous_input(dev: &Device) -> Result<()> {
+    let input_data: Vec<f32> = (0..2 * 5 * 6).map(|v| (v as f32 - 17.0) / 11.0).collect();
+    let kernel_data: Vec<f32> = (0..3 * 2 * 3 * 3)
+        .map(|v| (v as f32 - 13.0) / 7.0)
+        .collect();
+
+    let input_base = Tensor::from_vec(input_data, (1, 2, 5, 6), dev)?;
+    let input = input_base.i((.., .., .., 1..6))?;
+    let input_ref = input.contiguous()?;
+    let kernel = Tensor::from_vec(kernel_data, (3, 2, 3, 3), dev)?;
+
+    let actual = input.conv2d(&kernel, 1, 1, 1, 1)?;
+    let expected = input_ref.conv2d(&kernel, 1, 1, 1, 1)?;
+    let diff = actual
+        .sub(&expected)?
+        .abs()?
+        .flatten_all()?
+        .max(0)?
+        .to_scalar::<f32>()?;
+    assert!(
+        diff < 1e-6,
+        "conv2d non-contiguous input should match contiguous copy, got diff={diff}"
+    );
+    Ok(())
+}
+
 test_device!(conv1d, conv1d_cpu, conv1d_gpu, conv1d_metal);
 test_device!(
     conv1d_small,
@@ -1018,4 +1046,10 @@ test_device!(
     conv2d_grad_noncontiguous_kernel_cpu,
     conv2d_grad_noncontiguous_kernel_gpu,
     conv2d_grad_noncontiguous_kernel_metal
+);
+test_device!(
+    conv2d_noncontiguous_input,
+    conv2d_noncontiguous_input_cpu,
+    conv2d_noncontiguous_input_gpu,
+    conv2d_noncontiguous_input_metal
 );


### PR DESCRIPTION
### Summary

This removes the full NCHW-to-NHWC input repack from tiled CPU Conv2d. The tiled
kernel reads input directly through the source layout strides instead.

### Scope

- Remove the full input repack from `conv2d_tiled`.
- Read input directly using layout strides.
- Preserve tiled output ordering and padding/stride/dilation behavior.
- Keep non-contiguous input coverage.

### Validation

- `cargo fmt`
- `cargo test -p candle-core conv2d`
- `cargo test -p candle-core conv2d_noncontiguous_input`
- `git diff --check`

### Benchmark

Release microbenchmark on 2026-07-29:

| Shape | `main` | PR branch | Ratio |
| --- | ---: | ---: | ---: |
| `[1, 32, 192, 192] * [64, 32, 3, 3]`, padding 1 | 70.953 ms | 55.370 ms | 1.28x faster |

Checksums matched.

### Audit

Two audit passes found no major or medium issues. The change is scoped to tiled
direct-stride reads plus focused non-contiguous input coverage.