### PR TITLE
fix(core): reject overflowing shapes/byte sizes in GGUF/GGML loaders

### DIFF
--- a/candle-core/src/error.rs
+++ b/candle-core/src/error.rs
@@ -95,6 +95,14 @@ pub enum Error {
         n_parts: usize,
     },
 
+    #[error(
+        "element count overflows usize for shape {shape:?}; the dimension product does not fit"
+    )]
+    ShapeElementCountOverflow { shape: Shape },
+
+    #[error("tensor byte size overflows usize for shape {shape:?} with dtype {dtype:?}")]
+    TensorSizeOverflow { shape: Shape, dtype: String },
+
     #[error("{op} can only be performed on a single dimension")]
     OnlySingleDimension { op: &'static str, dims: Vec<usize> },
 

--- a/candle-core/src/quantized/ggml_file.rs
+++ b/candle-core/src/quantized/ggml_file.rs
@@ -141,14 +141,20 @@ pub fn qtensor_from_ggml(
     dims: Vec<usize>,
     device: &Device,
 ) -> Result<super::QTensor> {
-    let tensor_elems = dims.iter().product::<usize>();
+    let shape = crate::Shape::from(dims.as_slice());
+    let tensor_elems = shape.elem_count_checked()?;
     let block_size = ggml_dtype.block_size();
     if tensor_elems % block_size != 0 {
         crate::bail!(
             "the number of elements {tensor_elems} is not divisible by the block size {block_size}"
         )
     }
-    let size_in_bytes = tensor_elems / block_size * ggml_dtype.type_size();
+    let size_in_bytes = (tensor_elems / block_size)
+        .checked_mul(ggml_dtype.type_size())
+        .ok_or_else(|| crate::Error::TensorSizeOverflow {
+            shape: shape.clone(),
+            dtype: format!("{:?}", ggml_dtype),
+        })?;
 
     match ggml_dtype {
         GgmlDType::F32 => from_raw_data::<f32>(raw_data, size_in_bytes, dims, device),
@@ -211,8 +217,21 @@ fn read_one_tensor<R: std::io::Seek + std::io::Read>(
         reader.seek(std::io::SeekFrom::Current(((32 - pos % 32) % 32) as i64))?;
     }
     let dims = dims.iter().map(|&u| u as usize).collect::<Vec<_>>();
-    let tensor_elems = dims.iter().product::<usize>();
-    let size_in_bytes = tensor_elems * ggml_dtype.type_size() / ggml_dtype.block_size();
+    let shape = crate::Shape::from(dims.as_slice());
+    let tensor_elems = shape.elem_count_checked()?;
+    let type_size = ggml_dtype.type_size();
+    let block_size = ggml_dtype.block_size();
+    if tensor_elems % block_size != 0 {
+        crate::bail!(
+            "the number of elements {tensor_elems} is not divisible by the block size {block_size}"
+        )
+    }
+    let size_in_bytes = (tensor_elems / block_size)
+        .checked_mul(type_size)
+        .ok_or_else(|| crate::Error::TensorSizeOverflow {
+            shape: shape.clone(),
+            dtype: format!("{:?}", ggml_dtype),
+        })?;
     // TODO: Mmap version to avoid copying the data around?
     let mut raw_data = vec![0u8; size_in_bytes];
     reader.read_exact(&mut raw_data)?;

--- a/candle-core/src/quantized/gguf_file.rs
+++ b/candle-core/src/quantized/gguf_file.rs
@@ -91,14 +91,19 @@ impl TensorInfo {
         tensor_data_offset: u64,
         device: &Device,
     ) -> Result<QTensor> {
-        let tensor_elems = self.shape.elem_count();
+        let tensor_elems = self.shape.elem_count_checked()?;
         let block_size = self.ggml_dtype.block_size();
         if !tensor_elems.is_multiple_of(block_size) {
             crate::bail!(
             "the number of elements {tensor_elems} is not divisible by the block size {block_size}"
         )
         }
-        let size_in_bytes = tensor_elems / block_size * self.ggml_dtype.type_size();
+        let size_in_bytes = (tensor_elems / block_size)
+            .checked_mul(self.ggml_dtype.type_size())
+            .ok_or_else(|| crate::Error::TensorSizeOverflow {
+                shape: self.shape.clone(),
+                dtype: format!("{:?}", self.ggml_dtype),
+            })?;
         let tensor_start = tensor_data_offset.saturating_add(self.offset);
         let file_size = reader.seek(std::io::SeekFrom::End(0))?;
         let remaining = file_size.saturating_sub(tensor_start);
@@ -523,14 +528,25 @@ impl Content {
 
             let mut dimensions: Vec<usize> = match magic {
                 VersionedMagic::GgufV1 => {
-                    let mut dimensions = vec![0; n_dimensions as usize];
+                    let mut dimensions = vec![0u32; n_dimensions as usize];
                     reader.read_u32_into::<LittleEndian>(&mut dimensions)?;
+                    // u32 always fits in usize (usize is >= 32 bits).
                     dimensions.into_iter().map(|c| c as usize).collect()
                 }
                 VersionedMagic::GgufV2 | VersionedMagic::GgufV3 => {
-                    let mut dimensions = vec![0; n_dimensions as usize];
+                    let mut dimensions = vec![0u64; n_dimensions as usize];
                     reader.read_u64_into::<LittleEndian>(&mut dimensions)?;
-                    dimensions.into_iter().map(|c| c as usize).collect()
+                    dimensions
+                        .into_iter()
+                        .map(|c| {
+                            usize::try_from(c).map_err(|_| {
+                                crate::Error::Msg(format!(
+                                    "gguf: tensor '{tensor_name}' dimension {c} \
+                                     exceeds the address space"
+                                ))
+                            })
+                        })
+                        .collect::<Result<Vec<_>>>()?
                 }
             };
 
@@ -635,4 +651,67 @@ pub fn write<W: std::io::Seek + std::io::Write>(
         w.write_all(&vec![0u8; padding])?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// Regression test for the silent `elem_count` overflow reported in #3816.
+    ///
+    /// A tensor info declaring attacker-controlled dimensions whose product
+    /// exceeds `usize` (here `usize::MAX x usize::MAX`) used to wrap to 0 in
+    /// release builds, making the loader accept a zero-byte buffer and hand
+    /// back a `Tensor` claiming an impossible shape. After the fix the loader
+    /// rejects the shape up front instead of corrupting the tensor.
+    #[test]
+    fn gguf_rejects_overflowing_shape() {
+        let info = TensorInfo {
+            // Any dtype works; the overflow check runs before block math.
+            ggml_dtype: GgmlDType::F32,
+            shape: crate::Shape::from(vec![usize::MAX, usize::MAX]),
+            offset: 0,
+        };
+        let mut reader = Cursor::new(Vec::<u8>::new());
+        let device = Device::Cpu;
+        let err = info
+            .read(&mut reader, 0, &device)
+            .expect_err("loader must reject a shape whose element count overflows usize");
+        // Assert the specific overflow variant, not just any error.
+        assert!(
+            matches!(err, crate::Error::ShapeElementCountOverflow { .. }),
+            "expected ShapeElementCountOverflow, got {err}"
+        );
+    }
+
+    /// The element count itself fits in `usize`, but multiplying it by the
+    /// dtype's byte size would wrap. F32 has a 4-byte type size and a 1-byte
+    /// block size; a single dimension of `usize::MAX / 4 + 1` gives a valid
+    /// element count whose unchecked `* 4` wraps to 0. The loader must reject
+    /// this at the byte-size step rather than allocating 0 bytes for a tensor
+    /// that claims a large element count.
+    ///
+    /// The dimension is chosen so the unchecked product wraps all the way to 0
+    /// (not merely to a non-zero remainder); this makes the regression test
+    /// faithful to the reported defect and to release builds, where the
+    /// subsequent file-length check would otherwise still catch the empty
+    /// reader and mask a missing overflow guard.
+    #[test]
+    fn gguf_rejects_overflowing_byte_size() {
+        let info = TensorInfo {
+            ggml_dtype: GgmlDType::F32,
+            shape: crate::Shape::from(vec![usize::MAX / 4 + 1]),
+            offset: 0,
+        };
+        let mut reader = Cursor::new(Vec::<u8>::new());
+        let result = info.read(&mut reader, 0, &Device::Cpu);
+        let err = result.expect_err("loader must reject a tensor whose byte size overflows usize");
+        // Assert the specific overflow variant, not just any error — a plain
+        // file-length failure would also make `is_err()` pass.
+        assert!(
+            matches!(err, crate::Error::TensorSizeOverflow { .. }),
+            "expected TensorSizeOverflow, got {err}"
+        );
+    }
 }

--- a/candle-core/src/shape.rs
+++ b/candle-core/src/shape.rs
@@ -128,8 +128,45 @@ impl Shape {
     }
 
     /// The total number of elements, this is the product of all dimension sizes.
+    ///
+    /// This is unchecked: on shapes whose dimension product overflows `usize`
+    /// (e.g. attacker/model-controlled GGUF dimensions such as `[2^32, 2^32]`)
+    /// it silently wraps in release builds. Prefer [`Shape::elem_count_checked`]
+    /// whenever the dimensions come from an untrusted source.
     pub fn elem_count(&self) -> usize {
         self.0.iter().product()
+    }
+
+    /// Checked variant of [`Shape::elem_count`]: returns the product of all
+    /// dimension sizes, or an [`Error::ShapeElementCountOverflow`] when that
+    /// product does not fit in a `usize`.
+    ///
+    /// A shape containing any zero dimension has an element count of `0`
+    /// regardless of the other dimensions, so this short-circuits to `Ok(0)`
+    /// in that case — making the result independent of dimension order (e.g.
+    /// both `[usize::MAX, 2, 0]` and `[0, usize::MAX, 2]` return `Ok(0)`).
+    ///
+    /// Use this on shapes built from untrusted input (e.g. GGUF/GGML tensor
+    /// dimensions read from a file); keep using `elem_count` for shapes that
+    /// originate from trusted tensor construction, where the product is known
+    /// not to overflow.
+    pub fn elem_count_checked(&self) -> Result<usize> {
+        // A zero dimension makes the element count 0 regardless of the other
+        // dimensions, so scan for one first — before any multiply — to make
+        // the result independent of dimension order (e.g. both
+        // `[usize::MAX, 2, 0]` and `[0, usize::MAX, 2]` return `Ok(0)`).
+        if self.0.contains(&0) {
+            return Ok(0);
+        }
+        let mut acc: usize = 1;
+        for &dim in self.0.iter() {
+            acc = acc
+                .checked_mul(dim)
+                .ok_or(crate::Error::ShapeElementCountOverflow {
+                    shape: self.clone(),
+                })?;
+        }
+        Ok(acc)
     }
 
     /// The strides given in number of elements for a contiguous n-dimensional
@@ -630,5 +667,48 @@ mod tests {
         assert_eq!(shape.dims(), &[2, 3, 4, 5, 6]);
         let shape = Shape::from((2, 3, 4, 5, 6, 7));
         assert_eq!(shape.dims(), &[2, 3, 4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn elem_count_checked_matches_unchecked() {
+        let shape = Shape::from((2, 3, 4));
+        assert_eq!(shape.elem_count_checked().unwrap(), 24);
+        assert_eq!(shape.elem_count_checked().unwrap(), shape.elem_count());
+
+        // Edge cases: scalar and single-dim shapes.
+        assert_eq!(Shape::from(()).elem_count_checked().unwrap(), 1);
+        assert_eq!(Shape::from(7).elem_count_checked().unwrap(), 7);
+        assert_eq!(Shape::from(0).elem_count_checked().unwrap(), 0);
+    }
+
+    #[test]
+    fn elem_count_checked_rejects_overflow() {
+        // Mirrors the GGUF report (#3816): two large dimensions whose product
+        // exceeds usize. The unchecked `elem_count` wraps to 0 in release, but
+        // the checked variant must reject the shape instead.
+        let max = usize::MAX;
+        let shape = Shape::from(vec![max, max]);
+        assert!(shape.elem_count_checked().is_err());
+    }
+
+    #[test]
+    fn elem_count_checked_zero_dim_is_order_independent() {
+        // A zero dimension makes the element count 0 no matter how large the
+        // other dimensions are, and that must hold regardless of dimension
+        // order — otherwise the same shape could be accepted or rejected
+        // based purely on how the loader happened to order the dims.
+        let max = usize::MAX;
+        assert_eq!(
+            Shape::from(vec![max, 2, 0]).elem_count_checked().unwrap(),
+            0
+        );
+        assert_eq!(
+            Shape::from(vec![0, max, 2]).elem_count_checked().unwrap(),
+            0
+        );
+        assert_eq!(
+            Shape::from(vec![2, 0, max]).elem_count_checked().unwrap(),
+            0
+        );
     }
 }

--- a/candle-core/src/shape.rs
+++ b/candle-core/src/shape.rs
@@ -128,8 +128,45 @@ impl Shape {
     }
 
     /// The total number of elements, this is the product of all dimension sizes.
+    ///
+    /// This is unchecked: on shapes whose dimension product overflows `usize`
+    /// (e.g. attacker/model-controlled GGUF dimensions such as `[2^32, 2^32]`)
+    /// it silently wraps in release builds. Prefer [`Shape::elem_count_checked`]
+    /// whenever the dimensions come from an untrusted source.
     pub fn elem_count(&self) -> usize {
         self.0.iter().product()
+    }
+
+    /// Checked variant of [`Shape::elem_count`]: returns the product of all
+    /// dimension sizes, or an [`Error::ShapeElementCountOverflow`] when that
+    /// product does not fit in a `usize`.
+    ///
+    /// A shape containing any zero dimension has an element count of `0`
+    /// regardless of the other dimensions, so this short-circuits to `Ok(0)`
+    /// in that case — making the result independent of dimension order (e.g.
+    /// both `[usize::MAX, 2, 0]` and `[0, usize::MAX, 2]` return `Ok(0)`).
+    ///
+    /// Use this on shapes built from untrusted input (e.g. GGUF/GGML tensor
+    /// dimensions read from a file); keep using `elem_count` for shapes that
+    /// originate from trusted tensor construction, where the product is known
+    /// not to overflow.
+    pub fn elem_count_checked(&self) -> Result<usize> {
+        // A zero dimension makes the element count 0 regardless of the other
+        // dimensions, so scan for one first — before any multiply — to make
+        // the result independent of dimension order (e.g. both
+        // `[usize::MAX, 2, 0]` and `[0, usize::MAX, 2]` return `Ok(0)`).
+        if self.0.contains(&0) {
+            return Ok(0);
+        }
+        let mut acc: usize = 1;
+        for &dim in self.0.iter() {
+            acc = acc
+                .checked_mul(dim)
+                .ok_or(crate::Error::ShapeElementCountOverflow {
+                    shape: self.clone(),
+                })?;
+        }
+        Ok(acc)
     }
 
     /// The strides given in number of elements for a contiguous n-dimensional
@@ -638,5 +675,48 @@ mod tests {
         assert_eq!(shape.dims(), &[2, 3, 4, 5, 6]);
         let shape = Shape::from((2, 3, 4, 5, 6, 7));
         assert_eq!(shape.dims(), &[2, 3, 4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn elem_count_checked_matches_unchecked() {
+        let shape = Shape::from((2, 3, 4));
+        assert_eq!(shape.elem_count_checked().unwrap(), 24);
+        assert_eq!(shape.elem_count_checked().unwrap(), shape.elem_count());
+
+        // Edge cases: scalar and single-dim shapes.
+        assert_eq!(Shape::from(()).elem_count_checked().unwrap(), 1);
+        assert_eq!(Shape::from(7).elem_count_checked().unwrap(), 7);
+        assert_eq!(Shape::from(0).elem_count_checked().unwrap(), 0);
+    }
+
+    #[test]
+    fn elem_count_checked_rejects_overflow() {
+        // Mirrors the GGUF report (#3816): two large dimensions whose product
+        // exceeds usize. The unchecked `elem_count` wraps to 0 in release, but
+        // the checked variant must reject the shape instead.
+        let max = usize::MAX;
+        let shape = Shape::from(vec![max, max]);
+        assert!(shape.elem_count_checked().is_err());
+    }
+
+    #[test]
+    fn elem_count_checked_zero_dim_is_order_independent() {
+        // A zero dimension makes the element count 0 no matter how large the
+        // other dimensions are, and that must hold regardless of dimension
+        // order — otherwise the same shape could be accepted or rejected
+        // based purely on how the loader happened to order the dims.
+        let max = usize::MAX;
+        assert_eq!(
+            Shape::from(vec![max, 2, 0]).elem_count_checked().unwrap(),
+            0
+        );
+        assert_eq!(
+            Shape::from(vec![0, max, 2]).elem_count_checked().unwrap(),
+            0
+        );
+        assert_eq!(
+            Shape::from(vec![2, 0, max]).elem_count_checked().unwrap(),
+            0
+        );
     }
 }


### PR DESCRIPTION
Closes #3816.

## Problem

`Shape::elem_count()` computes the dimension product with an unchecked `usize` multiply, which silently wraps in release builds. GGUF/GGML loaders feed attacker/model-controlled dimensions straight into this, so a tensor declaring `[2^32, 2^32]` is accepted with `elem_count == 0`, yielding a `Tensor` whose reported shape disagrees with its (empty) backing storage. As the reporter notes the corrupted state stays contained (every data path is bounds-checked), but the desync is surprising rather than a clean rejection.

The defect is **release-only**: a debug build panics at the multiply, so it is invisible to debug test runs.

## Fix

- **`Shape::elem_count_checked()`** — a new checked variant using `checked_mul`. A zero dimension short-circuits to `Ok(0)` before any multiply, so the result is order-independent (`[MAX, 2, 0]` and `[0, MAX, 2]` both return `Ok(0)`). `elem_count()` itself is left unchanged (105 call sites) but now documents the release-only overflow and points at the checked variant.
- **Loader hardening** — `gguf_file::TensorInfo::read` and the two `ggml_file` loaders switch to `elem_count_checked()`, and the trailing byte-size multiply becomes `checked_mul` too: a valid element count can still overflow once multiplied by `type_size`. The `read_one_tensor` byte-size computation was reordered to divide by `block_size` *before* the `checked_mul(type_size)`, so quantized dtypes (large `block_size`, small `type_size`) are not falsely rejected.
- **32-bit safety** — GGUF v2/v3 `u64` dimensions now go through `usize::try_from` instead of `as usize`, so a 32-bit / `wasm32` target rejects a `2^32` dimension rather than truncating it to `0`. (v1 `u32` stays `as usize`, which is always safe since `usize` is ≥ 32 bits.)
- **Distinct error variants** — `Error::ShapeElementCountOverflow` for the dimension product and `Error::TensorSizeOverflow` for the byte-size product, so the two failure modes carry accurate messages.

## Tests

- `elem_count_checked_matches_unchecked` — parity with the unchecked path, plus scalar/zero edge cases.
- `elem_count_checked_rejects_overflow` — `[usize::MAX, usize::MAX]` errors.
- `elem_count_checked_zero_dim_is_order_independent` — three orderings of `[MAX, 2, 0]`.
- `gguf_rejects_overflowing_shape` — end-to-end; asserts the specific `ShapeElementCountOverflow` variant (not just `is_err()`).
- `gguf_rejects_overflowing_byte_size` — F32 with `[usize::MAX / 4 + 1]` so the unchecked `* 4` would wrap to `0` in release; asserts `TensorSizeOverflow`. The dimension is chosen so the wrap reaches `0` (the file-length check would otherwise still catch the empty reader and mask a missing guard).

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p candle-core` (debug) — all green, no regressions
- `cargo clippy -p candle-core --tests --examples --benches -- -D warnings`
- `cargo test -p candle-core --release --lib` — the 5 overflow tests pass with overflow checks disabled, confirming the guards hold in release builds

## Notes / limitations

- The 32-bit `usize::try_from(u64)` path is statically correct, but I did **not** run it on a `wasm32`/32-bit target locally (no such toolchain on this machine), and I could not find an explicit 32-bit job in candle's existing CI. Flagging this so CI can confirm or a maintainer can decide whether a dedicated 32-bit test is wanted.
- `elem_count()` is intentionally left unchecked to avoid a sweeping 105-call-site API change; only the untrusted-input (loader) paths are hardened.