### PR TITLE
Fix the Metal f16/f32 quantized matvec dispatch, add bf16

### DIFF
--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -43,18 +43,10 @@ pub fn call_quantized_matmul_mv_t(
     let ne02 = b as i64;
     let ne03 = 1i64;
 
-    let nb00 = 0i64;
-    let nb01 = 0i64;
-    let nb02 = 0i64;
-
     let ne10 = k as i64;
     let ne11 = m as i64;
     let ne12 = b as i64;
     let ne13 = 1i64;
-
-    let nb10 = 0i64;
-    let nb11 = 0i64;
-    let nb12 = 0i64;
 
     let ne0 = n as i64;
     let ne1 = m as i64;
@@ -100,22 +92,42 @@ pub fn call_quantized_matmul_mv_t(
             (nth0, nth1, align)
         }
         GgmlDType::F16 | GgmlDType::BF16 | GgmlDType::Q8K => {
-            // Original implem uses rows
+            // The dense kernel covers one dst row per threadgroup.
             let nth0 = 32;
             let nth1 = 1;
-            let align = 8;
+            let align = 1;
             (nth0, nth1, align)
         }
         GgmlDType::F32 => {
             let nth0 = 32;
             let nth1 = 1;
-            let align = 8;
+            let align = 1;
             (nth0, nth1, align)
         }
     };
