### PR TITLE
Add CPU conv3d tensor operation

### DIFF
--- a/candle-core/src/backend.rs
+++ b/candle-core/src/backend.rs
@@ -57,6 +57,14 @@ pub trait BackendStorage: Sized {
         _params: &crate::conv::ParamsConv2D,
     ) -> Result<Self>;
 
+    fn conv3d(
+        &self,
+        _l: &Layout,
+        _kernel: &Self,
+        _kernel_l: &Layout,
+        _params: &crate::conv::ParamsConv3D,
+    ) -> Result<Self>;
+
     fn conv_transpose2d(
         &self,
         _l: &Layout,

--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -80,6 +80,11 @@ impl Tensor {
                         kernel: rhs,
                         ..
                     }
+                    | Op::Conv3D {
+                        arg: lhs,
+                        kernel: rhs,
+                        ..
+                    }
                     | Op::ConvTranspose2D {
                         arg: lhs,
                         kernel: rhs,
@@ -314,6 +319,7 @@ impl Tensor {
                     Op::ConvTranspose1D { .. } => Err(Error::BackwardNotSupported {
                         op: "conv-transpose1d",
                     })?,
+                    Op::Conv3D { .. } => Err(Error::BackwardNotSupported { op: "conv3d" })?,
                     Op::ConvTranspose2D {
                         arg,
                         kernel,

--- a/candle-core/src/conv.rs
+++ b/candle-core/src/conv.rs
@@ -1,4 +1,4 @@
-//! 1D and 2D Convolutions
+//! 1D, 2D, and 3D Convolutions
 //!
 use crate::{op::BackpropOp, op::Op, Error, Result, Tensor};
 
@@ -83,6 +83,23 @@ pub struct ParamsConv2D {
     pub cudnn_fwd_algo: Option<CudnnFwdAlgo>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParamsConv3D {
+    pub(crate) b_size: usize,
+    pub(crate) i_d: usize,
+    pub(crate) i_h: usize,
+    pub(crate) i_w: usize,
+    pub(crate) k_d: usize,
+    pub(crate) k_h: usize,
+    pub(crate) k_w: usize,
+    pub(crate) c_out: usize,
+    pub(crate) c_in: usize,
+    pub(crate) padding: [usize; 3],
+    pub(crate) stride: [usize; 3],
+    pub(crate) dilation: [usize; 3],
+    pub cudnn_fwd_algo: Option<CudnnFwdAlgo>,
+}
+
 impl ParamsConv2D {
     pub(crate) fn out_h(&self) -> usize {
         (self.i_h + 2 * self.padding - self.dilation * (self.k_h - 1) - 1) / self.stride + 1
@@ -94,6 +111,33 @@ impl ParamsConv2D {
 
     pub(crate) fn out_dims(&self) -> Vec<usize> {
         vec![self.b_size, self.c_out, self.out_h(), self.out_w()]
+    }
+}
+
+impl ParamsConv3D {
+    pub(crate) fn out_d(&self) -> usize {
+        (self.i_d + 2 * self.padding[0] - self.dilation[0] * (self.k_d - 1) - 1) / self.stride[0]
+            + 1
+    }
+
+    pub(crate) fn out_h(&self) -> usize {
+        (self.i_h + 2 * self.padding[1] - self.dilation[1] * (self.k_h - 1) - 1) / self.stride[1]
+            + 1
+    }
+
+    pub(crate) fn out_w(&self) -> usize {
+        (self.i_w + 2 * self.padding[2] - self.dilation[2] * (self.k_w - 1) - 1) / self.stride[2]
+            + 1
+    }
+
+    pub(crate) fn out_dims(&self) -> Vec<usize> {
+        vec![
+            self.b_size,
+            self.c_out,
+            self.out_d(),
+            self.out_h(),
+            self.out_w(),
+        ]
     }
 }
 
@@ -335,6 +379,91 @@ impl Tensor {
                 .iter()
                 .zip(&kernel)
                 .map(|(block, kernel)| block.conv2d_single_group(kernel, &params))
+                .collect::<Result<Vec<_>>>()?;
+            Tensor::cat(&blocks, 1)
+        }
+    }
+
+    fn conv3d_single_group(&self, kernel: &Self, params: &ParamsConv3D) -> Result<Self> {
+        let storage =
+            self.storage()
+                .conv3d(self.layout(), &kernel.storage(), kernel.layout(), params)?;
+        let op = BackpropOp::new2(self, kernel, |arg, kernel| Op::Conv3D {
+            arg,
+            kernel,
+            padding: params.padding,
+            stride: params.stride,
+            dilation: params.dilation,
+        });
+        let out_dims = params.out_dims();
+        Ok(crate::tensor::from_storage(storage, out_dims, op, false))
+    }
+
+    /// Applies a 3D convolution over the input tensor.
+    pub fn conv3d(
+        &self,
+        kernel: &Self,
+        padding: usize,
+        stride: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<Self> {
+        self.conv3d_with_algo(
+            kernel,
+            [padding; 3],
+            [stride; 3],
+            [dilation; 3],
+            groups,
+            None,
+        )
+    }
+
+    /// Applies a 3D convolution over the input tensor.
+    pub fn conv3d_with_algo(
+        &self,
+        kernel: &Self,
+        padding: [usize; 3],
+        stride: [usize; 3],
+        dilation: [usize; 3],
+        groups: usize,
+        cudnn_fwd_algo: Option<CudnnFwdAlgo>,
+    ) -> Result<Self> {
+        let (b_size, c_in, i_d, i_h, i_w) = self.dims5()?;
+        let (c_out, c_in_k, k_d, k_h, k_w) = kernel.dims5()?;
+        if c_in != c_in_k * groups {
+            Err(Error::Conv3dInvalidArgs {
+                inp_shape: self.shape().clone(),
+                k_shape: kernel.shape().clone(),
+                padding,
+                stride,
+                msg: "the number of in-channels on the input doesn't match the kernel size",
+            }
+            .bt())?
+        }
+        let params = ParamsConv3D {
+            b_size,
+            i_d,
+            i_h,
+            i_w,
+            k_d,
+            k_h,
+            k_w,
+            c_out: c_out / groups,
+            c_in: c_in / groups,
+            padding,
+            stride,
+            dilation,
+            cudnn_fwd_algo,
+        };
+        if groups == 1 {
+            self.conv3d_single_group(kernel, &params)
+        } else {
+            let blocks = self.chunk(groups, 1)?;
+            let kernel = kernel.chunk(groups, 0)?;
+            let blocks = blocks
+                .iter()
+                .zip(&kernel)
+                .map(|(block, kernel)| block.conv3d_single_group(kernel, &params))
                 .collect::<Result<Vec<_>>>()?;
             Tensor::cat(&blocks, 1)
         }

--- a/candle-core/src/cpu_backend/conv3d.rs
+++ b/candle-core/src/cpu_backend/conv3d.rs
@@ -1,0 +1,91 @@
+use crate::{conv::ParamsConv3D, cpu_backend::Map2, shape::dims5, Layout, Result, WithDType};
+
+pub(super) struct Conv3D<'a>(pub(super) &'a crate::conv::ParamsConv3D);
+
+impl Map2 for Conv3D<'_> {
+    const OP: &'static str = "conv3d";
+
+    fn f<T: WithDType + num_traits::Num + Copy + 'static>(
+        &self,
+        inp: &[T],
+        inp_l: &Layout,
+        k: &[T],
+        k_l: &Layout,
+    ) -> Result<Vec<T>> {
+        conv3d_direct(self.0, inp, inp_l, k, k_l)
+    }
+}
+
+fn conv3d_direct<T: WithDType + num_traits::Num + Copy + 'static>(
+    p: &ParamsConv3D,
+    inp: &[T],
+    inp_l: &Layout,
+    k: &[T],
+    k_l: &Layout,
+) -> Result<Vec<T>> {
+    let inp = &inp[inp_l.start_offset()..];
+    let (inp_s0, inp_s1, inp_s2, inp_s3, inp_s4) = dims5(inp_l.stride())?;
+    let k = &k[k_l.start_offset()..];
+    let (k_s0, k_s1, k_s2, k_s3, k_s4) = dims5(k_l.stride())?;
+    let (out_d, out_h, out_w) = (p.out_d(), p.out_h(), p.out_w());
+
+    let mut dst = vec![T::zero(); p.b_size * p.c_out * out_d * out_h * out_w];
+    let out_s0 = p.c_out * out_d * out_h * out_w;
+    let out_s1 = out_d * out_h * out_w;
+    let out_s2 = out_h * out_w;
+    let out_s3 = out_w;
+
+    for b_idx in 0..p.b_size {
+        for dst_c_idx in 0..p.c_out {
+            for dst_d in 0..out_d {
+                for dst_h in 0..out_h {
+                    for dst_w in 0..out_w {
+                        let mut acc = T::zero();
+                        for src_c_idx in 0..p.c_in {
+                            for offset_d in 0..p.k_d {
+                                let src_d = p.stride[0] * dst_d + offset_d * p.dilation[0];
+                                if src_d < p.padding[0] || src_d >= p.padding[0] + p.i_d {
+                                    continue;
+                                }
+                                let src_d = src_d - p.padding[0];
+                                for offset_h in 0..p.k_h {
+                                    let src_h = p.stride[1] * dst_h + offset_h * p.dilation[1];
+                                    if src_h < p.padding[1] || src_h >= p.padding[1] + p.i_h {
+                                        continue;
+                                    }
+                                    let src_h = src_h - p.padding[1];
+                                    for offset_w in 0..p.k_w {
+                                        let src_w = p.stride[2] * dst_w + offset_w * p.dilation[2];
+                                        if src_w < p.padding[2] || src_w >= p.padding[2] + p.i_w {
+                                            continue;
+                                        }
+                                        let src_w = src_w - p.padding[2];
+                                        let inp_idx = b_idx * inp_s0
+                                            + src_c_idx * inp_s1
+                                            + src_d * inp_s2
+                                            + src_h * inp_s3
+                                            + src_w * inp_s4;
+                                        let k_idx = dst_c_idx * k_s0
+                                            + src_c_idx * k_s1
+                                            + offset_d * k_s2
+                                            + offset_h * k_s3
+                                            + offset_w * k_s4;
+                                        acc = acc + inp[inp_idx] * k[k_idx];
+                                    }
+                                }
+                            }
+                        }
+                        let dst_idx = b_idx * out_s0
+                            + dst_c_idx * out_s1
+                            + dst_d * out_s2
+                            + dst_h * out_s3
+                            + dst_w;
+                        dst[dst_idx] = acc;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(dst)
+}

--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -11,7 +11,9 @@ pub use utils::{
     binary_map, binary_map_vec, unary_map, unary_map_vec, Map1, Map1Any, Map2, Map2InPlace, Map2U8,
 };
 mod conv2d;
+mod conv3d;
 use conv2d::Conv2D;
+use conv3d::Conv3D;
 
 const USE_IM2COL_CONV1D: bool = true;
 const USE_COL2IM_CONV1D_TR: bool = true;
@@ -2859,6 +2861,16 @@ impl BackendStorage for CpuStorage {
         params: &crate::conv::ParamsConv2D,
     ) -> Result<Self> {
         Conv2D(params).map(self, l, kernel, kernel_l)
+    }
+
+    fn conv3d(
+        &self,
+        l: &Layout,
+        kernel: &Self,
+        kernel_l: &Layout,
+        params: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        Conv3D(params).map(self, l, kernel, kernel_l)
     }
 
     fn conv_transpose2d(

--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -2111,6 +2111,16 @@ impl BackendStorage for CudaStorage {
         Ok(Self { slice, device })
     }
 
+    fn conv3d(
+        &self,
+        _l: &Layout,
+        _kernel: &Self,
+        _kernel_l: &Layout,
+        _params: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        crate::bail!("conv3d is not implemented for the cuda backend")
+    }
+
     fn conv_transpose2d(
         &self,
         l: &Layout,

--- a/candle-core/src/dummy_cuda_backend.rs
+++ b/candle-core/src/dummy_cuda_backend.rs
@@ -122,6 +122,16 @@ impl crate::backend::BackendStorage for CudaStorage {
         Err(Error::NotCompiledWithCudaSupport)
     }
 
+    fn conv3d(
+        &self,
+        _: &Layout,
+        _: &Self,
+        _: &Layout,
+        _: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        Err(Error::NotCompiledWithCudaSupport)
+    }
+
     fn conv_transpose2d(
         &self,
         _l: &Layout,

--- a/candle-core/src/dummy_metal_backend.rs
+++ b/candle-core/src/dummy_metal_backend.rs
@@ -115,6 +115,16 @@ impl crate::backend::BackendStorage for MetalStorage {
         Err(Error::NotCompiledWithMetalSupport)
     }
 
+    fn conv3d(
+        &self,
+        _: &Layout,
+        _: &Self,
+        _: &Layout,
+        _: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        Err(Error::NotCompiledWithMetalSupport)
+    }
+
     fn conv_transpose2d(
         &self,
         _l: &Layout,

--- a/candle-core/src/error.rs
+++ b/candle-core/src/error.rs
@@ -128,6 +128,15 @@ pub enum Error {
         msg: &'static str,
     },
 
+    #[error("conv3d invalid args {msg}: inp: {inp_shape:?}, k: {k_shape:?}, pad: {padding:?}, stride: {stride:?}")]
+    Conv3dInvalidArgs {
+        inp_shape: Shape,
+        k_shape: Shape,
+        padding: [usize; 3],
+        stride: [usize; 3],
+        msg: &'static str,
+    },
+
     #[error("{op} invalid index {index} with dim size {size}")]
     InvalidIndex {
         op: &'static str,

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -1,7 +1,9 @@
 //! Implementation of Backend traits for Metal
 //!
 use crate::backend::{BackendDevice, BackendStorage};
-use crate::conv::{ParamsConv1D, ParamsConv2D, ParamsConvTranspose1D, ParamsConvTranspose2D};
+use crate::conv::{
+    ParamsConv1D, ParamsConv2D, ParamsConv3D, ParamsConvTranspose1D, ParamsConvTranspose2D,
+};
 use crate::op::{BinaryOpT, CmpOp, ReduceOp, UnaryOpT};
 use crate::{CpuStorage, CpuStorageRef, DType, Error, Layout, Result, Shape};
 use candle_metal_kernels::kernels::binary::contiguous;
@@ -1187,6 +1189,16 @@ impl BackendStorage for MetalStorage {
         let mut res_t = self.device().zeros_impl(res_l.shape(), res.dtype())?;
         res.copy_strided_src(&mut res_t, 0, &res_l)?;
         Ok(res_t)
+    }
+
+    fn conv3d(
+        &self,
+        _layout: &Layout,
+        _kernel: &Self,
+        _kernel_l: &Layout,
+        _params: &ParamsConv3D,
+    ) -> Result<Self> {
+        crate::bail!("conv3d is not implemented for the metal backend")
     }
 
     fn conv_transpose2d(

--- a/candle-core/src/op.rs
+++ b/candle-core/src/op.rs
@@ -116,6 +116,15 @@ pub enum Op {
     },
 
     #[allow(dead_code)]
+    Conv3D {
+        arg: Tensor,
+        kernel: Tensor,
+        padding: [usize; 3],
+        stride: [usize; 3],
+        dilation: [usize; 3],
+    },
+
+    #[allow(dead_code)]
     ConvTranspose2D {
         arg: Tensor,
         kernel: Tensor,

--- a/candle-core/src/storage.rs
+++ b/candle-core/src/storage.rs
@@ -461,6 +461,37 @@ impl Storage {
         }
     }
 
+    pub(crate) fn conv3d(
+        &self,
+        l: &Layout,
+        kernel: &Self,
+        kernel_l: &Layout,
+        params: &crate::conv::ParamsConv3D,
+    ) -> Result<Self> {
+        self.same_device(kernel, "conv3d")?;
+        self.same_dtype(kernel, "conv3d")?;
+        match (self, &kernel) {
+            (Storage::Cpu(inp), Storage::Cpu(kernel)) => {
+                let s = inp.conv3d(l, kernel, kernel_l, params)?;
+                Ok(Self::Cpu(s))
+            }
+            (Storage::Cuda(inp), Storage::Cuda(kernel)) => {
+                let s = inp.conv3d(l, kernel, kernel_l, params)?;
+                Ok(Self::Cuda(s))
+            }
+            (Storage::Metal(inp), Storage::Metal(kernel)) => {
+                let s = inp.conv3d(l, kernel, kernel_l, params)?;
+                Ok(Self::Metal(s))
+            }
+            (lhs, rhs) => Err(Error::DeviceMismatchBinaryOp {
+                lhs: lhs.device().location(),
+                rhs: rhs.device().location(),
+                op: "conv3d",
+            }
+            .bt()),
+        }
+    }
+
     pub(crate) fn conv_transpose2d(
         &self,
         l: &Layout,

--- a/candle-core/tests/conv_tests.rs
+++ b/candle-core/tests/conv_tests.rs
@@ -975,6 +975,263 @@ fn conv2d_grad_noncontiguous_kernel(dev: &Device) -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn conv3d_cpu() -> Result<()> {
+    let dev = &Device::Cpu;
+    let t = Tensor::new((0..27).map(|v| v as f32).collect::<Vec<_>>(), dev)?
+        .reshape((1, 1, 3, 3, 3))?;
+    let w = Tensor::ones((1, 1, 2, 2, 2), candle_core::DType::F32, dev)?;
+
+    let res = t.conv3d(&w, 0, 1, 1, 1)?;
+    assert_eq!(
+        test_utils::to_vec1_round(&res.flatten_all()?, 4)?,
+        &[52., 60., 76., 84., 124., 132., 148., 156.]
+    );
+    assert_eq!(res.dims(), &[1, 1, 2, 2, 2]);
+
+    let res = t.conv3d(&w, 1, 2, 1, 1)?;
+    assert_eq!(
+        test_utils::to_vec1_round(&res.flatten_all()?, 4)?,
+        &[0., 3., 9., 24., 27., 60., 72., 156.]
+    );
+    assert_eq!(res.dims(), &[1, 1, 2, 2, 2]);
+
+    Ok(())
+}
+
+fn conv3d_reference(
+    input: &[f32],
+    kernel: &[f32],
+    shape: (usize, usize, usize, usize, usize),
+    kernel_shape: (usize, usize, usize, usize, usize),
+    padding: [usize; 3],
+    stride: [usize; 3],
+    dilation: [usize; 3],
+) -> Vec<f32> {
+    let (b_size, c_in, i_d, i_h, i_w) = shape;
+    let (c_out, c_in_k, k_d, k_h, k_w) = kernel_shape;
+    assert_eq!(c_in, c_in_k);
+    let out_d = (i_d + 2 * padding[0] - dilation[0] * (k_d - 1) - 1) / stride[0] + 1;
+    let out_h = (i_h + 2 * padding[1] - dilation[1] * (k_h - 1) - 1) / stride[1] + 1;
+    let out_w = (i_w + 2 * padding[2] - dilation[2] * (k_w - 1) - 1) / stride[2] + 1;
+    let mut out = vec![0.; b_size * c_out * out_d * out_h * out_w];
+
+    for b in 0..b_size {
+        for oc in 0..c_out {
+            for od in 0..out_d {
+                for oh in 0..out_h {
+                    for ow in 0..out_w {
+                        let mut sum = 0.;
+                        for ic in 0..c_in {
+                            for kd in 0..k_d {
+                                let id = od * stride[0] + kd * dilation[0];
+                                if id < padding[0] || id >= i_d + padding[0] {
+                                    continue;
+                                }
+                                let id = id - padding[0];
+                                for kh in 0..k_h {
+                                    let ih = oh * stride[1] + kh * dilation[1];
+                                    if ih < padding[1] || ih >= i_h + padding[1] {
+                                        continue;
+                                    }
+                                    let ih = ih - padding[1];
+                                    for kw in 0..k_w {
+                                        let iw = ow * stride[2] + kw * dilation[2];
+                                        if iw < padding[2] || iw >= i_w + padding[2] {
+                                            continue;
+                                        }
+                                        let iw = iw - padding[2];
+                                        let input_idx =
+                                            ((((b * c_in + ic) * i_d + id) * i_h + ih) * i_w) + iw;
+                                        let kernel_idx =
+                                            ((((oc * c_in + ic) * k_d + kd) * k_h + kh) * k_w) + kw;
+                                        sum += input[input_idx] * kernel[kernel_idx];
+                                    }
+                                }
+                            }
+                        }
+                        let out_idx = ((((b * c_out + oc) * out_d + od) * out_h + oh) * out_w) + ow;
+                        out[out_idx] = sum;
+                    }
+                }
+            }
+        }
+    }
+
+    out
+}
+
+fn assert_vec_close(left: &[f32], right: &[f32], max_abs: f32) {
+    assert_eq!(left.len(), right.len());
+    let diff = left
+        .iter()
+        .zip(right.iter())
+        .map(|(left, right)| (left - right).abs())
+        .fold(0.0f32, f32::max);
+    assert!(diff <= max_abs, "max_abs={diff} > {max_abs}");
+}
+
+#[test]
+fn conv3d_cpu_plan_cases() -> Result<()> {
+    let dev = &Device::Cpu;
+
+    let input = (0..8).map(|v| v as f32).collect::<Vec<_>>();
+    let kernel = vec![2.];
+    let res = Tensor::new(input.clone(), dev)?
+        .reshape((1, 1, 2, 2, 2))?
+        .conv3d(
+            &Tensor::new(kernel.clone(), dev)?.reshape((1, 1, 1, 1, 1))?,
+            0,
+            1,
+            1,
+            1,
+        )?;
+    assert_eq!(res.dims(), &[1, 1, 2, 2, 2]);
+    assert_vec_close(
+        &res.flatten_all()?.to_vec1::<f32>()?,
+        &conv3d_reference(
+            &input,
+            &kernel,
+            (1, 1, 2, 2, 2),
+            (1, 1, 1, 1, 1),
+            [0; 3],
+            [1; 3],
+            [1; 3],
+        ),
+        1e-5,
+    );
+
+    let input = (0..27).map(|v| v as f32).collect::<Vec<_>>();
+    let kernel = vec![1.; 27];
+    let res = Tensor::new(input.clone(), dev)?
+        .reshape((1, 1, 3, 3, 3))?
+        .conv3d(
+            &Tensor::new(kernel.clone(), dev)?.reshape((1, 1, 3, 3, 3))?,
+            1,
+            1,
+            1,
+            1,
+        )?;
+    assert_eq!(res.dims(), &[1, 1, 3, 3, 3]);
+    assert_vec_close(
+        &res.flatten_all()?.to_vec1::<f32>()?,
+        &conv3d_reference(
+            &input,
+            &kernel,
+            (1, 1, 3, 3, 3),
+            (1, 1, 3, 3, 3),
+            [1; 3],
+            [1; 3],
+            [1; 3],
+        ),
+        1e-5,
+    );
+
+    let input = (0..125).map(|v| v as f32).collect::<Vec<_>>();
+    let kernel = vec![1.; 27];
+    let res = Tensor::new(input.clone(), dev)?
+        .reshape((1, 1, 5, 5, 5))?
+        .conv3d(
+            &Tensor::new(kernel.clone(), dev)?.reshape((1, 1, 3, 3, 3))?,
+            0,
+            2,
+            1,
+            1,
+        )?;
+    assert_eq!(res.dims(), &[1, 1, 2, 2, 2]);
+    assert_vec_close(
+        &res.flatten_all()?.to_vec1::<f32>()?,
+        &conv3d_reference(
+            &input,
+            &kernel,
+            (1, 1, 5, 5, 5),
+            (1, 1, 3, 3, 3),
+            [0; 3],
+            [2; 3],
+            [1; 3],
+        ),
+        1e-5,
+    );
+
+    let input = (0..108).map(|v| (v % 17) as f32 - 8.).collect::<Vec<_>>();
+    let kernel = (0..32).map(|v| (v % 7) as f32 - 3.).collect::<Vec<_>>();
+    let res = Tensor::new(input.clone(), dev)?
+        .reshape((2, 2, 3, 3, 3))?
+        .conv3d(
+            &Tensor::new(kernel.clone(), dev)?.reshape((2, 2, 2, 2, 2))?,
+            0,
+            1,
+            1,
+            1,
+        )?;
+    assert_eq!(res.dims(), &[2, 2, 2, 2, 2]);
+    assert_vec_close(
+        &res.flatten_all()?.to_vec1::<f32>()?,
+        &conv3d_reference(
+            &input,
+            &kernel,
+            (2, 2, 3, 3, 3),
+            (2, 2, 2, 2, 2),
+            [0; 3],
+            [1; 3],
+            [1; 3],
+        ),
+        1e-5,
+    );
+
+    let input = (0..16).map(|v| v as f32).collect::<Vec<_>>();
+    let kernel = vec![2f32, -1.];
+    let res = Tensor::new(input.clone(), dev)?
+        .reshape((1, 2, 2, 2, 2))?
+        .conv3d(
+            &Tensor::new(kernel, dev)?.reshape((2, 1, 1, 1, 1))?,
+            0,
+            1,
+            1,
+            2,
+        )?;
+    let expected = input[..8]
+        .iter()
+        .map(|v| v * 2.)
+        .chain(input[8..].iter().map(|v| -v))
+        .collect::<Vec<_>>();
+    assert_eq!(res.dims(), &[1, 2, 2, 2, 2]);
+    assert_vec_close(&res.flatten_all()?.to_vec1::<f32>()?, &expected, 1e-5);
+
+    let input = (0..2 * 4 * 6 * 6)
+        .map(|v| (v % 19) as f32 / 9. - 1.)
+        .collect::<Vec<_>>();
+    let kernel = (0..3 * 2 * 3 * 3 * 3)
+        .map(|v| (v % 13) as f32 / 6. - 1.)
+        .collect::<Vec<_>>();
+    let res = Tensor::new(input.clone(), dev)?
+        .reshape((1, 2, 4, 6, 6))?
+        .conv3d_with_algo(
+            &Tensor::new(kernel.clone(), dev)?.reshape((3, 2, 3, 3, 3))?,
+            [1, 1, 1],
+            [1, 2, 2],
+            [1, 1, 1],
+            1,
+            None,
+        )?;
+    assert_eq!(res.dims(), &[1, 3, 4, 3, 3]);
+    assert_vec_close(
+        &res.flatten_all()?.to_vec1::<f32>()?,
+        &conv3d_reference(
+            &input,
+            &kernel,
+            (1, 2, 4, 6, 6),
+            (3, 2, 3, 3, 3),
+            [1, 1, 1],
+            [1, 2, 2],
+            [1, 1, 1],
+        ),
+        1e-5,
+    );
+
+    Ok(())
+}
+
 test_device!(conv1d, conv1d_cpu, conv1d_gpu, conv1d_metal);
 test_device!(
     conv1d_small,


### PR DESCRIPTION
### Summary

This adds the core Tensor Conv3d API and a CPU direct Conv3d backend. Support for this is crucial for 3d image analysis (e.g. biology, medicine)

The API supports per-axis `[usize; 3]` `padding`, `stride`, and `dilation`,
while retaining a scalar convenience wrapper consistent with existing Conv1d
and Conv2d APIs.

### Scope

- Add `ParamsConv3D`.
- Add `Tensor::conv3d` and `Tensor::conv3d_with_algo`.
- Add backend trait/storage plumbing.
- Add CPU direct Conv3d implementation.
- Add dummy CUDA/Metal backend stubs.
- Add reference tests, including anisotropic stride and grouped Conv3d.
- Add structured `Conv3dInvalidArgs` error.

### Validation

- `cargo fmt`
- `cargo test -p candle-core conv3d`
- `cargo test -p candle-core conv3d_cpu_plan_cases`
- `cargo test -p candle-core conv`
- `git diff --check`

Note: `cargo check -p candle-core --features cuda` was attempted on this branch
but local CUDA headers failed in `candle-kernels` before reaching the Rust
backend changes because `/usr/include` lacks `cuda_fp8.h`.

### Audit

Two audit passes found no major or medium issues. The API is generalized to
per-axis 3D parameters and shared reference tests are ready for CUDA/Metal
follow-ups.