### PR TITLE
Fix non-contiguous conv kernels on Metal, and conv1d on CPU

### DIFF
--- a/candle-core/src/cpu_backend/mod.rs
+++ b/candle-core/src/cpu_backend/mod.rs
@@ -2779,16 +2779,18 @@ impl BackendStorage for CpuStorage {
                 .broadcast_as((b, k, n))?;
             col.matmul(kernel, (b, m, n, k), &col_l, &kernel_l)?
         } else {
-            // Make the kernel contiguous if not already the case.
+            // copy_strided_src materializes the kernel into kernel_c starting at index 0, so
+            // the matmul must read kernel_c and use offset 0, not the original (strided)
+            // kernel and its start offset.
             let mut kernel_c = unsafe {
                 self.device()
                     .alloc_uninit(kernel_l.shape(), kernel.dtype())?
             };
             kernel.copy_strided_src(&mut kernel_c, 0, kernel_l)?;
-            let kernel_l = Layout::contiguous_with_offset((1, n, k), kernel_l.start_offset())
+            let kernel_l = Layout::contiguous_with_offset((1, n, k), 0)
                 .transpose(1, 2)?
                 .broadcast_as((b, k, n))?;
-            col.matmul(kernel, (b, m, n, k), &col_l, &kernel_l)?
+            col.matmul(&kernel_c, (b, m, n, k), &col_l, &kernel_l)?
         };
         let res_l = Layout::contiguous((b, l_out, params.c_out)).transpose(1, 2)?;
         let mut res_t = unsafe { self.device().alloc_uninit(res_l.shape(), res.dtype())? };

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -970,13 +970,15 @@ impl BackendStorage for MetalStorage {
                 .broadcast_as((b, k, n))?;
             col.matmul(kernel, (b, m, n, k), &col_l, &kernel_l)?
         } else {
-            // Make the kernel contiguous if not already the case.
+            // copy_strided_src materializes the kernel into kernel_c starting at index 0, so
+            // the matmul must read kernel_c and use offset 0, not the original (strided)
+            // kernel and its start offset.
             let mut kernel_c = self.device().zeros_impl(kernel_l.shape(), kernel.dtype())?;
             kernel.copy_strided_src(&mut kernel_c, 0, kernel_l)?;
-            let kernel_l = Layout::contiguous_with_offset((1, n, k), kernel_l.start_offset())
+            let kernel_l = Layout::contiguous_with_offset((1, n, k), 0)
                 .transpose(1, 2)?
                 .broadcast_as((b, k, n))?;
-            col.matmul(kernel, (b, m, n, k), &col_l, &kernel_l)?
+            col.matmul(&kernel_c, (b, m, n, k), &col_l, &kernel_l)?
         };
         let res_l = Layout::contiguous((b, l_out, n)).transpose(1, 2)?;
         let mut res_t = self.device().zeros_impl(res_l.shape(), res.dtype())?;
@@ -1173,13 +1175,15 @@ impl BackendStorage for MetalStorage {
                 .broadcast_as((b, k, n))?;
             col.matmul(kernel, (b, m, n, k), &col_l, &kernel_l)?
         } else {
-            // Make the kernel contiguous if not already the case.
+            // copy_strided_src materializes the kernel into kernel_c starting at index 0, so
+            // the matmul must read kernel_c and use offset 0, not the original (strided)
+            // kernel and its start offset.
             let mut kernel_c = self.device().zeros_impl(kernel_l.shape(), kernel.dtype())?;
             kernel.copy_strided_src(&mut kernel_c, 0, kernel_l)?;
-            let kernel_l = Layout::contiguous_with_offset((1, n, k), kernel_l.start_offset())
+            let kernel_l = Layout::contiguous_with_offset((1, n, k), 0)
                 .transpose(1, 2)?
                 .broadcast_as((b, k, n))?;
-            col.matmul(kernel, (b, m, n, k), &col_l, &kernel_l)?
+            col.matmul(&kernel_c, (b, m, n, k), &col_l, &kernel_l)?
         };
         let res_l = Layout::contiguous((b, h_out, w_out, n))
             .transpose(1, 2)?

--- a/candle-core/tests/conv_tests.rs
+++ b/candle-core/tests/conv_tests.rs
@@ -1019,3 +1019,54 @@ test_device!(
     conv2d_grad_noncontiguous_kernel_gpu,
     conv2d_grad_noncontiguous_kernel_metal
 );
