### PR TITLE
Avoid unstable AArch64 FP16 vector type

### DIFF
--- a/candle-core/src/cpu/neon.rs
+++ b/candle-core/src/cpu/neon.rs
@@ -157,7 +157,7 @@ mod fp16 {
         pub struct CurrentCpuF16 {}
 
         impl CurrentCpuF16 {
-            fn reduce_one(x: float16x8_t) -> f32 {
+            fn reduce_one(x: uint16x8_t) -> f32 {
                 let result: f32;
                 unsafe {
                     asm!(
@@ -185,8 +185,10 @@ mod fp16 {
         }
 
         impl CpuF16 for CurrentCpuF16 {
-            type Unit = float16x8_t;
-            type Array = [float16x8_t; Self::ARR];
+            // Keep the f16 lane bits in the stable integer vector type. The
+            // inline assembly assigns the floating-point interpretation.
+            type Unit = uint16x8_t;
+            type Array = [uint16x8_t; Self::ARR];
 
             const STEP: usize = 32;
             const EPR: usize = 8;


### PR DESCRIPTION
## Summary

- store FP16 lane bits in stable `uint16x8_t` while inline assembly supplies floating-point semantics
- avoid `stdarch_neon_f16`, which fails on stable Rust when `target-feature=+fp16` is enabled
- preserve the existing optimized FMLA.8h implementation and register layout

## Test plan

- `RUSTFLAGS="-C target-feature=+fp16" cargo check -p candle-core` on aarch64-darwin with stable Rust
- `cargo fmt --all -- --check`

This also unblocks Nix desktop builds that target Apple Silicon FP16.