### PR TITLE
Align norm weights to the activation dtype

### DIFF
--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -668,7 +668,9 @@ pub fn rms_norm_slow(x: &Tensor, alpha: &Tensor, eps: f32) -> Result<Tensor> {
     let x = x.to_dtype(internal_dtype)?;
     let norm_x = (x.sqr()?.sum_keepdim(D::Minus1)? / hidden_size as f64)?;
     let x_normed = x.broadcast_div(&(norm_x + eps as f64)?.sqrt()?)?;
-    x_normed.to_dtype(x_dtype)?.broadcast_mul(alpha)
+    x_normed
+        .to_dtype(x_dtype)?
+        .broadcast_mul(&alpha.to_dtype(x_dtype)?)
 }
 
 pub fn rms_norm(xs: &Tensor, alpha: &Tensor, eps: f32) -> Result<Tensor> {
@@ -681,7 +683,10 @@ pub fn rms_norm(xs: &Tensor, alpha: &Tensor, eps: f32) -> Result<Tensor> {
             alpha.shape()
         )
     }
-    xs.apply_op2_no_bwd(alpha, &RmsNorm { eps })
+    // The fused kernels are same-dtype, so a weight stored at a different precision
+    // than the activations is aligned to them rather than rejected.
+    let alpha = alpha.to_dtype(xs.dtype())?;
+    xs.apply_op2_no_bwd(&alpha, &RmsNorm { eps })
 }
 
 #[derive(Debug, Clone)]
@@ -925,8 +930,8 @@ pub fn layer_norm_slow(x: &Tensor, alpha: &Tensor, beta: &Tensor, eps: f32) -> R
     let x_normed = x.broadcast_div(&(norm_x + eps as f64)?.sqrt()?)?;
     x_normed
         .to_dtype(x_dtype)?
-        .broadcast_mul(alpha)?
-        .broadcast_add(beta)
+        .broadcast_mul(&alpha.to_dtype(x_dtype)?)?
+        .broadcast_add(&beta.to_dtype(x_dtype)?)
 }
 
 pub fn layer_norm(xs: &Tensor, alpha: &Tensor, beta: &Tensor, eps: f32) -> Result<Tensor> {
@@ -941,7 +946,11 @@ pub fn layer_norm(xs: &Tensor, alpha: &Tensor, beta: &Tensor, eps: f32) -> Resul
             beta.shape()
         )
     }
-    xs.apply_op3_no_bwd(alpha, beta, &LayerNorm { eps })
+    // The fused kernels are same-dtype, so weights stored at a different precision
+    // than the activations are aligned to them rather than rejected.
+    let alpha = alpha.to_dtype(xs.dtype())?;
+    let beta = beta.to_dtype(xs.dtype())?;
+    xs.apply_op3_no_bwd(&alpha, &beta, &LayerNorm { eps })
 }
 
 // https://pytorch.org/docs/stable/generated/torch.nn.PixelShuffle.html

--- a/candle-nn/tests/ops.rs
+++ b/candle-nn/tests/ops.rs
@@ -187,6 +187,42 @@ fn layer_norml(device: &Device) -> Result<()> {
     Ok(())
 }
 
+// A GGUF norm weight dequantizes to F32 while the model runs F16 activations, so
+// both norms have to align the weight instead of rejecting the pair.
+fn norm_mixed_dtype(device: &Device) -> Result<()> {
+    let data = &[[[3f32, 1., 4.], [1., 5., 9.]], [[2., 1., 7.], [8., 2., 8.]]];
+    let xs = Tensor::new(data, device)?.to_dtype(candle::DType::F16)?;
+    let alpha = Tensor::new(&[1f32, 2., 3.], device)?;
+    let beta = Tensor::new(&[0.5f32, -0.5, 1.], device)?;
+
+    let max_diff = |a: Tensor, b: Tensor| -> Result<f32> {
+        Ok(
+            (a.to_dtype(candle::DType::F32)? - b.to_dtype(candle::DType::F32)?)?
+                .abs()?
+                .flatten_all()?
+                .max(0)?
+                .to_vec0::<f32>()?,
+        )
+    };
+    // Fused and composed round to F16 at different points, so allow an ulp at these
+    // magnitudes (2^-8 = 0.0039).
+    let tol = 5e-3;
+
+    let rms = candle_nn::ops::rms_norm(&xs, &alpha, 1e-5)?;
+    assert_eq!(rms.dtype(), candle::DType::F16);
+    let diff = max_diff(rms, candle_nn::ops::rms_norm_slow(&xs, &alpha, 1e-5)?)?;
+    assert!(diff < tol, "rms_norm: {diff}");
+
+    let ln = candle_nn::ops::layer_norm(&xs, &alpha, &beta, 1e-5)?;
+    assert_eq!(ln.dtype(), candle::DType::F16);
+    let diff = max_diff(
+        ln,
+        candle_nn::ops::layer_norm_slow(&xs, &alpha, &beta, 1e-5)?,
+    )?;
+    assert!(diff < tol, "layer_norm: {diff}");
+    Ok(())
+}
+
 #[test]
 fn softmax_numerical_stability() -> Result<()> {
     let dev = &Device::Cpu;
@@ -379,4 +415,10 @@ test_device!(
 );
 test_device!(layer_norm, ln_cpu, ln_gpu, ln_metal);
 test_device!(layer_norml, lnl_cpu, lnl_gpu, lnl_metal);
+test_device!(
+    norm_mixed_dtype,
+    norm_mixed_dtype_cpu,
+    norm_mixed_dtype_gpu,
+    norm_mixed_dtype_metal
+);
 test_device!(sigmoid, sigmoid_cpu, sigmoid_gpu, sigmoid_metal);


### PR DESCRIPTION
## Summary

`rms_norm` and `layer_norm` dispatch fused kernels that require the weights and the activations to share a dtype. An F32 norm weight against F16 activations fails:

```
rmsnorm is not implemented for F16 F32
layernorm is not implemented for F16 F32 F32
```

This shows up with GGUF, where the norm weight dequantizes to F32 while the model runs F16 activations.

`rms_norm_slow` and `layer_norm_slow` hit the same mismatch one step later: they multiply the weight in after casting the normalized activations back to the input dtype, so `broadcast_mul` sees the mismatched pair.

## Fix

Cast the weights to the activation dtype before dispatch, in all four functions. The result is the activation dtype, so no weight precision that would survive the output is lost.

Same-dtype callers are unaffected — `Tensor::to_dtype` returns a clone when the dtype already matches, so there is no extra allocation on the common path.

## Test plan

Added `norm_mixed_dtype`: F16 activations with F32 weights, covering `rms_norm` and `layer_norm` against their slow references. It fails on `main` with the two errors above.

The tolerance is 5e-3 rather than something tighter. Fused and composed round to F16 at different points and the observed difference is 2^-8 (0.00390625), one ulp at these magnitudes. That matches the tolerance `rms_norm_large_magnitude` already uses in this file.

Ran:

- `cargo nextest run -p candle-nn --features metal` (75/75)
- `cargo nextest run -p candle-nn --features cuda -E 'test(norm)'` on an RTX 4070 (12/12)
- `cargo fmt --all -- --check`
- `cargo clippy -p candle-nn --features metal --all-targets -- -D warnings`