+
+    // The dense f16/f32 kernel addresses src0/src1 through these byte strides;
+    // the quantized kernels derive theirs from ne00/ne01 and ignore nb00..nb02.
+    let src0_elem_size = match dtype {
+        GgmlDType::F32 => 4i64,
+        GgmlDType::F16 | GgmlDType::BF16 => 2i64,
+        _ => 0i64,
+    };
+    let nb00 = src0_elem_size;
+    let nb01 = src0_elem_size * ne00;
+    let nb02 = src0_elem_size * ne00 * ne01;
+    let nb10 = 4i64;
+    let nb11 = nb10 * ne10;
+    let nb12 = nb11 * ne11;
+
+    // Number of src1 rows the kernel covers per threadgroup in grid y.
+    let ny = match dtype {
+        GgmlDType::F16 | GgmlDType::BF16 | GgmlDType::F32 => 4,
+        _ => 1,
+    };
     let thread_groups_count = MTLSize {
         width: divide(ne01 as usize, align),
-        height: ne11 as usize,
+        height: divide(ne11 as usize, ny),
         depth: (ne12 * ne13) as usize,
     };
     let threads_per_threadgroup = MTLSize {
@@ -129,16 +141,21 @@ pub fn call_quantized_matmul_mv_t(
         GgmlDType::Q5_0 => "kernel_mul_mv_q5_0_f32",
         GgmlDType::Q5_1 => "kernel_mul_mv_q5_1_f32",
         GgmlDType::Q8_0 => "kernel_mul_mv_q8_0_f32",
-        GgmlDType::Q8_1 => "kernel_mul_mv_q8_1_f32",
         GgmlDType::Q2K => "kernel_mul_mv_q2_K_f32",
         GgmlDType::Q3K => "kernel_mul_mv_q3_K_f32",
         GgmlDType::Q4K => "kernel_mul_mv_q4_K_f32",
         GgmlDType::Q5K => "kernel_mul_mv_q5_K_f32",
         GgmlDType::Q6K => "kernel_mul_mv_q6_K_f32",
-        GgmlDType::Q8K => "kernel_mul_mv_q8_K_f32",
         GgmlDType::F16 => "kernel_mul_mv_f16_f32",
         GgmlDType::BF16 => "kernel_mul_mv_bf16_f32",
         GgmlDType::F32 => "kernel_mul_mv_f32_f32",
+        // Activation-side formats in ggml, never weights: nothing in the shader
+        // references block_q8_1 or block_q8_K. mm_t and get_rows reject them too.
+        GgmlDType::Q8_1 => Err(MetalKernelError::UnsupportedDTypeForOp(
+            "Q8_1",
+            "qmatmul_mv",
+        ))?,
+        GgmlDType::Q8K => Err(MetalKernelError::UnsupportedDTypeForOp("Q8K", "qmatmul_mv"))?,
     };
 
     let pipeline = kernels.load_pipeline(device, Source::Quantized, name)?;

--- a/candle-metal-kernels/src/metal_src/quantized.metal
+++ b/candle-metal-kernels/src/metal_src/quantized.metal
@@ -2713,6 +2713,7 @@ typedef decltype(kernel_mul_mv<half, half4, half, half4>) mul_mv_t;
 template [[host_name("kernel_mul_mv_f32_f32")]]   kernel mul_mv_t kernel_mul_mv<float,  float4,  float,  float4>;
 template [[host_name("kernel_mul_mv_f16_f32")]]   kernel mul_mv_t kernel_mul_mv<half,   half4,   float,  float4>;
 template [[host_name("kernel_mul_mv_f16_f16")]]   kernel mul_mv_t kernel_mul_mv<half,   half4,   half,   half4>;
+template [[host_name("kernel_mul_mv_bf16_f32")]]  kernel mul_mv_t kernel_mul_mv<bfloat, bfloat4, float,  float4>;
 
 template<typename T, typename T4>
 kernel void kernel_mul_mv_1row(

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2491,3 +2491,100 @@ fn residency_set_batch_insert_remove() {
     set.remove_batch(std::iter::empty());
     assert_eq!(raw.allocationCount(), base);
 }
+
+// QMatMul dequantizes float dtypes, so these arms are only reachable by calling
+// the kernel directly. Every dst row must be written, and each must read its own
+// weight row rather than row 0.
+fn run_mv_float_weights<T: Clone>(dtype: GgmlDType, weights: &[T], k: usize) -> Vec<f32> {
+    let device = device();
+    let kernels = Kernels::new();
+    let n = weights.len() / k;
+    let lhs: Vec<f32> = (0..k).map(|i| ((i % 7) as f32 - 3.0) * 0.25).collect();
+
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    let weights_buf = new_buffer(&device, weights);
+    let lhs_buf = new_buffer(&device, &lhs);
+    let dst_buf = new_buffer(&device, &vec![f32::NAN; n]);
+    call_quantized_matmul_mv_t(
+        &device,
+        &encoder,
+        &kernels,
+        dtype,
+        (1, 1, n, k),
+        &lhs_buf,
+        0,
+        &weights_buf,
+        0,
+        &dst_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+    read_to_vec(&dst_buf, n)
+}
+
+#[test]
+fn quantized_matmul_mv_float_weights() {
+    let (n, k) = (32usize, 64usize);
+    let weights: Vec<f32> = (0..n * k)
+        .map(|i| ((i % 23) as f32 - 11.0) * 0.125)
+        .collect();
+    let lhs: Vec<f32> = (0..k).map(|i| ((i % 7) as f32 - 3.0) * 0.25).collect();
+    // The kernel widens each weight to f32 and accumulates there, so the
+    // reference rounds the weights the same way and stays exact otherwise.
+    let reference = |round: &dyn Fn(f32) -> f32| -> Vec<f32> {
+        (0..n)
+            .map(|row| {
+                (0..k)
+                    .map(|col| round(weights[row * k + col]) * lhs[col])
+                    .sum::<f32>()
+            })
+            .collect()
+    };
+
+    let got = run_mv_float_weights(GgmlDType::F32, &weights, k);
+    assert_eq!(approx(got, 4), approx(reference(&|v| v), 4));
+
+    let half: Vec<f16> = weights.iter().map(|v| f16::from_f32(*v)).collect();
+    let got = run_mv_float_weights(GgmlDType::F16, &half, k);
+    assert_eq!(
+        approx(got, 4),
+        approx(reference(&|v| f16::from_f32(v).to_f32()), 4)
+    );
+
+    let brain: Vec<bf16> = weights.iter().map(|v| bf16::from_f32(*v)).collect();
+    let got = run_mv_float_weights(GgmlDType::BF16, &brain, k);
+    assert_eq!(
+        approx(got, 4),
+        approx(reference(&|v| bf16::from_f32(v).to_f32()), 4)
+    );
+}
+
+// Q8_1 and Q8_K are activation-side formats in ggml, never weights, so neither
+// the mat-vec nor the mat-mat path has a kernel for them.
+#[test]
+fn quantized_matmul_mv_rejects_activation_only_dtypes() {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    let buf = new_buffer(&device, &[0f32; 32]);
+    for dtype in [GgmlDType::Q8_1, GgmlDType::Q8K] {
+        assert!(matches!(
+            call_quantized_matmul_mv_t(
+                &device,
+                &encoder,
+                &kernels,
+                dtype,
+                (1, 1, 8, 4),
+                &buf,
+                0,
+                &buf,
+                0,
+                &buf,
+            ),
+            Err(MetalKernelError::UnsupportedDTypeForOp(_, "qmatmul_mv"))
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

The dense f16/f32 arm of `call_quantized_matmul_mv_t` does not work.

`kernel_mul_mv_impl` takes `r0 = tgpig.x` as the dst row, so it covers one row per threadgroup, and it addresses the weights as `offset0 = r0*nb01 + ...`. The host passed `nb00..nb02 = nb10..nb12 = 0` and `align = 8`:

- with zeroed strides every output row reads weight row 0;
- with `align = 8` the grid is `ceil(n/8)` wide, so seven eighths of `dst` is never written;
- the grid height ignores the kernel's `N_MV_T_T = 4` src1 tiling, so `m > 1` launches four times the threadgroups it needs. The kernel breaks on `r1 >= ne11`, so that one is wasted work rather than a wrong result.

`BF16` named `kernel_mul_mv_bf16_f32`, which the shader never instantiated, even though `kernel_mul_mm_bf16_f32` and `kernel_get_rows_bf16` both exist. bf16 weights worked for mat-mat and embeddings but fell over at mat-vec.

`Q8_1` and `Q8K` named kernels that do not exist either, but unlike bf16 these are not weight formats. In ggml they are the activation side of a dot product — `VecDotType` in `k_quants.rs` pairs Q4_1/Q5_1 with Q8_1 and the K-quants with Q8_K — and nothing in the shader references `block_q8_1` or `block_q8_K`, so there is no machinery to hook a kernel onto. `call_quantized_matmul_mm_t` and `call_quantized_get_rows` already reject both.

None of this is reachable through `QMatMul`, which dequantizes F32/F16/BF16 in `from_arc`. It is reachable by anything calling `candle-metal-kernels` directly.

## Fix

Real byte strides from the dtype's element size, one threadgroup per dst row, and a grid height divided by the src1 tiling.

Instantiate the existing `kernel_mul_mv` template for `bfloat` — one line, and the shader already requires `bfloat` unconditionally for `kernel_mul_mm_bf16_f32`.

Return `UnsupportedDTypeForOp` for Q8_1/Q8K from the name match, matching `call_quantized_matmul_mm_t` and `call_quantized_get_rows`.

## Test plan

Two tests in `candle-metal-kernels`, which is where the kernel can be dispatched directly.

`quantized_matmul_mv_float_weights` fills dst with NaN and checks every row for f32, f16 and bf16 against a reference that rounds the weights the same way the kernel does, so the tolerance stays tight across all three. On `main` the f32 case gives:

```
left:  [-0.5938, -0.5938, -0.5938, -0.5938, NaN, NaN, ... NaN]
right: [-0.5938,  0.5938,  0.3438, -1.3438, 2.7188, ...]
```

The first four rows are row 0 repeated, and the remaining 28 were never written.

`quantized_matmul_mv_rejects_activation_only_dtypes` covers Q8_1 and Q8K.

CI will not exercise either: `cargo test --workspace` on macOS carries no metal feature, and `candle-metal-kernels` is not a workspace member, so its test module never runs there. The shader is also compiled at runtime, so the new bf16 instantiation is only validated by running on a device.

Ran on an M3:

- `cargo nextest run --manifest-path candle-metal-kernels/Cargo.toml` (62/62)
- `cargo nextest run -p candle-core --features metal -E 'test(quantized)'` (34/34)
- `cargo fmt --all -- --check`

This does not touch the quantized dtypes. The mat-vec tail out-of-bounds behaviour for the K-quants is a separate fix.
