### PR TITLE
fix(metal): cap how far above its size a request may reuse a pooled buffer

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run macos with metal
         if: matrix.os == 'macOS-latest' 
-        run: cargo check --workspace --features metal
+        run: cargo check --workspace --features metal --all-targets
 
       - name: Run normal cpu
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'windows-latest'

--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -353,9 +353,9 @@ fn buf_size(size: usize) -> usize {
     size.next_power_of_two()
 }
 
-/// How many size classes above its own a request may be served from when reusing a
-/// pooled buffer. See [`reuse_cap`].
-const REUSE_SLACK: usize = 4;
+/// How many power-of-two size classes above its own a request may be served from when
+/// reusing a pooled buffer. See [`reuse_cap`].
+const REUSE_SLACK: u32 = 2;
 
 /// The largest pooled buffer a request of `size` bytes may be reused from.
 ///
@@ -368,8 +368,16 @@ const REUSE_SLACK: usize = 4;
 /// tensors of 9-12 MB each were served from the 256 MB class that the attention scores
 /// use, forcing 46 new 256 MB allocations. Peak activations 15.12 GB, against 4.38 GB
 /// with this cap in place, and the memory-vs-chunk-size curve was non-monotonic.
+///
+/// The cap is deliberately loose. Restricting reuse to the exact size class also removes
+/// the pathology, but costs +36 % at chunk 128 (2.95 GB against 2.19 GB) by forbidding
+/// harmless reuse; allowing only one class above costs +29 %. Two classes is the knee.
+///
+/// Every pooled buffer is allocated at [`buf_size`], so the map is keyed by powers of two
+/// and only power-of-two steps are representable: a cap of `3 * buf_size` would admit
+/// exactly the same buffers as `2 * buf_size`. Hence the shift.
 fn reuse_cap(size: usize) -> usize {
-    REUSE_SLACK.saturating_mul(buf_size(size))
+    buf_size(size).saturating_mul(1usize << REUSE_SLACK)
 }
 
 /// Applies the [`BufferBuilder`] label, clearing any stale label on a reused pooled buffer.
@@ -513,6 +521,9 @@ mod tests {
         // not force exact-size matching, which measured worse (2.95 GB vs 2.19 GB at
         // chunk 128) because it also forbids harmless reuse.
         assert!(reuse_cap(kv) >= buf_size(kv));
+        // 9 MB rounds to the 16 MB class, and REUSE_SLACK = 2 classes above it is 64 MB.
+        assert_eq!(buf_size(kv), 16 << 20);
+        assert_eq!(reuse_cap(kv), buf_size(kv) << REUSE_SLACK);
         assert_eq!(reuse_cap(kv), 64 << 20);
     }
 

--- a/candle-core/src/metal_backend/device.rs
+++ b/candle-core/src/metal_backend/device.rs
@@ -353,6 +353,25 @@ fn buf_size(size: usize) -> usize {
     size.next_power_of_two()
 }
 
+/// How many size classes above its own a request may be served from when reusing a
+/// pooled buffer. See [`reuse_cap`].
+const REUSE_SLACK: usize = 4;
+
+/// The largest pooled buffer a request of `size` bytes may be reused from.
+///
+/// Without a cap, [`find_available_buffer`] hands out the smallest *available* buffer of
+/// any size, however much larger than the request. A long-lived tensor that allocates at a
+/// moment when only much larger buffers happen to be free captures one for the rest of its
+/// life, and every later allocation of that larger size must then allocate a fresh buffer.
+///
+/// Measured on a Qwen2.5-7B Q4_K_M prefill (Metal, ctx 5831, chunk 512): 44 KV-cache
+/// tensors of 9-12 MB each were served from the 256 MB class that the attention scores
+/// use, forcing 46 new 256 MB allocations. Peak activations 15.12 GB, against 4.38 GB
+/// with this cap in place, and the memory-vs-chunk-size curve was non-monotonic.
+fn reuse_cap(size: usize) -> usize {
+    REUSE_SLACK.saturating_mul(buf_size(size))
+}
+
 /// Applies the [`BufferBuilder`] label, clearing any stale label on a reused pooled buffer.
 #[cfg(feature = "metal-debug-labels")]
 #[inline]
@@ -483,13 +502,55 @@ mod tests {
         // a 2-byte buffer. This must not be rounded down to 1.
         assert_eq!(buf_size(2), 2);
     }
