### PR TITLE
Fix CUDA 12.8 half compatibility guards

### DIFF
--- a/candle-kernels/src/compatibility.cuh
+++ b/candle-kernels/src/compatibility.cuh
@@ -7,7 +7,10 @@
 
 // FIXME: the minimum compute capabilities are just guesses since the table is not specific enough
 
-#if __CUDA_ARCH__ < 800
+// CUDA 12.8+ provides these helpers in cuda_fp16.hpp. Keep Candle's fallback for
+// older toolkits on pre-Ampere devices, where the helpers may be missing.
+#if __CUDA_ARCH__ < 800 && \
+    (__CUDACC_VER_MAJOR__ < 12 || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ < 8))
 __device__ __forceinline__ __half __hmax_nan(__half a, __half b) {
     return __hisnan(a) ? a : (__hisnan(b) ? b : __hmax(a, b));
 }


### PR DESCRIPTION
## Summary

This updates the CUDA kernel compatibility header so Candle builds on sm75 hardware with CUDA 12.8.

## Motivation

CUDA 12.8 exposes newer half-related APIs through headers that can trip builds on older architectures such as Turing/sm75. This patch keeps the compatibility guards explicit so users with still-supported NVIDIA cards can build Candle CUDA kernels.

## Scope

- Add compatibility guards for the affected CUDA half APIs.
- Keep the change local to the shared CUDA compatibility header.
- Do not change runtime behavior for newer architectures beyond the guarded compatibility path.

## Validation

Validated locally with:

```bash
CUDA_HOME=/usr/local/cuda-12.8 \
CUDA_PATH=/usr/local/cuda-12.8 \
NVCC=/usr/local/cuda-12.8/bin/nvcc \
CUDA_COMPUTE_CAP=75 \
LD_LIBRARY_PATH=/usr/local/cuda-12.8/targets/x86_64-linux/lib:$LD_LIBRARY_PATH \
cargo check -p candle-core --features cuda

git diff --check
```

## Review Notes

- I was only able to validate on sm75/CUDA 12.8 hardware. Review from someone with sm80+ hardware would be useful before merge.