### PR TITLE
Fix concrete shape element count validation

### DIFF
--- a/candle-core/src/shape.rs
+++ b/candle-core/src/shape.rs
@@ -472,8 +472,16 @@ pub trait ShapeWithOneHole {
 }
 
 impl<S: Into<Shape>> ShapeWithOneHole for S {
-    fn into_shape(self, _el_count: usize) -> Result<Shape> {
-        Ok(self.into())
+    fn into_shape(self, el_count: usize) -> Result<Shape> {
+        let shape = self.into();
+        if shape.elem_count() != el_count {
+            return Err(Error::ShapeMismatch {
+                buffer_size: el_count,
+                shape,
+            }
+            .bt());
+        }
+        Ok(shape)
     }
 }
 

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -2003,6 +2003,28 @@ fn test_flip_3d_channels() -> Result<()> {
 }
 
 #[test]
+fn tensor_from_data_validates_concrete_shape() -> Result<()> {
+    let values = [1f32, 2., 3., 4.];
+
+    assert!(Tensor::from_slice(&values, (2, 2, 2), &Device::Cpu).is_err());
+    assert!(Tensor::from_slice(&values, (2, 1), &Device::Cpu).is_err());
+    assert!(Tensor::from_vec(values.to_vec(), (2, 2, 2), &Device::Cpu).is_err());
+    assert!(Tensor::from_vec(values.to_vec(), (2, 1), &Device::Cpu).is_err());
+
+    let tensor = Tensor::from_slice(&values, (2, 2), &Device::Cpu)?;
+    assert_eq!(tensor.dims(), &[2, 2]);
+
+    let tensor = Tensor::from_vec(values.to_vec(), ((), 2), &Device::Cpu)?;
+    assert_eq!(tensor.dims(), &[2, 2]);
+
+    let empty: &[f32] = &[];
+    let tensor = Tensor::from_slice(empty, (0, 3), &Device::Cpu)?;
+    assert_eq!(tensor.dims(), &[0, 3]);
+
+    Ok(())
+}
+
+#[test]
 fn tensor_new() -> Result<()> {
     let t1 = Tensor::new(vec![1f32, 2.0, 3.0], &Device::Cpu)?;
     assert_eq!(t1.to_vec1::<f32>()?, [1.0, 2.0, 3.0]);


### PR DESCRIPTION
## Summary

- validate fully concrete shapes against the input element count in `ShapeWithOneHole::into_shape`
- return the existing structured `ShapeMismatch` error before creating inconsistent tensors
- add regression coverage for `from_slice` and `from_vec`, including shorter and longer inputs, valid inferred shapes, and zero-sized concrete shapes

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p candle-core --no-default-features --tests -- -D warnings`
- `cargo test -p candle-core --no-default-features --tests` (172 passed)
- `cargo test -p candle-core --no-default-features --doc` (45 passed, 1 ignored)

Closes #3812
