### PR TITLE
Speed up non-contiguous where_cond on CPU by migrating to NdIter

### DIFF
--- a/candle-core/benches/benchmarks/where_cond.rs
+++ b/candle-core/benches/benchmarks/where_cond.rs
@@ -18,6 +18,18 @@ const fn create_cond_arr<const N: usize>() -> [u8; N] {
     arr
 }
 
+const fn create_causal_arr<const S: usize, const N: usize>() -> [u8; N] {
+    let mut arr = [0u8; N];
+    let mut i = 0;
+    while i < N {
+        let row = (i / S) % S;
+        let col = i % S;
+        arr[i] = if col > row { 1 } else { 0 };
+        i += 1;
+    }
+    arr
+}
+
 const B: usize = 1;
 const M: usize = 1024;
 const K: usize = 1024;
@@ -53,12 +65,177 @@ fn run_where_cond_benchmark(c: &mut Criterion, device: &Device, dtype: DType, na
     group.finish();
 }
 
+const AB: usize = 1;
+const AH: usize = 4;
+const AS: usize = 512;
+
+static CAUSAL: [u8; AB * AH * AS * AS] = create_causal_arr::<AS, { AB * AH * AS * AS }>();
+
+fn run_masked_fill_benchmark(c: &mut Criterion, device: &Device, dtype: DType, name: &str) {
+    let shape = (AB, AH, AS, AS);
+    let tensor = Tensor::from_slice(CAUSAL.as_slice(), shape, device).unwrap();
+    let on_true = Tensor::new(1.0, device)
+        .unwrap()
+        .to_dtype(dtype)
+        .unwrap()
+        .broadcast_as(shape)
+        .unwrap();
+    let on_false = Tensor::zeros(shape, dtype, device).unwrap();
+
+    let elements = AB * AH * AS * AS;
+    let flops = (2 * elements * dtype.size_in_bytes()) + elements;
+
+    let mut group = c.benchmark_group(device.bench_name(name));
+    group.throughput(Throughput::Bytes(flops as u64));
+    group.bench_function("iter", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            for _i in 0..iters {
+                run(
+                    black_box(&tensor),
+                    black_box(&on_true),
+                    black_box(&on_false),
+                );
+            }
+            device.sync().unwrap();
+            start.elapsed()
+        })
+    });
+    group.finish();
+}
+
+fn run_masked_fill_bcast_benchmark(c: &mut Criterion, device: &Device, dtype: DType, name: &str) {
+    let shape = (AB, AH, AS, AS);
+    let tensor = Tensor::from_slice(&CAUSAL[..AS * AS], (1, 1, AS, AS), device)
+        .unwrap()
+        .broadcast_as(shape)
+        .unwrap();
+    let on_true = Tensor::new(1.0, device)
+        .unwrap()
+        .to_dtype(dtype)
+        .unwrap()
+        .broadcast_as(shape)
+        .unwrap();
+    let on_false = Tensor::zeros(shape, dtype, device).unwrap();
+
+    let elements = AB * AH * AS * AS;
+    let flops = (2 * elements * dtype.size_in_bytes()) + elements;
+
+    let mut group = c.benchmark_group(device.bench_name(name));
+    group.throughput(Throughput::Bytes(flops as u64));
+    group.bench_function("iter", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            for _i in 0..iters {
+                run(
+                    black_box(&tensor),
+                    black_box(&on_true),
+                    black_box(&on_false),
+                );
+            }
+            device.sync().unwrap();
+            start.elapsed()
+        })
+    });
+    group.finish();
+}
+
+fn run_transposed_benchmark(c: &mut Criterion, device: &Device, dtype: DType, name: &str) {
+    let tensor = Tensor::from_slice(DATA.as_slice(), (M, K), device).unwrap();
+    let on_true = Tensor::ones((M, K), dtype, device).unwrap();
+    let on_false = Tensor::zeros((K, M), dtype, device)
+        .unwrap()
+        .transpose(0, 1)
+        .unwrap();
+
+    let elements = M * K;
+    let flops = (2 * elements * dtype.size_in_bytes()) + elements;
+
+    let mut group = c.benchmark_group(device.bench_name(name));
+    group.throughput(Throughput::Bytes(flops as u64));
+    group.bench_function("iter", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            for _i in 0..iters {
+                run(
+                    black_box(&tensor),
+                    black_box(&on_true),
+                    black_box(&on_false),
+                );
+            }
+            device.sync().unwrap();
+            start.elapsed()
+        })
+    });
+    group.finish();
+}
+
+const NB: usize = 256;
+const NS: usize = 512;
+const ND_PAD: usize = 8;
+const ND: usize = 3;
+
+fn run_narrow_inner_benchmark(c: &mut Criterion, device: &Device, dtype: DType, name: &str) {
+    let padded = (NB, NS, ND_PAD);
+    let tensor = Tensor::from_slice(DATA.as_slice(), padded, device)
+        .unwrap()
+        .narrow(2, 0, ND)
+        .unwrap();
+    let on_true = Tensor::new(0f32, device)
+        .unwrap()
+        .to_dtype(dtype)
+        .unwrap()
+        .broadcast_as((NB, NS, ND))
+        .unwrap();
+    let on_false = Tensor::zeros(padded, dtype, device)
+        .unwrap()
+        .narrow(2, 0, ND)
+        .unwrap();
+
+    let elements = NB * NS * ND;
+    let flops = (2 * elements * dtype.size_in_bytes()) + elements;
+
+    let mut group = c.benchmark_group(device.bench_name(name));
+    group.throughput(Throughput::Bytes(flops as u64));
+    group.bench_function("iter", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            for _i in 0..iters {
+                run(
+                    black_box(&tensor),
+                    black_box(&on_true),
+                    black_box(&on_false),
+                );
+            }
+            device.sync().unwrap();
+            start.elapsed()
+        })
+    });
+    group.finish();
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     let device = BenchDeviceHandler::new().unwrap();
     for d in device.devices {
         run_where_cond_benchmark(c, &d, DType::F32, "where_cond_f32");
         run_where_cond_benchmark(c, &d, DType::BF16, "where_cond_bf16");
         run_where_cond_benchmark(c, &d, DType::F16, "where_cond_f16");
+
+        run_masked_fill_benchmark(c, &d, DType::F32, "where_cond_masked_fill_f32");
+        run_masked_fill_benchmark(c, &d, DType::BF16, "where_cond_masked_fill_bf16");
+        run_masked_fill_benchmark(c, &d, DType::F16, "where_cond_masked_fill_f16");
+
+        run_masked_fill_bcast_benchmark(c, &d, DType::F32, "where_cond_masked_fill_bcast_f32");
+        run_masked_fill_bcast_benchmark(c, &d, DType::BF16, "where_cond_masked_fill_bcast_bf16");
+        run_masked_fill_bcast_benchmark(c, &d, DType::F16, "where_cond_masked_fill_bcast_f16");
+
+        run_transposed_benchmark(c, &d, DType::F32, "where_cond_transposed_f32");
+        run_transposed_benchmark(c, &d, DType::BF16, "where_cond_transposed_bf16");
+        run_transposed_benchmark(c, &d, DType::F16, "where_cond_transposed_f16");
+
+        run_narrow_inner_benchmark(c, &d, DType::F32, "where_cond_narrow_inner_f32");
+        run_narrow_inner_benchmark(c, &d, DType::BF16, "where_cond_narrow_inner_bf16");
+        run_narrow_inner_benchmark(c, &d, DType::F16, "where_cond_narrow_inner_f16");
     }
 }
 

