### PR TITLE
Metal fixes for Apple Silicon: device init, conv backward, error surfacing, wired-memory bound

### DIFF
--- a/candle-core/src/backprop.rs
+++ b/candle-core/src/backprop.rs
@@ -261,7 +261,14 @@ impl Tensor {
 
                         let grad_kernel = arg
                             .transpose(0, 1)?
-                            .conv1d(&grad.transpose(0, 1)?, *padding, *dilation, *stride, 1)?
+                            .contiguous()?
+                            .conv1d(
+                                &grad.transpose(0, 1)?.contiguous()?,
+                                *padding,
+                                *dilation,
+                                *stride,
+                                1,
+                            )?
                             .transpose(0, 1)?;
                         let sum_grad = grads.or_insert(kernel)?;
                         let (_, _, k0) = kernel.dims3()?;
@@ -299,7 +306,14 @@ impl Tensor {
 
                         let grad_kernel = arg
                             .transpose(0, 1)?
-                            .conv2d(&grad.transpose(0, 1)?, *padding, *dilation, *stride, 1)?
+                            .contiguous()?
+                            .conv2d(
+                                &grad.transpose(0, 1)?.contiguous()?,
+                                *padding,
+                                *dilation,
+                                *stride,
+                                1,
+                            )?
                             .transpose(0, 1)?;
                         let sum_grad = grads.or_insert(kernel)?;
                         let (_, _, k0, k1) = kernel.dims4()?;
@@ -328,7 +342,14 @@ impl Tensor {
 
                         let grad_kernel = grad
                             .transpose(0, 1)?
-                            .conv2d(&arg.transpose(0, 1)?, *padding, *dilation, *stride, 1)?
+                            .contiguous()?
+                            .conv2d(
+                                &arg.transpose(0, 1)?.contiguous()?,
+                                *padding,
+                                *dilation,
+                                *stride,
+                                1,
+                            )?
                             .transpose(0, 1)?;
                         let sum_grad = grads.or_insert(kernel)?;
                         let (_, _, k0, k1) = kernel.dims4()?;

--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -59,6 +59,14 @@ pub struct MetalDevice {
     /// Intermediate compute buffers don't need CPU access so Private avoids coherency overhead.
     pub(crate) private_buffers: Arc<RwLock<BufferMap>>,
 
+    /// Bytes allocated since the last pool sweep. The residency set wires every
+    /// pooled buffer and only [`Self::drop_unused_buffers`] unwires them — with
+    /// no sync in a long encode (whole-image inference) the wired set grows to
+    /// every temporary of the run and the GPU aborts with
+    /// kIOGPUCommandBufferCallbackErrorOutOfMemory. Crossing the sweep budget
+    /// forces a wait + sweep to bound the peak (JOURNAL vtracer 2026-08-04).
+    pub(crate) alloc_since_sweep: Arc<std::sync::atomic::AtomicUsize>,
+
     /// Simple keeper struct to keep track of the already compiled kernels so we can reuse them.
     /// Heavily used by [`candle_metal_kernels`]
     pub(crate) kernels: Arc<Kernels>,
@@ -126,6 +134,30 @@ impl MetalDevice {
 
     pub fn metal_device(&self) -> &Device {
         &self.device
+    }
+
+    /// Called before taking a pool lock in the allocate paths: if the bytes
+    /// allocated since the last sweep exceed the budget, drain the GPU and
+    /// sweep so wired memory is released before growing the pool further.
+    fn maybe_sweep(&self, incoming: usize) -> Result<()> {
+        use std::sync::atomic::Ordering;
+        let total = self.alloc_since_sweep.fetch_add(incoming, Ordering::Relaxed) + incoming;
+        if total >= sweep_budget() {
+            self.alloc_since_sweep.store(0, Ordering::Relaxed);
+            self.wait_until_completed()?;
+            if std::env::var("CANDLE_METAL_LOG_SWEEP").is_ok() {
+                let gauge = |m: &BufferMap| -> (usize, usize) {
+                    m.iter().map(|(sz, v)| (v.len(), sz * v.len())).fold((0, 0), |a, b| (a.0 + b.0, a.1 + b.1))
+                };
+                let (ns, bs) = gauge(&self.buffers.read().unwrap());
+                let (np, bp) = gauge(&self.private_buffers.read().unwrap());
+                eprintln!(
+                    "[sweep] after drain: shared {} bufs {:.2} GB, private {} bufs {:.2} GB",
+                    ns, bs as f64 / 1e9, np, bp as f64 / 1e9
+                );
+            }
+        }
+        Ok(())
     }
 
     fn drop_unused_buffers(&self) -> Result<()> {
@@ -226,9 +258,13 @@ impl MetalDevice {
         _name: &str,
     ) -> Result<Arc<Buffer>> {
         let size = element_count * dtype.size_in_bytes();
+        self.maybe_sweep(size)?;
         let mut buffers = self.private_buffers.write().map_err(MetalError::from)?;
-        if let Some(b) = find_available_buffer(size, &buffers) {
-            return Ok(b.clone());
+        if !no_pool_reuse() {
+            if let Some(b) = find_available_buffer(size, &buffers) {
+                // Cloning also ensures we increment the strong count
+                return Ok(b.clone());
+            }
         }
         let size = buf_size(size);
         let subbuffers = buffers.entry(size).or_insert(vec![]);
@@ -308,10 +344,13 @@ impl MetalDevice {
 
     /// The critical allocator algorithm
     pub fn allocate_buffer(&self, size: usize) -> Result<Arc<Buffer>> {
+        self.maybe_sweep(size)?;
         let mut buffers = self.buffers.write().map_err(MetalError::from)?;
-        if let Some(b) = find_available_buffer(size, &buffers) {
-            // Cloning also ensures we increment the strong count
-            return Ok(b.clone());
+        if !no_pool_reuse() {
+            if let Some(b) = find_available_buffer(size, &buffers) {
+                // Cloning also ensures we increment the strong count
+                return Ok(b.clone());
+            }
         }
         let size = buf_size(size);
         let subbuffers = buffers.entry(size).or_insert(vec![]);
@@ -349,8 +388,37 @@ impl MetalDevice {
     }
 }
 
+
+/// Sweep budget: force a wait + pool sweep after this many freshly-allocated
+/// bytes. Tunable via CANDLE_METAL_SWEEP_BYTES; default 6 GiB.
+fn sweep_budget() -> usize {
+    static V: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *V.get_or_init(|| {
+        std::env::var("CANDLE_METAL_SWEEP_BYTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(6 << 30)
+    })
+}
+
+/// Debug kill-switch: `CANDLE_METAL_NO_POOL=1` disables buffer-pool reuse so
+/// every allocation is fresh — used to bisect pool-recycling races.
+fn no_pool_reuse() -> bool {
+    static V: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *V.get_or_init(|| std::env::var("CANDLE_METAL_NO_POOL").is_ok_and(|v| v == "1"))
+}
+
 fn buf_size(size: usize) -> usize {
-    size.next_power_of_two()
+    // Power-of-two bucketing wastes up to 2x; above 64MB (whole-image im2col
+    // scratch is ~800MB) that overhead alone can push the GPU working set into
+    // kIOGPUCommandBufferCallbackErrorOutOfMemory territory. Large sizes round
+    // to a 32MB grain instead — still few buckets, half the waste.
+    const GRAIN: usize = 32 << 20;
+    if size <= (64 << 20) {
+        size.next_power_of_two()
+    } else {
+        size.div_ceil(GRAIN) * GRAIN
+    }
 }
 
 /// Applies the [`BufferBuilder`] label, clearing any stale label on a reused pooled buffer.

--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -60,11 +60,8 @@ pub struct MetalDevice {
     pub(crate) private_buffers: Arc<RwLock<BufferMap>>,
 
     /// Bytes allocated since the last pool sweep. The residency set wires every
-    /// pooled buffer and only [`Self::drop_unused_buffers`] unwires them — with
-    /// no sync in a long encode (whole-image inference) the wired set grows to
-    /// every temporary of the run and the GPU aborts with
-    /// kIOGPUCommandBufferCallbackErrorOutOfMemory. Crossing the sweep budget
-    /// forces a wait + sweep to bound the peak (JOURNAL vtracer 2026-08-04).
+    /// pooled buffer; crossing the sweep budget forces a wait + sweep so wired
+    /// memory stays bounded in long encodes.
     pub(crate) alloc_since_sweep: Arc<std::sync::atomic::AtomicUsize>,
 
     /// Simple keeper struct to keep track of the already compiled kernels so we can reuse them.
@@ -143,8 +140,11 @@ impl MetalDevice {
         use std::sync::atomic::Ordering;
         let total = self.alloc_since_sweep.fetch_add(incoming, Ordering::Relaxed) + incoming;
         if total >= sweep_budget() {
+            if !self.commands.try_flush_and_wait().map_err(MetalError::from)? {
+                return Ok(());
+            }
             self.alloc_since_sweep.store(0, Ordering::Relaxed);
-            self.wait_until_completed()?;
+            self.drop_unused_buffers()?;
             if std::env::var("CANDLE_METAL_LOG_SWEEP").is_ok() {
                 let gauge = |m: &BufferMap| -> (usize, usize) {
                     m.iter().map(|(sz, v)| (v.len(), sz * v.len())).fold((0, 0), |a, b| (a.0 + b.0, a.1 + b.1))

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -2023,7 +2023,21 @@ impl BackendDevice for MetalDevice {
     type Storage = MetalStorage;
 
     fn new(ordinal: usize) -> Result<Self> {
-        let device = Device::all().swap_remove(ordinal);
+        // `Device::all()` (MTLCopyAllDevices) returns no devices on Apple Silicon.
+        // Use `system_default()` (MTLCreateSystemDefaultDevice) for the default
+        // device and fall back to `all()` for explicit additional GPUs.
+        let device = if ordinal == 0 {
+            Device::system_default()
+                .ok_or_else(|| MetalError::from("no Metal device found".to_string()))?
+        } else {
+            let mut devices = Device::all();
+            if ordinal >= devices.len() {
+                return Err(
+                    MetalError::Message(format!("Metal device {ordinal} not found")).into(),
+                );
+            }
+            devices.swap_remove(ordinal)
+        };
         let command_queue = device.new_command_queue().map_err(MetalError::from)?;
         #[cfg(feature = "metal-debug-labels")]
         command_queue.setLabel(Some(&NSString::from_str("candle-metal")));

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -2061,6 +2061,7 @@ impl BackendDevice for MetalDevice {
             commands: Arc::new(commands),
             buffers: Arc::new(RwLock::new(HashMap::new())),
             private_buffers: Arc::new(RwLock::new(HashMap::new())),
+            alloc_since_sweep: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             kernels,
             seed,
             seed_value: Arc::new(RwLock::new(299792458)),

--- a/candle-metal-kernels/src/metal/commands.rs
+++ b/candle-metal-kernels/src/metal/commands.rs
@@ -232,6 +232,36 @@ impl Commands {
         self.flush_and_wait()
     }
 
+    pub fn try_flush_and_wait(&self) -> Result<bool, MetalKernelError> {
+        let to_wait = {
+            let mut state = match self.state.try_lock() {
+                Ok(g) => g,
+                Err(std::sync::TryLockError::WouldBlock) => return Ok(false),
+                Err(std::sync::TryLockError::Poisoned(e)) => {
+                    return Err(MetalKernelError::LockError(e.to_string()))
+                }
+            };
+            if self.compute_count.load(Ordering::Acquire) > 0 {
+                self.commit_swap_locked(&mut state, 0)?;
+            }
+            std::mem::take(&mut state.in_flight)
+        };
+        if let Some(last) = to_wait.last() {
+            Self::ensure_completed(last)?;
+        }
+        for cb in &to_wait[..to_wait.len().saturating_sub(1)] {
+            if cb.status() == MTLCommandBufferStatus::Error {
+                let msg = cb
+                    .error()
+                    .map(|e| e.to_string())
+                    .unwrap_or_else(|| "unknown error".to_string());
+                return Err(MetalKernelError::CommandBufferError(msg));
+            }
+        }
+        self.prev_ce_outputs.lock()?.clear();
+        Ok(true)
+    }
+
     pub fn flush_and_wait(&self) -> Result<(), MetalKernelError> {
         let to_wait = {
             let mut state = self.state.lock()?;
@@ -277,9 +307,8 @@ impl Commands {
             // queue is FIFO: everything committed before cb is done too
             let mut state = self.state.lock()?;
             // A GPU-side abort (e.g. kIOGPUCommandBufferCallbackErrorOutOfMemory)
-            // leaves an earlier CB in Error status with its outputs unwritten.
-            // Silently dropping it here turns the abort into downstream garbage
-            // reads — surface it instead (JOURNAL vtracer 2026-08-04).
+            // leaves an earlier CB in Error status with its outputs unwritten;
+            // surface it instead of silently dropping it.
             for c in state.in_flight.iter() {
                 if c.status() == MTLCommandBufferStatus::Error {
                     let msg = c

--- a/candle-metal-kernels/src/metal/commands.rs
+++ b/candle-metal-kernels/src/metal/commands.rs
@@ -276,6 +276,22 @@ impl Commands {
             Self::ensure_completed(&cb)?;
             // queue is FIFO: everything committed before cb is done too
             let mut state = self.state.lock()?;
+            // A GPU-side abort (e.g. kIOGPUCommandBufferCallbackErrorOutOfMemory)
+            // leaves an earlier CB in Error status with its outputs unwritten.
+            // Silently dropping it here turns the abort into downstream garbage
+            // reads — surface it instead (JOURNAL vtracer 2026-08-04).
+            for c in state.in_flight.iter() {
+                if c.status() == MTLCommandBufferStatus::Error {
+                    let msg = c
+                        .error()
+                        .map(|e| e.to_string())
+                        .unwrap_or_else(|| "unknown error".to_string());
+                    state
+                        .in_flight
+                        .retain(|c| c.status() != MTLCommandBufferStatus::Completed);
+                    return Err(MetalKernelError::CommandBufferError(msg));
+                }
+            }
             state
                 .in_flight
                 .retain(|c| c.status() != MTLCommandBufferStatus::Completed);


### PR DESCRIPTION
Four fixes for candle's Metal backend on Apple Silicon, found while training and running inference on M-series machines. Rebased onto current main (0.11.0); supersedes #3640, which contained the first two.

### 1. Use `system_default` Metal device
`Device::new_metal` panics on M-series because `metal::Device::all()` can return an empty list there; `system_default()` is the reliable path on Apple Silicon.

### 2. Make conv weight-gradient inputs contiguous
The conv2d backward pass for the weight gradient feeds a non-contiguous (transposed) tensor into im2col/gemm on Metal, producing a **wrong weight gradient** — training silently diverges. Forcing contiguity fixes it; CPU and Metal gradients now agree.

### 3. Surface errored in-flight command buffers in `flush_and_wait_current`
Only the most recent command buffer's status was checked. If an earlier in-flight command buffer aborted (e.g. `kIOGPUCommandBufferCallbackErrorOutOfMemory` under memory pressure), the error was swallowed and its unwritten output buffers were read back as garbage — nondeterministic, impossible results with no error. Now every in-flight command buffer is checked and an errored one becomes a Rust error.

### 4. Bound Metal wired-memory growth from the buffer pool
Two changes to the buffer pool's allocation behavior:
- Allocations >64MB round to a 32MB grain instead of next-power-of-two (an ~800MB im2col buffer no longer costs 1GB of wired memory).
- A drain-and-sweep backstop (`CANDLE_METAL_SWEEP_BYTES`, default 6GiB): after that many bytes of fresh allocation, wait for in-flight work and drop unused pooled buffers. Long whole-image encodes previously grew wired (residency-pinned) memory without bound, which can freeze the whole machine rather than fail.

Debug switches kept from the investigation: `CANDLE_METAL_NO_POOL=1` disables pool reuse, `CANDLE_METAL_LOG_SWEEP=1` logs a pool gauge at each sweep.

Fixes 3 and 4 came out of a full bisection of nondeterministic large-image inference corruption (op-level probes, f64-refereed reduce comparisons, Metal shader validation); the reduce kernels, group_norm, and the pool recycle protocol were each exonerated — the root cause was the swallowed GPU aborts under memory pressure.
