### PR TITLE
Bound the causal SDPA key-block limit to the allocated K/V

### DIFF
--- a/candle-metal-kernels/src/metal_src/scaled_dot_product_attention.metal
+++ b/candle-metal-kernels/src/metal_src/scaled_dot_product_attention.metal
@@ -2064,7 +2064,8 @@ template <
 
   if (do_causal) {
     int q_max = (tid.x + 1) * BQ + params->qL_off;
-    kb_lim = (q_max + BK - 1) / BK;
+    // A partial final query tile still pads to BQ rows, so this can round past NK.
+    kb_lim = min(params->NK, (q_max + BK - 1) / BK);
   }
 
   // Loop over KV seq length

--- a/candle-nn/tests/sdpa.rs
+++ b/candle-nn/tests/sdpa.rs
@@ -184,4 +184,54 @@ mod metal_sdpa_tests {
         assert!(error <= 0.0013, "{}", error);
         Ok(())
     }
+
+    #[test]
+    fn sdpa_causal_partial_query_tile() -> Result<()> {
+        // R is not a multiple of the kernel's BQ tile and L is much larger, so the
+        // final query tile pads past the allocated K/V blocks.
+        const BS: usize = 1;
+        const H: usize = 12;
+        const R: usize = 6;
+        const PREFIX: usize = 376;
+        const L: usize = PREFIX + R;
+        const DK: usize = 64;
+
+        let scale: f64 = f64::from(DK as u32).sqrt().recip();
+        let device = Device::new_metal(0)?;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0x00CA_55A1);
+        let q = randn(&mut rng, (BS, H, R, DK), &device)?;
+        let k = randn(&mut rng, (BS, H, L, DK), &device)?;
+        let v = randn(&mut rng, (BS, H, L, DK), &device)?;
+
+        let mut mask_values = vec![0f32; R * L];
+        for row in 0..R {
+            for column in (PREFIX + row + 1)..L {
+                mask_values[row * L + column] = f32::NEG_INFINITY;
+            }
+        }
+        let mask = Tensor::from_vec(mask_values, (R, L), &device)?.broadcast_as((BS, H, R, L))?;
+        let ground_truth = {
+            let att = ((q.matmul(&k.t()?)? * scale)?.to_dtype(DType::F32)? + mask)?;
+            candle_nn::ops::softmax_last_dim(&att)?
+                .to_dtype(q.dtype())?
+                .matmul(&v)?
+        };
+
+        let sdpa_output = candle_nn::ops::sdpa(&q, &k, &v, None, true, scale as f32, 1.)?;
+        let values = sdpa_output
+            .to_dtype(DType::F32)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        assert!(
+            values.iter().all(|v| v.is_finite()),
+            "causal SDPA produced non-finite output"
+        );
+        let error = (&ground_truth - &sdpa_output)?
+            .abs()?
+            .to_dtype(DType::F32)?
+            .max_all()?
+            .to_scalar::<f32>()?;
+        assert!(error < 0.05, "{}", error);
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

The full Metal SDPA kernel derives its causal key-block limit from a query tile padded to `BQ` rows:

```c
int q_max = (tid.x + 1) * BQ + params->qL_off;
kb_lim = (q_max + BK - 1) / BK;
```

When `q_seq` is not a multiple of `BQ`, `q_max` overshoots the key length and `kb_lim` can exceed `params->NK`. The K/V loop then runs extra iterations, and those take `load_unsafe()` — `load_safe()` is only selected for the single tail block at `kb == params->NK_aligned` — so the kernel reads past the K/V allocation.

At `q_seq = 6` against 382 keys, f32, head_dim 64 (`BQ = BK = 32`, `qL_off = 376`): `kb_lim = 13`, `NK = 12`.

Two things usually hide it. The causal mask assigns `-inf` over every score in the overshoot blocks, so garbage keys cannot reach the output through `S`. And the buffer pool rounds allocations with `next_power_of_two`, so the overread normally lands in that buffer's own padding. It bites when the allocation is exactly sized, or when the padding holds non-finite data, since `P @ V` accumulates `0 * NaN = NaN` and the output goes entirely non-finite despite every probability in those columns being zero.

## Fix

Clamp the derived limit to `params->NK`.

## Test plan

Added `sdpa_causal_partial_query_tile`, covering a partial final query tile against a rectangular K/V with a causal mask, asserting finite output and agreement with a masked-softmax reference.

To be clear, this test passes with and without the fix. Whether the overread lands on harmful data is not controllable from the public API, so it cannot be made to fail deterministically without manipulating allocator internals. The evidence for the fix is shader validation.

With `MTL_SHADER_VALIDATION=1` on an M3, before:

```
Invalid Metal usage: Invalid load in 'device' or 'constant' address space at offset 1174016,
executing compute function: "steel_attention_float32_bq32_bk32_bd64_wm4_wn1_maskfloat32"
MTLBuffer: <no label>, length: 1173504

GPU stack trace:
	* frame #0: load_unsafe() - /program_source:868:48
	* frame #1: attention<float, 32, 32, 64, 4, 1, float, float>() - /program_source:2077:16
```

512 bytes past a 1,173,504-byte buffer. No violations after.

The test is worth keeping on its own: `do_causal = true` on the full kernel had no coverage before it, every existing `sdpa_*` test passes `false`.

Ran:

- `cargo nextest run -p candle-nn --features metal` (98/98)
- the same under `MTL_SHADER_VALIDATION=1`, one violation before, none after
- `cargo fmt --all -- --check`
- `cargo clippy -p candle-nn --features metal --all-targets -- -D warnings`
