### PR TITLE
Fix CUDA conv im2col reading the original strided kernel

### DIFF
--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -1839,15 +1839,14 @@ impl BackendStorage for CudaStorage {
                 Layout::contiguous_with_offset((n, k), kernel_l.start_offset()).transpose(0, 1)?;
             col.matmul(kernel, (1, b * m, n, k), &col_l, &kernel_l)?
         } else {
-            // Make the kernel contiguous if not already the case.
+            // kernel_c is materialized at offset 0, so the layout must not carry the source offset.
             let mut kernel_c = unsafe {
                 self.device()
                     .alloc_uninit(kernel_l.shape(), kernel.dtype())?
             };
             kernel.copy_strided_src(&mut kernel_c, 0, kernel_l)?;
-            let kernel_l =
-                Layout::contiguous_with_offset((n, k), kernel_l.start_offset()).transpose(0, 1)?;
-            col.matmul(kernel, (1, b * m, n, k), &col_l, &kernel_l)?
+            let kernel_l = Layout::contiguous_with_offset((n, k), 0).transpose(0, 1)?;
+            col.matmul(&kernel_c, (1, b * m, n, k), &col_l, &kernel_l)?
         };
         let res_l = Layout::contiguous((b, l_out, n)).transpose(1, 2)?;
         let mut res_t = unsafe { self.device().alloc_uninit(res_l.shape(), res.dtype())? };
@@ -2022,15 +2021,14 @@ impl BackendStorage for CudaStorage {
                 Layout::contiguous_with_offset((n, k), kernel_l.start_offset()).transpose(0, 1)?;
             col.matmul(kernel, (1, b * m, n, k), &col_l, &kernel_l)?
         } else {
-            // Make the kernel contiguous if not already the case.
+            // kernel_c is materialized at offset 0, so the layout must not carry the source offset.
             let mut kernel_c = unsafe {
                 self.device()
                     .alloc_uninit(kernel_l.shape(), kernel.dtype())?
             };
             kernel.copy_strided_src(&mut kernel_c, 0, kernel_l)?;
-            let kernel_l =
-                Layout::contiguous_with_offset((n, k), kernel_l.start_offset()).transpose(0, 1)?;
-            col.matmul(kernel, (1, b * m, n, k), &col_l, &kernel_l)?
+            let kernel_l = Layout::contiguous_with_offset((n, k), 0).transpose(0, 1)?;
+            col.matmul(&kernel_c, (1, b * m, n, k), &col_l, &kernel_l)?
         };
         let res_l = Layout::contiguous((b, h_out, w_out, n))
             .transpose(1, 2)?


### PR DESCRIPTION
## Summary

The non-contiguous branches of CUDA `conv1d` and `conv2d` materialize a contiguous kernel copy with `copy_strided_src`, then build the matmul layout from the original strided kernel's `start_offset()` and pass the matmul the original storage instead of the copy. Both operands are wrong, so a non-contiguous kernel reads garbage.

Same defect as #3736 for CPU `conv2d` and #3836 for CPU `conv1d` and Metal `conv1d`/`conv2d`. Neither covers CUDA, so this is CUDA-only to avoid overlapping #3836.

`conv2d_grad_noncontiguous_kernel` came in with #3736 and is registered for every backend, so the `_gpu` variant already exists and fails on `main` today. It has gone unnoticed because `test-cuda` is skipped on fork PRs.

## Fix

Build the layout at offset 0 to match the materialized buffer, and pass `kernel_c` to the matmul.

## Test plan

No new test. `conv2d_grad_noncontiguous_kernel_gpu` already covers the `conv2d` site. `conv1d` has no regression on `main`; #3836 adds one registered for every backend, which will cover the `conv1d` site here once it lands. Happy to add one if you would rather this stand alone.

On an RTX 4070, CUDA 12.0, at `ab9c3ab1`:

```
FAIL conv2d_grad_noncontiguous_kernel_gpu
assertion `left == right` failed
  left: 25.926
 right: 57.6732
```

The same values #3836 reports for the Metal variant. It passes with this change. I also verified the `conv1d` site separately by temporarily applying #3836's shape of regression locally: it fails on CUDA before this change and passes after.

Ran:

- `cargo nextest run -p candle-core --features cuda --test conv_tests` (18/18)
- `cargo nextest run -p candle-core --features cuda` (283/283)
- `cargo fmt --all -- --check`