+
+// Companion to conv2d_grad_noncontiguous_kernel: conv1d takes the same im2col path and had
+// the same defect, but was not covered. A non-contiguous kernel and its contiguous copy must
+// produce identical forward results and gradients.
+fn conv1d_grad_noncontiguous_kernel(dev: &Device) -> Result<()> {
+    use candle_core::Var;
+    let input_data: Vec<f32> = (1..=16).map(|v| v as f32 * 0.1).collect();
+    let weight_data: Vec<f32> = (1..=12).map(|v| v as f32 * 0.1).collect();
+
+    // Non-contiguous kernel: a channel slice of a larger weight, so it has a non-zero offset.
+    let input = Var::from_slice(&input_data, (1, 2, 8), dev)?;
+    let weight = Var::from_slice(&weight_data, (3, 4, 1), dev)?;
+    let kernel = weight.i((.., 1..3, ..))?;
+    let loss = input.conv1d(&kernel, 0, 1, 1, 1)?.sqr()?.sum_all()?;
+    let grads = loss.backward()?;
+    let grad_input = grads.get(&input).unwrap();
+    let grad_weight = grads.get(&weight).unwrap();
+
+    // Reference: the same logical kernel forced contiguous.
+    let input_ref = Var::from_slice(&input_data, (1, 2, 8), dev)?;
+    let weight_ref = Var::from_slice(&weight_data, (3, 4, 1), dev)?;
+    let kernel_ref = weight_ref.i((.., 1..3, ..))?.contiguous()?;
+    let loss_ref = input_ref
+        .conv1d(&kernel_ref, 0, 1, 1, 1)?
+        .sqr()?
+        .sum_all()?;
+    let grads_ref = loss_ref.backward()?;
+    let grad_input_ref = grads_ref.get(&input_ref).unwrap();
+    let grad_weight_ref = grads_ref.get(&weight_ref).unwrap();
+
+    assert_eq!(
+        test_utils::to_vec0_round(&loss, 4)?,
+        test_utils::to_vec0_round(&loss_ref, 4)?,
+    );
+    assert_eq!(
+        test_utils::to_vec1_round(&grad_input.flatten_all()?, 4)?,
+        test_utils::to_vec1_round(&grad_input_ref.flatten_all()?, 4)?,
+    );
+    assert_eq!(
+        test_utils::to_vec1_round(&grad_weight.flatten_all()?, 4)?,
+        test_utils::to_vec1_round(&grad_weight_ref.flatten_all()?, 4)?,
+    );
+    Ok(())
+}
+
+test_device!(
+    conv1d_grad_noncontiguous_kernel,
+    conv1d_grad_noncontiguous_kernel_cpu,
+    conv1d_grad_noncontiguous_kernel_gpu,
+    conv1d_grad_noncontiguous_kernel_metal
+);


### PR DESCRIPTION
## What this fixes

`conv2d_grad_noncontiguous_kernel_metal` currently fails on `main`:

```
test conv2d_grad_noncontiguous_kernel_metal ... FAILED
assertion `left == right` failed
  left: 25.926
 right: 57.6732
```

That is the regression test added by #3736 for #3735. #3736 fixed the CPU `conv2d` path, and the test is registered for every backend, so the Metal variant has been failing since it landed. The assertion that trips is the forward loss, before gradients are involved: a non-contiguous kernel and its `.contiguous()` copy give different results.

## Cause

The non-contiguous branch of `conv1d` and `conv2d` in the Metal backend has two problems:

```rust
let mut kernel_c = self.device().zeros_impl(kernel_l.shape(), kernel.dtype())?;
kernel.copy_strided_src(&mut kernel_c, 0, kernel_l)?;
let kernel_l = Layout::contiguous_with_offset((1, n, k), kernel_l.start_offset())
    .transpose(1, 2)?
    .broadcast_as((b, k, n))?;
col.matmul(kernel, (b, m, n, k), &col_l, &kernel_l)?
```

1. `copy_strided_src` materializes the kernel into `kernel_c` starting at index 0, but the layout is built with the original strided kernel's `start_offset()` — the same mistake #3736 fixed for CPU `conv2d`.
2. The matmul is passed `kernel`, not `kernel_c`. The contiguous copy is computed and then discarded, so the matmul reads the strided buffer through a contiguous layout.

## A third site, on CPU

Adding a `conv1d` regression test — the same op path, which had no coverage — showed that CPU `conv1d` carries the offset defect too. #3736 fixed `cpu_backend/conv2d.rs`; the `conv1d` implementation in `cpu_backend/mod.rs` was not touched.

Before this change:

```
conv2d_grad_noncontiguous_kernel_cpu     ok        (fixed by #3736)
conv1d_grad_noncontiguous_kernel_cpu     FAILED
conv2d_grad_noncontiguous_kernel_metal   FAILED
conv1d_grad_noncontiguous_kernel_metal   FAILED
```

After it, all four pass.

## Verification

- Full `candle-core` suite with `--features metal`: green.
- `candle-nn` with `--features metal`: green.
- `cargo fmt --all -- --check` clean; `cargo clippy -p candle-core --features metal` reports only the pre-existing `candle_metal_kernels::kernels::binary::contiguous` unused-import warning, which is present on `main` too.
- Each of the three failing cases was confirmed to fail with the source changes reverted and the tests kept, so the tests do reject the bug rather than merely passing.

Tested on Apple M-series, `metal` feature enabled.

## Note on CI

The Metal variants need Apple hardware, so this was not visible to the current workflows. I see #3770 adds `ci_metal.yaml` on a GitHub-hosted Apple Silicon runner — if that lands first it should turn red on `main` for this exact test, so the two changes go together well.