--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -1,7 +1,7 @@
 //! Implementation of Backend Fns for CPU
 use crate::backend::{BackendDevice, BackendStorage};
 use crate::op::{BinaryOpT, CmpOp, ReduceOp, UnaryOpT};
-use crate::{DType, Error, IntDType, Layout, Result, Shape, WithDType};
+use crate::{DType, Error, IntDType, Layout, NdIter, Result, Shape, WithDType};
 use float8::F8E4M3;
 use half::{bf16, f16};
 use rayon::prelude::*;
@@ -84,6 +84,39 @@ impl Map2U8 for Cmp {
 
 struct WCond<'a, T: IntDType>(&'a [T], &'a Layout);
 
+#[allow(clippy::too_many_arguments)]
+#[inline(always)]
+fn where_impl<I, T, P, R, G>(
+    nd_iter: NdIter<3>,
+    ys_to_set: &mut [T],
+    pred: &[I],
+    t: &[T],
+    f: &[T],
+    pred_fn: P,
+    t_fn: R,
+    f_fn: G,
+) where
+    I: IntDType,
+    T: Copy,
+    P: Fn(usize, usize, usize) -> usize,
+    R: Fn(usize, usize, usize) -> usize,
+    G: Fn(usize, usize, usize) -> usize,
+{
+    let inner_size = nd_iter.inner_size;
+    let [inner_ps, inner_ts, inner_fs] = nd_iter.inner_strides;
+    let mut dst_off = 0usize;
+    for [p_off, t_off, f_off] in nd_iter {
+        for i in 0..inner_size {
+            let ep = pred[pred_fn(p_off, i, inner_ps)];
+            let et = t[t_fn(t_off, i, inner_ts)];
+            let ef = f[f_fn(f_off, i, inner_fs)];
+
+            ys_to_set[dst_off + i] = if ep.is_true() { et } else { ef };
+        }
+        dst_off += inner_size;
+    }
+}
+
 impl<I: IntDType> Map2 for WCond<'_, I> {
     const OP: &'static str = "where";
     #[inline(always)]
@@ -102,18 +135,57 @@ impl<I: IntDType> Map2 for WCond<'_, I> {
                     .map(|(p, (&t, &f))| if p.is_true() { t } else { f })
                     .collect::<Vec<_>>()
             }
