### PR TITLE
Add candle-nvfp4-kernels for NVIDIA ModelOpt FP4 weights

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "candle-core",
     "candle-datasets",
     "candle-examples",
+    "candle-nvfp4-kernels",
     "candle-nn",
     "candle-pyo3",
     "candle-transformers",

--- a/candle-nvfp4-kernels/Cargo.toml
+++ b/candle-nvfp4-kernels/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "candle-nvfp4-kernels"
+version = "0.11.0"
+edition = "2021"
+
+description = "CUDA kernels for NVIDIA ModelOpt NVFP4 quantized linear layers in Candle."
+repository = "https://github.com/huggingface/candle"
+keywords = ["blas", "tensor", "machine-learning", "cuda", "quantization"]
+categories = ["science"]
+license = "MIT OR Apache-2.0"
+
+[features]
+default = []
+cuda = []
+
+[build-dependencies]
+anyhow = "1"
+cudaforge = "0.1.2"

--- a/candle-nvfp4-kernels/build.rs
+++ b/candle-nvfp4-kernels/build.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+
+fn main() -> anyhow::Result<()> {
+    println!("cargo::rerun-if-changed=build.rs");
+    if std::env::var("CARGO_FEATURE_CUDA").is_err() {
+        return Ok(());
+    }
+
+    println!("cargo::rerun-if-changed=kernels/nvfp4_gemm.cu");
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let mut builder = cudaforge::KernelBuilder::new()
+        .source_files(vec!["kernels/nvfp4_gemm.cu"])
+        .out_dir(&out_dir)
+        .arg("-std=c++17")
+        .arg("-O3");
+    if !std::env::var("TARGET").is_ok_and(|target| target.contains("msvc")) {
+        builder = builder.arg("-Xcompiler").arg("-fPIC");
+    }
+    builder.build_lib(out_dir.join("libnvfp4kernels.a"))?;
+    println!("cargo::rustc-link-search={}", out_dir.display());
+    println!("cargo::rustc-link-lib=nvfp4kernels");
+    println!("cargo::rustc-link-lib=dylib=cudart");
+    if !std::env::var("TARGET").is_ok_and(|target| target.contains("msvc")) {
+        println!("cargo::rustc-link-lib=stdc++");
+    }
+    Ok(())
+}

--- a/candle-nvfp4-kernels/kernels/nvfp4_gemm.cu
+++ b/candle-nvfp4-kernels/kernels/nvfp4_gemm.cu
@@ -1,0 +1,83 @@
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace {
+constexpr int kBlockSize = 16;
+
+__device__ __forceinline__ float e2m1_to_f32(uint8_t x) {
+  constexpr float table[16] = {0., .5, 1., 1.5, 2., 3., 4., 6.,
+                                0., -.5, -1., -1.5, -2., -3., -4., -6.};
+  return table[x & 0xf];
+}
+
+// NVIDIA's FP8 E4M3FN encoding, used for the per-16-value NVFP4 scales.
+__device__ __forceinline__ float e4m3_to_f32(uint8_t x) {
+  const float sign = (x & 0x80) ? -1.f : 1.f;
+  const int exponent = (x >> 3) & 0xf;
+  const int mantissa = x & 0x7;
+  if (exponent == 0) return sign * mantissa * 0.001953125f;
+  // E4M3FN has no infinities; 0x7f/0xff encode NaN.
+  if (exponent == 0xf && mantissa == 0x7) return nanf("");
+  return sign * (1.f + mantissa * .125f) * exp2f(float(exponent - 7));
+}
+
+__global__ void linear_f32(const float* input, const uint8_t* weight,
+                           const uint8_t* scales, float tensor_scale,
+                           float* output, int64_t tokens, int64_t rows,
+                           int64_t cols) {
+  const int64_t index = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= tokens * rows) return;
+  const int64_t token = index / rows;
+  const int64_t row = index % rows;
+  const int64_t packed_cols = cols / 2;
+  const int64_t scale_cols = cols / kBlockSize;
+  float sum = 0.f;
+  for (int64_t col = 0; col < cols; ++col) {
+    const uint8_t packed = weight[row * packed_cols + col / 2];
+    const uint8_t nibble = (col & 1) ? packed & 0xf : packed >> 4;
+    const float scale = e4m3_to_f32(scales[row * scale_cols + col / kBlockSize]);
+    sum += input[token * cols + col] * e2m1_to_f32(nibble) * scale * tensor_scale;
+  }
+  output[index] = sum;
+}
+
+bool valid(int64_t rows, int64_t cols, int64_t tokens) {
+  return rows > 0 && cols > 0 && tokens > 0 && cols % kBlockSize == 0;
+}
+}  // namespace
+
+extern "C" int candle_nvfp4_cuda_is_available() {
+  int device;
+  cudaDeviceProp properties{};
+  return cudaGetDevice(&device) == cudaSuccess &&
+                 cudaGetDeviceProperties(&properties, device) == cudaSuccess &&
+                 properties.major >= 10
+             ? 1
+             : 0;
+}
+
+extern "C" int candle_nvfp4_linear_f32_host_batched(
+    const float* input, const uint8_t* weight, const uint8_t* scales,
+    float tensor_scale, float* output, int64_t tokens, int64_t rows, int64_t cols) {
+  if (!valid(rows, cols, tokens) || !input || !weight || !scales || !output)
+    return cudaErrorInvalidValue;
+  float *d_input = nullptr, *d_output = nullptr;
+  uint8_t *d_weight = nullptr, *d_scales = nullptr;
+  cudaError_t status = cudaMalloc(&d_input, size_t(tokens * cols) * sizeof(float));
+  if (status != cudaSuccess) goto cleanup;
+  status = cudaMalloc(&d_weight, size_t(rows * cols / 2));
+  if (status != cudaSuccess) goto cleanup;
+  status = cudaMalloc(&d_scales, size_t(rows * cols / kBlockSize));
+  if (status != cudaSuccess) goto cleanup;
+  status = cudaMalloc(&d_output, size_t(tokens * rows) * sizeof(float));
+  if (status != cudaSuccess) goto cleanup;
+  if ((status = cudaMemcpy(d_input, input, size_t(tokens * cols) * sizeof(float), cudaMemcpyHostToDevice)) != cudaSuccess ||
+      (status = cudaMemcpy(d_weight, weight, size_t(rows * cols / 2), cudaMemcpyHostToDevice)) != cudaSuccess ||
+      (status = cudaMemcpy(d_scales, scales, size_t(rows * cols / kBlockSize), cudaMemcpyHostToDevice)) != cudaSuccess) goto cleanup;
+  linear_f32<<<unsigned((tokens * rows + 255) / 256), 256>>>(d_input, d_weight, d_scales, tensor_scale, d_output, tokens, rows, cols);
+  if ((status = cudaGetLastError()) != cudaSuccess) goto cleanup;
+  status = cudaMemcpy(output, d_output, size_t(tokens * rows) * sizeof(float), cudaMemcpyDeviceToHost);
+cleanup:
+  cudaFree(d_output); cudaFree(d_scales); cudaFree(d_weight); cudaFree(d_input);
+  return status;
+}

