### PR TITLE
Validate concrete tensor shapes against data length

### DIFF
--- a/candle-core/src/shape.rs
+++ b/candle-core/src/shape.rs
@@ -472,8 +472,12 @@ pub trait ShapeWithOneHole {
 }
 
 impl<S: Into<Shape>> ShapeWithOneHole for S {
-    fn into_shape(self, _el_count: usize) -> Result<Shape> {
-        Ok(self.into())
+    fn into_shape(self, el_count: usize) -> Result<Shape> {
+        let shape = self.into();
+        if shape.elem_count() != el_count {
+            crate::bail!("cannot reshape tensor with {el_count} elements to {shape:?}")
+        }
+        Ok(shape)
     }
 }
 
@@ -630,5 +634,11 @@ mod tests {
         assert_eq!(shape.dims(), &[2, 3, 4, 5, 6]);
         let shape = Shape::from((2, 3, 4, 5, 6, 7));
         assert_eq!(shape.dims(), &[2, 3, 4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn concrete_shape_requires_matching_element_count() {
+        assert!((2, 3).into_shape(6).is_ok());
+        assert!((2, 3).into_shape(5).is_err());
     }
 }

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -9,6 +9,13 @@ fn zeros(device: &Device) -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn from_vec_and_from_slice_reject_mismatched_concrete_shapes() {
+    let data = [1f32, 2., 3., 4.];
+    assert!(Tensor::from_slice(&data, (2, 2, 2), &Device::Cpu).is_err());
+    assert!(Tensor::from_vec(data.to_vec(), (2, 2, 2), &Device::Cpu).is_err());
+}
+
 fn ones(device: &Device) -> Result<()> {
     assert_eq!(
         Tensor::ones((2, 3), DType::U8, device)?.to_vec2::<u8>()?,


### PR DESCRIPTION
Fixes #3812

## Summary

Validate the documented invariant for `Tensor::from_vec` and
`Tensor::from_slice`: when given a concrete shape, its element count must
match the input data length.

## Root cause

`ShapeWithOneHole::into_shape` ignored `el_count` for shapes without a hole.
This allowed tensors to be constructed with logical shapes larger or smaller
than their backing storage.

## Changes

- Reject concrete shapes whose element count differs from the data length.
- Add unit coverage for concrete-shape validation.
- Add regression coverage for both `Tensor::from_vec` and
  `Tensor::from_slice`.

## Validation

```text
cargo fmt --check
cargo test -p candle-core --lib concrete_shape_requires_matching_element_count
cargo test -p candle-core --test tensor_tests from_vec_and_from_slice_reject_mismatched_concrete_shapes