-            _ => self
-                .1
-                .strided_index()
-                .zip(t_l.strided_index().zip(f_l.strided_index()))
-                .map(|(i_p, (i_t, i_f))| {
-                    if self.0[i_p].is_true() {
-                        t[i_t]
-                    } else {
-                        f[i_f]
+            _ => {
+                // Same allocation strategy as `binary_map_vec`
+                let el_count = self.1.shape().elem_count();
+
+                let mut ys: Vec<T> = Vec::with_capacity(el_count);
+                let ys_to_set = unsafe {
+                    let s = ys.spare_capacity_mut();
+                    std::mem::transmute::<&mut [std::mem::MaybeUninit<T>], &mut [T]>(s)
+                };
+
+                let nd_iter = NdIter::new([self.1, t_l, f_l]);
+                let [inner_ps, inner_ts, inner_fs] = nd_iter.inner_strides;
+
+                let offset = |off, i, _| off + i;
+                let boffset = |off, _, _| off;
+
+                match (inner_ps, inner_ts, inner_fs) {
+                    (1, 1, 1) => {
+                        where_impl(nd_iter, ys_to_set, self.0, t, f, offset, offset, offset);
                     }
-                })
-                .collect::<Vec<_>>(),
+                    (1, 1, 0) => {
+                        where_impl(nd_iter, ys_to_set, self.0, t, f, offset, offset, boffset);
+                    }
+                    (1, 0, 1) => {
+                        where_impl(nd_iter, ys_to_set, self.0, t, f, offset, boffset, offset);
+                    }
+                    (1, 0, 0) => {
+                        where_impl(nd_iter, ys_to_set, self.0, t, f, offset, boffset, boffset);
+                    }
+                    (0, 1, 1) => {
+                        where_impl(nd_iter, ys_to_set, self.0, t, f, boffset, offset, offset);
+                    }
+                    (0, 1, 0) => {
+                        where_impl(nd_iter, ys_to_set, self.0, t, f, boffset, offset, boffset);
+                    }
+                    (0, 0, 1) => {
+                        where_impl(nd_iter, ys_to_set, self.0, t, f, boffset, boffset, offset);
+                    }
+                    (0, 0, 0) => {
+                        where_impl(nd_iter, ys_to_set, self.0, t, f, boffset, boffset, boffset);
+                    }
+                    _ => {
+                        let offset = |off, i, inner| off + i * inner;
+                        where_impl(nd_iter, ys_to_set, self.0, t, f, offset, offset, offset);
+                    }
+                }
+
+                // SAFETY: all el_count elements have been written in the dispatch loop above.
+                unsafe { ys.set_len(el_count) };
+                ys
+            }
         };
         Ok(vs)
     }

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -379,6 +379,73 @@ fn ternary_op(device: &Device) -> Result<()> {
     assert_eq!(dims, [2, 5]);
     let result: Vec<f32> = tensor.flatten_all()?.to_vec1()?;
     assert_eq!(result, [10., 1., 12., 3., 14., 5., 6., 7., 18., 19.]);
+
+    let fill = Tensor::new(7f32, device)?.broadcast_as((2, 5))?; // strides [0, 0]
+    assert_eq!(
+        ids.where_cond(&fill, &b)?.to_vec2::<f32>()?,
+        [[10., 7., 12., 7., 14.], [7., 7., 7., 18., 19.]],
+    );
+
+    let mask = Tensor::new(&[[0u8, 1, 1, 0, 1]], device)?.broadcast_as((2, 5))?; // strides [0, 1]
+    assert_eq!(
+        mask.where_cond(&a, &b)?.to_vec2::<f32>()?,
+        mask.contiguous()?.where_cond(&a, &b)?.to_vec2::<f32>()?,
+    );
+
+    let a_t = Tensor::arange(0f32, 10., device)?.reshape((5, 2))?.t()?;
+    let ids_t = Tensor::new(&[[0u8, 1], [1, 1], [0, 0], [1, 0], [1, 1]], device)?.t()?;
+    assert_eq!(
+        ids_t.where_cond(&a_t, &b)?.to_vec2::<f32>()?,
+        ids_t
+            .contiguous()?
+            .where_cond(&a_t.contiguous()?, &b)?
+            .to_vec2::<f32>()?,
+    );
+
+    let narrowed = Tensor::arange(0f32, 14., device)?
+        .reshape((2, 7))?
+        .narrow(1, 1, 5)?; // strides [7, 1], offset 1
+    assert_eq!(
+        ids.where_cond(&fill, &narrowed)?.to_vec2::<f32>()?,
+        ids.where_cond(&fill.contiguous()?, &narrowed.contiguous()?)?
+            .to_vec2::<f32>()?,
+    );
+
+    let fill2 = Tensor::new(9f32, device)?.broadcast_as((2, 5))?;
+    assert_eq!(
+        ids.where_cond(&a, &fill)?.to_vec2::<f32>()?,
+        ids.where_cond(&a, &fill.contiguous()?)?.to_vec2::<f32>()?,
+    );
+    assert_eq!(
+        ids.where_cond(&fill, &fill2)?.to_vec2::<f32>()?,
+        ids.where_cond(&fill.contiguous()?, &fill2.contiguous()?)?
+            .to_vec2::<f32>()?,
+    );
+
+    let row_mask = Tensor::new(&[[1u8], [0u8]], device)?.broadcast_as((2, 5))?; // strides [1, 0]
+    let row_ref = row_mask.contiguous()?;
+    assert_eq!(
+        row_mask.where_cond(&a, &b)?.to_vec2::<f32>()?,
+        row_ref.where_cond(&a, &b)?.to_vec2::<f32>()?,
+    );
+    assert_eq!(
+        row_mask.where_cond(&a, &fill)?.to_vec2::<f32>()?,
+        row_ref
+            .where_cond(&a, &fill.contiguous()?)?
+            .to_vec2::<f32>()?,
+    );
+    assert_eq!(
+        row_mask.where_cond(&fill, &b)?.to_vec2::<f32>()?,
+        row_ref
+            .where_cond(&fill.contiguous()?, &b)?
+            .to_vec2::<f32>()?,
+    );
+    assert_eq!(
+        row_mask.where_cond(&fill, &fill2)?.to_vec2::<f32>()?,
+        row_ref
+            .where_cond(&fill.contiguous()?, &fill2.contiguous()?)?
+            .to_vec2::<f32>()?,
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## What this changes

On the non-contiguous path, the CPU `where_cond` zipped three `strided_index()` iterators,
recomputing full multi-dimensional index arithmetic per element, per tensor. In the same vein
as `binary_map`, switching to an `NdIter` that walks all three tensors at once is
significantly faster.

This adds `where_impl`, which is generic over how each operand's offset is computed, so
specializing a new stride combination is just another match arm. This PR specializes the 0/1
combinations and leaves everything else on the generic path. The combination that matters in
practice is a causal/attention mask against a broadcast scalar fill.

The fully contiguous fast path is unchanged, so the pre-existing all-contiguous benchmarks
are not listed below.

## Results

Benchmarked on CPU via `cargo bench --bench bench_main -- where_cond`, criterion medians.
All four scenarios are new benchmarks added in this PR.

### f32

| benchmark | before | after | change |
|---|---|---|---|
| `where_cond_masked_fill` | 4.49 ms | 755 µs | −83.2% |
| `where_cond_masked_fill_bcast` | 4.76 ms | 757 µs | −84.1% |
| `where_cond_transposed` | 5.60 ms | 2.64 ms | −52.9% |
| `where_cond_narrow_inner` | 2.07 ms | 1.10 ms | −46.8% |

### bf16

| benchmark | before | after | change |
|---|---|---|---|
| `where_cond_masked_fill` | 4.24 ms | 387 µs | −90.9% |
| `where_cond_masked_fill_bcast` | 4.56 ms | 412 µs | −91.0% |
| `where_cond_transposed` | 5.22 ms | 2.16 ms | −58.6% |
| `where_cond_narrow_inner` | 1.99 ms | 592 µs | −70.3% |

### f16

| benchmark | before | after | change |
|---|---|---|---|
| `where_cond_masked_fill` | 4.28 ms | 396 µs | −90.7% |
| `where_cond_masked_fill_bcast` | 4.39 ms | 393 µs | −91.0% |
| `where_cond_transposed` | 5.71 ms | 1.94 ms | −66.0% |
| `where_cond_narrow_inner` | 1.57 ms | 603 µs | −61.7% |

## New benchmarks

There were no benchmarks for the non-contiguous branches. The added ones are:

- `where_cond_masked_fill`: causal `u8` mask, broadcast scalar `on_true`, contiguous
  `on_false`. Strides `(1, 0, 1)`. This is the attention-mask shape.
- `where_cond_masked_fill_bcast`: same, but the mask itself is broadcast across the batch
  and head dims.
- `where_cond_transposed`: `on_false` transposed, so the inner stride is neither 0 nor 1
  and the generic path is exercised.
- `where_cond_narrow_inner`: narrowed innermost dim.

## Tests

Extended the existing `ternary_op` test (so it runs on CPU, CUDA and Metal) to cover the
broadcast (`0`) and contiguous (`1`) inner-stride combinations, plus the transposed and
narrowed layouts that land on the generic path. Each case asserts the strided result matches
the same op run on `.contiguous()` inputs.

## Checks

- `cargo test -p candle-core`
- `cargo clippy -p candle-core --all-targets`
- `cargo fmt --all -- --check`

CUDA and Metal backends are untouched; the new tests do exercise them via `test_device!`.