--- a/candle-nvfp4-kernels/src/lib.rs
+++ b/candle-nvfp4-kernels/src/lib.rs
@@ -1,0 +1,185 @@
+//! CUDA execution for NVIDIA ModelOpt W4A16 NVFP4 linear layers.
+//!
+//! Weights use two E2M1 values per byte, one E4M3FN scale per 16 input values,
+//! and a tensor-wide `f32` scale. The host API is intentionally batched: it
+//! avoids launching and re-uploading a weight matrix once per token during prefill.
+
+#[cfg(feature = "cuda")]
+use std::ffi::c_int;
+
+pub const BLOCK_SIZE: usize = 16;
+
+#[cfg(feature = "cuda")]
+unsafe extern "C" {
+    fn candle_nvfp4_cuda_is_available() -> c_int;
+    fn candle_nvfp4_linear_f32_host_batched(
+        input: *const f32,
+        weight: *const u8,
+        scales: *const u8,
+        tensor_scale: f32,
+        output: *mut f32,
+        tokens: i64,
+        rows: i64,
+        cols: i64,
+    ) -> c_int;
+}
+
+/// Whether the active CUDA device meets the native NVFP4 execution contract
+/// (compute capability 10.0 / Blackwell or newer).
+#[cfg(feature = "cuda")]
+pub fn is_available() -> bool {
+    unsafe { candle_nvfp4_cuda_is_available() == 1 }
+}
+
+#[cfg(not(feature = "cuda"))]
+pub fn is_available() -> bool {
+    false
+}
+
+fn validate(
+    input: &[f32],
+    weight: &[u8],
+    scales: &[u8],
+    rows: usize,
+    cols: usize,
+    tokens: usize,
+) -> Result<(), String> {
+    if rows == 0 || cols == 0 || tokens == 0 || !cols.is_multiple_of(BLOCK_SIZE) {
+        return Err(format!(
+            "NVFP4 requires non-zero rows/tokens and cols divisible by {BLOCK_SIZE}"
+        ));
+    }
+    if [rows, cols, tokens]
+        .into_iter()
+        .any(|dimension| dimension > i64::MAX as usize)
+    {
+        return Err("NVFP4 dimensions exceed the CUDA kernel's i64 range".into());
+    }
+    if input.len() != tokens * cols {
+        return Err(format!(
+            "NVFP4 input has {} values, expected {}",
+            input.len(),
+            tokens * cols
+        ));
+    }
+    if weight.len() != rows * cols / 2 {
+        return Err(format!(
+            "NVFP4 packed weight has {} bytes, expected {}",
+            weight.len(),
+            rows * cols / 2
+        ));
+    }
+    if scales.len() != rows * cols / BLOCK_SIZE {
+        return Err(format!(
+            "NVFP4 scale tensor has {} bytes, expected {}",
+            scales.len(),
+            rows * cols / BLOCK_SIZE
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn e2m1_to_f32(nibble: u8) -> f32 {
+    [
+        0., 0.5, 1., 1.5, 2., 3., 4., 6., 0., -0.5, -1., -1.5, -2., -3., -4., -6.,
+    ][(nibble & 0xf) as usize]
+}
+
+#[cfg(test)]
+fn e4m3fn_to_f32(byte: u8) -> f32 {
+    let sign = if byte & 0x80 == 0 { 1. } else { -1. };
+    let exponent = (byte >> 3) & 0xf;
+    let mantissa = byte & 0x7;
+    if exponent == 0 {
+        sign * mantissa as f32 / 512.
+    } else if exponent == 0xf && mantissa == 0x7 {
+        f32::NAN
+    } else {
+        sign * (1. + mantissa as f32 / 8.) * 2f32.powi(exponent as i32 - 7)
+    }
+}
+
+/// Computes `[tokens, cols] @ dequant([rows, cols]).T` on CUDA.
+pub fn linear_f32_host_batched(
+    input: &[f32],
+    packed_weight: &[u8],
+    weight_scale_e4m3: &[u8],
+    tensor_scale: f32,
+    rows: usize,
+    cols: usize,
+    tokens: usize,
+) -> Result<Vec<f32>, String> {
+    validate(input, packed_weight, weight_scale_e4m3, rows, cols, tokens)?;
+    let _ = tensor_scale;
+    if !is_available() {
+        return Err(
+            "NVFP4 CUDA kernels require compute capability 10.0 (Blackwell) or newer".into(),
+        );
+    }
+    #[cfg(feature = "cuda")]
+    {
+        let mut output = vec![0.; tokens * rows];
+        let status = unsafe {
+            candle_nvfp4_linear_f32_host_batched(
+                input.as_ptr(),
+                packed_weight.as_ptr(),
+                weight_scale_e4m3.as_ptr(),
+                tensor_scale,
+                output.as_mut_ptr(),
+                tokens as i64,
+                rows as i64,
+                cols as i64,
+            )
+        };
+        if status == 0 {
+            Ok(output)
+        } else {
+            Err(format!("NVFP4 CUDA execution failed with status {status}"))
+        }
+    }
+    #[cfg(not(feature = "cuda"))]
+    unreachable!("availability is false without the cuda feature")
+}
+
+/// Single-token convenience wrapper around [`linear_f32_host_batched`].
+pub fn linear_f32_host(
+    input: &[f32],
+    packed_weight: &[u8],
+    weight_scale_e4m3: &[u8],
+    tensor_scale: f32,
+    rows: usize,
+    cols: usize,
+) -> Result<Vec<f32>, String> {
+    linear_f32_host_batched(
+        input,
+        packed_weight,
+        weight_scale_e4m3,
+        tensor_scale,
+        rows,
+        cols,
+        1,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn shape_validation_rejects_malformed_packed_tensors() {
+        assert!(validate(&[0.; 16], &[0; 7], &[0; 1], 1, 16, 1).is_err());
+        assert!(validate(&[0.; 15], &[0; 8], &[0; 1], 1, 16, 1).is_err());
+        assert!(validate(&[0.; 16], &[0; 8], &[0; 2], 1, 16, 1).is_err());
+        assert!(validate(&[0.; 15], &[0; 8], &[0; 1], 1, 15, 1).is_err());
+    }
+
+    #[test]
+    fn nvfp4_encoding_matches_modelopt_layout() {
+        assert_eq!(e2m1_to_f32(0x0), 0.0);
+        assert_eq!(e2m1_to_f32(0x7), 6.0);
+        assert_eq!(e2m1_to_f32(0xd), -3.0);
+        assert_eq!(e4m3fn_to_f32(0x38), 1.0);
+        assert_eq!(e4m3fn_to_f32(0x40), 2.0);
+        assert_eq!(e4m3fn_to_f32(0xb8), -1.0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `candle-nvfp4-kernels` crate for executing NVIDIA ModelOpt W4A16/NVFP4 quantized linear layers on CUDA.

The crate provides:

- `linear_f32_host_batched` for `[tokens, cols] @ [rows, cols]^T`
- `linear_f32_host` as a single-token convenience wrapper
- Validation of activation, packed-weight, and E4M3 scale buffer sizes before kernel launch
- An explicit runtime capability gate: native NVFP4 execution requires CUDA compute capability 10.0 (Blackwell) or newer
- CUDA-side decoding of packed E2M1 nibbles, E4M3FN per-block scales (block size 16), and the tensor-wide F32 scale

The CUDA feature is opt-in so normal CPU-only workspace builds remain unaffected.

## Why

ModelOpt checkpoints increasingly use W4A16/NVFP4 weights. Decoding them on the host materializes dense weights repeatedly and defeats the format's memory and throughput benefits. This crate keeps unpacking and the linear operation on the GPU, while offering a batched entry point for prefill workloads.

## Validation

- `cargo test -p candle-nvfp4-kernels`
- `cargo clippy -p candle-nvfp4-kernels -- -D warnings`

Native CUDA compilation was not run locally because the Windows CUDA toolchain could not locate `cl.exe` in `PATH`.