### PR TITLE
Preserve Wuerstchen timestep embedding dtype

### DIFF
--- a/candle-transformers/src/models/wuerstchen/diffnext.rs
+++ b/candle-transformers/src/models/wuerstchen/diffnext.rs
@@ -289,7 +289,8 @@ impl WDiffNeXt {
         let emb = (MAX_POSITIONS as f64).ln() / (half_dim - 1) as f64;
         let emb = (Tensor::arange(0u32, half_dim as u32, r.device())?.to_dtype(DType::F32)?
             * -emb)?
-            .exp()?;
+            .exp()?
+            .to_dtype(r.dtype())?;
         let emb = r.unsqueeze(1)?.broadcast_mul(&emb.unsqueeze(0)?)?;
         let emb = Tensor::cat(&[emb.sin()?, emb.cos()?], 1)?;
         let emb = if self.c_r % 2 == 1 {

--- a/candle-transformers/src/models/wuerstchen/prior.rs
+++ b/candle-transformers/src/models/wuerstchen/prior.rs
@@ -73,7 +73,8 @@ impl WPrior {
         let emb = (MAX_POSITIONS as f64).ln() / (half_dim - 1) as f64;
         let emb = (Tensor::arange(0u32, half_dim as u32, r.device())?.to_dtype(DType::F32)?
             * -emb)?
-            .exp()?;
+            .exp()?
+            .to_dtype(r.dtype())?;
         let emb = r.unsqueeze(1)?.broadcast_mul(&emb.unsqueeze(0)?)?;
         let emb = Tensor::cat(&[emb.sin()?, emb.cos()?], 1)?;
         let emb = if self.c_r % 2 == 1 {


### PR DESCRIPTION
## Summary

- cast the F32 sinusoidal timestep basis to the model input dtype before the linear projection
- apply the same correction to the prior and DiffNeXt paths
- allow F16/BF16 Wuerstchen weights to avoid mixed-dtype matmul failures

## Test plan

- `cargo test -p candle-transformers wuerstchen --lib`
- Mold workspace CPU and Metal feature checks