### PR TITLE
fix: correct SmolLM typo in Llama example CLI arguments

### DIFF
--- a/candle-examples/examples/llama/main.rs
+++ b/candle-examples/examples/llama/main.rs
@@ -43,17 +43,17 @@ enum Which {
     Solar10_7B,
     #[value(name = "tiny-llama-1.1b-chat")]
     TinyLlama1_1BChat,
-    #[value(name = "SmoLM2-1.7B")]
+    #[value(name = "SmolLM2-1.7B")]
     SmolLM2_1B,
-    #[value(name = "SmoLM2-1.7B-Instruct")]
+    #[value(name = "SmolLM2-1.7B-Instruct")]
     SmolLM2_1BInstruct,
-    #[value(name = "SmoLM2-360M")]
+    #[value(name = "SmolLM2-360M")]
     SmolLM2_360M,
-    #[value(name = "SmoLM2-360M-Instruct")]
+    #[value(name = "SmolLM2-360M-Instruct")]
     SmolLM2_360MInstruct,
-    #[value(name = "SmoLM2-135M")]
+    #[value(name = "SmolLM2-135M")]
     SmolLM2_135M,
-    #[value(name = "SmoLM2-135M-Instruct")]
+    #[value(name = "SmolLM2-135M-Instruct")]
     SmolLM2_135MInstruct,
 }
 


### PR DESCRIPTION
## Description
This PR fixes a typo in the `candle-examples/examples/llama/main.rs` file where the CLI argument values for the SmolLM models were missing the letter 'l' (written as `SmoLM` instead of `SmolLM`).

This typo caused `clap` to throw an invalid value error when users tried to run the example using the correct model name (e.g., `cargo run --example llama -- --which SmolLM2-135M`). 

## Changes
- Fixed `SmoLM2-1.7B` -> `SmolLM2-1.7B`
- Fixed `SmoLM2-1.7B-Instruct` -> `SmolLM2-1.7B-Instruct`
- Fixed `SmoLM2-360M` -> `SmolLM2-360M`
- Fixed `SmoLM2-360M-Instruct` -> `SmolLM2-360M-Instruct`
- Fixed `SmoLM2-135M` -> `SmolLM2-135M`
- Fixed `SmoLM2-135M-Instruct` -> `SmolLM2-135M-Instruct`