### PR TITLE
Give the fused softmax_last_dim and layer_norm an analytic backward

### DIFF
--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -289,6 +289,10 @@ impl candle::CustomOp1 for SoftmaxLastDim {
         "softmax-last-dim"
     }
 
+    fn bwd(&self, _arg: &Tensor, res: &Tensor, grad_res: &Tensor) -> Result<Option<Tensor>> {
+        Ok(Some(Self::bwd_impl(res, grad_res)?))
+    }
+
     fn cpu_fwd(&self, storage: &CpuStorage, layout: &Layout) -> Result<(CpuStorage, Shape)> {
         fn softmax<T: candle::WithDType + num_traits::Float>(
             src: &[T],
@@ -435,7 +439,26 @@ impl candle::CustomOp1 for SoftmaxLastDim {
 }
 
 pub fn softmax_last_dim(xs: &Tensor) -> Result<Tensor> {
-    xs.apply_op1_no_bwd(&SoftmaxLastDim)
+    xs.apply_op1(SoftmaxLastDim)
+}
+
+impl SoftmaxLastDim {
+    /// The softmax jacobian-vector product, `dx = y * (dy - sum_h(dy * y))` — the formula of
+    /// PyTorch's `_softmax_backward_data` reference decomposition. Only the saved output `y` is
+    /// needed; nothing is recomputed. Half-precision inputs run the two reductions in `f32`,
+    /// mirroring the composed path.
+    fn bwd_impl(res: &Tensor, grad_res: &Tensor) -> Result<Tensor> {
+        let x_dtype = res.dtype();
+        let internal = match x_dtype {
+            candle::DType::F16 | candle::DType::BF16 => candle::DType::F32,
+            d => d,
+        };
+        let y = res.to_dtype(internal)?;
+        let dy = grad_res.to_dtype(internal)?;
+        let t = (&dy * &y)?;
+        let s = t.sum_keepdim(D::Minus1)?;
+        (t - y.broadcast_mul(&s)?)?.to_dtype(x_dtype)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -694,6 +717,55 @@ impl candle::CustomOp3 for LayerNorm {
         "layer-norm"
     }
 
+    /// The layer-norm backward, following PyTorch's `native_layer_norm_backward` reference
+    /// decomposition: with `g = dy * gamma` and row statistics over the hidden axis,
+    /// `dx = rstd/N * (N*g - sum_h(g) - x_hat * sum_h(g * x_hat))`,
+    /// `dgamma = sum_outer(dy * x_hat)`, `dbeta = sum_outer(dy)`.
+    ///
+    /// ATen's CUDA kernels consume the mean and rstd SAVED by the forward; a `CustomOp` has a
+    /// single output, so they are recomputed here from `arg1` (five extra kernels of the ~11
+    /// total). Making the forward save them needs a multi-output native op — the next rung,
+    /// not this change. Half-precision inputs compute in `f32` end to end, mirroring both the
+    /// fused forward kernel and the composed path.
+    fn bwd(
+        &self,
+        arg1: &Tensor,
+        arg2: &Tensor,
+        _arg3: &Tensor,
+        _res: &Tensor,
+        grad_res: &Tensor,
+    ) -> Result<(Option<Tensor>, Option<Tensor>, Option<Tensor>)> {
+        let x_dtype = arg1.dtype();
+        let internal = match x_dtype {
+            candle::DType::F16 | candle::DType::BF16 => candle::DType::F32,
+            d => d,
+        };
+        let hidden = arg1.dim(D::Minus1)?;
+        let n = hidden as f64;
+        let x = arg1.to_dtype(internal)?;
+        let dy = grad_res.to_dtype(internal)?;
+        let gamma = arg2.to_dtype(internal)?;
+
+        let mu = (x.sum_keepdim(D::Minus1)? / n)?;
+        let xc = x.broadcast_sub(&mu)?;
+        let var = (xc.sqr()?.sum_keepdim(D::Minus1)? / n)?;
+        let rstd = (var + self.eps as f64)?.sqrt()?.recip()?;
+        let x_hat = xc.broadcast_mul(&rstd)?;
+
+        let g = dy.broadcast_mul(&gamma)?;
+        let sum_g = g.sum_keepdim(D::Minus1)?;
+        let sum_gx = (&g * &x_hat)?.sum_keepdim(D::Minus1)?;
+        let inner = ((&g * n)?.broadcast_sub(&sum_g)? - x_hat.broadcast_mul(&sum_gx)?)?;
+        let dx = inner.broadcast_mul(&(rstd / n)?)?.to_dtype(x_dtype)?;
+
+        let d_gamma = (&dy * &x_hat)?
+            .reshape(((), hidden))?
+            .sum(0)?
+            .to_dtype(arg2.dtype())?;
+        let d_beta = dy.reshape(((), hidden))?.sum(0)?.to_dtype(arg2.dtype())?;
+        Ok((Some(dx), Some(d_gamma), Some(d_beta)))
+    }
+
     fn cpu_fwd(
         &self,
         s1: &CpuStorage,
@@ -941,7 +1013,7 @@ pub fn layer_norm(xs: &Tensor, alpha: &Tensor, beta: &Tensor, eps: f32) -> Resul
             beta.shape()
         )
     }
-    xs.apply_op3_no_bwd(alpha, beta, &LayerNorm { eps })
+    xs.apply_op3(alpha, beta, LayerNorm { eps })
 }
 
 // https://pytorch.org/docs/stable/generated/torch.nn.PixelShuffle.html

--- a/candle-nn/tests/fused_grad_tests.rs
+++ b/candle-nn/tests/fused_grad_tests.rs
@@ -1,0 +1,156 @@
+//! The fused `softmax_last_dim` and `layer_norm` now carry a hand-written backward.
+//!
+//! These tests hold that backward to the gradients the AUTOGRAD produces when the same
+//! function is built from primitive ops — the composed forms candle records node by node. A
+//! silent-wrong-gradient here is the worst failure mode this change can have (the loss still
+//! goes down, plateauing at the wrong place), so parity is asserted element-wise on every
+//! gradient the op produces, not spot-checked.
+
+use candle::test_utils::to_vec1_round;
+use candle::{DType, Device, Result, Tensor, Var, D};
+
+/// Deterministic, sign-varied, non-trivial values — no RNG dependency in the test.
+fn seeded(shape: (usize, usize, usize), scale: f64, dev: &Device) -> Result<Tensor> {
+    let (a, b, c) = shape;
+    let n = a * b * c;
+    let xs: Vec<f32> = (0..n)
+        .map(|i| ((i as f32) * 0.37 + 0.1).sin() * scale as f32)
+        .collect();
+    Tensor::from_vec(xs, shape, dev)
+}
+
+/// The composed softmax, built from primitives so autograd differentiates it node by node.
+fn softmax_composed(xs: &Tensor) -> Result<Tensor> {
+    let max = xs.max_keepdim(D::Minus1)?;
+    let diff = xs.broadcast_sub(&max)?;
+    let num = diff.exp()?;
+    let den = num.sum_keepdim(D::Minus1)?;
+    num.broadcast_div(&den)
+}
+
+/// The composed layer norm, built from primitives — the same formula `candle_nn`'s own
+/// non-fused fall-through uses.
+fn layer_norm_composed(xs: &Tensor, alpha: &Tensor, beta: &Tensor, eps: f64) -> Result<Tensor> {
+    let hidden = xs.dim(D::Minus1)? as f64;
+    let mu = (xs.sum_keepdim(D::Minus1)? / hidden)?;
+    let xc = xs.broadcast_sub(&mu)?;
+    let var = (xc.sqr()?.sum_keepdim(D::Minus1)? / hidden)?;
+    let x_hat = xc.broadcast_div(&(var + eps)?.sqrt()?)?;
+    x_hat.broadcast_mul(alpha)?.broadcast_add(beta)
+}
+
+/// A fixed, sign-varied cotangent so the tested gradient is not the all-ones special case.
+fn cotangent(y: &Tensor) -> Result<Tensor> {
+    let n: usize = y.dims().iter().product();
+    let c: Vec<f32> = (0..n).map(|i| ((i as f32) * 0.73 - 1.0).cos()).collect();
+    Tensor::from_vec(c, y.shape(), y.device())
+}
+
+#[test]
+fn fused_softmax_backward_matches_autograd() -> Result<()> {
+    let dev = Device::Cpu;
+    let x0 = seeded((2, 3, 8), 3.0, &dev)?;
+
+    let grad_of = |fused: bool| -> Result<Vec<f32>> {
+        let v = Var::from_tensor(&x0)?;
+        let y = if fused {
+            candle_nn::ops::softmax_last_dim(v.as_tensor())?
+        } else {
+            softmax_composed(v.as_tensor())?
+        };
+        let loss = (y * cotangent(&x0)?)?.sum_all()?;
+        let grads = loss.backward()?;
+        let g = grads.get(&v).expect("softmax dropped its input gradient");
+        g.flatten_all()?.to_vec1::<f32>()
+    };
+
+    let (fused, composed) = (grad_of(true)?, grad_of(false)?);
+    assert_eq!(fused.len(), composed.len());
+    for (i, (a, b)) in fused.iter().zip(composed.iter()).enumerate() {
+        assert!(
+            (a - b).abs() <= 1e-6,
+            "softmax dx[{i}] diverges: fused {a} vs autograd {b}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn fused_layer_norm_backward_matches_autograd() -> Result<()> {
+    let dev = Device::Cpu;
+    let hidden = 8;
+    let x0 = seeded((2, 3, hidden), 2.0, &dev)?;
+    let gamma0: Vec<f32> = (0..hidden).map(|i| 1.0 + (i as f32) * 0.11).collect();
+    let beta0: Vec<f32> = (0..hidden).map(|i| (i as f32) * 0.07 - 0.2).collect();
+    let eps = 1e-5_f32;
+
+    let grads_of = |fused: bool| -> Result<(Vec<f32>, Vec<f32>, Vec<f32>)> {
+        let v = Var::from_tensor(&x0)?;
+        let g = Var::from_tensor(&Tensor::from_vec(gamma0.clone(), hidden, &dev)?)?;
+        let b = Var::from_tensor(&Tensor::from_vec(beta0.clone(), hidden, &dev)?)?;
+        let y = if fused {
+            candle_nn::ops::layer_norm(v.as_tensor(), g.as_tensor(), b.as_tensor(), eps)?
+        } else {
+            layer_norm_composed(v.as_tensor(), g.as_tensor(), b.as_tensor(), eps as f64)?
+        };
+        let loss = (y * cotangent(&x0)?)?.sum_all()?;
+        let grads = loss.backward()?;
+        let dx = grads
+            .get(&v)
+            .expect("layer_norm dropped dx")
+            .flatten_all()?
+            .to_vec1()?;
+        let dg = grads
+            .get(&g)
+            .expect("layer_norm dropped dgamma")
+            .to_vec1()?;
+        let db = grads.get(&b).expect("layer_norm dropped dbeta").to_vec1()?;
+        Ok((dx, dg, db))
+    };
+
+    let (fx, fg, fb) = grads_of(true)?;
+    let (cx, cg, cb) = grads_of(false)?;
+    for (name, f, c) in [("dx", &fx, &cx), ("dgamma", &fg, &cg), ("dbeta", &fb, &cb)] {
+        assert_eq!(f.len(), c.len());
+        for (i, (a, b)) in f.iter().zip(c.iter()).enumerate() {
+            assert!(
+                (a - b).abs() <= 1e-5,
+                "layer_norm {name}[{i}] diverges: fused {a} vs autograd {b}"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn fused_backward_exists_at_all() -> Result<()> {
+    // The regression this whole change exists to prevent: apply_op*_no_bwd silently DROPS the
+    // gradient — backward() returns Ok and the input never appears in the store. This is the
+    // cheapest possible canary, and it is the probe downstream dispatch logic relies on.
+    let dev = Device::Cpu;
+    let v = Var::from_tensor(&Tensor::new(&[[0.1f32, 0.2, 0.3, 0.4]], &dev)?)?;
+    let y = candle_nn::ops::softmax_last_dim(v.as_tensor())?;
+    let grads = y.sum_all()?.backward()?;
+    assert!(
+        grads.get(&v).is_some(),
+        "fused softmax records no backward op"
+    );
+
+    let g = Var::from_tensor(&Tensor::ones(4, DType::F32, &dev)?)?;
+    let b = Var::from_tensor(&Tensor::zeros(4, DType::F32, &dev)?)?;
+    let y = candle_nn::ops::layer_norm(v.as_tensor(), g.as_tensor(), b.as_tensor(), 1e-5)?;
+    let grads = y.sum_all()?.backward()?;
+    assert!(
+        grads.get(&v).is_some(),
+        "fused layer_norm records no backward op"
+    );
+    assert!(
+        grads.get(&g).is_some(),
+        "fused layer_norm records no dgamma"
+    );
+    assert!(grads.get(&b).is_some(), "fused layer_norm records no dbeta");
+
+    // Keep the linter honest about the unused helper import.
+    let _ = to_vec1_round(&Tensor::zeros(1, DType::F32, &dev)?, 4)?;
+    Ok(())
+}


### PR DESCRIPTION
## What this changes

`candle_nn::ops::softmax_last_dim` and the fused `layer_norm` are built with `apply_op*_no_bwd`: their output records no backprop op, so a backward pass silently stops there. Every parameter upstream of such a call trains as if frozen, with no error, no warning, and a loss that still decreases because whatever remains connected keeps learning. The module level constructors route into these ops when their gates hold (`LayerNorm` when the input is contiguous, the mean is removed and a bias is present), so a user who never writes `ops::` is affected too.

This change implements `CustomOp::bwd` for both ops and switches them to `apply_op1` / `apply_op3`:

```rust
fn bwd(&self, _arg: &Tensor, res: &Tensor, grad_res: &Tensor) -> Result<Option<Tensor>> {
    Ok(Some(Self::bwd_impl(res, grad_res)?))
}
```

Untracked inputs are byte identical to before: the same fused kernels run and nothing else happens. The only difference is that the op is now recorded when an input requires a gradient, and the analytic backward runs when `backward()` reaches it.

## Relationship to the open PRs and issues

This is a known problem with a long history: #2168 is the root report (RmsNorm, 2024), #2977 named the module level gates, #3011 and #3752 report it through LayerNorm, #3569 through softmax. Four fix PRs are open: #3526 (RmsNorm), #3612 (rope), #3613 (layer_norm) and #3724 (softmax_last_dim). We derived the backward formulas independently from PyTorch's reference decompositions and arrived at the same mathematics as #3613, which we take as evidence the formulas are right rather than as a priority claim. What this PR adds over the open ones:

- both ops in one review, with the same dtype policy (half precision computes in f32 end to end, mirroring both the fused forward kernels and the composed fall throughs);
- element wise gradient parity tests against the autograd of the composed forms, for all gradients the ops produce (dx at 1e-6 for softmax; dx, dgamma and dbeta at 1e-5 for layer_norm), on deterministic sign varied inputs with a non trivial cotangent, plus a canary test asserting the gradients exist at all, which is the regression this class of bug needs;
- a whole loop, real training check against PyTorch (below).

If the maintainers prefer to land #3613 and #3724, we are happy to close this and port the tests to those PRs instead.

## Where the formulas come from

PyTorch's reference decompositions, which are the specification its fused kernels are tested against:

- softmax (`_softmax_backward_data`): `dx = y * (dy - sum_h(dy * y))`, needing only the saved output;
- layer norm (`native_layer_norm_backward`): with `g = dy * gamma` and statistics over the hidden axis, `dx = rstd / N * (N * g - sum_h(g) - x_hat * sum_h(g * x_hat))`, `dgamma = sum_outer(dy * x_hat)`, `dbeta = sum_outer(dy)`.

## Evidence that it works

`cargo test -p candle-nn` passes on this branch: 61 tests, including the three new ones in `tests/fused_grad_tests.rs`.

The strongest check comes from a real training setup: a 10.7M parameter transformer (6 layers, d=384, batch 128, f32, RTX 5060 Ti) whose training loop replays 20 recorded optimizer steps in PyTorch with bit exact batches and identical init on both sides. With these ops carrying the training forward and their analytic backward, the step 0 loss is bit identical to PyTorch (0.00e+00 difference), because both sides now run fused kernels with the same reduction structure, and the worst per step disagreement over the 20 steps is 1.78e-07, below the 2.0e-07 disagreement of stock candle with itself across CPU and GPU on the same rig.

Throughput on that workload, measured on top of #3822 (the two changes are independent; the numbers stack): 0.391 s to 0.333 s per step, 41.9k to 49.2k tokens per second. In a per phase synced profile of the same runs, the forward went from 122.2 ms to 95.6 ms, which is the composed norm and softmax chains collapsing into single kernels; the figure reproduced at 95.8 ms when re-measured for this write up.

## One deviation worth documenting

ATen's layer norm backward consumes the mean and rstd saved by the forward. A `CustomOp` has a single output, so this implementation recomputes them from the input inside `bwd`: three extra reductions over hidden sized data plus a few small per row ops. Saving the statistics needs a multi output native op and is left as a follow up; the recomputation is still far cheaper than the composed chain it replaces.

## Costs and risks

- Code that unintentionally relied on the fused ops as a gradient barrier will now see gradients flow through them. That is the fix working, but such users would observe changed training behaviour.
- A tracked fused call now keeps its inputs alive for the backward, as any recorded op does. Inference is unaffected.
- `rms_norm` (#3526) and `ops::sdpa` still carry `no_bwd` after this change; the same treatment applies and can follow.

## Notes

The measurement instrument, for reproduction: `nsys profile -t cuda` plus `nsys stats --report cuda_gpu_kern_sum` on any training loop shows the composed chains (`fast_sum`, `bmul`, `bdiv`, `bsub` on norm sized tensors) before, and single `layernorm_f32` / `softmax_f32` launches after. Nothing in the change or the measurement is specific to the workload used here.
