### PR TITLE
feat(generation): add JSON Schema decoding constraints

### DIFF
--- a/candle-transformers/Cargo.toml
+++ b/candle-transformers/Cargo.toml
@@ -23,6 +23,8 @@ rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_plain = { workspace = true }
+tokenizers = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [features]

--- a/candle-transformers/src/generation/incremental_decoder.rs
+++ b/candle-transformers/src/generation/incremental_decoder.rs
@@ -1,0 +1,726 @@
+//! Incremental detokenization for autoregressive decode loops.
+//!
+//! An autoregressive loop needs the text produced so far on every step, both to match stop
+//! sequences and to stream deltas back to the caller. Re-decoding the whole token sequence on
+//! every step is correct but quadratic in the generated length. Appending the decode of each
+//! token is linear but wrong: a BPE/SentencePiece decode is *not* the concatenation of its
+//! tokens' decodes. A multi-byte character can span several tokens (the prefix decodes to
+//! U+FFFD, and a later token retroactively replaces it), and decoding a sub-sequence can gain
+//! or lose a leading space.
+//!
+//! [`IncrementalDecoder`] keeps a bounded trailing window of tokens, re-decodes only that
+//! window, and appends the difference against the *previous* window decode, so any artifact
+//! caused by decoding a sub-sequence appears in both decodes and cancels out. The window is
+//! only moved forward when the shorter decode is provably a suffix of the current one, and
+//! only when the tokenizer's decoder has been shown to have a bounded context; otherwise the
+//! decoder degrades to whole-sequence decoding rather than corrupting the output.
+//!
+//! The invariant is that [`IncrementalDecoder::text`] equals a whole-sequence decode of every
+//! token pushed so far, at every step.
+//!
+//! ```no_run
+//! use candle_transformers::generation::IncrementalDecoder;
+//!
+//! # fn main() -> candle::Result<()> {
+//! # let tokenizer: tokenizers::Tokenizer = unimplemented!();
+//! # let next_token = |_: &[u32]| -> candle::Result<u32> { unimplemented!() };
+//! let mut decoder = IncrementalDecoder::new(&tokenizer);
+//! let mut tokens = vec![1u32];
+//! for _ in 0..128 {
+//!     let token = next_token(&tokens)?;
+//!     tokens.push(token);
+//!     let delta = decoder.push(token)?;
+//!     print!("{delta}");
+//!     if decoder.text().ends_with("</s>") {
+//!         break;
+//!     }
+//! }
+//! print!("{}", decoder.finish());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The decoder only ever reads the tokenizer, and is generic over how it holds it, so a loop
+//! that runs one decoder per row does not have to clone the vocabulary per row:
+//!
+//! ```no_run
+//! use candle_transformers::generation::IncrementalDecoder;
+//! use std::sync::Arc;
+//!
+//! # fn main() {
+//! # let tokenizer: Arc<tokenizers::Tokenizer> = unimplemented!();
+//! # let batch_size = 8;
+//! let decoders: Vec<_> = (0..batch_size)
+//!     .map(|_| IncrementalDecoder::from_tokenizer(Arc::clone(&tokenizer)))
+//!     .collect();
+//! # let _ = decoders;
+//! # }
+//! ```
+
+use candle::{Error, Result};
+use serde_json::Value;
+use std::borrow::Borrow;
+use std::collections::HashSet;
+use tokenizers::Tokenizer;
+
+/// The character `String::from_utf8_lossy` (and `ByteFallback`) emits for bytes that do not
+/// form a valid UTF-8 sequence yet. A trailing run of these is never emitted, as a later token
+/// may complete the sequence and replace them.
+const REPLACEMENT: char = '\u{FFFD}';
+
+/// Number of trailing tokens kept in the window after a successful re-anchor.
+const MIN_WINDOW_TOKENS: usize = 8;
+
+/// Window length that triggers a re-anchoring attempt. Re-anchoring costs one extra decode of
+/// `MIN_WINDOW_TOKENS` tokens and happens at most once every
+/// `MAX_WINDOW_TOKENS - MIN_WINDOW_TOKENS` pushes, so the amortized cost per token is constant.
+const MAX_WINDOW_TOKENS: usize = 64;
+
+/// How many window lengths to try around each re-anchoring candidate before doubling.
+const ANCHOR_CANDIDATES: usize = 3;
+
+/// Longest pattern rewritten by `tokenizers`' wordpiece `cleanup` helper (`" do not"`).
+const CLEANUP_PATTERN_LEN: usize = 7;
+
+/// What could be established about the tokenizer's decoder by inspecting its serialized form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DecoderContext {
+    /// Whether the decode of a token depends only on a bounded amount of surrounding context.
+    /// When false, windowing is unsound and the whole sequence is re-decoded on every step.
+    bounded: bool,
+    /// Number of trailing bytes of the decoded text that a future token may still rewrite.
+    unstable_tail: usize,
+    /// Whether the decode of the last token depends on it being last, so that text only
+    /// becomes stable once a further token has been pushed.
+    lag_one_step: bool,
+    /// Whether a `ByteFallback` renders the tokens. It groups a run of `<0xXX>` markers and
+    /// converts the run as a whole, so an open run's text is not settled until a non-marker
+    /// token closes it - one invalid byte turns the entire run into replacement characters,
+    /// including the part that already decoded cleanly.
+    byte_fallback: bool,
+}
+
+impl DecoderContext {
+    const UNBOUNDED: Self = Self {
+        bounded: false,
+        unstable_tail: 0,
+        lag_one_step: false,
+        byte_fallback: false,
+    };
+
+    /// Resolve the bounded-context property of a tokenizer's decoder.
+    ///
+    /// `tokenizers` keeps the decoder fields private, so the decoder is inspected through its
+    /// serialized form. Anything unrecognized is treated as unbounded.
+    fn resolve(tokenizer: &Tokenizer) -> Self {
+        let decoder = match tokenizer.get_decoder() {
+            // Without a decoder `Tokenizer::decode` joins the tokens with a space, which is
+            // strictly per-token.
+            None => {
+                return Self {
+                    bounded: true,
+                    unstable_tail: 0,
+                    lag_one_step: false,
+                    byte_fallback: false,
+                }
+            }
+            Some(decoder) => decoder,
+        };
+        let value = match serde_json::to_value(decoder) {
+            Ok(value) => value,
+            Err(_) => return Self::UNBOUNDED,
+        };
+        let mut ctx = Self {
+            bounded: true,
+            unstable_tail: 0,
+            lag_one_step: false,
+            byte_fallback: false,
+        };
+        let mut scan = Scan::default();
+        if !scan_decoder(&value, &mut scan, &mut ctx) {
+            return Self::UNBOUNDED;
+        }
+        ctx
+    }
+}
+
+/// What the decoders seen so far in the chain have done to the token list, which decides how
+/// the ones after them have to be read.
+#[derive(Debug, Clone, Copy, Default)]
+struct Scan {
+    /// The list has been collapsed into a single string. Before that point a decoder only ever
+    /// sees one token at a time and cannot rewrite across token boundaries; after it, string
+    /// rewrites apply to the whole decoded text and their reach has to be accounted for.
+    fused: bool,
+    /// The list can lose entries, so pushing a token does not necessarily hand the decoders
+    /// after this one an extra element.
+    suppresses: bool,
+    /// A token's string can be rewritten into something that is not what the vocabulary holds,
+    /// so whether a `<0xXX>` marker reaches `ByteFallback` can no longer be told from the raw
+    /// id. Forging a marker where the vocabulary has none would let already-emitted text be
+    /// re-rendered; destroying one would leave a run open that never closes.
+    alters_markers: bool,
+}
+
+/// Characters that can appear in a `<0xXX>` byte marker.
+///
+/// A marker is made of these characters and nothing else, which cuts both ways. A rewrite whose
+/// output holds none of them cannot forge a marker, since its result always carries a character
+/// no marker has; and one whose input pattern holds none of them cannot match inside a marker,
+/// so it cannot destroy one either.
+fn in_marker_alphabet(c: char) -> bool {
+    matches!(c, '<' | '>' | 'x' | 'X' | '0'..='9' | 'a'..='f' | 'A'..='F')
+}
+
+/// Record that a fused decoder can reach `reach` bytes back into the text it produces.
+///
+/// Returns false when reach is already pending from an earlier decoder in the chain. That reach
+/// was measured against the string this decoder takes as *input*, and a rewrite that changes
+/// lengths moves the boundary it refers to, so the two cannot simply be added: with
+/// `Fuse -> Replace("ab", "q") -> Replace("a", "xxxxxxxxxx")`, two bytes of pending reach cover
+/// ten bytes of output.
+fn add_fused_reach(ctx: &mut DecoderContext, reach: usize) -> bool {
+    if reach == 0 {
+        return true;
+    }
+    if ctx.unstable_tail != 0 {
+        return false;
+    }
+    ctx.unstable_tail = reach;
+    true
+}
+
+/// Whether a rewrite of `pattern` into `content`, applied to a token, can leave it a marker when
+/// it was not one or stop it being one when it was.
+fn alters_markers(pattern: &str, content: &str) -> bool {
+    // An empty replacement shortens the token, which can expose a marker hidden behind a prefix.
+    content.is_empty()
+        || content.chars().any(in_marker_alphabet)
+        || pattern.chars().any(in_marker_alphabet)
+}
+
+/// Walk a serialized decoder, accumulating how far a future token can reach back into the text
+/// already produced. Returns false as soon as the reach cannot be bounded.
+fn scan_decoder(value: &Value, scan: &mut Scan, ctx: &mut DecoderContext) -> bool {
+    let ty = match value.get("type").and_then(Value::as_str) {
+        Some(ty) => ty,
+        None => return false,
+    };
+    match ty {
+        "Sequence" => match value.get("decoders").and_then(Value::as_array) {
+            Some(decoders) => decoders.iter().all(|d| scan_decoder(d, scan, ctx)),
+            None => false,
+        },
+        // Joins the token list into a single string.
+        "Fuse" => {
+            scan.fused = true;
+            true
+        }
+        // Concatenates every token's bytes before a single lossy UTF-8 conversion, which is what
+        // lets a multi-byte character span tokens and be fixed up retroactively. It also
+        // collapses the list into one string.
+        //
+        // Applied to an already fused string it is unbounded: a token whose characters are not
+        // all in the byte-level alphabet falls back to that token's raw UTF-8 bytes, so one
+        // appended character can flip the whole accumulated string onto the fallback path and
+        // rewrite the entire prefix.
+        "ByteLevel" => {
+            if scan.fused {
+                return false;
+            }
+            scan.fused = true;
+            true
+        }
+        // Groups runs of `<0xXX>` tokens before converting them to text, so an incomplete run
+        // shows up as a trailing run of U+FFFD which a later token replaces.
+        //
+        // Applied to an already fused string it is unbounded: the `<0xXX>` shape is matched
+        // against the whole accumulated string, so appending anything can retroactively turn a
+        // decoded byte back into its literal marker.
+        "ByteFallback" => {
+            // Recognizing an open marker run means testing the shape of each pushed token, which
+            // is only meaningful against the string the vocabulary holds. A decoder ahead of this
+            // one that can change whether a token is a marker defeats that.
+            if scan.fused || scan.alters_markers {
+                return false;
+            }
+            // Merges a run of markers into one entry, so the list can shrink.
+            scan.suppresses = true;
+            ctx.byte_fallback = true;
+            true
+        }
+        // Per-token, apart from the prepend scheme which only affects the first token, i.e. the
+        // start of the text.
+        "Metaspace" => {
+            let replacement = value
+                .get("replacement")
+                .and_then(Value::as_str)
+                .unwrap_or("\u{2581}");
+            let prepend = value
+                .get("prepend_scheme")
+                .and_then(Value::as_str)
+                .unwrap_or("always");
+            if prepend == "never" {
+                // Every occurrence becomes a space, so this is the ordinary rewrite test.
+                scan.alters_markers |= alters_markers(replacement, " ");
+            } else {
+                // On the first token the replacement is *dropped* rather than turned into a
+                // space, so `\u{2581}<0x61>` comes out as a marker the vocabulary never had.
+                scan.alters_markers = true;
+            }
+            true
+        }
+        "WordPiece" => {
+            // Strips a `##` prefix, which can expose a marker underneath it.
+            scan.alters_markers = true;
+            if scan.fused
+                && value
+                    .get("cleanup")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true)
+            {
+                return add_fused_reach(ctx, CLEANUP_PATTERN_LEN);
+            }
+            true
+        }
+        "CTC" => {
+            // Deduplicates and drops entries that decode to nothing, and deleting the pad token
+            // from a string can expose a marker underneath it.
+            scan.suppresses = true;
+            scan.alters_markers = true;
+            if scan.fused {
+                // The pad token is stripped from the string whatever `cleanup` says, so its
+                // reach counts even when the cleanup patterns do not.
+                let pad = value.get("pad_token").and_then(Value::as_str).unwrap_or("");
+                let cleanup = value
+                    .get("cleanup")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true);
+                let delimiter = value
+                    .get("word_delimiter_token")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let reach =
+                    pad.len() + delimiter.len() + if cleanup { CLEANUP_PATTERN_LEN } else { 0 };
+                return add_fused_reach(ctx, reach);
+            }
+            true
+        }
+        "BPEDecoder" => {
+            // Replacing the suffix with nothing can expose a marker underneath it.
+            scan.alters_markers = true;
+            if scan.fused {
+                // On a fused string every occurrence of the suffix is dropped, wherever it is,
+                // so a suffix completed across pushes rewrites up to its own length of text.
+                let suffix = value.get("suffix").and_then(Value::as_str).unwrap_or("");
+                if !add_fused_reach(ctx, suffix.len()) {
+                    return false;
+                }
+            } else {
+                // The end-of-word suffix of the *last* token is dropped rather than turned into
+                // a space, so the tail of the text changes as soon as another token is pushed.
+                // The lag that compensates for it assumes each push hands this decoder one more
+                // entry, which an upstream decoder that drops entries breaks.
+                if scan.suppresses {
+                    return false;
+                }
+                ctx.lag_one_step = true;
+            }
+            true
+        }
+        "Strip" => {
+            // Trims characters off either end, which can expose a marker underneath them.
+            scan.alters_markers = true;
+            if scan.fused {
+                let stop = value.get("stop").and_then(Value::as_u64).unwrap_or(0) as usize;
+                let content = value.get("content").and_then(Value::as_str).unwrap_or("");
+                return add_fused_reach(ctx, stop * content.len());
+            }
+            true
+        }
+        "Replace" => {
+            let content = value.get("content").and_then(Value::as_str).unwrap_or("");
+            let literal = value
+                .get("pattern")
+                .and_then(|p| p.get("String"))
+                .and_then(Value::as_str);
+            // A regex pattern cannot be reasoned about at all; a literal one is judged on both
+            // what it can spell and what it can match.
+            match literal {
+                Some(pattern) => scan.alters_markers |= alters_markers(pattern, content),
+                None => scan.alters_markers = true,
+            }
+            if !scan.fused {
+                // Applied to each token independently, so it cannot reach across tokens.
+                return true;
+            }
+            // Applied to the whole text: appending bytes can create a match straddling the
+            // boundary, rewriting up to `pattern.len()` bytes already emitted. A regex pattern
+            // can match arbitrarily far back, which is exactly the unbounded case.
+            match literal {
+                Some(pattern) => add_fused_reach(ctx, pattern.len()),
+                None => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+/// An open run of `<0xXX>` byte markers. `ByteFallback` converts such a run as a whole, so none
+/// of its text is settled until a non-marker token closes it, and the window may not start
+/// inside it.
+#[derive(Debug, Clone, Copy)]
+struct ByteRun {
+    /// Offset in `text` where the run's output begins.
+    text_start: usize,
+    /// How many entries at the end of `window` the run spans.
+    tokens: usize,
+}
+
+/// A detokenizer that turns a stream of token ids into a stream of text deltas in amortized
+/// constant time per token.
+///
+/// See the [module documentation](self) for the approach.
+///
+/// `T` is how the decoder holds the tokenizer, which it only ever reads: `Tokenizer` to own it,
+/// `&Tokenizer` to borrow it, or `Arc<Tokenizer>` to share one across the decoders of a batch
+/// without cloning the vocabulary per row. It defaults to `Tokenizer`, so `IncrementalDecoder`
+/// on its own still names the owning form.
+///
+/// Cloning a decoder carries over the tokenizer and its resolved decoder context, so a batch
+/// loop can resolve both once and clone a decoder per row rather than rebuilding one.
+#[derive(Clone)]
+pub struct IncrementalDecoder<T = Tokenizer> {
+    tokenizer: T,
+    skip_special_tokens: bool,
+    ctx: DecoderContext,
+    /// Special ids that `Tokenizer::decode` filters out before the decoder ever sees them.
+    /// Not the whole set it drops - see [`IncrementalDecoder::is_dropped`].
+    dropped: HashSet<u32>,
+    /// Every token pushed so far.
+    tokens: Vec<u32>,
+    /// The tokens the next decode runs over: a trailing slice of `tokens`, with the ids that
+    /// `decode` filters out left out. Dropping those is a no-op on the decode - the decoder is
+    /// handed the exact same input either way - and it keeps a run of skipped special tokens
+    /// from growing the window, since such a run offers no tail long enough to re-anchor on.
+    window: Vec<u32>,
+    /// Decode of `window`; always a suffix of `text`.
+    window_text: String,
+    /// Decode of the whole token sequence.
+    text: String,
+    /// Number of bytes of `text` already returned by `push`.
+    emitted: usize,
+    /// The currently open run of `<0xXX>` byte markers, if one is open.
+    open_byte_run: Option<ByteRun>,
+    /// How far emission may go while `lag_one_step` holds. It only advances on a push the
+    /// decoder actually sees: an id `decode` filters out leaves the text alone, so treating it
+    /// as a step would release the previous token's text a step early.
+    lag_limit: usize,
+    /// Bytes of previously returned text invalidated by the last `push`.
+    retracted: usize,
+}
+
+impl IncrementalDecoder<Tokenizer> {
+    /// Create a decoder owning a clone of `tokenizer`, resolving the bounded-context property
+    /// of its decoder.
+    ///
+    /// The clone deep-copies the vocabulary. Use [`IncrementalDecoder::from_tokenizer`] to hold
+    /// the tokenizer by reference or by `Arc` instead, which matters for a batched loop that
+    /// needs one decoder per row.
+    pub fn new(tokenizer: &Tokenizer) -> Self {
+        Self::from_tokenizer(tokenizer.clone())
+    }
+}
+
+impl<T: Borrow<Tokenizer>> IncrementalDecoder<T> {
+    /// Create a decoder holding `tokenizer` however the caller has it: by value, by reference,
+    /// or behind an `Arc` shared with the rest of a batch.
+    ///
+    /// ```no_run
+    /// # use candle_transformers::generation::IncrementalDecoder;
+    /// # use std::sync::Arc;
+    /// # let tokenizer: tokenizers::Tokenizer = unimplemented!();
+    /// let owning = IncrementalDecoder::from_tokenizer(tokenizer.clone());
+    /// let borrowing = IncrementalDecoder::from_tokenizer(&tokenizer);
+    /// let sharing = IncrementalDecoder::from_tokenizer(Arc::new(tokenizer));
+    /// ```
+    pub fn from_tokenizer(tokenizer: T) -> Self {
+        let ctx = DecoderContext::resolve(tokenizer.borrow());
+        let dropped = dropped_ids(tokenizer.borrow(), true);
+        Self {
+            tokenizer,
+            skip_special_tokens: true,
+            ctx,
+            dropped,
+            tokens: Vec::new(),
+            window: Vec::new(),
+            window_text: String::new(),
+            text: String::new(),
+            emitted: 0,
+            open_byte_run: None,
+            lag_limit: 0,
+            retracted: 0,
+        }
+    }
+
+    /// Whether special tokens are dropped from the decoded text, `true` by default.
+    pub fn with_skip_special_tokens(mut self, skip_special_tokens: bool) -> Self {
+        self.skip_special_tokens = skip_special_tokens;
+        self.dropped = dropped_ids(self.tokenizer.borrow(), skip_special_tokens);
+        self.clear();
+        self
+    }
+
+    /// Whether the tokenizer's decoder was shown to have a bounded context.
+    ///
+    /// When false the decoder is still correct, but it re-decodes the whole sequence on every
+    /// push - quadratic in the number of generated tokens - and [`IncrementalDecoder::push`]
+    /// streams nothing, since no part of the text can be shown to be settled. Use
+    /// [`IncrementalDecoder::text`] to observe it as it grows, and
+    /// [`IncrementalDecoder::finish`] to collect it at the end.
+    pub fn is_windowed(&self) -> bool {
+        self.ctx.bounded
+    }
+
+    /// Push a token and return the text that became available because of it.
+    ///
+    /// The returned slice may be empty: text that a further token could still rewrite is held
+    /// back until it is settled - a trailing run of U+FFFD from an incomplete multi-byte
+    /// character, an open run of `ByteFallback` byte markers, the reach of a rewriting decoder,
+    /// or, for a decoder that is not [windowed](IncrementalDecoder::is_windowed), all of it.
+    ///
+    /// Emission is append-only: concatenating every value returned by `push`, followed by
+    /// [`IncrementalDecoder::finish`], reproduces [`IncrementalDecoder::text`] exactly.
+    pub fn push(&mut self, token: u32) -> Result<&str> {
+        self.retracted = 0;
+        self.tokens.push(token);
+        let dropped = self.is_dropped(token);
+        if !dropped {
+            self.window.push(token);
+        }
+
+        let new_window = self.decode(&self.window)?;
+        let committed = self.text.len() - self.window_text.len();
+        // The delta is taken against the *previous* decode of the same window, so a leading
+        // space gained or lost by decoding a sub-sequence is present in both and cancels.
+        let common = committed + common_prefix_len(&self.window_text, &new_window);
+        self.text.truncate(committed);
+        self.text.push_str(&new_window);
+        self.window_text = new_window;
+
+        if !dropped {
+            self.lag_limit = common;
+        }
+        // Before re-anchoring, which needs to know how far back the open run reaches.
+        self.track_byte_run(token, common);
+        if self.ctx.bounded && self.window.len() >= MAX_WINDOW_TOKENS {
+            self.reanchor()?;
+        }
+
+        if common < self.emitted {
+            self.retracted = self.emitted - common;
+            self.emitted = common;
+        }
+        let start = self.emitted;
+        self.emitted = self.emission_limit();
+        Ok(&self.text[start..self.emitted])
+    }
+
+    /// The whole text decoded so far.
+    ///
+    /// This is always equal to decoding every pushed token in one go.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// The text held back by [`IncrementalDecoder::push`] because a future token could still
+    /// rewrite it.
+    pub fn pending(&self) -> &str {
+        &self.text[self.emitted..]
+    }
+
+    /// Release the text held back by [`IncrementalDecoder::push`], for use once generation is
+    /// over. Any trailing U+FFFD is genuinely undecodable at that point.
+    pub fn finish(&mut self) -> &str {
+        let start = self.emitted;
+        self.emitted = self.text.len();
+        &self.text[start..]
+    }
+
+    /// Number of bytes of previously returned text invalidated by the last
+    /// [`IncrementalDecoder::push`].
+    ///
+    /// This is a diagnostic, and is always zero: text is only ever emitted once it has been
+    /// shown to be settled. A non-zero value means the rewrite reach of some decoder was
+    /// under-estimated, i.e. a bug here rather than something a caller has to handle.
+    pub fn retracted(&self) -> usize {
+        self.retracted
+    }
+
+    /// The tokens pushed so far.
+    pub fn tokens(&self) -> &[u32] {
+        &self.tokens
+    }
+
+    /// Number of tokens re-decoded by the next [`IncrementalDecoder::push`].
+    ///
+    /// This stays bounded for a windowed decoder, and grows with the sequence otherwise.
+    pub fn window_len(&self) -> usize {
+        self.window.len()
+    }
+
+    /// The underlying tokenizer.
+    pub fn tokenizer(&self) -> &Tokenizer {
+        self.tokenizer.borrow()
+    }
+
+    /// Consume the decoder, returning however the tokenizer was handed to it.
+    pub fn into_tokenizer(self) -> T {
+        self.tokenizer
+    }
+
+    /// Reset the decoder, keeping the tokenizer and its resolved decoder context.
+    pub fn clear(&mut self) {
+        self.tokens.clear();
+        self.window.clear();
+        self.window_text.clear();
+        self.text.clear();
+        self.emitted = 0;
+        self.open_byte_run = None;
+        self.lag_limit = 0;
+        self.retracted = 0;
+    }
+
+    fn decode(&self, tokens: &[u32]) -> Result<String> {
+        if tokens.is_empty() {
+            // Some decoders (`BPEDecoder`) index the last token unconditionally.
+            return Ok(String::new());
+        }
+        self.tokenizer()
+            .decode(tokens, self.skip_special_tokens)
+            .map_err(|err| Error::Msg(format!("cannot decode: {err}")))
+    }
+
+    /// Try to move the window forward, keeping the text unchanged.
+    ///
+    /// The window is only moved when the shorter decode is provably a suffix of the current
+    /// window decode, and long enough that a rewriting decoder cannot reach past it. When no
+    /// split is acceptable the window simply keeps growing, degrading towards whole-sequence
+    /// decoding rather than dropping or duplicating text.
+    fn reanchor(&mut self) -> Result<()> {
+        let min_tail = self.ctx.unstable_tail.max(1);
+        // `ByteFallback` converts a marker run as a whole, so a window that starts inside an
+        // open one renders it differently from the full sequence: the shorter decode is a
+        // suffix *now*, but the next marker re-renders the part left outside the window.
+        let mut keep = MIN_WINDOW_TOKENS.max(self.open_byte_run.map_or(0, |run| run.tokens));
+        while keep < self.window.len() {
+            // A candidate can fail purely because of what its own first token turns into - a
+            // `WordPiece` continuation piece keeps its `##` when it leads, a `Metaspace` token
+            // loses its space - so try the neighbouring lengths before doubling away from them.
+            for candidate in keep..(keep + ANCHOR_CANDIDATES).min(self.window.len()) {
+                let start = self.window.len() - candidate;
+                let tail = self.decode(&self.window[start..])?;
+                if tail.len() >= min_tail && self.window_text.ends_with(&tail) {
+                    self.window.drain(..start);
+                    self.window_text = tail;
+                    return Ok(());
+                }
+            }
+            keep *= 2;
+        }
+        Ok(())
+    }
+
+    /// Note which tokens are still inside an open `ByteFallback` run, so their text can be held
+    /// back: the run is converted as a whole, so a later marker can re-render all of it.
+    fn track_byte_run(&mut self, token: u32, common: usize) {
+        // A dropped id never reaches the decoder, so it neither opens nor closes a run.
+        if !self.ctx.byte_fallback || self.is_dropped(token) {
+            return;
+        }
+        match (self.is_byte_marker(token), self.open_byte_run.as_mut()) {
+            (false, _) => self.open_byte_run = None,
+            (true, Some(run)) => run.tokens += 1,
+            (true, None) => {
+                self.open_byte_run = Some(ByteRun {
+                    text_start: common,
+                    tokens: 1,
+                })
+            }
+        }
+    }
+
+    /// Whether `Tokenizer::decode` drops this id before the decoder runs: a special token being
+    /// skipped, or an id the vocabulary has no token for at all.
+    fn is_dropped(&self, token: u32) -> bool {
+        self.dropped.contains(&token) || self.tokenizer().id_to_token(token).is_none()
+    }
+
+    /// Whether an id decodes to a `<0xXX>` marker, matching `ByteFallback`'s own test.
+    fn is_byte_marker(&self, token: u32) -> bool {
+        match self.tokenizer().id_to_token(token) {
+            Some(t) => {
+                t.len() == 6
+                    && t.starts_with("<0x")
+                    && t.ends_with('>')
+                    && t.get(3..5)
+                        .is_some_and(|hex| u8::from_str_radix(hex, 16).is_ok())
+            }
+            None => false,
+        }
+    }
+
+    /// Largest prefix of `text` that no future token can rewrite.
+    fn emission_limit(&self) -> usize {
+        // Nothing can be proven about an unbounded decoder, so nothing is emitted until
+        // `finish`: this type never hands out text it may have to take back.
+        if !self.ctx.bounded {
+            return self.emitted;
+        }
+        let mut limit = self.text.len();
+        // An incomplete multi-byte character decodes to U+FFFD, which a later token replaces.
+        while limit > 0 && self.text[..limit].ends_with(REPLACEMENT) {
+            limit -= REPLACEMENT.len_utf8();
+        }
+        limit = limit.saturating_sub(self.ctx.unstable_tail);
+        while limit > 0 && !self.text.is_char_boundary(limit) {
+            limit -= 1;
+        }
+        if self.ctx.lag_one_step {
+            limit = limit.min(self.lag_limit);
+        }
+        if let Some(run) = self.open_byte_run {
+            limit = limit.min(run.text_start);
+        }
+        limit.max(self.emitted)
+    }
+}
+
+/// Ids that `Tokenizer::decode` drops before running the decoder: special tokens when they are
+/// being skipped, and ids that map to no token at all.
+///
+/// Conservative on purpose - an id missing from this set only means the window advances less
+/// eagerly, never that it advances when it should not.
+fn dropped_ids(tokenizer: &Tokenizer, skip_special_tokens: bool) -> HashSet<u32> {
+    if !skip_special_tokens {
+        return HashSet::new();
+    }
+    tokenizer
+        .get_added_tokens_decoder()
+        .into_iter()
+        .filter(|(_, token)| token.special)
+        .map(|(id, _)| id)
+        .collect()
+}
+
+/// Length in bytes of the longest common prefix of `a` and `b`, on a character boundary.
+fn common_prefix_len(a: &str, b: &str) -> usize {
+    let mut len = 0;
+    for (ca, cb) in a.chars().zip(b.chars()) {
+        if ca != cb {
+            break;
+        }
+        len += ca.len_utf8();
+    }
+    len
+}

--- a/candle-transformers/src/generation/json_schema.rs
+++ b/candle-transformers/src/generation/json_schema.rs
@@ -16,91 +16,773 @@ pub enum SchemaCompileError {
 }
 
 #[derive(Clone, Debug)]
-pub struct CompiledFsm { schema: Schema }
+pub struct CompiledFsm {
+    schema: Schema,
+}
 
 #[derive(Clone, Debug)]
 enum Schema {
-    Any, Null, Bool, Number { integer: bool }, String,
+    Any,
+    Null,
+    Bool,
+    Number {
+        integer: bool,
+    },
+    String,
     Array(Box<Schema>),
-    Object { properties: Vec<(String, Schema)>, required: Vec<String>, additional: bool },
+    Object {
+        properties: Vec<(String, Schema)>,
+        required: Vec<String>,
+        additional: bool,
+    },
     Enum(Vec<Value>),
 }
 
 /// Compile the supported, deliberately small JSON Schema subset into a shareable constraint.
 pub fn compile_schema(schema: &str) -> Result<CompiledFsm, SchemaCompileError> {
-    let value = serde_json::from_str(schema).map_err(|e| SchemaCompileError::InvalidJson(e.to_string()))?;
-    Ok(CompiledFsm { schema: Schema::compile(&value)? })
+    let value =
+        serde_json::from_str(schema).map_err(|e| SchemaCompileError::InvalidJson(e.to_string()))?;
+    Ok(CompiledFsm {
+        schema: Schema::compile(&value)?,
+    })
 }
 
 impl Schema {
     fn compile(value: &Value) -> Result<Self, SchemaCompileError> {
-        let object = value.as_object().ok_or_else(|| SchemaCompileError::InvalidSchema("the root must be an object".into()))?;
+        let object = value.as_object().ok_or_else(|| {
+            SchemaCompileError::InvalidSchema("the root must be an object".into())
+        })?;
         for key in object.keys() {
-            if !matches!(key.as_str(), "type" | "properties" | "required" | "additionalProperties" | "items" | "enum" | "const" | "title" | "description" | "default") {
+            if !matches!(
+                key.as_str(),
+                "type"
+                    | "properties"
+                    | "required"
+                    | "additionalProperties"
+                    | "items"
+                    | "enum"
+                    | "const"
+                    | "title"
+                    | "description"
+                    | "default"
+            ) {
                 return Err(SchemaCompileError::Unsupported(key.clone()));
             }
         }
-        if let Some(values) = object.get("enum") { return Ok(Self::Enum(values.as_array().ok_or_else(|| SchemaCompileError::InvalidSchema("enum must be an array".into()))?.clone())); }
-        if let Some(value) = object.get("const") { return Ok(Self::Enum(vec![value.clone()])); }
+        if let Some(values) = object.get("enum") {
+            if values
+                .as_array()
+                .is_some_and(|values| values.iter().any(Value::is_array))
+                || values
+                    .as_array()
+                    .is_some_and(|values| values.iter().any(Value::is_object))
+            {
+                return Err(SchemaCompileError::Unsupported("non-scalar enum".into()));
+            }
+            return Ok(Self::Enum(
+                values
+                    .as_array()
+                    .ok_or_else(|| {
+                        SchemaCompileError::InvalidSchema("enum must be an array".into())
+                    })?
+                    .clone(),
+            ));
+        }
+        if let Some(value) = object.get("const") {
+            if value.is_array() || value.is_object() {
+                return Err(SchemaCompileError::Unsupported("non-scalar const".into()));
+            }
+            return Ok(Self::Enum(vec![value.clone()]));
+        }
         let ty = object.get("type").and_then(Value::as_str).unwrap_or("any");
         match ty {
-            "any" => Ok(Self::Any), "null" => Ok(Self::Null), "boolean" => Ok(Self::Bool),
-            "number" => Ok(Self::Number { integer: false }), "integer" => Ok(Self::Number { integer: true }), "string" => Ok(Self::String),
-            "array" => Ok(Self::Array(Box::new(Self::compile(object.get("items").ok_or_else(|| SchemaCompileError::InvalidSchema("array requires items".into()))?)?))),
+            "any" => Ok(Self::Any),
+            "null" => Ok(Self::Null),
+            "boolean" => Ok(Self::Bool),
+            "number" => Ok(Self::Number { integer: false }),
+            "integer" => Ok(Self::Number { integer: true }),
+            "string" => Ok(Self::String),
+            "array" => Ok(Self::Array(Box::new(Self::compile(
+                object.get("items").ok_or_else(|| {
+                    SchemaCompileError::InvalidSchema("array requires items".into())
+                })?,
+            )?))),
             "object" => {
-                let properties = object.get("properties").and_then(Value::as_object).ok_or_else(|| SchemaCompileError::InvalidSchema("object requires properties".into()))?
-                    .iter().map(|(k, v)| Ok((k.clone(), Self::compile(v)?))).collect::<Result<_, SchemaCompileError>>()?;
-                let required = object.get("required").map(|v| v.as_array().ok_or_else(|| SchemaCompileError::InvalidSchema("required must be an array".into()))
-                    .and_then(|v| v.iter().map(|v| v.as_str().map(str::to_owned).ok_or_else(|| SchemaCompileError::InvalidSchema("required entries must be strings".into()))).collect())).transpose()?.unwrap_or_default();
-                let additional = object.get("additionalProperties").and_then(Value::as_bool).unwrap_or(true);
-                Ok(Self::Object { properties, required, additional })
+                let properties = object
+                    .get("properties")
+                    .and_then(Value::as_object)
+                    .ok_or_else(|| {
+                        SchemaCompileError::InvalidSchema("object requires properties".into())
+                    })?
+                    .iter()
+                    .map(|(k, v)| Ok((k.clone(), Self::compile(v)?)))
+                    .collect::<Result<_, SchemaCompileError>>()?;
+                let required = object
+                    .get("required")
+                    .map(|v| {
+                        v.as_array()
+                            .ok_or_else(|| {
+                                SchemaCompileError::InvalidSchema(
+                                    "required must be an array".into(),
+                                )
+                            })
+                            .and_then(|v| {
+                                v.iter()
+                                    .map(|v| {
+                                        v.as_str().map(str::to_owned).ok_or_else(|| {
+                                            SchemaCompileError::InvalidSchema(
+                                                "required entries must be strings".into(),
+                                            )
+                                        })
+                                    })
+                                    .collect()
+                            })
+                    })
+                    .transpose()?
+                    .unwrap_or_default();
+                let additional = object
+                    .get("additionalProperties")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(true);
+                Ok(Self::Object {
+                    properties,
+                    required,
+                    additional,
+                })
             }
             other => Err(SchemaCompileError::Unsupported(format!("type {other}"))),
         }
     }
 
-    fn matches(&self, value: &Value) -> bool { match self {
-        Self::Any => true, Self::Null => value.is_null(), Self::Bool => value.is_boolean(), Self::String => value.is_string(),
-        Self::Number { integer } => value.as_f64().is_some_and(|n| !integer || n.fract() == 0.0),
-        Self::Array(item) => value.as_array().is_some_and(|a| a.iter().all(|v| item.matches(v))),
-        Self::Enum(values) => values.contains(value),
-        Self::Object { properties, required, additional } => value.as_object().is_some_and(|o| {
-            required.iter().all(|k| o.contains_key(k)) && o.iter().all(|(k, v)| properties.iter().find(|(name, _)| name == k).map_or(*additional, |(_, s)| s.matches(v)))
-        }),
-    }}
+    fn matches(&self, value: &Value) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Null => value.is_null(),
+            Self::Bool => value.is_boolean(),
+            Self::String => value.is_string(),
+            Self::Number { integer } => {
+                value.as_f64().is_some_and(|n| !integer || n.fract() == 0.0)
+            }
+            Self::Array(item) => value
+                .as_array()
+                .is_some_and(|a| a.iter().all(|v| item.matches(v))),
+            Self::Enum(values) => values.contains(value),
+            Self::Object {
+                properties,
+                required,
+                additional,
+            } => value.as_object().is_some_and(|o| {
+                required.iter().all(|k| o.contains_key(k))
+                    && o.iter().all(|(k, v)| {
+                        properties
+                            .iter()
+                            .find(|(name, _)| name == k)
+                            .map_or(*additional, |(_, s)| s.matches(v))
+                    })
+            }),
+        }
+    }
 }
 
 /// Per-request state for a compiled schema.
-pub struct FsmLogitProcessor { fsm: Arc<CompiledFsm>, text: String }
+pub struct FsmLogitProcessor {
+    cursor: Cursor,
+    text: String,
+}
 impl FsmLogitProcessor {
-    pub fn new(fsm: Arc<CompiledFsm>) -> Self { Self { fsm, text: String::new() } }
-    pub fn allowed_token_ids(&self, vocab_size: usize, eos_tokens: &[u32], decode_one: impl Fn(u32) -> String) -> Vec<u32> {
-        (0..vocab_size as u32).filter(|id| {
-            if eos_tokens.contains(id) { self.is_complete() } else { self.accepts(&decode_one(*id)) }
-        }).collect()
+    pub fn new(fsm: Arc<CompiledFsm>) -> Self {
+        Self {
+            cursor: Cursor::new(fsm.schema.clone()),
+            text: String::new(),
+        }
+    }
+    pub fn allowed_token_ids(
+        &self,
+        vocab_size: usize,
+        eos_tokens: &[u32],
+        decode_one: impl Fn(u32) -> String,
+    ) -> Vec<u32> {
+        (0..vocab_size as u32)
+            .filter(|id| {
+                if eos_tokens.contains(id) {
+                    self.is_complete()
+                } else {
+                    self.accepts(&decode_one(*id))
+                }
+            })
+            .collect()
     }
     /// Advance after sampling the actual token (not necessarily the best-scoring one).
-    pub fn commit(&mut self, token_text: &str) { self.text.push_str(token_text); }
-    pub fn is_complete(&self) -> bool { serde_json::from_str(&self.text).is_ok_and(|v| self.fsm.schema.matches(&v)) }
-    pub fn text(&self) -> &str { &self.text }
+    pub fn commit(&mut self, token_text: &str) {
+        debug_assert!(self.cursor.clone().apply(token_text));
+        let mut cursor = self.cursor.clone();
+        if cursor.apply(token_text) {
+            self.cursor = cursor;
+            self.text.push_str(token_text);
+        }
+    }
+    pub fn is_complete(&self) -> bool {
+        self.cursor.is_complete()
+    }
+    pub fn text(&self) -> &str {
+        &self.text
+    }
     fn accepts(&self, token: &str) -> bool {
-        // A complete root JSON value cannot be followed by another token (except EOS).
-        if self.is_complete() { return false; }
-        let candidate = format!("{}{}", self.text, token);
-        if serde_json::from_str::<Value>(&candidate).is_ok_and(|v| self.fsm.schema.matches(&v)) { return true; }
-        json_prefix(&candidate)
+        let mut cursor = self.cursor.clone();
+        cursor.apply(token)
     }
 }
 
-// Reject impossible JSON structure while leaving unfinished lexical values available to later tokens.
-fn json_prefix(text: &str) -> bool {
-    if let Some(first) = text.chars().find(|c| !c.is_whitespace()) {
-        if !matches!(first, '{' | '[' | '"' | 't' | 'f' | 'n' | '-' | '0'..='9') { return false; }
+#[derive(Clone)]
+struct Cursor {
+    root: Schema,
+    state: Root,
+    frames: Vec<Frame>,
+    scalar: Option<Scalar>,
+}
+#[derive(Clone, Copy, PartialEq)]
+enum Root {
+    Value,
+    Done,
+}
+#[derive(Clone)]
+enum Frame {
+    Object(Object),
+    Array(Array),
+}
+#[derive(Clone)]
+struct Object {
+    schema: Schema,
+    seen: Vec<String>,
+    key: String,
+    state: Obj,
+}
+#[derive(Clone, Copy, PartialEq)]
+enum Obj {
+    KeyOrEnd,
+    Key,
+    Colon,
+    Value,
+    CommaOrEnd,
+}
+#[derive(Clone)]
+struct Array {
+    schema: Schema,
+    state: Arr,
+}
+#[derive(Clone, Copy, PartialEq)]
+enum Arr {
+    ValueOrEnd,
+    CommaOrEnd,
+}
+#[derive(Clone)]
+enum Scalar {
+    Key(Text),
+    String {
+        schema: Schema,
+        text: Text,
+    },
+    Number {
+        schema: Schema,
+        state: Number,
+        raw: String,
+    },
+    Literal {
+        expected: &'static str,
+        at: usize,
+    },
+}
+#[derive(Clone, Default)]
+struct Text {
+    value: String,
+    escape: Escape,
+}
+#[derive(Clone, Default)]
+enum Escape {
+    #[default]
+    None,
+    Slash,
+    Unicode(String),
+}
+#[derive(Clone, Copy)]
+enum Number {
+    Minus,
+    Zero,
+    Int,
+    Dot,
+    Frac,
+    Exp,
+    ExpSign,
+    ExpDigits,
+}
+
+impl Cursor {
+    fn new(root: Schema) -> Self {
+        Self {
+            root,
+            state: Root::Value,
+            frames: vec![],
+            scalar: None,
+        }
     }
-    let mut stack = Vec::new(); let mut string = false; let mut escape = false;
-    for c in text.chars() {
-        if string { if escape { escape = false } else if c == '\\' { escape = true } else if c == '"' { string = false }; continue; }
-        match c { '"' => string = true, '{' => stack.push('}'), '[' => stack.push(']'), '}' | ']' => if stack.pop() != Some(c) { return false }, _ => {} }
+    fn apply(&mut self, text: &str) -> bool {
+        text.chars().all(|c| self.step(c))
     }
-    true
+    fn is_complete(&self) -> bool {
+        self.frames.is_empty()
+            && match (&self.state, &self.scalar) {
+                (Root::Done, None) => true,
+                (Root::Value, Some(Scalar::Number { schema, state, raw })) => {
+                    state.complete() && number_matches(schema, *state, raw)
+                }
+                _ => false,
+            }
+    }
+    fn step(&mut self, c: char) -> bool {
+        if let Some(scalar) = self.scalar.take() {
+            return self.scalar_step(scalar, c);
+        }
+        self.structural(c)
+    }
+    fn scalar_step(&mut self, mut scalar: Scalar, c: char) -> bool {
+        match &mut scalar {
+            Scalar::Key(text) => match text.push(c) {
+                TextResult::More => {
+                    let allowed = matches!(self.frames.last(), Some(Frame::Object(object)) if object.key_prefix_allowed(&text.value));
+                    if allowed {
+                        self.scalar = Some(scalar);
+                    }
+                    allowed
+                }
+                TextResult::Done => {
+                    let Some(Frame::Object(object)) = self.frames.last_mut() else {
+                        return false;
+                    };
+                    if !object.key_allowed(&text.value) {
+                        return false;
+                    }
+                    object.key = text.value.clone();
+                    object.state = Obj::Colon;
+                    true
+                }
+                TextResult::Invalid => false,
+            },
+            Scalar::String { schema, text } => match text.push(c) {
+                TextResult::More => {
+                    if string_prefix_possible(schema, &text.value) {
+                        self.scalar = Some(scalar);
+                        true
+                    } else {
+                        false
+                    }
+                }
+                TextResult::Done => {
+                    if !schema.matches(&Value::String(text.value.clone())) {
+                        return false;
+                    }
+                    self.value_done()
+                }
+                TextResult::Invalid => false,
+            },
+            Scalar::Literal { expected, at } => {
+                if *at >= expected.len() || c != expected.as_bytes()[*at] as char {
+                    return false;
+                }
+                *at += 1;
+                if *at == expected.len() {
+                    self.value_done()
+                } else {
+                    self.scalar = Some(scalar);
+                    true
+                }
+            }
+            Scalar::Number { schema, state, raw } => match state.advance(c) {
+                Some(next) => {
+                    *state = next;
+                    raw.push(c);
+                    if number_prefix_possible(schema, raw) {
+                        self.scalar = Some(scalar);
+                        true
+                    } else {
+                        false
+                    }
+                }
+                None if state.complete() && delimiter(c) => {
+                    let valid = number_matches(schema, *state, raw);
+                    if !valid || !self.value_done() {
+                        return false;
+                    }
+                    self.step(c)
+                }
+                None => false,
+            },
+        }
+    }
+    fn structural(&mut self, c: char) -> bool {
+        if c.is_whitespace() {
+            return true;
+        }
+        if self.frames.is_empty() {
+            return match self.state {
+                Root::Value => self.start(self.root.clone(), c),
+                Root::Done => false,
+            };
+        }
+        match self.frames.last().cloned().expect("non-empty") {
+            Frame::Object(object) => match object.state {
+                Obj::KeyOrEnd => {
+                    if c == '}' {
+                        self.close_object()
+                    } else if c == '"' {
+                        self.set_object(Obj::Key, String::new());
+                        self.scalar = Some(Scalar::Key(Text::default()));
+                        true
+                    } else {
+                        false
+                    }
+                }
+                Obj::Colon => {
+                    if c == ':' {
+                        self.set_object(Obj::Value, object.key);
+                        true
+                    } else {
+                        false
+                    }
+                }
+                Obj::Value => self.start(object.value_schema(), c),
+                Obj::CommaOrEnd => {
+                    if c == ',' {
+                        self.set_object(Obj::KeyOrEnd, String::new());
+                        true
+                    } else if c == '}' {
+                        self.close_object()
+                    } else {
+                        false
+                    }
+                }
+                Obj::Key => false,
+            },
+            Frame::Array(array) => match array.state {
+                Arr::ValueOrEnd => {
+                    if c == ']' {
+                        self.close_array()
+                    } else {
+                        self.start(array.item_schema(), c)
+                    }
+                }
+                Arr::CommaOrEnd => {
+                    if c == ',' {
+                        self.set_array(Arr::ValueOrEnd);
+                        true
+                    } else if c == ']' {
+                        self.close_array()
+                    } else {
+                        false
+                    }
+                }
+            },
+        }
+    }
+    fn start(&mut self, schema: Schema, c: char) -> bool {
+        if c.is_whitespace() {
+            return true;
+        }
+        match c {
+            '{' if schema_object(&schema) => {
+                self.frames.push(Frame::Object(Object {
+                    schema,
+                    seen: vec![],
+                    key: String::new(),
+                    state: Obj::KeyOrEnd,
+                }));
+                true
+            }
+            '[' if schema_array(&schema) => {
+                self.frames.push(Frame::Array(Array {
+                    schema,
+                    state: Arr::ValueOrEnd,
+                }));
+                true
+            }
+            '"' if schema_string(&schema) => {
+                self.scalar = Some(Scalar::String {
+                    schema,
+                    text: Text::default(),
+                });
+                true
+            }
+            't' => self.literal(schema, "true", 1),
+            'f' => self.literal(schema, "false", 1),
+            'n' => self.literal(schema, "null", 1),
+            '-' => self.number(schema, Number::Minus, "-"),
+            '0' => self.number(schema, Number::Zero, "0"),
+            '1'..='9' => self.number(schema, Number::Int, &c.to_string()),
+            _ => false,
+        }
+    }
+    fn literal(&mut self, schema: Schema, expected: &'static str, at: usize) -> bool {
+        if schema_allows_literal(&schema, expected) {
+            self.scalar = Some(Scalar::Literal { expected, at });
+            true
+        } else {
+            false
+        }
+    }
+    fn number(&mut self, schema: Schema, state: Number, raw: &str) -> bool {
+        if schema_allows_number(&schema) && number_prefix_possible(&schema, raw) {
+            self.scalar = Some(Scalar::Number {
+                schema,
+                state,
+                raw: raw.into(),
+            });
+            true
+        } else {
+            false
+        }
+    }
+    fn value_done(&mut self) -> bool {
+        if let Some(frame) = self.frames.last_mut() {
+            match frame {
+                Frame::Object(object) if object.state == Obj::Value => {
+                    object.seen.push(std::mem::take(&mut object.key));
+                    object.state = Obj::CommaOrEnd;
+                    true
+                }
+                Frame::Array(array) if array.state == Arr::ValueOrEnd => {
+                    array.state = Arr::CommaOrEnd;
+                    true
+                }
+                _ => false,
+            }
+        } else if self.state == Root::Value {
+            self.state = Root::Done;
+            true
+        } else {
+            false
+        }
+    }
+    fn close_object(&mut self) -> bool {
+        let Some(Frame::Object(object)) = self.frames.pop() else {
+            return false;
+        };
+        if !object.valid() {
+            return false;
+        }
+        self.value_done()
+    }
+    fn close_array(&mut self) -> bool {
+        let Some(Frame::Array(_)) = self.frames.pop() else {
+            return false;
+        };
+        self.value_done()
+    }
+    fn set_object(&mut self, state: Obj, key: String) {
+        if let Some(Frame::Object(object)) = self.frames.last_mut() {
+            object.state = state;
+            object.key = key;
+        }
+    }
+    fn set_array(&mut self, state: Arr) {
+        if let Some(Frame::Array(array)) = self.frames.last_mut() {
+            array.state = state;
+        }
+    }
+}
+
+enum TextResult {
+    More,
+    Done,
+    Invalid,
+}
+impl Text {
+    fn push(&mut self, c: char) -> TextResult {
+        match &mut self.escape {
+            Escape::None => match c {
+                '"' => TextResult::Done,
+                '\\' => {
+                    self.escape = Escape::Slash;
+                    TextResult::More
+                }
+                c if c >= ' ' => {
+                    self.value.push(c);
+                    TextResult::More
+                }
+                _ => TextResult::Invalid,
+            },
+            Escape::Slash => {
+                match c {
+                    '"' | '\\' | '/' => self.value.push(c),
+                    'b' => self.value.push('\u{8}'),
+                    'f' => self.value.push('\u{c}'),
+                    'n' => self.value.push('\n'),
+                    'r' => self.value.push('\r'),
+                    't' => self.value.push('\t'),
+                    'u' => {
+                        self.escape = Escape::Unicode(String::new());
+                        return TextResult::More;
+                    }
+                    _ => return TextResult::Invalid,
+                };
+                self.escape = Escape::None;
+                TextResult::More
+            }
+            Escape::Unicode(hex) => {
+                if !c.is_ascii_hexdigit() {
+                    return TextResult::Invalid;
+                }
+                hex.push(c);
+                if hex.len() == 4 {
+                    let code = u32::from_str_radix(hex, 16).unwrap();
+                    let Some(c) = char::from_u32(code) else {
+                        return TextResult::Invalid;
+                    };
+                    self.value.push(c);
+                    self.escape = Escape::None;
+                }
+                TextResult::More
+            }
+        }
+    }
+}
+impl Number {
+    fn advance(self, c: char) -> Option<Self> {
+        match (self, c) {
+            (Self::Minus, '0') => Some(Self::Zero),
+            (Self::Minus, '1'..='9') => Some(Self::Int),
+            (Self::Zero, '.') | (Self::Int, '.') => Some(Self::Dot),
+            (Self::Zero, 'e' | 'E') | (Self::Int, 'e' | 'E') | (Self::Frac, 'e' | 'E') => {
+                Some(Self::Exp)
+            }
+            (Self::Int, '0'..='9') => Some(Self::Int),
+            (Self::Dot, '0'..='9') => Some(Self::Frac),
+            (Self::Frac, '0'..='9') => Some(Self::Frac),
+            (Self::Exp, '+' | '-') => Some(Self::ExpSign),
+            (Self::Exp, '0'..='9') | (Self::ExpSign, '0'..='9') => Some(Self::ExpDigits),
+            (Self::ExpDigits, '0'..='9') => Some(Self::ExpDigits),
+            _ => None,
+        }
+    }
+    fn complete(self) -> bool {
+        matches!(self, Self::Zero | Self::Int | Self::Frac | Self::ExpDigits)
+    }
+}
+impl Object {
+    fn key_prefix_allowed(&self, key: &str) -> bool {
+        match &self.schema {
+            Schema::Object {
+                properties,
+                additional,
+                ..
+            } => *additional || properties.iter().any(|(name, _)| name.starts_with(key)),
+            Schema::Any => true,
+            _ => false,
+        }
+    }
+    fn key_allowed(&self, key: &str) -> bool {
+        match &self.schema {
+            Schema::Object {
+                properties,
+                additional,
+                ..
+            } => *additional || properties.iter().any(|(name, _)| name == key),
+            Schema::Any => true,
+            _ => false,
+        }
+    }
+    fn value_schema(&self) -> Schema {
+        match &self.schema {
+            Schema::Object {
+                properties,
+                additional,
+                ..
+            } => properties
+                .iter()
+                .find(|(name, _)| name == &self.key)
+                .map(|(_, s)| s.clone())
+                .unwrap_or_else(|| {
+                    if *additional {
+                        Schema::Any
+                    } else {
+                        unreachable!()
+                    }
+                }),
+            Schema::Any => Schema::Any,
+            _ => unreachable!(),
+        }
+    }
+    fn valid(&self) -> bool {
+        match &self.schema {
+            Schema::Object { required, .. } => required.iter().all(|key| self.seen.contains(key)),
+            Schema::Any => true,
+            _ => false,
+        }
+    }
+}
+impl Array {
+    fn item_schema(&self) -> Schema {
+        match &self.schema {
+            Schema::Array(item) => (**item).clone(),
+            Schema::Any => Schema::Any,
+            _ => unreachable!(),
+        }
+    }
+}
+fn delimiter(c: char) -> bool {
+    c.is_whitespace() || matches!(c, ',' | ']' | '}')
+}
+fn schema_object(s: &Schema) -> bool {
+    matches!(s, Schema::Object { .. } | Schema::Any)
+}
+fn schema_array(s: &Schema) -> bool {
+    matches!(s, Schema::Array(_) | Schema::Any)
+}
+fn schema_string(s: &Schema) -> bool {
+    matches!(s, Schema::String | Schema::Any)
+        || matches!(s, Schema::Enum(values) if values.iter().any(Value::is_string))
+}
+fn schema_allows_literal(s: &Schema, literal: &str) -> bool {
+    matches!(s, Schema::Any)
+        || matches!(s, Schema::Bool if literal == "true" || literal == "false")
+        || matches!(s, Schema::Null if literal == "null")
+        || matches!(s, Schema::Enum(values) if values.iter().any(|value| match literal {
+            "true" => value == &Value::Bool(true),
+            "false" => value == &Value::Bool(false),
+            "null" => value.is_null(),
+            _ => false,
+        }))
+}
+fn schema_allows_number(s: &Schema) -> bool {
+    matches!(s, Schema::Number { .. } | Schema::Any)
+        || matches!(s, Schema::Enum(values) if values.iter().any(Value::is_number))
+}
+fn string_prefix_possible(schema: &Schema, prefix: &str) -> bool {
+    match schema {
+        Schema::Enum(values) => values
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|value| value.starts_with(prefix)),
+        _ => true,
+    }
+}
+fn number_prefix_possible(schema: &Schema, prefix: &str) -> bool {
+    match schema {
+        Schema::Enum(values) => values
+            .iter()
+            .filter(|value| value.is_number())
+            .any(|value| serde_json::to_string(value).is_ok_and(|value| value.starts_with(prefix))),
+        _ => true,
+    }
+}
+fn number_matches(s: &Schema, state: Number, raw: &str) -> bool {
+    match s {
+        Schema::Any => true,
+        Schema::Number { integer } => {
+            !integer || !matches!(state, Number::Frac | Number::ExpDigits)
+        }
+        Schema::Enum(values) => values
+            .iter()
+            .filter(|value| value.is_number())
+            .any(|value| serde_json::to_string(value).is_ok_and(|value| value == raw)),
+        _ => false,
+    }
 }

--- a/candle-transformers/src/generation/json_schema.rs
+++ b/candle-transformers/src/generation/json_schema.rs
@@ -1,0 +1,106 @@
+//! JSON-schema constraints for autoregressive decoding.
+//!
+//! The constraint deliberately operates on decoded token text: token ids are tokenizer-specific.
+
+use serde_json::Value;
+use std::sync::Arc;
+
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum SchemaCompileError {
+    #[error("invalid JSON schema: {0}")]
+    InvalidJson(String),
+    #[error("unsupported JSON schema construct: {0}")]
+    Unsupported(String),
+    #[error("invalid JSON schema: {0}")]
+    InvalidSchema(String),
+}
+
+#[derive(Clone, Debug)]
+pub struct CompiledFsm { schema: Schema }
+
+#[derive(Clone, Debug)]
+enum Schema {
+    Any, Null, Bool, Number { integer: bool }, String,
+    Array(Box<Schema>),
+    Object { properties: Vec<(String, Schema)>, required: Vec<String>, additional: bool },
+    Enum(Vec<Value>),
+}
+
+/// Compile the supported, deliberately small JSON Schema subset into a shareable constraint.
+pub fn compile_schema(schema: &str) -> Result<CompiledFsm, SchemaCompileError> {
+    let value = serde_json::from_str(schema).map_err(|e| SchemaCompileError::InvalidJson(e.to_string()))?;
+    Ok(CompiledFsm { schema: Schema::compile(&value)? })
+}
+
+impl Schema {
+    fn compile(value: &Value) -> Result<Self, SchemaCompileError> {
+        let object = value.as_object().ok_or_else(|| SchemaCompileError::InvalidSchema("the root must be an object".into()))?;
+        for key in object.keys() {
+            if !matches!(key.as_str(), "type" | "properties" | "required" | "additionalProperties" | "items" | "enum" | "const" | "title" | "description" | "default") {
+                return Err(SchemaCompileError::Unsupported(key.clone()));
+            }
+        }
+        if let Some(values) = object.get("enum") { return Ok(Self::Enum(values.as_array().ok_or_else(|| SchemaCompileError::InvalidSchema("enum must be an array".into()))?.clone())); }
+        if let Some(value) = object.get("const") { return Ok(Self::Enum(vec![value.clone()])); }
+        let ty = object.get("type").and_then(Value::as_str).unwrap_or("any");
+        match ty {
+            "any" => Ok(Self::Any), "null" => Ok(Self::Null), "boolean" => Ok(Self::Bool),
+            "number" => Ok(Self::Number { integer: false }), "integer" => Ok(Self::Number { integer: true }), "string" => Ok(Self::String),
+            "array" => Ok(Self::Array(Box::new(Self::compile(object.get("items").ok_or_else(|| SchemaCompileError::InvalidSchema("array requires items".into()))?)?))),
+            "object" => {
+                let properties = object.get("properties").and_then(Value::as_object).ok_or_else(|| SchemaCompileError::InvalidSchema("object requires properties".into()))?
+                    .iter().map(|(k, v)| Ok((k.clone(), Self::compile(v)?))).collect::<Result<_, SchemaCompileError>>()?;
+                let required = object.get("required").map(|v| v.as_array().ok_or_else(|| SchemaCompileError::InvalidSchema("required must be an array".into()))
+                    .and_then(|v| v.iter().map(|v| v.as_str().map(str::to_owned).ok_or_else(|| SchemaCompileError::InvalidSchema("required entries must be strings".into()))).collect())).transpose()?.unwrap_or_default();
+                let additional = object.get("additionalProperties").and_then(Value::as_bool).unwrap_or(true);
+                Ok(Self::Object { properties, required, additional })
+            }
+            other => Err(SchemaCompileError::Unsupported(format!("type {other}"))),
+        }
+    }
+
+    fn matches(&self, value: &Value) -> bool { match self {
+        Self::Any => true, Self::Null => value.is_null(), Self::Bool => value.is_boolean(), Self::String => value.is_string(),
+        Self::Number { integer } => value.as_f64().is_some_and(|n| !integer || n.fract() == 0.0),
+        Self::Array(item) => value.as_array().is_some_and(|a| a.iter().all(|v| item.matches(v))),
+        Self::Enum(values) => values.contains(value),
+        Self::Object { properties, required, additional } => value.as_object().is_some_and(|o| {
+            required.iter().all(|k| o.contains_key(k)) && o.iter().all(|(k, v)| properties.iter().find(|(name, _)| name == k).map_or(*additional, |(_, s)| s.matches(v)))
+        }),
+    }}
+}
+
+/// Per-request state for a compiled schema.
+pub struct FsmLogitProcessor { fsm: Arc<CompiledFsm>, text: String }
+impl FsmLogitProcessor {
+    pub fn new(fsm: Arc<CompiledFsm>) -> Self { Self { fsm, text: String::new() } }
+    pub fn allowed_token_ids(&self, vocab_size: usize, eos_tokens: &[u32], decode_one: impl Fn(u32) -> String) -> Vec<u32> {
+        (0..vocab_size as u32).filter(|id| {
+            if eos_tokens.contains(id) { self.is_complete() } else { self.accepts(&decode_one(*id)) }
+        }).collect()
+    }
+    /// Advance after sampling the actual token (not necessarily the best-scoring one).
+    pub fn commit(&mut self, token_text: &str) { self.text.push_str(token_text); }
+    pub fn is_complete(&self) -> bool { serde_json::from_str(&self.text).is_ok_and(|v| self.fsm.schema.matches(&v)) }
+    pub fn text(&self) -> &str { &self.text }
+    fn accepts(&self, token: &str) -> bool {
+        // A complete root JSON value cannot be followed by another token (except EOS).
+        if self.is_complete() { return false; }
+        let candidate = format!("{}{}", self.text, token);
+        if serde_json::from_str::<Value>(&candidate).is_ok_and(|v| self.fsm.schema.matches(&v)) { return true; }
+        json_prefix(&candidate)
+    }
+}
+
+// Reject impossible JSON structure while leaving unfinished lexical values available to later tokens.
+fn json_prefix(text: &str) -> bool {
+    if let Some(first) = text.chars().find(|c| !c.is_whitespace()) {
+        if !matches!(first, '{' | '[' | '"' | 't' | 'f' | 'n' | '-' | '0'..='9') { return false; }
+    }
+    let mut stack = Vec::new(); let mut string = false; let mut escape = false;
+    for c in text.chars() {
+        if string { if escape { escape = false } else if c == '\\' { escape = true } else if c == '"' { string = false }; continue; }
+        match c { '"' => string = true, '{' => stack.push('}'), '[' => stack.push(']'), '}' | ']' => if stack.pop() != Some(c) { return false }, _ => {} }
+    }
+    true
+}

--- a/candle-transformers/src/generation/json_schema.rs
+++ b/candle-transformers/src/generation/json_schema.rs
@@ -260,6 +260,7 @@ struct Object {
 #[derive(Clone, Copy, PartialEq)]
 enum Obj {
     KeyOrEnd,
+    KeyRequired,
     Key,
     Colon,
     Value,
@@ -273,6 +274,7 @@ struct Array {
 #[derive(Clone, Copy, PartialEq)]
 enum Arr {
     ValueOrEnd,
+    ValueRequired,
     CommaOrEnd,
 }
 #[derive(Clone)]
@@ -303,6 +305,9 @@ enum Escape {
     None,
     Slash,
     Unicode(String),
+    HighSurrogateSlash(u16),
+    HighSurrogateU(u16),
+    LowSurrogate(u16, String),
 }
 #[derive(Clone, Copy)]
 enum Number {
@@ -419,7 +424,7 @@ impl Cursor {
         }
     }
     fn structural(&mut self, c: char) -> bool {
-        if c.is_whitespace() {
+        if json_whitespace(c) {
             return true;
         }
         if self.frames.is_empty() {
@@ -441,6 +446,15 @@ impl Cursor {
                         false
                     }
                 }
+                Obj::KeyRequired => {
+                    if c == '"' {
+                        self.set_object(Obj::Key, String::new());
+                        self.scalar = Some(Scalar::Key(Text::default()));
+                        true
+                    } else {
+                        false
+                    }
+                }
                 Obj::Colon => {
                     if c == ':' {
                         self.set_object(Obj::Value, object.key);
@@ -452,7 +466,7 @@ impl Cursor {
                 Obj::Value => self.start(object.value_schema(), c),
                 Obj::CommaOrEnd => {
                     if c == ',' {
-                        self.set_object(Obj::KeyOrEnd, String::new());
+                        self.set_object(Obj::KeyRequired, String::new());
                         true
                     } else if c == '}' {
                         self.close_object()
@@ -470,9 +484,10 @@ impl Cursor {
                         self.start(array.item_schema(), c)
                     }
                 }
+                Arr::ValueRequired => self.start(array.item_schema(), c),
                 Arr::CommaOrEnd => {
                     if c == ',' {
-                        self.set_array(Arr::ValueOrEnd);
+                        self.set_array(Arr::ValueRequired);
                         true
                     } else if c == ']' {
                         self.close_array()
@@ -484,7 +499,7 @@ impl Cursor {
         }
     }
     fn start(&mut self, schema: Schema, c: char) -> bool {
-        if c.is_whitespace() {
+        if json_whitespace(c) {
             return true;
         }
         match c {
@@ -548,7 +563,9 @@ impl Cursor {
                     object.state = Obj::CommaOrEnd;
                     true
                 }
-                Frame::Array(array) if array.state == Arr::ValueOrEnd => {
+                Frame::Array(array)
+                    if matches!(array.state, Arr::ValueOrEnd | Arr::ValueRequired) =>
+                {
                     array.state = Arr::CommaOrEnd;
                     true
                 }
@@ -633,10 +650,49 @@ impl Text {
                 hex.push(c);
                 if hex.len() == 4 {
                     let code = u32::from_str_radix(hex, 16).unwrap();
-                    let Some(c) = char::from_u32(code) else {
+                    match code {
+                        0xd800..=0xdbff => {
+                            self.escape = Escape::HighSurrogateSlash(code as u16);
+                        }
+                        0xdc00..=0xdfff => return TextResult::Invalid,
+                        _ => {
+                            self.value.push(char::from_u32(code).expect("valid scalar"));
+                            self.escape = Escape::None;
+                        }
+                    }
+                }
+                TextResult::More
+            }
+            Escape::HighSurrogateSlash(high) => {
+                if c == '\\' {
+                    self.escape = Escape::HighSurrogateU(*high);
+                    TextResult::More
+                } else {
+                    TextResult::Invalid
+                }
+            }
+            Escape::HighSurrogateU(high) => {
+                if c == 'u' {
+                    self.escape = Escape::LowSurrogate(*high, String::new());
+                    TextResult::More
+                } else {
+                    TextResult::Invalid
+                }
+            }
+            Escape::LowSurrogate(high, hex) => {
+                if !c.is_ascii_hexdigit() {
+                    return TextResult::Invalid;
+                }
+                hex.push(c);
+                if hex.len() == 4 {
+                    let low = u16::from_str_radix(hex, 16).unwrap();
+                    if !(0xdc00..=0xdfff).contains(&low) {
                         return TextResult::Invalid;
-                    };
-                    self.value.push(c);
+                    }
+                    let scalar =
+                        0x1_0000 + (((*high as u32 - 0xd800) << 10) | (low as u32 - 0xdc00));
+                    self.value
+                        .push(char::from_u32(scalar).expect("valid surrogate pair"));
                     self.escape = Escape::None;
                 }
                 TextResult::More
@@ -728,7 +784,10 @@ impl Array {
     }
 }
 fn delimiter(c: char) -> bool {
-    c.is_whitespace() || matches!(c, ',' | ']' | '}')
+    json_whitespace(c) || matches!(c, ',' | ']' | '}')
+}
+fn json_whitespace(c: char) -> bool {
+    matches!(c, ' ' | '\t' | '\n' | '\r')
 }
 fn schema_object(s: &Schema) -> bool {
     matches!(s, Schema::Object { .. } | Schema::Any)
@@ -773,16 +832,20 @@ fn number_prefix_possible(schema: &Schema, prefix: &str) -> bool {
         _ => true,
     }
 }
-fn number_matches(s: &Schema, state: Number, raw: &str) -> bool {
+fn number_matches(s: &Schema, _state: Number, raw: &str) -> bool {
+    let Ok(number) = raw.parse::<f64>() else {
+        return false;
+    };
+    if !number.is_finite() {
+        return false;
+    }
     match s {
         Schema::Any => true,
-        Schema::Number { integer } => {
-            !integer || !matches!(state, Number::Frac | Number::ExpDigits)
-        }
+        Schema::Number { integer } => !integer || number.fract() == 0.0,
         Schema::Enum(values) => values
             .iter()
             .filter(|value| value.is_number())
-            .any(|value| serde_json::to_string(value).is_ok_and(|value| value == raw)),
+            .any(|value| value.as_f64().is_some_and(|value| value == number)),
         _ => false,
     }
 }

--- a/candle-transformers/src/generation/json_schema.rs
+++ b/candle-transformers/src/generation/json_schema.rs
@@ -17,7 +17,7 @@ pub enum SchemaCompileError {
 
 #[derive(Clone, Debug)]
 pub struct CompiledFsm {
-    schema: Schema,
+    schema: Arc<Schema>,
 }
 
 #[derive(Clone, Debug)]
@@ -29,9 +29,9 @@ enum Schema {
         integer: bool,
     },
     String,
-    Array(Box<Schema>),
+    Array(Arc<Schema>),
     Object {
-        properties: Vec<(String, Schema)>,
+        properties: Vec<(String, Arc<Schema>)>,
         required: Vec<String>,
         additional: bool,
     },
@@ -39,11 +39,14 @@ enum Schema {
 }
 
 /// Compile the supported, deliberately small JSON Schema subset into a shareable constraint.
+///
+/// Scalar string, boolean, and null `enum`/`const` values are supported. Numeric and composite
+/// enum values are rejected rather than being approximated by a lexical prefix check.
 pub fn compile_schema(schema: &str) -> Result<CompiledFsm, SchemaCompileError> {
     let value =
         serde_json::from_str(schema).map_err(|e| SchemaCompileError::InvalidJson(e.to_string()))?;
     Ok(CompiledFsm {
-        schema: Schema::compile(&value)?,
+        schema: Arc::new(Schema::compile(&value)?),
     })
 }
 
@@ -69,55 +72,110 @@ impl Schema {
                 return Err(SchemaCompileError::Unsupported(key.clone()));
             }
         }
+        let has_enum = object.contains_key("enum");
+        let has_const = object.contains_key("const");
+        if (has_enum || has_const)
+            && (has_enum && has_const
+                || object.keys().any(|key| {
+                    matches!(
+                        key.as_str(),
+                        "properties" | "required" | "additionalProperties" | "items"
+                    )
+                }))
+        {
+            return Err(SchemaCompileError::Unsupported(
+                "combined enum/const constraints".into(),
+            ));
+        }
+        if (has_enum || has_const) && object.contains_key("type") {
+            let ty = object
+                .get("type")
+                .and_then(Value::as_str)
+                .ok_or_else(|| SchemaCompileError::Unsupported("non-string type".into()))?;
+            let values = if let Some(values) = object.get("enum") {
+                values.as_array().ok_or_else(|| {
+                    SchemaCompileError::InvalidSchema("enum must be an array".into())
+                })?
+            } else {
+                std::slice::from_ref(object.get("const").expect("const is present"))
+            };
+            if !values.iter().all(|value| type_matches(ty, value)) {
+                return Err(SchemaCompileError::InvalidSchema(
+                    "type conflicts with enum/const".into(),
+                ));
+            }
+        }
         if let Some(values) = object.get("enum") {
-            if values
+            let values = values
                 .as_array()
-                .is_some_and(|values| values.iter().any(Value::is_array))
-                || values
-                    .as_array()
-                    .is_some_and(|values| values.iter().any(Value::is_object))
+                .ok_or_else(|| SchemaCompileError::InvalidSchema("enum must be an array".into()))?;
+            if values.is_empty() {
+                return Err(SchemaCompileError::InvalidSchema(
+                    "enum must not be empty".into(),
+                ));
+            }
+            if values
+                .iter()
+                .any(|value| value.is_array() || value.is_object())
             {
                 return Err(SchemaCompileError::Unsupported("non-scalar enum".into()));
             }
-            return Ok(Self::Enum(
-                values
-                    .as_array()
-                    .ok_or_else(|| {
-                        SchemaCompileError::InvalidSchema("enum must be an array".into())
-                    })?
-                    .clone(),
-            ));
+            if values.iter().any(Value::is_number) {
+                return Err(SchemaCompileError::Unsupported("numeric enum".into()));
+            }
+            return Ok(Self::Enum(values.clone()));
         }
         if let Some(value) = object.get("const") {
             if value.is_array() || value.is_object() {
                 return Err(SchemaCompileError::Unsupported("non-scalar const".into()));
             }
+            if value.is_number() {
+                return Err(SchemaCompileError::Unsupported("numeric const".into()));
+            }
             return Ok(Self::Enum(vec![value.clone()]));
         }
-        let ty = object.get("type").and_then(Value::as_str).unwrap_or("any");
+        let object_keywords = object.contains_key("properties")
+            || object.contains_key("required")
+            || object.contains_key("additionalProperties");
+        let array_keywords = object.contains_key("items");
+        let ty = match object.get("type") {
+            None if !object_keywords && !array_keywords => return Ok(Self::Any),
+            None => {
+                return Err(SchemaCompileError::Unsupported(
+                    "structural keywords without their matching type".into(),
+                ))
+            }
+            Some(Value::String(ty)) => ty.as_str(),
+            Some(_) => return Err(SchemaCompileError::Unsupported("non-string type".into())),
+        };
+        if (object_keywords && ty != "object") || (array_keywords && ty != "array") {
+            return Err(SchemaCompileError::Unsupported(
+                "structural keywords without their matching type".into(),
+            ));
+        }
         match ty {
-            "any" => Ok(Self::Any),
             "null" => Ok(Self::Null),
             "boolean" => Ok(Self::Bool),
             "number" => Ok(Self::Number { integer: false }),
             "integer" => Ok(Self::Number { integer: true }),
             "string" => Ok(Self::String),
-            "array" => Ok(Self::Array(Box::new(Self::compile(
-                object.get("items").ok_or_else(|| {
-                    SchemaCompileError::InvalidSchema("array requires items".into())
-                })?,
-            )?))),
+            "array" => Ok(Self::Array(Arc::new(match object.get("items") {
+                Some(items) => Self::compile(items)?,
+                None => Self::Any,
+            }))),
             "object" => {
-                let properties = object
-                    .get("properties")
-                    .and_then(Value::as_object)
-                    .ok_or_else(|| {
-                        SchemaCompileError::InvalidSchema("object requires properties".into())
-                    })?
-                    .iter()
-                    .map(|(k, v)| Ok((k.clone(), Self::compile(v)?)))
-                    .collect::<Result<_, SchemaCompileError>>()?;
-                let required = object
+                let properties: Vec<(String, Arc<Schema>)> = match object.get("properties") {
+                    None => vec![],
+                    Some(properties) => properties
+                        .as_object()
+                        .ok_or_else(|| {
+                            SchemaCompileError::InvalidSchema("properties must be an object".into())
+                        })?
+                        .iter()
+                        .map(|(k, v)| Ok((k.clone(), Arc::new(Self::compile(v)?))))
+                        .collect::<Result<_, SchemaCompileError>>()?,
+                };
+                let required: Vec<String> = object
                     .get("required")
                     .map(|v| {
                         v.as_array()
@@ -140,10 +198,24 @@ impl Schema {
                     })
                     .transpose()?
                     .unwrap_or_default();
-                let additional = object
-                    .get("additionalProperties")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(true);
+                let additional = match object.get("additionalProperties") {
+                    None => true,
+                    Some(Value::Bool(additional)) => *additional,
+                    Some(_) => {
+                        return Err(SchemaCompileError::Unsupported(
+                            "non-boolean additionalProperties".into(),
+                        ))
+                    }
+                };
+                if !additional
+                    && required
+                        .iter()
+                        .any(|key| !properties.iter().any(|(name, _)| name == key))
+                {
+                    return Err(SchemaCompileError::InvalidSchema(
+                        "required property is not declared".into(),
+                    ));
+                }
                 Ok(Self::Object {
                     properties,
                     required,
@@ -214,9 +286,10 @@ impl FsmLogitProcessor {
     }
     /// Advance after sampling the actual token (not necessarily the best-scoring one).
     pub fn commit(&mut self, token_text: &str) {
-        debug_assert!(self.cursor.clone().apply(token_text));
         let mut cursor = self.cursor.clone();
-        if cursor.apply(token_text) {
+        let accepted = cursor.apply(token_text);
+        debug_assert!(accepted, "committed text must be accepted by the cursor");
+        if accepted {
             self.cursor = cursor;
             self.text.push_str(token_text);
         }
@@ -228,6 +301,9 @@ impl FsmLogitProcessor {
         &self.text
     }
     fn accepts(&self, token: &str) -> bool {
+        if token.is_empty() {
+            return false;
+        }
         let mut cursor = self.cursor.clone();
         cursor.apply(token)
     }
@@ -235,7 +311,7 @@ impl FsmLogitProcessor {
 
 #[derive(Clone)]
 struct Cursor {
-    root: Schema,
+    root: Arc<Schema>,
     state: Root,
     frames: Vec<Frame>,
     scalar: Option<Scalar>,
@@ -252,7 +328,7 @@ enum Frame {
 }
 #[derive(Clone)]
 struct Object {
-    schema: Schema,
+    schema: Arc<Schema>,
     seen: Vec<String>,
     key: String,
     state: Obj,
@@ -268,7 +344,7 @@ enum Obj {
 }
 #[derive(Clone)]
 struct Array {
-    schema: Schema,
+    schema: Arc<Schema>,
     state: Arr,
 }
 #[derive(Clone, Copy, PartialEq)]
@@ -281,11 +357,11 @@ enum Arr {
 enum Scalar {
     Key(Text),
     String {
-        schema: Schema,
+        schema: Arc<Schema>,
         text: Text,
     },
     Number {
-        schema: Schema,
+        schema: Arc<Schema>,
         state: Number,
         raw: String,
     },
@@ -322,7 +398,7 @@ enum Number {
 }
 
 impl Cursor {
-    fn new(root: Schema) -> Self {
+    fn new(root: Arc<Schema>) -> Self {
         Self {
             root,
             state: Root::Value,
@@ -331,7 +407,7 @@ impl Cursor {
         }
     }
     fn apply(&mut self, text: &str) -> bool {
-        text.chars().all(|c| self.step(c))
+        self.state != Root::Done && text.chars().all(|c| self.step(c))
     }
     fn is_complete(&self) -> bool {
         self.frames.is_empty()
@@ -405,7 +481,7 @@ impl Cursor {
                 Some(next) => {
                     *state = next;
                     raw.push(c);
-                    if number_prefix_possible(schema, raw) {
+                    if number_prefix_possible(schema, *state, raw) {
                         self.scalar = Some(scalar);
                         true
                     } else {
@@ -438,7 +514,7 @@ impl Cursor {
                 Obj::KeyOrEnd => {
                     if c == '}' {
                         self.close_object()
-                    } else if c == '"' {
+                    } else if c == '"' && object.key_prefix_allowed("") {
                         self.set_object(Obj::Key, String::new());
                         self.scalar = Some(Scalar::Key(Text::default()));
                         true
@@ -447,7 +523,7 @@ impl Cursor {
                     }
                 }
                 Obj::KeyRequired => {
-                    if c == '"' {
+                    if c == '"' && object.key_prefix_allowed("") {
                         self.set_object(Obj::Key, String::new());
                         self.scalar = Some(Scalar::Key(Text::default()));
                         true
@@ -498,7 +574,7 @@ impl Cursor {
             },
         }
     }
-    fn start(&mut self, schema: Schema, c: char) -> bool {
+    fn start(&mut self, schema: Arc<Schema>, c: char) -> bool {
         if json_whitespace(c) {
             return true;
         }
@@ -535,7 +611,7 @@ impl Cursor {
             _ => false,
         }
     }
-    fn literal(&mut self, schema: Schema, expected: &'static str, at: usize) -> bool {
+    fn literal(&mut self, schema: Arc<Schema>, expected: &'static str, at: usize) -> bool {
         if schema_allows_literal(&schema, expected) {
             self.scalar = Some(Scalar::Literal { expected, at });
             true
@@ -543,8 +619,8 @@ impl Cursor {
             false
         }
     }
-    fn number(&mut self, schema: Schema, state: Number, raw: &str) -> bool {
-        if schema_allows_number(&schema) && number_prefix_possible(&schema, raw) {
+    fn number(&mut self, schema: Arc<Schema>, state: Number, raw: &str) -> bool {
+        if schema_allows_number(&schema) && number_prefix_possible(&schema, state, raw) {
             self.scalar = Some(Scalar::Number {
                 schema,
                 state,
@@ -724,7 +800,7 @@ impl Number {
 }
 impl Object {
     fn key_prefix_allowed(&self, key: &str) -> bool {
-        match &self.schema {
+        match &*self.schema {
             Schema::Object {
                 properties,
                 additional,
@@ -735,7 +811,7 @@ impl Object {
         }
     }
     fn key_allowed(&self, key: &str) -> bool {
-        match &self.schema {
+        match &*self.schema {
             Schema::Object {
                 properties,
                 additional,
@@ -745,8 +821,8 @@ impl Object {
             _ => false,
         }
     }
-    fn value_schema(&self) -> Schema {
-        match &self.schema {
+    fn value_schema(&self) -> Arc<Schema> {
+        match &*self.schema {
             Schema::Object {
                 properties,
                 additional,
@@ -757,17 +833,17 @@ impl Object {
                 .map(|(_, s)| s.clone())
                 .unwrap_or_else(|| {
                     if *additional {
-                        Schema::Any
+                        Arc::new(Schema::Any)
                     } else {
                         unreachable!()
                     }
                 }),
-            Schema::Any => Schema::Any,
+            Schema::Any => Arc::new(Schema::Any),
             _ => unreachable!(),
         }
     }
     fn valid(&self) -> bool {
-        match &self.schema {
+        match &*self.schema {
             Schema::Object { required, .. } => required.iter().all(|key| self.seen.contains(key)),
             Schema::Any => true,
             _ => false,
@@ -775,10 +851,10 @@ impl Object {
     }
 }
 impl Array {
-    fn item_schema(&self) -> Schema {
-        match &self.schema {
-            Schema::Array(item) => (**item).clone(),
-            Schema::Any => Schema::Any,
+    fn item_schema(&self) -> Arc<Schema> {
+        match &*self.schema {
+            Schema::Array(item) => Arc::clone(item),
+            Schema::Any => Arc::new(Schema::Any),
             _ => unreachable!(),
         }
     }
@@ -791,6 +867,18 @@ fn json_whitespace(c: char) -> bool {
 }
 fn schema_object(s: &Schema) -> bool {
     matches!(s, Schema::Object { .. } | Schema::Any)
+}
+fn type_matches(ty: &str, value: &Value) -> bool {
+    match ty {
+        "null" => value.is_null(),
+        "boolean" => value.is_boolean(),
+        "number" => value.is_number(),
+        "integer" => value.as_f64().is_some_and(|number| number.fract() == 0.0),
+        "string" => value.is_string(),
+        "array" => value.is_array(),
+        "object" => value.is_object(),
+        _ => false,
+    }
 }
 fn schema_array(s: &Schema) -> bool {
     matches!(s, Schema::Array(_) | Schema::Any)
@@ -812,7 +900,6 @@ fn schema_allows_literal(s: &Schema, literal: &str) -> bool {
 }
 fn schema_allows_number(s: &Schema) -> bool {
     matches!(s, Schema::Number { .. } | Schema::Any)
-        || matches!(s, Schema::Enum(values) if values.iter().any(Value::is_number))
 }
 fn string_prefix_possible(schema: &Schema, prefix: &str) -> bool {
     match schema {
@@ -823,29 +910,49 @@ fn string_prefix_possible(schema: &Schema, prefix: &str) -> bool {
         _ => true,
     }
 }
-fn number_prefix_possible(schema: &Schema, prefix: &str) -> bool {
-    match schema {
-        Schema::Enum(values) => values
-            .iter()
-            .filter(|value| value.is_number())
-            .any(|value| serde_json::to_string(value).is_ok_and(|value| value.starts_with(prefix))),
-        _ => true,
+fn number_prefix_possible(schema: &Schema, state: Number, prefix: &str) -> bool {
+    if !state.complete() || !json_number_is_finite(prefix) {
+        return !state.complete();
     }
+    !matches!(schema, Schema::Number { integer: true })
+        || !matches!(state, Number::ExpDigits)
+        || number_is_integer(prefix)
 }
 fn number_matches(s: &Schema, _state: Number, raw: &str) -> bool {
-    let Ok(number) = raw.parse::<f64>() else {
-        return false;
-    };
-    if !number.is_finite() {
+    if !json_number_is_finite(raw) {
         return false;
     }
     match s {
         Schema::Any => true,
-        Schema::Number { integer } => !integer || number.fract() == 0.0,
-        Schema::Enum(values) => values
-            .iter()
-            .filter(|value| value.is_number())
-            .any(|value| value.as_f64().is_some_and(|value| value == number)),
+        Schema::Number { integer } => !integer || number_is_integer(raw),
         _ => false,
     }
+}
+fn json_number_is_finite(raw: &str) -> bool {
+    serde_json::from_str::<Value>(raw)
+        .ok()
+        .and_then(|value| value.as_f64())
+        .is_some_and(f64::is_finite)
+}
+fn number_is_integer(raw: &str) -> bool {
+    let (mantissa, exponent) = match raw.find(['e', 'E']) {
+        Some(index) => (&raw[..index], &raw[index + 1..]),
+        None => (raw, "0"),
+    };
+    let mantissa = mantissa.strip_prefix('-').unwrap_or(mantissa);
+    let (whole, fraction) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+    let digits = format!("{whole}{fraction}");
+    if digits.bytes().all(|byte| byte == b'0') {
+        return true;
+    }
+    let Ok(exponent) = exponent.parse::<i128>() else {
+        return false;
+    };
+    let trailing_zeroes = digits
+        .bytes()
+        .rev()
+        .take_while(|byte| *byte == b'0')
+        .count() as i128;
+    let decimal_places = fraction.len() as i128 - exponent;
+    decimal_places <= 0 || trailing_zeroes >= decimal_places
 }

--- a/candle-transformers/src/generation/json_schema.rs
+++ b/candle-transformers/src/generation/json_schema.rs
@@ -917,6 +917,11 @@ fn number_prefix_possible(schema: &Schema, state: Number, prefix: &str) -> bool 
     !matches!(schema, Schema::Number { integer: true })
         || !matches!(state, Number::ExpDigits)
         || number_is_integer(prefix)
+        || !has_negative_exponent(prefix)
+}
+fn has_negative_exponent(raw: &str) -> bool {
+    raw.find(['e', 'E'])
+        .is_some_and(|index| raw[index + 1..].starts_with('-'))
 }
 fn number_matches(s: &Schema, _state: Number, raw: &str) -> bool {
     if !json_number_is_finite(raw) {

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -7,8 +7,10 @@ use candle::{DType, Error, Result, Tensor};
 use rand::{distr::Distribution, SeedableRng};
 
 mod incremental_decoder;
+mod json_schema;
 mod stop_criteria;
 pub use incremental_decoder::IncrementalDecoder;
+pub use json_schema::{compile_schema, CompiledFsm, FsmLogitProcessor, SchemaCompileError};
 pub use stop_criteria::{FinishReason, StopCriteria};
 #[derive(Clone, PartialEq, Debug)]
 pub enum Sampling {

--- a/candle-transformers/src/generation/mod.rs
+++ b/candle-transformers/src/generation/mod.rs
@@ -6,6 +6,10 @@
 use candle::{DType, Error, Result, Tensor};
 use rand::{distr::Distribution, SeedableRng};
 
+mod incremental_decoder;
+mod stop_criteria;
+pub use incremental_decoder::IncrementalDecoder;
+pub use stop_criteria::{FinishReason, StopCriteria};
 #[derive(Clone, PartialEq, Debug)]
 pub enum Sampling {
     ArgMax,

--- a/candle-transformers/src/generation/stop_criteria.rs
+++ b/candle-transformers/src/generation/stop_criteria.rs
@@ -1,0 +1,97 @@
+//! Stop-sequence matching and finish reasons for autoregressive decode loops.
+//!
+//! Stop sequences are strings, rather than token ids: a sequence can span token boundaries or
+//! use a tokenization different from the one that produced the completion.  [`StopCriteria`]
+//! therefore operates on the text maintained by [`super::IncrementalDecoder`].
+
+/// Why a generation finished.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FinishReason {
+    /// The model produced an EOS token or a configured stop sequence.
+    Stop,
+    /// The configured token budget was spent before the model stopped.
+    Length,
+}
+
+/// Text and token conditions that end an autoregressive generation.
+///
+/// A decode loop should retain [`Self::hold`] bytes of its decoded text before streaming it.
+/// [`Self::safe_emit_end`] returns the corresponding character-boundary offset, and accounts
+/// for an already matched stop sequence.  This lets a stop sequence spanning two tokens be
+/// detected without sending any part of it to the consumer.
+#[derive(Clone, Debug)]
+pub struct StopCriteria {
+    stop: Vec<String>,
+    eos: Vec<u32>,
+    hold: usize,
+}
+
+impl StopCriteria {
+    /// Creates criteria from text stop sequences and EOS token ids.
+    ///
+    /// Empty stop sequences are ignored: they would match before any generated text and do not
+    /// describe a useful stopping condition.
+    pub fn new(stop: impl IntoIterator<Item = String>, eos: Vec<u32>) -> Self {
+        let stop: Vec<_> = stop.into_iter().filter(|stop| !stop.is_empty()).collect();
+        let hold = stop
+            .iter()
+            .map(|stop| stop.len().saturating_sub(1))
+            .max()
+            .unwrap_or(0);
+        Self { stop, eos, hold }
+    }
+
+    /// Number of trailing bytes that must be retained while looking for a stop sequence.
+    pub fn hold(&self) -> usize {
+        self.hold
+    }
+
+    /// Returns whether `token` is an EOS token configured for this generation.
+    pub fn is_eos(&self, token: u32) -> bool {
+        self.eos.contains(&token)
+    }
+
+    /// Returns the byte offset of the earliest configured stop sequence in `text`.
+    ///
+    /// When several sequences match, position wins over configuration order.  This avoids
+    /// truncating at a later stop merely because it appeared earlier in the configuration.
+    pub fn matched(&self, text: &str) -> Option<usize> {
+        self.stop.iter().filter_map(|stop| text.find(stop)).min()
+    }
+
+    /// Returns the largest character-boundary offset that may be streamed from `text` now.
+    ///
+    /// If a stop sequence has matched, its beginning is returned so that the sequence itself is
+    /// not emitted.  Otherwise this retains [`Self::hold`] trailing bytes, rounded down to a
+    /// UTF-8 character boundary.
+    pub fn safe_emit_end(&self, text: &str) -> usize {
+        if let Some(matched) = self.matched(text) {
+            return matched;
+        }
+        let mut end = text.len().saturating_sub(self.hold);
+        while !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        end
+    }
+
+    /// Determines a known finish reason after a token has been decoded.
+    ///
+    /// Model-controlled endings win when they land on the last allowed token: an EOS token or a
+    /// stop sequence at that boundary is [`FinishReason::Stop`], not `Length`.  If the loop
+    /// ended for a reason outside these criteria, do not call this method and report no reason.
+    pub fn finish_reason(
+        &self,
+        token: u32,
+        text: &str,
+        budget_exhausted: bool,
+    ) -> Option<FinishReason> {
+        if self.is_eos(token) || self.matched(text).is_some() {
+            Some(FinishReason::Stop)
+        } else if budget_exhausted {
+            Some(FinishReason::Length)
+        } else {
+            None
+        }
+    }
+}

--- a/candle-transformers/tests/incremental_decoder_tests.rs
+++ b/candle-transformers/tests/incremental_decoder_tests.rs
@@ -1,0 +1,603 @@
+use candle_transformers::generation::IncrementalDecoder;
+use serde_json::{json, Value};
+use tokenizers::Tokenizer;
+
+/// Build a tokenizer from an explicit vocabulary and decoder, so the tests exercise decoder
+/// behaviour without downloading anything.
+fn tokenizer(vocab: &[&str], decoder: Value) -> Tokenizer {
+    tokenizer_with_added(vocab, decoder, json!([]))
+}
+
+fn tokenizer_with_added(vocab: &[&str], decoder: Value, added_tokens: Value) -> Tokenizer {
+    let vocab: serde_json::Map<String, Value> = vocab
+        .iter()
+        .enumerate()
+        .map(|(i, token)| ((*token).to_string(), json!(i)))
+        .collect();
+    let spec = json!({
+        "version": "1.0",
+        "truncation": null,
+        "padding": null,
+        "added_tokens": added_tokens,
+        "normalizer": null,
+        "pre_tokenizer": null,
+        "post_processor": null,
+        "decoder": decoder,
+        "model": {
+            "type": "BPE",
+            "dropout": null,
+            "unk_token": null,
+            "continuing_subword_prefix": null,
+            "end_of_word_suffix": null,
+            "fuse_unk": false,
+            "byte_fallback": false,
+            "ignore_merges": false,
+            "vocab": vocab,
+            "merges": [],
+        },
+    });
+    Tokenizer::from_bytes(serde_json::to_vec(&spec).unwrap()).unwrap()
+}
+
+fn byte_level() -> Value {
+    json!({"type": "ByteLevel", "add_prefix_space": false, "trim_offsets": true, "use_regex": true})
+}
+
+/// The invariant from the issue: the incremental text equals a whole-sequence decode at every
+/// step, and the concatenation of the emitted deltas reproduces it exactly.
+fn check_stream(tokenizer: &Tokenizer, ids: &[u32]) -> String {
+    let mut decoder = IncrementalDecoder::new(tokenizer);
+    let mut streamed = String::new();
+    for (i, &id) in ids.iter().enumerate() {
+        let delta = decoder.push(id).unwrap().to_string();
+        assert_eq!(decoder.retracted(), 0, "unexpected retraction at step {i}");
+        streamed.push_str(&delta);
+        let expected = tokenizer.decode(&ids[..=i], true).unwrap();
+        assert_eq!(decoder.text(), expected, "diverged at step {i}");
+        assert!(
+            expected.starts_with(&streamed),
+            "emitted text is not a prefix of the decode at step {i}: {streamed:?} vs {expected:?}"
+        );
+    }
+    streamed.push_str(decoder.finish());
+    assert_eq!(streamed, decoder.text());
+    streamed
+}
+
+#[test]
+fn multi_byte_char_spanning_tokens() {
+    // "Ã" and "©" are the byte-level spellings of 0xC3 and 0xA9, the two bytes of "é".
+    let tokenizer = tokenizer(&["Hello", "Ġworld", "Ã", "©"], byte_level());
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    assert!(decoder.is_windowed());
+
+    assert_eq!(decoder.push(0).unwrap(), "Hello");
+    assert_eq!(decoder.push(1).unwrap(), " world");
+    // The lone 0xC3 decodes to U+FFFD, which the next token replaces, so nothing is emitted.
+    assert_eq!(decoder.push(2).unwrap(), "");
+    assert_eq!(decoder.text(), "Hello world\u{FFFD}");
+    assert_eq!(decoder.push(3).unwrap(), "é");
+    assert_eq!(decoder.text(), "Hello worldé");
+
+    check_stream(&tokenizer, &[0, 1, 2, 3]);
+}
+
+#[test]
+fn undecodable_bytes_are_released_by_finish() {
+    let tokenizer = tokenizer(&["Hello", "Ã"], byte_level());
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    assert_eq!(decoder.push(0).unwrap(), "Hello");
+    assert_eq!(decoder.push(1).unwrap(), "");
+    assert_eq!(decoder.finish(), "\u{FFFD}");
+    assert_eq!(decoder.finish(), "");
+}
+
+#[test]
+fn sentencepiece_leading_space() {
+    // The decoder shipped by the Llama-style tokenizers: a per-token replace, byte fallback,
+    // a fuse, then a strip of the leading space introduced by the first "▁".
+    let decoder = json!({"type": "Sequence", "decoders": [
+        {"type": "Replace", "pattern": {"String": "▁"}, "content": " "},
+        {"type": "ByteFallback"},
+        {"type": "Fuse"},
+        {"type": "Strip", "content": " ", "start": 1, "stop": 0},
+    ]});
+    let tokenizer = tokenizer(&["▁Hello", "▁world", "<0xE5>", "<0x8f>", "<0xab>"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(incremental.is_windowed());
+
+    // The leading space is stripped from the first token but not from the second, so a naive
+    // per-token decode would produce "HelloWorld".
+    assert_eq!(incremental.push(0).unwrap(), "Hello");
+    assert_eq!(incremental.push(1).unwrap(), " world");
+    // 叫 is three byte-fallback tokens. The run stays open until a non-marker token closes it,
+    // since one more marker could re-render the whole of it, so it lands with `finish`.
+    assert_eq!(incremental.push(2).unwrap(), "");
+    assert_eq!(incremental.push(3).unwrap(), "");
+    assert_eq!(incremental.push(4).unwrap(), "");
+    assert_eq!(incremental.text(), "Hello world叫");
+    assert_eq!(incremental.finish(), "叫");
+
+    check_stream(&tokenizer, &[0, 1, 2, 3, 4]);
+}
+
+#[test]
+fn wordpiece_decoder() {
+    let decoder = json!({"type": "WordPiece", "prefix": "##", "cleanup": true});
+    let tokenizer = tokenizer(&["Ara", "##új", "##o", "No", "##guera"], decoder);
+    let streamed = check_stream(&tokenizer, &[0, 1, 2, 3, 4]);
+    assert_eq!(streamed, "Araújo Noguera");
+}
+
+#[test]
+fn no_decoder_joins_with_spaces() {
+    let tokenizer = tokenizer(&["a", "b", "c"], Value::Null);
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    assert!(decoder.is_windowed());
+    assert_eq!(decoder.push(0).unwrap(), "a");
+    assert_eq!(decoder.push(1).unwrap(), " b");
+    assert_eq!(check_stream(&tokenizer, &[0, 1, 2]), "a b c");
+}
+
+#[test]
+fn bpe_decoder_defers_the_last_token() {
+    // `BPEDecoder` drops the end-of-word suffix of the last token instead of turning it into a
+    // space, so the tail of the text is rewritten by the next push and must not be emitted yet.
+    let decoder = json!({"type": "BPEDecoder", "suffix": "</w>"});
+    let tokenizer = tokenizer(&["ab</w>", "cd</w>"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert_eq!(incremental.push(0).unwrap(), "");
+    assert_eq!(incremental.text(), "ab");
+    assert_eq!(incremental.push(1).unwrap(), "ab");
+    assert_eq!(incremental.text(), "ab cd");
+    assert_eq!(incremental.finish(), " cd");
+
+    check_stream(&tokenizer, &[0, 1, 0, 1, 0]);
+}
+
+#[test]
+fn window_stays_bounded_over_a_long_run() {
+    let tokenizer = tokenizer(
+        &["Hello", "Ġworld", "Ã", "©", "Ġthe", "Ġquick", "."],
+        byte_level(),
+    );
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    let mut ids = Vec::new();
+    // A cheap deterministic shuffle, so the run mixes plain tokens with byte pairs.
+    let mut state = 12345u64;
+    for _ in 0..2000 {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let id = (state >> 33) as u32 % 7;
+        ids.push(id);
+        decoder.push(id).unwrap();
+        assert_eq!(decoder.text(), tokenizer.decode(&ids, true).unwrap());
+        // A window that fails to re-anchor keeps growing until the next attempt, so the bound
+        // is on the order of the re-anchoring threshold rather than exactly it.
+        assert!(
+            decoder.window_len() <= 128,
+            "window grew to {} tokens",
+            decoder.window_len()
+        );
+    }
+}
+
+#[test]
+fn unbounded_decoder_falls_back_to_whole_sequence() {
+    // A `Replace` with a regex pattern, applied after the tokens have been fused, can rewrite
+    // text arbitrarily far back: windowing has to be disabled for it.
+    let decoder = json!({"type": "Sequence", "decoders": [
+        byte_level(),
+        {"type": "Replace", "pattern": {"Regex": "\\s+"}, "content": " "},
+    ]});
+    let tokenizer = tokenizer(&["Hello", "Ġworld", "Ġ", "Ġthe"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(!incremental.is_windowed());
+
+    let mut ids = Vec::new();
+    for id in [0, 1, 2, 2, 3, 2, 0] {
+        ids.push(id);
+        incremental.push(id).unwrap();
+        assert_eq!(incremental.text(), tokenizer.decode(&ids, true).unwrap());
+    }
+    assert_eq!(incremental.window_len(), ids.len());
+}
+
+#[test]
+fn fused_bpe_decoder_accounts_for_its_suffix() {
+    // After a `Fuse` the decoder sees one string, so every occurrence of the suffix is dropped
+    // wherever it lands - including one assembled across several pushed tokens, which rewrites
+    // text that a per-token reading would have considered settled.
+    let decoder = json!({"type": "Sequence", "decoders": [
+        {"type": "Fuse"},
+        {"type": "BPEDecoder", "suffix": "abc"},
+    ]});
+    let tokenizer = tokenizer(&["a", "b", "c", "x"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(incremental.is_windowed());
+
+    // "a", then "ab", then the suffix completes and the text collapses to "".
+    for (i, id) in [0, 1, 2].into_iter().enumerate() {
+        assert_eq!(incremental.push(id).unwrap(), "");
+        assert_eq!(incremental.retracted(), 0, "retraction at step {i}");
+    }
+    assert_eq!(incremental.text(), "");
+    check_stream(&tokenizer, &[3, 0, 1, 2, 3]);
+}
+
+#[test]
+fn fused_ctc_accounts_for_its_pad_token() {
+    // The pad token is stripped from the fused string whether or not `cleanup` is set.
+    let decoder = json!({"type": "Sequence", "decoders": [
+        {"type": "Fuse"},
+        {"type": "CTC", "pad_token": "<pad>", "word_delimiter_token": "|", "cleanup": false},
+    ]});
+    let tokenizer = tokenizer(&["<", "p", "a", "d", ">"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(incremental.is_windowed());
+
+    for (i, id) in [0, 1, 2, 3, 4].into_iter().enumerate() {
+        assert_eq!(incremental.push(id).unwrap(), "");
+        assert_eq!(incremental.retracted(), 0, "retraction at step {i}");
+    }
+    assert_eq!(incremental.text(), "");
+}
+
+#[test]
+fn byte_decoders_after_a_fuse_are_unbounded() {
+    // Both match a shape against the whole accumulated string, so appending one token can
+    // rewrite the entire prefix; neither may be windowed once the tokens have been fused.
+    for inner in [byte_level(), json!({"type": "ByteFallback"})] {
+        let fused = json!({"type": "Sequence", "decoders": [{"type": "Fuse"}, inner.clone()]});
+        let after_fuse = tokenizer(&["<0x61>", "Hello", "Ã"], fused);
+        assert!(
+            !IncrementalDecoder::new(&after_fuse).is_windowed(),
+            "{inner} after a Fuse must not be windowed"
+        );
+        // On its own it stays windowed.
+        let alone = tokenizer(&["<0x61>", "Hello", "Ã"], inner);
+        assert!(IncrementalDecoder::new(&alone).is_windowed());
+    }
+}
+
+#[test]
+fn a_run_of_special_tokens_keeps_the_window_bounded() {
+    // Skipped special tokens decode to nothing, so no candidate tail is ever long enough to
+    // re-anchor on. They never reach the decoder either, so the window can simply skip them.
+    let added = json!([{
+        "id": 2, "content": "<eos>", "single_word": false,
+        "lstrip": false, "rstrip": false, "normalized": false, "special": true,
+    }]);
+    let tokenizer = tokenizer_with_added(&["Hello", "Ġworld", "<eos>"], byte_level(), added);
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    decoder.push(0).unwrap();
+
+    let mut ids = vec![0];
+    for _ in 0..500 {
+        ids.push(2);
+        decoder.push(2).unwrap();
+        assert_eq!(decoder.text(), tokenizer.decode(&ids, true).unwrap());
+        // The skipped tokens never enter the window at all.
+        assert_eq!(decoder.window_len(), 1);
+    }
+    ids.push(1);
+    assert_eq!(decoder.push(1).unwrap(), " world");
+    assert_eq!(decoder.text(), tokenizer.decode(&ids, true).unwrap());
+}
+
+#[test]
+fn byte_fallback_run_is_withheld_until_it_closes() {
+    // `ByteFallback` converts a run of `<0xXX>` markers as a whole: `String::from_utf8` is
+    // applied to every byte accumulated so far, so a single invalid byte re-renders the entire
+    // run as replacement characters - including the part that had already decoded cleanly.
+    let decoder = json!({"type": "ByteFallback"});
+    let tokenizer = tokenizer(&["<0x61>", "<0xFF>", "z"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(incremental.is_windowed());
+
+    // "a" on its own, but nothing is emitted: the run is still open.
+    assert_eq!(incremental.push(0).unwrap(), "");
+    assert_eq!(incremental.text(), "a");
+    // The invalid byte turns the whole run into replacement characters.
+    assert_eq!(incremental.push(1).unwrap(), "");
+    assert_eq!(incremental.text(), "\u{FFFD}\u{FFFD}");
+    assert_eq!(incremental.retracted(), 0);
+    // A non-marker token closes the run, settling it.
+    assert_eq!(incremental.push(2).unwrap(), "\u{FFFD}\u{FFFD}z");
+
+    check_stream(&tokenizer, &[0, 1, 2, 0, 2, 1]);
+}
+
+#[test]
+fn unbounded_decoder_emits_nothing_until_finish() {
+    // A fused regex `Replace` rewriting a trailing "!" into "?": the first token decodes to
+    // "?", and the second rewrites it back to "!". Nothing may be streamed from a decoder that
+    // can do that, or a caller appending the deltas would print "?!a" instead of "!a".
+    let decoder = json!({"type": "Sequence", "decoders": [
+        {"type": "Fuse"},
+        {"type": "Replace", "pattern": {"Regex": "!$"}, "content": "?"},
+    ]});
+    let tokenizer = tokenizer(&["!", "a"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(!incremental.is_windowed());
+
+    assert_eq!(incremental.push(0).unwrap(), "");
+    assert_eq!(incremental.text(), "?");
+    assert_eq!(incremental.push(1).unwrap(), "");
+    assert_eq!(incremental.text(), "!a");
+    assert_eq!(incremental.retracted(), 0);
+    assert_eq!(incremental.finish(), "!a");
+}
+
+#[test]
+fn ctc_before_bpe_is_unbounded() {
+    // `BPEDecoder`'s one-step lag assumes every push hands it one more entry. `CTC` dedups and
+    // drops entries that decode to nothing, so a pushed pad token settles nothing, yet the lag
+    // would treat it as if it had.
+    let decoder = json!({"type": "Sequence", "decoders": [
+        {"type": "CTC", "pad_token": "<pad>", "word_delimiter_token": "|", "cleanup": false},
+        {"type": "BPEDecoder", "suffix": "</w>"},
+    ]});
+    let tokenizer = tokenizer(&["ab</w>z", "<pad>", "cd</w>"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(!incremental.is_windowed());
+
+    // The pad token leaves the text alone; only the third token settles anything.
+    for id in [0, 1, 2] {
+        assert_eq!(incremental.push(id).unwrap(), "");
+        assert_eq!(incremental.retracted(), 0);
+    }
+    assert_eq!(incremental.text(), "ab zcd");
+    assert_eq!(incremental.finish(), "ab zcd");
+
+    check_stream(&tokenizer, &[0, 1, 2]);
+}
+
+#[test]
+fn reanchoring_keeps_an_open_byte_run_whole() {
+    // A window starting inside an open marker run renders it differently from the full
+    // sequence: the shorter decode is a suffix at that moment, but the next marker re-renders
+    // the part left outside the window.
+    let decoder = json!({"type": "ByteFallback"});
+    let tokenizer = tokenizer(&["<0x61>", "<0xFF>", "z"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+
+    let mut ids = Vec::new();
+    for _ in 0..80 {
+        ids.push(0);
+        incremental.push(0).unwrap();
+        assert_eq!(incremental.text(), tokenizer.decode(&ids, true).unwrap());
+    }
+    // The whole run must still be in the window, so this re-renders all of it.
+    ids.push(1);
+    incremental.push(1).unwrap();
+    assert_eq!(incremental.text(), tokenizer.decode(&ids, true).unwrap());
+    assert_eq!(incremental.retracted(), 0);
+    assert_eq!(incremental.text().chars().count(), 81);
+    assert!(incremental.text().chars().all(|c| c == '\u{FFFD}'));
+}
+
+#[test]
+fn a_decoder_that_can_forge_byte_markers_is_unbounded() {
+    // Marker runs are recognized from the id's vocabulary token, so a decoder ahead of the
+    // `ByteFallback` that can turn something else into a marker defeats the tracking.
+    let forging = json!({"type": "Sequence", "decoders": [
+        {"type": "Replace", "pattern": {"String": "A"}, "content": "<0x61>"},
+        {"type": "ByteFallback"},
+    ]});
+    let forged = tokenizer(&["A", "<0xFF>"], forging);
+    assert!(!IncrementalDecoder::new(&forged).is_windowed());
+
+    // The SentencePiece chain replaces "▁" with a space, which cannot spell a marker, so it
+    // keeps the fast path.
+    let sentencepiece = json!({"type": "Sequence", "decoders": [
+        {"type": "Replace", "pattern": {"String": "▁"}, "content": " "},
+        {"type": "ByteFallback"},
+        {"type": "Fuse"},
+        {"type": "Strip", "content": " ", "start": 1, "stop": 0},
+    ]});
+    let tokenizer = tokenizer(&["▁Hello", "<0xE5>"], sentencepiece);
+    assert!(IncrementalDecoder::new(&tokenizer).is_windowed());
+}
+
+#[test]
+fn metaspace_before_byte_fallback_is_unbounded() {
+    // At the first token, a prepend scheme other than `Never` *drops* the replacement character
+    // rather than turning it into a space, so "▁<0x61>" comes out as a marker the vocabulary
+    // never had.
+    let prepending = json!({"type": "Sequence", "decoders": [
+        {"type": "Metaspace", "replacement": "▁", "prepend_scheme": "always", "split": true},
+        {"type": "ByteFallback"},
+    ]});
+    let forged = tokenizer(&["▁<0x61>", "<0xFF>"], prepending);
+    assert!(!IncrementalDecoder::new(&forged).is_windowed());
+
+    // With `never` every occurrence becomes a space, which spells no part of a marker.
+    let never = json!({"type": "Sequence", "decoders": [
+        {"type": "Metaspace", "replacement": "▁", "prepend_scheme": "never", "split": true},
+        {"type": "ByteFallback"},
+    ]});
+    let plain = tokenizer(&["▁<0x61>", "<0xFF>"], never);
+    assert!(IncrementalDecoder::new(&plain).is_windowed());
+}
+
+#[test]
+fn a_replace_that_destroys_byte_markers_is_unbounded() {
+    // Marker runs are recognized from the id's vocabulary token, so a rewrite that can match
+    // *inside* a marker leaves the tracking believing in runs the decoder never sees.
+    let destroying = json!({"type": "Sequence", "decoders": [
+        {"type": "Replace", "pattern": {"String": "<"}, "content": "_"},
+        {"type": "ByteFallback"},
+    ]});
+    let destroyed = tokenizer(&["<0x61>", "z"], destroying);
+    assert!(!IncrementalDecoder::new(&destroyed).is_windowed());
+}
+
+#[test]
+fn unknown_ids_stay_out_of_the_window() {
+    // `Tokenizer::decode` drops ids the vocabulary has no token for, so they never reach the
+    // decoder and must not hold the window open either.
+    let tokenizer = tokenizer(&["Hello", "Ġworld"], byte_level());
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    decoder.push(0).unwrap();
+
+    let mut ids = vec![0];
+    for _ in 0..500 {
+        ids.push(9999);
+        decoder.push(9999).unwrap();
+        assert_eq!(decoder.text(), tokenizer.decode(&ids, true).unwrap());
+        assert_eq!(decoder.window_len(), 1);
+    }
+    ids.push(1);
+    assert_eq!(decoder.push(1).unwrap(), " world");
+    assert_eq!(decoder.text(), tokenizer.decode(&ids, true).unwrap());
+}
+
+#[test]
+fn bpe_lag_survives_a_skipped_token() {
+    // The one-step lag assumes each push hands `BPEDecoder` one more entry. A skipped special
+    // token never reaches the decoder, so the text does not move and the lag must not treat it
+    // as a step - otherwise the previous token's text is released one push early.
+    let added = json!([{
+        "id": 1, "content": "<eos>", "single_word": false,
+        "lstrip": false, "rstrip": false, "normalized": false, "special": true,
+    }]);
+    let decoder = json!({"type": "BPEDecoder", "suffix": "</w>"});
+    let tokenizer = tokenizer_with_added(&["a</w>b", "<eos>", "c"], decoder, added);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+
+    assert_eq!(incremental.push(0).unwrap(), "");
+    assert_eq!(incremental.text(), "ab");
+    // The skipped token settles nothing.
+    assert_eq!(incremental.push(1).unwrap(), "");
+    assert_eq!(incremental.retracted(), 0);
+    assert_eq!(incremental.push(2).unwrap(), "a");
+    assert_eq!(incremental.text(), "a bc");
+    assert_eq!(incremental.retracted(), 0);
+
+    check_stream(&tokenizer, &[0, 1, 2]);
+}
+
+#[test]
+fn two_fused_rewrites_are_unbounded() {
+    // The first replace's reach is measured against the string the second one takes as input,
+    // and a length-changing rewrite moves the boundary it refers to: two bytes of pending reach
+    // end up covering ten bytes of output, so the reaches cannot simply be summed.
+    let decoder = json!({"type": "Sequence", "decoders": [
+        {"type": "Fuse"},
+        {"type": "Replace", "pattern": {"String": "ab"}, "content": "q"},
+        {"type": "Replace", "pattern": {"String": "a"}, "content": "xxxxxxxxxx"},
+    ]});
+    let tokenizer = tokenizer(&["a", "b"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    assert!(!incremental.is_windowed());
+
+    assert_eq!(incremental.push(0).unwrap(), "");
+    assert_eq!(incremental.text(), "xxxxxxxxxx");
+    assert_eq!(incremental.push(1).unwrap(), "");
+    assert_eq!(incremental.text(), "q");
+    assert_eq!(incremental.retracted(), 0);
+    assert_eq!(incremental.finish(), "q");
+}
+
+#[test]
+fn wordpiece_reanchors_around_continuation_pieces() {
+    // A candidate window starting on a `##` piece keeps the prefix that the full decode strips,
+    // so it can never be a suffix. Trying the neighbouring lengths finds a boundary that works.
+    let decoder = json!({"type": "WordPiece", "prefix": "##", "cleanup": true});
+    let tokenizer = tokenizer(&["Ara", "##új", "##o", "No", "##guera"], decoder);
+    let mut incremental = IncrementalDecoder::new(&tokenizer);
+    let mut ids = Vec::new();
+    let mut state = 999u64;
+    for _ in 0..600 {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let id = (state >> 33) as u32 % 5;
+        ids.push(id);
+        incremental.push(id).unwrap();
+        assert_eq!(incremental.text(), tokenizer.decode(&ids, true).unwrap());
+    }
+    assert!(
+        incremental.window_len() <= 128,
+        "window grew to {} tokens",
+        incremental.window_len()
+    );
+}
+
+#[test]
+fn clear_resets_the_stream() {
+    let tokenizer = tokenizer(&["Hello", "Ġworld"], byte_level());
+    let mut decoder = IncrementalDecoder::new(&tokenizer);
+    decoder.push(0).unwrap();
+    decoder.clear();
+    assert_eq!(decoder.text(), "");
+    assert!(decoder.tokens().is_empty());
+    assert_eq!(decoder.push(1).unwrap(), " world");
+}
+
+#[test]
+fn a_borrowed_or_shared_tokenizer_decodes_identically() {
+    // The tokenizer is only ever read, so how the decoder holds it must not change what it
+    // produces: owned, borrowed and shared have to agree step by step.
+    let tokenizer = tokenizer(&["Hello", "Ġworld", "Ã", "©"], byte_level());
+    let ids = [0u32, 1, 2, 3, 1];
+
+    let owning = IncrementalDecoder::new(&tokenizer);
+    let borrowing = IncrementalDecoder::from_tokenizer(&tokenizer);
+    let sharing = IncrementalDecoder::from_tokenizer(std::sync::Arc::new(tokenizer.clone()));
+
+    let mut owning = owning;
+    let mut borrowing = borrowing;
+    let mut sharing = sharing;
+    for &id in ids.iter() {
+        let expected = owning.push(id).unwrap().to_string();
+        assert_eq!(borrowing.push(id).unwrap(), expected);
+        assert_eq!(sharing.push(id).unwrap(), expected);
+        assert_eq!(borrowing.text(), owning.text());
+        assert_eq!(sharing.text(), owning.text());
+    }
+    assert_eq!(owning.is_windowed(), sharing.is_windowed());
+    assert_eq!(borrowing.finish(), owning.finish());
+    assert_eq!(sharing.finish(), "");
+}
+
+#[test]
+fn a_batch_of_decoders_shares_one_tokenizer() {
+    // What a continuous-batching loop needs: one decoder per row, without a vocabulary clone or
+    // a re-resolution of the decoder context per row. Cloning a decoder carries both over, so
+    // the shared tokenizer is only ever pointed at, never copied.
+    let shared = std::sync::Arc::new(tokenizer(&["Hello", "Ġworld"], byte_level()));
+    let row = IncrementalDecoder::from_tokenizer(std::sync::Arc::clone(&shared));
+    let mut rows: Vec<_> = (0..4).map(|_| row.clone()).collect();
+    assert_eq!(std::sync::Arc::strong_count(&shared), 6);
+
+    // Each row is an independent stream over the same tokenizer.
+    for (i, decoder) in rows.iter_mut().enumerate() {
+        let expected = if i % 2 == 0 { "Hello" } else { " world" };
+        assert_eq!(decoder.push(i as u32 % 2).unwrap(), expected);
+        assert_eq!(decoder.text(), expected);
+    }
+
+    // And the tokenizer can be handed back in the form it came in.
+    let returned = row.into_tokenizer();
+    assert!(std::sync::Arc::ptr_eq(&returned, &shared));
+}
+
+#[test]
+fn cloning_a_decoder_forks_its_stream() {
+    let tokenizer = tokenizer(&["Hello", "Ġworld", "Ã", "©"], byte_level());
+    let mut decoder = IncrementalDecoder::from_tokenizer(&tokenizer);
+    decoder.push(0).unwrap();
+    // Fork with a multi-byte character still open, so the pending state has to come along too.
+    decoder.push(2).unwrap();
+
+    let mut fork = decoder.clone();
+    assert_eq!(fork.text(), decoder.text());
+    // The fork completes the character; the original leaves it undecodable and moves on.
+    assert_eq!(fork.push(3).unwrap(), "é");
+    assert_eq!(decoder.push(1).unwrap(), "\u{fffd} world");
+    assert_eq!(decoder.text(), tokenizer.decode(&[0, 2, 1], true).unwrap());
+    assert_eq!(fork.text(), tokenizer.decode(&[0, 2, 3], true).unwrap());
+}

--- a/candle-transformers/tests/json_schema_tests.rs
+++ b/candle-transformers/tests/json_schema_tests.rs
@@ -7,8 +7,12 @@ fn allows_text_prefixes_and_eos_only_for_a_valid_value() {
     let mut processor = FsmLogitProcessor::new(fsm);
     let vocab = ["{", "\"answer\"", ":", "\"ok\"", "}", "x", "@"];
     let allowed = processor.allowed_token_ids(vocab.len(), &[5], |id| vocab[id as usize].into());
-    assert!(allowed.contains(&0)); assert!(!allowed.contains(&5)); assert!(!allowed.contains(&6));
-    for text in ["{", "\"answer\"", ":", "\"ok\"", "}"] { processor.commit(text); }
+    assert!(allowed.contains(&0));
+    assert!(!allowed.contains(&5));
+    assert!(!allowed.contains(&6));
+    for text in ["{", "\"answer\"", ":", "\"ok\"", "}"] {
+        processor.commit(text);
+    }
     assert!(processor.is_complete());
     let allowed = processor.allowed_token_ids(vocab.len(), &[5], |id| vocab[id as usize].into());
     assert!(allowed.contains(&5));
@@ -18,4 +22,76 @@ fn allows_text_prefixes_and_eos_only_for_a_valid_value() {
 #[test]
 fn rejects_unsupported_schema_constructs() {
     assert!(compile_schema(r#"{"oneOf":[]}"#).is_err());
+}
+
+#[test]
+fn rejects_an_unknown_object_key_before_the_object_is_complete() {
+    let fsm = Arc::new(compile_schema(r#"{"type":"object","properties":{"a":{"type":"number"}},"required":["a"],"additionalProperties":false}"#).unwrap());
+    let mut processor = FsmLogitProcessor::new(fsm);
+    processor.commit("{\"");
+    let vocab = ["a", "zz"];
+    let allowed = processor.allowed_token_ids(vocab.len(), &[], |id| vocab[id as usize].into());
+    assert_eq!(allowed, vec![0]);
+}
+
+#[test]
+fn transitions_through_nested_arrays_and_number_phases() {
+    let schema = r#"{
+        "type":"object",
+        "properties":{"items":{"type":"array","items":{"type":"integer"}}},
+        "required":["items"],
+        "additionalProperties":false
+    }"#;
+    let mut processor = FsmLogitProcessor::new(Arc::new(compile_schema(schema).unwrap()));
+    processor.commit("{\"items\":[1,2]}");
+    assert!(processor.is_complete());
+
+    let mut processor = FsmLogitProcessor::new(Arc::new(compile_schema(schema).unwrap()));
+    processor.commit("{\"items\":[");
+    let vocab = ["1", "1.", "\"bad\"", "]"];
+    let allowed = processor.allowed_token_ids(vocab.len(), &[], |id| vocab[id as usize].into());
+    assert_eq!(allowed, vec![0, 1, 3]);
+}
+
+#[test]
+fn restricts_enum_prefixes_without_reparsing_the_document() {
+    let fsm = Arc::new(compile_schema(r#"{"enum":["yes","no"]}"#).unwrap());
+    let mut processor = FsmLogitProcessor::new(fsm);
+    processor.commit("\"");
+    let vocab = ["y", "n", "x"];
+    assert_eq!(
+        processor.allowed_token_ids(vocab.len(), &[], |id| vocab[id as usize].into()),
+        vec![0, 1]
+    );
+    processor.commit("yes\"");
+    assert!(processor.is_complete());
+}
+
+#[test]
+fn rejects_the_wrong_scalar_kind_for_an_enum_at_the_first_transition() {
+    let processor = FsmLogitProcessor::new(Arc::new(compile_schema(r#"{"enum":[12]}"#).unwrap()));
+    let vocab = ["1", "\"", "t"];
+    assert_eq!(
+        processor.allowed_token_ids(vocab.len(), &[], |id| vocab[id as usize].into()),
+        vec![0]
+    );
+}
+
+#[test]
+fn tracks_escapes_literals_and_required_fields() {
+    let schema = Arc::new(
+        compile_schema(
+            r#"{"type":"object","properties":{"a":{"type":"string"},"ok":{"type":"boolean"}},"required":["a","ok"],"additionalProperties":false}"#,
+        )
+        .unwrap(),
+    );
+    let mut processor = FsmLogitProcessor::new(schema);
+    processor.commit("{\"\\u0061\":\"line\\n\",");
+    let vocab = ["\"ok\":true}", "}", "\"wrong\""];
+    assert_eq!(
+        processor.allowed_token_ids(vocab.len(), &[], |id| vocab[id as usize].into()),
+        vec![0]
+    );
+    processor.commit("\"ok\":true}");
+    assert!(processor.is_complete());
 }

--- a/candle-transformers/tests/json_schema_tests.rs
+++ b/candle-transformers/tests/json_schema_tests.rs
@@ -1,0 +1,21 @@
+use candle_transformers::generation::{compile_schema, FsmLogitProcessor};
+use std::sync::Arc;
+
+#[test]
+fn allows_text_prefixes_and_eos_only_for_a_valid_value() {
+    let fsm = Arc::new(compile_schema(r#"{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"],"additionalProperties":false}"#).unwrap());
+    let mut processor = FsmLogitProcessor::new(fsm);
+    let vocab = ["{", "\"answer\"", ":", "\"ok\"", "}", "x", "@"];
+    let allowed = processor.allowed_token_ids(vocab.len(), &[5], |id| vocab[id as usize].into());
+    assert!(allowed.contains(&0)); assert!(!allowed.contains(&5)); assert!(!allowed.contains(&6));
+    for text in ["{", "\"answer\"", ":", "\"ok\"", "}"] { processor.commit(text); }
+    assert!(processor.is_complete());
+    let allowed = processor.allowed_token_ids(vocab.len(), &[5], |id| vocab[id as usize].into());
+    assert!(allowed.contains(&5));
+    assert!(!allowed.contains(&0));
+}
+
+#[test]
+fn rejects_unsupported_schema_constructs() {
+    assert!(compile_schema(r#"{"oneOf":[]}"#).is_err());
+}

--- a/candle-transformers/tests/json_schema_tests.rs
+++ b/candle-transformers/tests/json_schema_tests.rs
@@ -43,7 +43,16 @@ fn transitions_through_nested_arrays_and_number_phases() {
         "additionalProperties":false
     }"#;
     let mut processor = FsmLogitProcessor::new(Arc::new(compile_schema(schema).unwrap()));
-    processor.commit("{\"items\":[1,2]}");
+    for text in [
+        "{", "\"", "i", "t", "e", "m", "s", "\"", ":", "[", "1", ",", "2", "]", "}",
+    ] {
+        assert_eq!(
+            processor.allowed_token_ids(1, &[], |_| text.into()),
+            vec![0],
+            "{text}"
+        );
+        processor.commit(text);
+    }
     assert!(processor.is_complete());
 
     let mut processor = FsmLogitProcessor::new(Arc::new(compile_schema(schema).unwrap()));
@@ -94,4 +103,47 @@ fn tracks_escapes_literals_and_required_fields() {
     );
     processor.commit("\"ok\":true}");
     assert!(processor.is_complete());
+}
+
+#[test]
+fn rejects_trailing_commas_and_non_json_whitespace() {
+    let object = Arc::new(
+        compile_schema(
+            r#"{"type":"object","properties":{"a":{"type":"number"}},"required":["a"],"additionalProperties":false}"#,
+        )
+        .unwrap(),
+    );
+    let mut processor = FsmLogitProcessor::new(object);
+    processor.commit("{\"a\":1,");
+    assert!(processor
+        .allowed_token_ids(1, &[], |_| "}".into())
+        .is_empty());
+
+    let array = Arc::new(compile_schema(r#"{"type":"array","items":{"type":"number"}}"#).unwrap());
+    let mut processor = FsmLogitProcessor::new(array);
+    processor.commit("[1,");
+    assert!(processor
+        .allowed_token_ids(1, &[], |_| "]".into())
+        .is_empty());
+
+    let processor =
+        FsmLogitProcessor::new(Arc::new(compile_schema(r#"{"type":"number"}"#).unwrap()));
+    assert!(processor
+        .allowed_token_ids(1, &[], |_| "1\u{00a0}".into())
+        .is_empty());
+}
+
+#[test]
+fn accepts_surrogate_pairs_and_integral_decimal_forms() {
+    let mut string =
+        FsmLogitProcessor::new(Arc::new(compile_schema(r#"{"type":"string"}"#).unwrap()));
+    string.commit("\"\\uD83D\\uDE00\"");
+    assert!(string.is_complete());
+
+    for number in ["1.0", "1e0", "-0.0"] {
+        let mut integer =
+            FsmLogitProcessor::new(Arc::new(compile_schema(r#"{"type":"integer"}"#).unwrap()));
+        integer.commit(number);
+        assert!(integer.is_complete(), "{number}");
+    }
 }

--- a/candle-transformers/tests/json_schema_tests.rs
+++ b/candle-transformers/tests/json_schema_tests.rs
@@ -77,13 +77,15 @@ fn restricts_enum_prefixes_without_reparsing_the_document() {
 }
 
 #[test]
-fn rejects_the_wrong_scalar_kind_for_an_enum_at_the_first_transition() {
-    let processor = FsmLogitProcessor::new(Arc::new(compile_schema(r#"{"enum":[12]}"#).unwrap()));
-    let vocab = ["1", "\"", "t"];
-    assert_eq!(
-        processor.allowed_token_ids(vocab.len(), &[], |id| vocab[id as usize].into()),
-        vec![0]
-    );
+fn rejects_numeric_and_composite_enum_forms_at_compile_time() {
+    for schema in [
+        r#"{"enum":[12]}"#,
+        r#"{"const":1.0}"#,
+        r#"{"enum":[{"a":1}]}"#,
+        r#"{"const":[1]}"#,
+    ] {
+        assert!(compile_schema(schema).is_err(), "{schema}");
+    }
 }
 
 #[test]
@@ -145,5 +147,127 @@ fn accepts_surrogate_pairs_and_integral_decimal_forms() {
             FsmLogitProcessor::new(Arc::new(compile_schema(r#"{"type":"integer"}"#).unwrap()));
         integer.commit(number);
         assert!(integer.is_complete(), "{number}");
+    }
+}
+
+#[test]
+fn uses_decimal_arithmetic_for_integers_and_rejects_out_of_range_numbers() {
+    let integer_schema = Arc::new(compile_schema(r#"{"type":"integer"}"#).unwrap());
+    let mut decimal_prefix = FsmLogitProcessor::new(Arc::clone(&integer_schema));
+    decimal_prefix.commit("9007199254740992.5");
+    assert!(!decimal_prefix.is_complete());
+    assert!(decimal_prefix
+        .allowed_token_ids(1, &[0], |_| "ignored".into())
+        .is_empty());
+
+    let processor = FsmLogitProcessor::new(Arc::clone(&integer_schema));
+    assert!(processor
+        .allowed_token_ids(1, &[], |_| "1e-400".into())
+        .is_empty());
+    let number_schema = Arc::new(compile_schema(r#"{"type":"number"}"#).unwrap());
+    let processor = FsmLogitProcessor::new(number_schema);
+    assert!(processor
+        .allowed_token_ids(1, &[], |_| "1e400".into())
+        .is_empty());
+    let mut underflow =
+        FsmLogitProcessor::new(Arc::new(compile_schema(r#"{"type":"number"}"#).unwrap()));
+    underflow.commit("1e-400");
+    assert!(underflow.is_complete());
+}
+
+#[test]
+fn permits_compatible_scalar_type_and_enum_constraints() {
+    let mut processor = FsmLogitProcessor::new(Arc::new(
+        compile_schema(r#"{"type":"string","enum":["yes","no"]}"#).unwrap(),
+    ));
+    processor.commit("\"yes\"");
+    assert!(processor.is_complete());
+}
+
+#[test]
+fn rejects_schema_forms_the_compiler_does_not_implement() {
+    for schema in [
+        r#"{"type":["string","null"]}"#,
+        r#"{"type":"object","properties":{},"additionalProperties":{"type":"string"}}"#,
+        r#"{"type":"object","properties":{},"required":["missing"],"additionalProperties":false}"#,
+        r#"{"enum":[]}"#,
+        r#"{"enum":["x"],"type":"number"}"#,
+        r#"{"enum":["a"],"const":"b"}"#,
+        r#"{"properties":{"a":{"type":"string"}},"additionalProperties":false}"#,
+        r#"{"items":{"type":"string"}}"#,
+        r#"{"type":"any"}"#,
+    ] {
+        assert!(compile_schema(schema).is_err(), "{schema}");
+    }
+}
+
+#[test]
+fn never_advances_after_a_complete_root_value_or_into_an_impossible_key() {
+    let mut processor =
+        FsmLogitProcessor::new(Arc::new(compile_schema(r#"{"type":"string"}"#).unwrap()));
+    processor.commit("\"done\"");
+    assert!(processor.is_complete());
+    assert!(processor
+        .allowed_token_ids(1, &[], |_| " ".into())
+        .is_empty());
+
+    let processor = FsmLogitProcessor::new(Arc::new(
+        compile_schema(r#"{"type":"object","properties":{},"additionalProperties":false}"#)
+            .unwrap(),
+    ));
+    let mut processor = processor;
+    processor.commit("{");
+    let vocab = ["{", "\""];
+    let allowed = processor.allowed_token_ids(vocab.len(), &[], |id| vocab[id as usize].into());
+    assert!(allowed.is_empty());
+}
+
+#[test]
+fn ignores_empty_decoded_tokens() {
+    let processor =
+        FsmLogitProcessor::new(Arc::new(compile_schema(r#"{"type":"string"}"#).unwrap()));
+    let vocab = ["", "\""];
+    assert_eq!(
+        processor.allowed_token_ids(vocab.len(), &[], |id| vocab[id as usize].into()),
+        vec![1]
+    );
+}
+
+#[test]
+fn uses_json_schema_defaults_for_object_and_array_contents() {
+    let mut object =
+        FsmLogitProcessor::new(Arc::new(compile_schema(r#"{"type":"object"}"#).unwrap()));
+    object.commit("{\"anything\":[true]}");
+    assert!(object.is_complete());
+
+    let mut array =
+        FsmLogitProcessor::new(Arc::new(compile_schema(r#"{"type":"array"}"#).unwrap()));
+    array.commit("[null,{\"anything\":false}]");
+    assert!(array.is_complete());
+}
+
+#[test]
+fn accepts_the_unconstrained_json_schema() {
+    let mut processor = FsmLogitProcessor::new(Arc::new(compile_schema("{}").unwrap()));
+    processor.commit("[true,{\"nested\":null}]");
+    assert!(processor.is_complete());
+}
+
+#[test]
+fn permits_trailing_json_whitespace_in_the_finishing_token_only() {
+    for (schema, token) in [
+        (r#"{"type":"number"}"#, "1 "),
+        (r#"{"type":"string"}"#, "\"x\"\n"),
+        (
+            r#"{"type":"object","properties":{},"additionalProperties":false}"#,
+            "{}\r",
+        ),
+    ] {
+        let mut processor = FsmLogitProcessor::new(Arc::new(compile_schema(schema).unwrap()));
+        processor.commit(token);
+        assert!(processor.is_complete(), "{token:?}");
+        assert!(processor
+            .allowed_token_ids(1, &[], |_| " ".into())
+            .is_empty());
     }
 }

--- a/candle-transformers/tests/json_schema_tests.rs
+++ b/candle-transformers/tests/json_schema_tests.rs
@@ -164,6 +164,16 @@ fn uses_decimal_arithmetic_for_integers_and_rejects_out_of_range_numbers() {
     assert!(processor
         .allowed_token_ids(1, &[], |_| "1e-400".into())
         .is_empty());
+
+    let mut exponent_prefix = FsmLogitProcessor::new(integer_schema);
+    exponent_prefix.commit("1.5e0");
+    assert!(!exponent_prefix.is_complete());
+    assert_eq!(
+        exponent_prefix.allowed_token_ids(1, &[], |_| "1".into()),
+        vec![0]
+    );
+    exponent_prefix.commit("1");
+    assert!(exponent_prefix.is_complete());
     let number_schema = Arc::new(compile_schema(r#"{"type":"number"}"#).unwrap());
     let processor = FsmLogitProcessor::new(number_schema);
     assert!(processor

--- a/candle-transformers/tests/stop_criteria_tests.rs
+++ b/candle-transformers/tests/stop_criteria_tests.rs
@@ -1,0 +1,54 @@
+use candle_transformers::generation::{FinishReason, StopCriteria};
+
+#[test]
+fn holds_back_the_longest_stop_sequence_on_a_char_boundary() {
+    let criteria = StopCriteria::new(["<end>".to_owned(), "éx".to_owned()], vec![]);
+    assert_eq!(criteria.hold(), 4);
+
+    // The byte cut is in the middle of `é`; retain that whole character instead.
+    assert_eq!(criteria.safe_emit_end("aéxyz"), 1);
+    assert_eq!(criteria.safe_emit_end("hello"), 1);
+}
+
+#[test]
+fn finds_the_earliest_stop_regardless_of_configuration_order() {
+    let criteria = StopCriteria::new(["later".to_owned(), "first".to_owned()], vec![]);
+    let text = "first, then later";
+    assert_eq!(criteria.matched(text), Some(0));
+    assert_eq!(criteria.safe_emit_end(text), 0);
+
+    // A stop that completes across token boundaries must not be streamed.
+    let split = StopCriteria::new(["<stop>".to_owned()], vec![]);
+    assert_eq!(split.safe_emit_end("answer<st"), 4);
+    assert_eq!(split.matched("answer<stop>"), Some(6));
+    assert_eq!(split.safe_emit_end("answer<stop>"), 6);
+}
+
+#[test]
+fn reports_model_stop_before_budget_exhaustion() {
+    let criteria = StopCriteria::new(["<stop>".to_owned()], vec![2]);
+    assert!(criteria.is_eos(2));
+    assert!(!criteria.is_eos(3));
+
+    assert_eq!(
+        criteria.finish_reason(2, "answer", true),
+        Some(FinishReason::Stop)
+    );
+    assert_eq!(
+        criteria.finish_reason(3, "answer<stop>", true),
+        Some(FinishReason::Stop)
+    );
+    assert_eq!(
+        criteria.finish_reason(3, "answer", true),
+        Some(FinishReason::Length)
+    );
+    assert_eq!(criteria.finish_reason(3, "answer", false), None);
+}
+
+#[test]
+fn ignores_empty_stop_sequences() {
+    let criteria = StopCriteria::new([String::new()], vec![]);
+    assert_eq!(criteria.hold(), 0);
+    assert_eq!(criteria.matched("answer"), None);
+    assert_eq!(criteria.safe_emit_end("answer"), 6);
+}


### PR DESCRIPTION
## Summary

Adds JSON Schema-aware constrained decoding to `candle-transformers::generation`.

The constraint is compiled once into a shareable `CompiledFsm`, while
`FsmLogitProcessor` holds independent per-request state. It evaluates
candidate token ids through caller-provided decoded token text, keeping the
implementation tokenizer-agnostic.

New public API: `compile_schema`, `CompiledFsm`, `SchemaCompileError`, and
`FsmLogitProcessor`.

EOS is allowed only after the generated text is a complete JSON value matching
the schema. Unsupported schema constructs fail at compile time.

Supported schema constructs currently include:

- `type`: `object`, `array`, `string`, `number`, `integer`, `boolean`, `null`
- object `properties`, `required`, and boolean `additionalProperties`
- array `items`
- `enum` and `const`

This branch also includes `IncrementalDecoder` and `StopCriteria`, the
preceding generation primitives referenced by #3826 and needed to bring this
branch from `sync/upstream-main` to the intended generation API.

## Tests

- `cargo test -p candle-transformers --test json_schema_tests`
- `cargo test -p candle-transformers --test incremental_decoder_tests --test stop_criteria_tests`

Closes #3826