### PR TITLE
Fix the ug+metal build against the guard-based encoder API

### DIFF
--- a/candle-core/src/custom_op.rs
+++ b/candle-core/src/custom_op.rs
@@ -451,6 +451,7 @@ impl InplaceOp1 for UgIOp1 {
             depth: 1,
         };
         let group_dims = candle_metal_kernels::utils::get_block_dims(b, 1, 1);
+        let encoder: &candle_metal_kernels::metal::ComputeCommandEncoder = encoder.as_ref();
         encoder.set_output_buffer(0, Some(sto.buffer()), 0);
         encoder.dispatch_threads(grid_dims, group_dims);
 


### PR DESCRIPTION
## Summary

`cargo build -p candle-core --features ug,metal` does not compile on `main`:

```
error[E0599]: no method named `set_output_buffer` found for struct `CommandsGuard<'a>` in the current scope
   --> candle-core/src/custom_op.rs:454:17

error[E0599]: no method named `dispatch_threads` found for struct `CommandsGuard<'a>` in the current scope
   --> candle-core/src/custom_op.rs:455:17
```

`UgIOp1::metal_fwd` calls both directly on the `CommandsGuard`, which only forwards pipeline-state and label calls since the concurrent-dispatch rework.

CI does not build any `ug` feature combination, so this was not caught.

## Fix

Deref to the underlying `ComputeCommandEncoder` before the buffer and dispatch calls, the same way the other metal call sites use the guard.

## Test plan

`ug_op` in `candle-core/tests/custom_op_tests.rs` already covers this path, gated on `ug` plus `cuda` or `metal`. It could not be compiled on `main`; it passes with this change.

Ran:

- `cargo build -p candle-core --features ug,metal`
- `cargo nextest run -p candle-core --features ug,metal --test custom_op_tests` (4/4)
- `cargo fmt --all -- --check`

Happy to follow up with a `cargo check --features ug` CI job if you want the combination covered, since that is what would have caught this.