+
+    #[test]
+    fn test_reuse_cap_excludes_grossly_oversized_buffers() {
+        // The measured case: a 9 MB KV-cache tensor must not be served from the 256 MB
+        // class the attention scores allocate, or it holds 256 MB for the whole forward.
+        let kv = 9_437_184;
+        assert!(reuse_cap(kv) < 256 << 20);
+        // Its own class and a few above stay reusable -- the cap bounds waste, it does
+        // not force exact-size matching, which measured worse (2.95 GB vs 2.19 GB at
+        // chunk 128) because it also forbids harmless reuse.
+        assert!(reuse_cap(kv) >= buf_size(kv));
+        assert_eq!(reuse_cap(kv), 64 << 20);
+    }
+
+    /// The gate that fails if the cap is not actually applied by the allocator: the pure
+    /// `reuse_cap` tests above pass whether or not `find_available_buffer` consults it.
+    #[test]
+    fn test_allocator_does_not_serve_a_small_request_from_a_huge_free_buffer() {
+        let Ok(crate::Device::Metal(dev)) = crate::Device::new_metal(0) else {
+            return; // no Metal device on this host
+        };
+        // Free a 256 MB buffer into the pool, as an attention-score tensor does.
+        let big = dev.allocate_buffer(256 << 20).unwrap();
+        let big_len = big.length() as usize;
+        drop(big);
+        // A 9 MB KV-cache-sized request must not capture it.
+        let small = dev.allocate_buffer(9_437_184).unwrap();
+        assert_eq!(big_len, 256 << 20);
+        assert!(
+            (small.length() as usize) < big_len,
+            "9MB request was served a {}-byte buffer",
+            small.length()
+        );
+    }
+
+    #[test]
+    fn test_reuse_cap_does_not_overflow() {
+        // A cap computed for a huge request must saturate rather than wrap to a small
+        // number, which would silently disable all reuse.
+        assert_eq!(reuse_cap(usize::MAX / 2), usize::MAX);
+    }
 }
 
 fn find_available_buffer(size: usize, buffers: &BufferMap) -> Option<Arc<Buffer>> {
+    let cap = reuse_cap(size);
     let mut best_buffer: Option<&Arc<Buffer>> = None;
     let mut best_buffer_size = usize::MAX;
     for (buffer_size, subbuffers) in buffers.iter() {
-        if buffer_size >= &size && buffer_size < &best_buffer_size {
+        if buffer_size >= &size && buffer_size <= &cap && buffer_size < &best_buffer_size {
             for sub in subbuffers {
                 if Arc::strong_count(sub) == 1 {
                     best_buffer = Some(sub);


### PR DESCRIPTION
## The problem

`find_available_buffer` returns the smallest **available** pooled buffer of at least the requested size — with no upper bound on how much larger that buffer may be:

```rust
if buffer_size >= &size && buffer_size < &best_buffer_size {
```

Since `buf_size` rounds every allocation up to a power of two, the pool is a set of size classes. A **long-lived** tensor that allocates at a moment when only much larger buffers happen to be free captures one for the rest of its life, and every later allocation of that larger size must then allocate a fresh buffer.

In LLM prefill this collides two tensors with very different lifetimes:

- **attention scores** — large, short-lived, freed and reallocated every layer;
- **the KV cache** — small, but alive for the whole forward, and *growing*, so it changes size class as the sequence grows.

## Measured instance

Qwen2.5-7B Q4_K_M on Metal, ctx 5831, prefill chunked at 512 (an M1 Max, 64 GB).

At chunk `pos=4096` the attention scores are `28 × 512 × 4608 × 4` = 264,241,152 B → the **256 MiB** class, and earlier chunks had already created and freed buffers there. In the same step the KV cache crosses a power-of-two boundary: the model is GQA (4 KV heads × 128 × f32 = 2048 B per token per layer), so each of the 56 K/V tensors grows from exactly 8 MiB at seq 4096 to 9,437,184 B at seq 4608. No 16/32/64/128 MiB buffer was free, so **44 KV-cache tensors were each served a 256 MiB buffer** (28.4× over-service) and held it permanently. The attention scores then had to allocate **46 fresh 256 MiB buffers**.

An allocation trace of that one chunk:

```
46 x new     requested=264241152  bucket=268435456
44 x reuse   requested=  9437184  served=268435456  waste=28.4x
44 x reuse   requested= 10485760  served=268435456  waste=25.6x
44 x reuse   requested= 11534336  served=268435456  waste=23.3x
```

The pool went from 8.51 GB to 20.01 GB in that single chunk — **11.3 GB of buffers holding 0.45 GB of data.**

Because the collision depends on *which size classes happen to be free* when the KV cache grows, the effect is not monotonic in the prefill chunk size — chunk 512 cost more than twice chunk 1024:

| prefill chunk | 128 | 256 | **512** | 1024 | 2048 |
|---|--:|--:|--:|--:|--:|
| activations, main | 2.17 | 5.04 | **15.12** | 6.81 | 12.86 |
| activations, this PR | 2.19 | 3.34 | **4.38** | 6.91 | 13.12 |

(GB; peak `currentAllocatedSize` during prefill minus the weights baseline.) So the conventional chunk size of 512 — the value llama.cpp and mlx use — was the worst available choice, and on a 32B model it was the difference between running and an out-of-memory abort.

## The fix

Cap reuse at 2 power-of-two size classes above the request. After it the curve is monotonic and no chunk size regresses by more than 2 %.

The cap is deliberately loose. Restricting reuse to the exact size class also removes the pathology, but costs **+36 % at chunk 128** (2.95 GB vs 2.19 GB) by forbidding harmless reuse; allowing only 1 class above costs +29 %. 2 classes is the knee of that curve.

Only power-of-two steps are representable here: every pooled buffer is allocated at `buf_size`, so the map is keyed by powers of two and a cap of `3 * buf_size` would admit exactly the same buffers as `2 * buf_size`. The knob is therefore a shift, and the swept values 1, 2, 4 are 0, 1, 2 classes above.

## Verification

- `cargo test --release --features metal -p candle-core` passes. (`conv2d_grad_noncontiguous_kernel_metal` fails, but it fails identically on unmodified `main` — unrelated to this change.)
- Generated token ids are byte-identical with and without the cap on Qwen2.5-0.5B and 7B, from one binary with a runtime override, so the change is numerically inert.
- The added test `test_allocator_does_not_serve_a_small_request_from_a_huge_free_buffer` exercises `allocate_buffer` rather than the helper, and was sabotage-checked: with the cap removed it is the only failure, reporting `9MB request was served a 268435456-byte buffer`.

Measurements were taken on `main` at ab9c3ab1 and on this branch, from separate builds, with the binary checksum recorded for each arm.

