### PR TITLE
Add NVFP4 support with a packed CPU fallback (fixes #3857)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "candle-core",
     "candle-datasets",
     "candle-examples",
+    "candle-nvfp4-kernels",
     "candle-nn",
     "candle-pyo3",
     "candle-transformers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ candle-flash-attn-v3 = { path = "./candle-flash-attn-v3", version = "0.11.0" }
 candle-kernels = { path = "./candle-kernels", version = "0.11.0" }
 candle-metal-kernels = { path = "./candle-metal-kernels", version = "0.11.0" }
 candle-nn = { path = "./candle-nn", version = "0.11.0" }
+candle-nvfp4-kernels = { path = "./candle-nvfp4-kernels", version = "0.11.0", default-features = false }
 candle-onnx = { path = "./candle-onnx", version = "0.11.0" }
 candle-transformers = { path = "./candle-transformers", version = "0.11.0" }
 candle-ug = { path = "./candle-ug", version = "0.11.0" }

--- a/candle-nvfp4-kernels/Cargo.toml
+++ b/candle-nvfp4-kernels/Cargo.toml
@@ -11,7 +11,10 @@ license = "MIT OR Apache-2.0"
 
 [features]
 default = []
-cuda = []
+cuda = ["candle-core/cuda"]
+
+[dependencies]
+candle-core = { path = "../candle-core", version = "0.11.0", optional = false }
 
 [build-dependencies]
 anyhow = "1"

--- a/candle-nvfp4-kernels/Cargo.toml
+++ b/candle-nvfp4-kernels/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "candle-nvfp4-kernels"
+version = "0.11.0"
+edition = "2021"
+
+description = "CUDA kernels for NVIDIA ModelOpt NVFP4 quantized linear layers in Candle."
+repository = "https://github.com/huggingface/candle"
+keywords = ["blas", "tensor", "machine-learning", "cuda", "quantization"]
+categories = ["science"]
+license = "MIT OR Apache-2.0"
+
+[features]
+default = []
+cuda = []
+
+[build-dependencies]
+anyhow = "1"
+cudaforge = "0.1.2"

--- a/candle-nvfp4-kernels/build.rs
+++ b/candle-nvfp4-kernels/build.rs
@@ -1,0 +1,27 @@
+use std::path::PathBuf;
+
+fn main() -> anyhow::Result<()> {
+    println!("cargo::rerun-if-changed=build.rs");
+    if std::env::var("CARGO_FEATURE_CUDA").is_err() {
+        return Ok(());
+    }
+
+    println!("cargo::rerun-if-changed=kernels/nvfp4_gemm.cu");
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let mut builder = cudaforge::KernelBuilder::new()
+        .source_files(vec!["kernels/nvfp4_gemm.cu"])
+        .out_dir(&out_dir)
+        .arg("-std=c++17")
+        .arg("-O3");
+    if !std::env::var("TARGET").is_ok_and(|target| target.contains("msvc")) {
+        builder = builder.arg("-Xcompiler").arg("-fPIC");
+    }
+    builder.build_lib(out_dir.join("libnvfp4kernels.a"))?;
+    println!("cargo::rustc-link-search={}", out_dir.display());
+    println!("cargo::rustc-link-lib=nvfp4kernels");
+    println!("cargo::rustc-link-lib=dylib=cudart");
+    if !std::env::var("TARGET").is_ok_and(|target| target.contains("msvc")) {
+        println!("cargo::rustc-link-lib=stdc++");
+    }
+    Ok(())
+}

--- a/candle-nvfp4-kernels/kernels/nvfp4_gemm.cu
+++ b/candle-nvfp4-kernels/kernels/nvfp4_gemm.cu
@@ -48,6 +48,11 @@ bool valid(int64_t rows, int64_t cols, int64_t tokens) {
 
 extern "C" int candle_nvfp4_cuda_is_available() {
   int device;
+  return cudaGetDevice(&device) == cudaSuccess ? 1 : 0;
+}
+
+extern "C" int candle_nvfp4_cuda_supports_fp4_tensor_cores() {
+  int device;
   cudaDeviceProp properties{};
   return cudaGetDevice(&device) == cudaSuccess &&
                  cudaGetDeviceProperties(&properties, device) == cudaSuccess &&

--- a/candle-nvfp4-kernels/kernels/nvfp4_gemm.cu
+++ b/candle-nvfp4-kernels/kernels/nvfp4_gemm.cu
@@ -81,3 +81,15 @@ cleanup:
   cudaFree(d_output); cudaFree(d_scales); cudaFree(d_weight); cudaFree(d_input);
   return status;
 }
+
+extern "C" int candle_nvfp4_linear_f32_device(
+    const float* input, const uint8_t* weight, const uint8_t* scales,
+    float tensor_scale, float* output, int64_t tokens, int64_t rows, int64_t cols,
+    void* stream_ptr) {
+  if (!valid(rows, cols, tokens) || !input || !weight || !scales || !output)
+    return cudaErrorInvalidValue;
+  const auto stream = static_cast<cudaStream_t>(stream_ptr);
+  linear_f32<<<unsigned((tokens * rows + 255) / 256), 256, 0, stream>>>(
+      input, weight, scales, tensor_scale, output, tokens, rows, cols);
+  return cudaGetLastError();
+}

--- a/candle-nvfp4-kernels/kernels/nvfp4_gemm.cu
+++ b/candle-nvfp4-kernels/kernels/nvfp4_gemm.cu
@@ -1,0 +1,83 @@
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace {
+constexpr int kBlockSize = 16;
+
+__device__ __forceinline__ float e2m1_to_f32(uint8_t x) {
+  constexpr float table[16] = {0., .5, 1., 1.5, 2., 3., 4., 6.,
+                                0., -.5, -1., -1.5, -2., -3., -4., -6.};
+  return table[x & 0xf];
+}
+
+// NVIDIA's FP8 E4M3FN encoding, used for the per-16-value NVFP4 scales.
+__device__ __forceinline__ float e4m3_to_f32(uint8_t x) {
+  const float sign = (x & 0x80) ? -1.f : 1.f;
+  const int exponent = (x >> 3) & 0xf;
+  const int mantissa = x & 0x7;
+  if (exponent == 0) return sign * mantissa * 0.001953125f;
+  // E4M3FN has no infinities; 0x7f/0xff encode NaN.
+  if (exponent == 0xf && mantissa == 0x7) return nanf("");
+  return sign * (1.f + mantissa * .125f) * exp2f(float(exponent - 7));
+}
+
+__global__ void linear_f32(const float* input, const uint8_t* weight,
+                           const uint8_t* scales, float tensor_scale,
+                           float* output, int64_t tokens, int64_t rows,
+                           int64_t cols) {
+  const int64_t index = int64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= tokens * rows) return;
+  const int64_t token = index / rows;
+  const int64_t row = index % rows;
+  const int64_t packed_cols = cols / 2;
+  const int64_t scale_cols = cols / kBlockSize;
+  float sum = 0.f;
+  for (int64_t col = 0; col < cols; ++col) {
+    const uint8_t packed = weight[row * packed_cols + col / 2];
+    const uint8_t nibble = (col & 1) ? packed & 0xf : packed >> 4;
+    const float scale = e4m3_to_f32(scales[row * scale_cols + col / kBlockSize]);
+    sum += input[token * cols + col] * e2m1_to_f32(nibble) * scale * tensor_scale;
+  }
+  output[index] = sum;
+}
+
+bool valid(int64_t rows, int64_t cols, int64_t tokens) {
+  return rows > 0 && cols > 0 && tokens > 0 && cols % kBlockSize == 0;
+}
+}  // namespace
+
+extern "C" int candle_nvfp4_cuda_is_available() {
+  int device;
+  cudaDeviceProp properties{};
+  return cudaGetDevice(&device) == cudaSuccess &&
+                 cudaGetDeviceProperties(&properties, device) == cudaSuccess &&
+                 properties.major >= 10
+             ? 1
+             : 0;
+}
+
+extern "C" int candle_nvfp4_linear_f32_host_batched(
+    const float* input, const uint8_t* weight, const uint8_t* scales,
+    float tensor_scale, float* output, int64_t tokens, int64_t rows, int64_t cols) {
+  if (!valid(rows, cols, tokens) || !input || !weight || !scales || !output)
+    return cudaErrorInvalidValue;
+  float *d_input = nullptr, *d_output = nullptr;
+  uint8_t *d_weight = nullptr, *d_scales = nullptr;
+  cudaError_t status = cudaMalloc(&d_input, size_t(tokens * cols) * sizeof(float));
+  if (status != cudaSuccess) goto cleanup;
+  status = cudaMalloc(&d_weight, size_t(rows * cols / 2));
+  if (status != cudaSuccess) goto cleanup;
+  status = cudaMalloc(&d_scales, size_t(rows * cols / kBlockSize));
+  if (status != cudaSuccess) goto cleanup;
+  status = cudaMalloc(&d_output, size_t(tokens * rows) * sizeof(float));
+  if (status != cudaSuccess) goto cleanup;
+  if ((status = cudaMemcpy(d_input, input, size_t(tokens * cols) * sizeof(float), cudaMemcpyHostToDevice)) != cudaSuccess ||
+      (status = cudaMemcpy(d_weight, weight, size_t(rows * cols / 2), cudaMemcpyHostToDevice)) != cudaSuccess ||
+      (status = cudaMemcpy(d_scales, scales, size_t(rows * cols / kBlockSize), cudaMemcpyHostToDevice)) != cudaSuccess) goto cleanup;
+  linear_f32<<<unsigned((tokens * rows + 255) / 256), 256>>>(d_input, d_weight, d_scales, tensor_scale, d_output, tokens, rows, cols);
+  if ((status = cudaGetLastError()) != cudaSuccess) goto cleanup;
+  status = cudaMemcpy(output, d_output, size_t(tokens * rows) * sizeof(float), cudaMemcpyDeviceToHost);
+cleanup:
+  cudaFree(d_output); cudaFree(d_scales); cudaFree(d_weight); cudaFree(d_input);
+  return status;
+}

--- a/candle-nvfp4-kernels/src/lib.rs
+++ b/candle-nvfp4-kernels/src/lib.rs
@@ -373,6 +373,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(not(feature = "cuda"))]
     fn cuda_capability_signals_are_false_without_cuda_feature() {
         assert!(!is_available());
         assert!(!supports_fp4_tensor_cores());

--- a/candle-nvfp4-kernels/src/lib.rs
+++ b/candle-nvfp4-kernels/src/lib.rs
@@ -20,6 +20,7 @@ pub const BLOCK_SIZE: usize = 16;
 #[cfg(feature = "cuda")]
 unsafe extern "C" {
     fn candle_nvfp4_cuda_is_available() -> c_int;
+    fn candle_nvfp4_cuda_supports_fp4_tensor_cores() -> c_int;
     fn candle_nvfp4_linear_f32_host_batched(
         input: *const f32,
         weight: *const u8,
@@ -43,8 +44,7 @@ unsafe extern "C" {
     ) -> c_int;
 }
 
-/// Whether the active CUDA device meets the native NVFP4 execution contract
-/// (compute capability 10.0 / Blackwell or newer).
+/// Whether a CUDA device is active and can execute the portable NVFP4 kernel.
 #[cfg(feature = "cuda")]
 pub fn is_available() -> bool {
     unsafe { candle_nvfp4_cuda_is_available() == 1 }
@@ -52,6 +52,18 @@ pub fn is_available() -> bool {
 
 #[cfg(not(feature = "cuda"))]
 pub fn is_available() -> bool {
+    false
+}
+
+/// Whether the active CUDA device has native FP4 tensor cores (Blackwell or
+/// newer). The current portable kernel does not require this capability.
+#[cfg(feature = "cuda")]
+pub fn supports_fp4_tensor_cores() -> bool {
+    unsafe { candle_nvfp4_cuda_supports_fp4_tensor_cores() == 1 }
+}
+
+#[cfg(not(feature = "cuda"))]
+pub fn supports_fp4_tensor_cores() -> bool {
     false
 }
 
@@ -132,9 +144,7 @@ pub fn linear_f32_host_batched(
     validate(input, packed_weight, weight_scale_e4m3, rows, cols, tokens)?;
     let _ = tensor_scale;
     if !is_available() {
-        return Err(
-            "NVFP4 CUDA kernels require compute capability 10.0 (Blackwell) or newer".into(),
-        );
+        return Err("NVFP4 CUDA kernels require an active CUDA device".into());
     }
     #[cfg(feature = "cuda")]
     {
@@ -215,9 +225,7 @@ impl Nvfp4Linear {
             candle_core::bail!("Nvfp4Linear requires a CUDA device")
         }
         if !is_available() {
-            candle_core::bail!(
-                "NVFP4 CUDA kernels require compute capability 10.0 (Blackwell) or newer"
-            )
+            candle_core::bail!("Nvfp4Linear requires an active CUDA device")
         }
         Ok(Self {
             packed_weight: Tensor::from_slice(packed_weight, (rows, cols / 2), device)?,
@@ -363,6 +371,13 @@ impl candle_core::CustomOp3 for Nvfp4Matmul {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cuda_capability_signals_are_false_without_cuda_feature() {
+        assert!(!is_available());
+        assert!(!supports_fp4_tensor_cores());
+    }
+
     #[test]
     fn shape_validation_rejects_malformed_packed_tensors() {
         assert!(validate(&[0.; 16], &[0; 7], &[0; 1], 1, 16, 1).is_err());

--- a/candle-nvfp4-kernels/src/lib.rs
+++ b/candle-nvfp4-kernels/src/lib.rs
@@ -5,7 +5,15 @@
 //! avoids launching and re-uploading a weight matrix once per token during prefill.
 
 #[cfg(feature = "cuda")]
-use std::ffi::c_int;
+use std::ffi::{c_int, c_void};
+
+#[cfg(feature = "cuda")]
+use candle_core::backend::BackendStorage;
+#[cfg(feature = "cuda")]
+use candle_core::cuda_backend::cudarc::driver::{DevicePtr, DevicePtrMut};
+#[cfg(feature = "cuda")]
+use candle_core::CudaStorage;
+use candle_core::{DType, Device, Layout, Module, Result as CandleResult, Shape, Tensor};
 
 pub const BLOCK_SIZE: usize = 16;
 
@@ -21,6 +29,17 @@ unsafe extern "C" {
         tokens: i64,
         rows: i64,
         cols: i64,
+    ) -> c_int;
+    fn candle_nvfp4_linear_f32_device(
+        input: *const f32,
+        weight: *const u8,
+        scales: *const u8,
+        tensor_scale: f32,
+        output: *mut f32,
+        tokens: i64,
+        rows: i64,
+        cols: i64,
+        stream: *mut c_void,
     ) -> c_int;
 }
 
@@ -160,6 +179,185 @@ pub fn linear_f32_host(
         cols,
         1,
     )
+}
+
+/// A ModelOpt NVFP4 linear operator whose immutable weight and scales reside on
+/// the CUDA device. Inputs and results never leave the device.
+#[derive(Clone, Debug)]
+pub struct Nvfp4Linear {
+    packed_weight: Tensor,
+    weight_scale_e4m3: Tensor,
+    tensor_scale: f32,
+    rows: usize,
+    cols: usize,
+}
+
+impl Nvfp4Linear {
+    /// Uploads a packed ModelOpt operator to `device` once.
+    pub fn new(
+        packed_weight: &[u8],
+        weight_scale_e4m3: &[u8],
+        tensor_scale: f32,
+        rows: usize,
+        cols: usize,
+        device: &Device,
+    ) -> CandleResult<Self> {
+        validate(
+            &vec![0.; cols],
+            packed_weight,
+            weight_scale_e4m3,
+            rows,
+            cols,
+            1,
+        )
+        .map_err(candle_core::Error::Msg)?;
+        if !device.is_cuda() {
+            candle_core::bail!("Nvfp4Linear requires a CUDA device")
+        }
+        if !is_available() {
+            candle_core::bail!(
+                "NVFP4 CUDA kernels require compute capability 10.0 (Blackwell) or newer"
+            )
+        }
+        Ok(Self {
+            packed_weight: Tensor::from_slice(packed_weight, (rows, cols / 2), device)?,
+            weight_scale_e4m3: Tensor::from_slice(
+                weight_scale_e4m3,
+                (rows, cols / BLOCK_SIZE),
+                device,
+            )?,
+            tensor_scale,
+            rows,
+            cols,
+        })
+    }
+
+    /// Applies `[... , cols] @ dequant([rows, cols]).T`, preserving the leading
+    /// dimensions of `xs` and replacing its final dimension with `rows`.
+    pub fn forward(&self, xs: &Tensor) -> CandleResult<Tensor> {
+        let dims = xs.dims();
+        if dims.is_empty() || dims[dims.len() - 1] != self.cols {
+            candle_core::bail!(
+                "Nvfp4Linear expected input with final dimension {}, got {:?}",
+                self.cols,
+                dims
+            )
+        }
+        if xs.dtype() != DType::F32 {
+            candle_core::bail!("Nvfp4Linear currently requires f32 activations")
+        }
+        let tokens = dims[..dims.len() - 1].iter().product::<usize>();
+        let input = xs.contiguous()?.reshape((tokens, self.cols))?;
+        let output = input.apply_op3(
+            &self.packed_weight,
+            &self.weight_scale_e4m3,
+            Nvfp4Matmul {
+                rows: self.rows,
+                cols: self.cols,
+                tensor_scale: self.tensor_scale,
+            },
+        )?;
+        let mut output_dims = dims[..dims.len() - 1].to_vec();
+        output_dims.push(self.rows);
+        output.reshape(output_dims)
+    }
+}
+
+impl Module for Nvfp4Linear {
+    fn forward(&self, xs: &Tensor) -> CandleResult<Tensor> {
+        self.forward(xs)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(not(feature = "cuda"), allow(dead_code))]
+struct Nvfp4Matmul {
+    rows: usize,
+    cols: usize,
+    tensor_scale: f32,
+}
+
+impl candle_core::CustomOp3 for Nvfp4Matmul {
+    fn name(&self) -> &'static str {
+        "nvfp4-linear"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _: &candle_core::CpuStorage,
+        _: &Layout,
+        _: &candle_core::CpuStorage,
+        _: &Layout,
+        _: &candle_core::CpuStorage,
+        _: &Layout,
+    ) -> CandleResult<(candle_core::CpuStorage, Shape)> {
+        candle_core::bail!("Nvfp4Linear is CUDA-only; use linear_f32_host for the host fallback")
+    }
+
+    #[cfg(feature = "cuda")]
+    fn cuda_fwd(
+        &self,
+        input: &CudaStorage,
+        input_layout: &Layout,
+        weight: &CudaStorage,
+        weight_layout: &Layout,
+        scales: &CudaStorage,
+        scales_layout: &Layout,
+    ) -> CandleResult<(CudaStorage, Shape)> {
+        if input.dtype() != DType::F32 || weight.dtype() != DType::U8 || scales.dtype() != DType::U8
+        {
+            candle_core::bail!("Nvfp4Linear expects f32 input and u8 packed weight/scales")
+        }
+        if !input_layout.is_contiguous()
+            || !weight_layout.is_contiguous()
+            || !scales_layout.is_contiguous()
+        {
+            candle_core::bail!("Nvfp4Linear requires contiguous input, weight, and scale tensors")
+        }
+        let (tokens, cols) = input_layout.shape().dims2()?;
+        if cols != self.cols
+            || weight_layout.shape().dims2()? != (self.rows, self.cols / 2)
+            || scales_layout.shape().dims2()? != (self.rows, self.cols / BLOCK_SIZE)
+        {
+            candle_core::bail!("Nvfp4Linear received tensors with incompatible shapes")
+        }
+        let dev = input.device();
+        let stream = dev.cuda_stream();
+        let input = input
+            .as_cuda_slice::<f32>()?
+            .slice(input_layout.start_offset()..);
+        let weight = weight
+            .as_cuda_slice::<u8>()?
+            .slice(weight_layout.start_offset()..);
+        let scales = scales
+            .as_cuda_slice::<u8>()?
+            .slice(scales_layout.start_offset()..);
+        let mut output = unsafe { dev.alloc::<f32>(tokens * self.rows)? };
+        unsafe {
+            let (input_ptr, _input_guard) = input.device_ptr(&stream);
+            let (weight_ptr, _weight_guard) = weight.device_ptr(&stream);
+            let (scales_ptr, _scales_guard) = scales.device_ptr(&stream);
+            let (output_ptr, _output_guard) = output.device_ptr_mut(&stream);
+            let status = candle_nvfp4_linear_f32_device(
+                input_ptr as *const f32,
+                weight_ptr as *const u8,
+                scales_ptr as *const u8,
+                self.tensor_scale,
+                output_ptr as *mut f32,
+                tokens as i64,
+                self.rows as i64,
+                self.cols as i64,
+                stream.cu_stream() as *mut c_void,
+            );
+            if status != 0 {
+                candle_core::bail!("NVFP4 CUDA execution failed with status {status}")
+            }
+        }
+        Ok((
+            CudaStorage::wrap_cuda_slice(output, dev.clone()),
+            Shape::from((tokens, self.rows)),
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/candle-nvfp4-kernels/src/lib.rs
+++ b/candle-nvfp4-kernels/src/lib.rs
@@ -1,0 +1,185 @@
+//! CUDA execution for NVIDIA ModelOpt W4A16 NVFP4 linear layers.
+//!
+//! Weights use two E2M1 values per byte, one E4M3FN scale per 16 input values,
+//! and a tensor-wide `f32` scale. The host API is intentionally batched: it
+//! avoids launching and re-uploading a weight matrix once per token during prefill.
+
+#[cfg(feature = "cuda")]
+use std::ffi::c_int;
+
+pub const BLOCK_SIZE: usize = 16;
+
+#[cfg(feature = "cuda")]
+unsafe extern "C" {
+    fn candle_nvfp4_cuda_is_available() -> c_int;
+    fn candle_nvfp4_linear_f32_host_batched(
+        input: *const f32,
+        weight: *const u8,
+        scales: *const u8,
+        tensor_scale: f32,
+        output: *mut f32,
+        tokens: i64,
+        rows: i64,
+        cols: i64,
+    ) -> c_int;
+}
+
+/// Whether the active CUDA device meets the native NVFP4 execution contract
+/// (compute capability 10.0 / Blackwell or newer).
+#[cfg(feature = "cuda")]
+pub fn is_available() -> bool {
+    unsafe { candle_nvfp4_cuda_is_available() == 1 }
+}
+
+#[cfg(not(feature = "cuda"))]
+pub fn is_available() -> bool {
+    false
+}
+
+fn validate(
+    input: &[f32],
+    weight: &[u8],
+    scales: &[u8],
+    rows: usize,
+    cols: usize,
+    tokens: usize,
+) -> Result<(), String> {
+    if rows == 0 || cols == 0 || tokens == 0 || !cols.is_multiple_of(BLOCK_SIZE) {
+        return Err(format!(
+            "NVFP4 requires non-zero rows/tokens and cols divisible by {BLOCK_SIZE}"
+        ));
+    }
+    if [rows, cols, tokens]
+        .into_iter()
+        .any(|dimension| dimension > i64::MAX as usize)
+    {
+        return Err("NVFP4 dimensions exceed the CUDA kernel's i64 range".into());
+    }
+    if input.len() != tokens * cols {
+        return Err(format!(
+            "NVFP4 input has {} values, expected {}",
+            input.len(),
+            tokens * cols
+        ));
+    }
+    if weight.len() != rows * cols / 2 {
+        return Err(format!(
+            "NVFP4 packed weight has {} bytes, expected {}",
+            weight.len(),
+            rows * cols / 2
+        ));
+    }
+    if scales.len() != rows * cols / BLOCK_SIZE {
+        return Err(format!(
+            "NVFP4 scale tensor has {} bytes, expected {}",
+            scales.len(),
+            rows * cols / BLOCK_SIZE
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn e2m1_to_f32(nibble: u8) -> f32 {
+    [
+        0., 0.5, 1., 1.5, 2., 3., 4., 6., 0., -0.5, -1., -1.5, -2., -3., -4., -6.,
+    ][(nibble & 0xf) as usize]
+}
+
+#[cfg(test)]
+fn e4m3fn_to_f32(byte: u8) -> f32 {
+    let sign = if byte & 0x80 == 0 { 1. } else { -1. };
+    let exponent = (byte >> 3) & 0xf;
+    let mantissa = byte & 0x7;
+    if exponent == 0 {
+        sign * mantissa as f32 / 512.
+    } else if exponent == 0xf && mantissa == 0x7 {
+        f32::NAN
+    } else {
+        sign * (1. + mantissa as f32 / 8.) * 2f32.powi(exponent as i32 - 7)
+    }
+}
+
+/// Computes `[tokens, cols] @ dequant([rows, cols]).T` on CUDA.
+pub fn linear_f32_host_batched(
+    input: &[f32],
+    packed_weight: &[u8],
+    weight_scale_e4m3: &[u8],
+    tensor_scale: f32,
+    rows: usize,
+    cols: usize,
+    tokens: usize,
+) -> Result<Vec<f32>, String> {
+    validate(input, packed_weight, weight_scale_e4m3, rows, cols, tokens)?;
+    let _ = tensor_scale;
+    if !is_available() {
+        return Err(
+            "NVFP4 CUDA kernels require compute capability 10.0 (Blackwell) or newer".into(),
+        );
+    }
+    #[cfg(feature = "cuda")]
+    {
+        let mut output = vec![0.; tokens * rows];
+        let status = unsafe {
+            candle_nvfp4_linear_f32_host_batched(
+                input.as_ptr(),
+                packed_weight.as_ptr(),
+                weight_scale_e4m3.as_ptr(),
+                tensor_scale,
+                output.as_mut_ptr(),
+                tokens as i64,
+                rows as i64,
+                cols as i64,
+            )
+        };
+        if status == 0 {
+            Ok(output)
+        } else {
+            Err(format!("NVFP4 CUDA execution failed with status {status}"))
+        }
+    }
+    #[cfg(not(feature = "cuda"))]
+    unreachable!("availability is false without the cuda feature")
+}
+
+/// Single-token convenience wrapper around [`linear_f32_host_batched`].
+pub fn linear_f32_host(
+    input: &[f32],
+    packed_weight: &[u8],
+    weight_scale_e4m3: &[u8],
+    tensor_scale: f32,
+    rows: usize,
+    cols: usize,
+) -> Result<Vec<f32>, String> {
+    linear_f32_host_batched(
+        input,
+        packed_weight,
+        weight_scale_e4m3,
+        tensor_scale,
+        rows,
+        cols,
+        1,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn shape_validation_rejects_malformed_packed_tensors() {
+        assert!(validate(&[0.; 16], &[0; 7], &[0; 1], 1, 16, 1).is_err());
+        assert!(validate(&[0.; 15], &[0; 8], &[0; 1], 1, 16, 1).is_err());
+        assert!(validate(&[0.; 16], &[0; 8], &[0; 2], 1, 16, 1).is_err());
+        assert!(validate(&[0.; 15], &[0; 8], &[0; 1], 1, 15, 1).is_err());
+    }
+
+    #[test]
+    fn nvfp4_encoding_matches_modelopt_layout() {
+        assert_eq!(e2m1_to_f32(0x0), 0.0);
+        assert_eq!(e2m1_to_f32(0x7), 6.0);
+        assert_eq!(e2m1_to_f32(0xd), -3.0);
+        assert_eq!(e4m3fn_to_f32(0x38), 1.0);
+        assert_eq!(e4m3fn_to_f32(0x40), 2.0);
+        assert_eq!(e4m3fn_to_f32(0xb8), -1.0);
+    }
+}

--- a/candle-transformers/Cargo.toml
+++ b/candle-transformers/Cargo.toml
@@ -15,7 +15,9 @@ byteorder = { workspace = true }
 candle = { workspace = true }
 candle-flash-attn = { workspace = true, optional = true }
 candle-nn = { workspace = true }
+candle-nvfp4-kernels = { workspace = true, optional = true }
 fancy-regex = { workspace = true }
+float8 = { workspace = true }
 intel-mkl-src = { workspace = true, optional = true }
 num-traits = { workspace = true }
 rand = { workspace = true }
@@ -32,5 +34,6 @@ cuda = ["candle/cuda", "candle-nn/cuda"]
 cudnn = ["candle/cudnn", "candle-nn/cudnn"]
 flash-attn = ["cuda", "dep:candle-flash-attn"]
 mkl = ["dep:intel-mkl-src", "candle/mkl", "candle-nn/mkl"]
+nvfp4-cuda = ["cuda", "dep:candle-nvfp4-kernels", "candle-nvfp4-kernels/cuda"]
 metal = ["candle/metal", "candle-nn/metal"]
 metal-debug-labels = ["metal", "candle/metal-debug-labels", "candle-nn/metal-debug-labels"]

--- a/candle-transformers/src/lib.rs
+++ b/candle-transformers/src/lib.rs
@@ -4,5 +4,6 @@ pub mod models;
 pub mod object_detection;
 pub mod pipelines;
 pub mod quantized_nn;
+pub mod quantized_nvfp4;
 pub mod quantized_var_builder;
 pub mod utils;

--- a/candle-transformers/src/quantized_nvfp4.rs
+++ b/candle-transformers/src/quantized_nvfp4.rs
@@ -1064,7 +1064,15 @@ mod tests {
             Nvfp4Config::default(),
         )?;
 
-        let xs_f16 = Tensor::rand(0f32, 1f32, (3, 5, in_dim), &device)?.to_dtype(DType::F16)?;
+        // A deterministic, non-uniform input: Tensor::rand is unseeded, and
+        // an unlucky draw could occasionally make packed's single rounding
+        // step land as large as dense's compounded one, flaking the
+        // dense_max_abs_diff > packed_max_abs_diff assertion below.
+        let batch = 3 * 5;
+        let xs_data: Vec<f32> = (0..batch * in_dim)
+            .map(|i| 0.01 + 0.037 * ((i % 13) as f32))
+            .collect();
+        let xs_f16 = Tensor::from_vec(xs_data, (3, 5, in_dim), &device)?.to_dtype(DType::F16)?;
         // What Nvfp4LinearPacked::forward computes with internally: xs_f16
         // upconverted to f32, losslessly (f16 -> f32 never rounds).
         let xs_ref = xs_f16.to_dtype(DType::F32)?;

--- a/candle-transformers/src/quantized_nvfp4.rs
+++ b/candle-transformers/src/quantized_nvfp4.rs
@@ -27,6 +27,25 @@
 //! dense tensor larger than an explicit byte budget. See the `nvfp4-cuda`
 //! feature's [`cuda`] submodule for a path that keeps the packed weight
 //! device-resident instead of expanding it 8x into a dense `f32` tensor.
+//!
+//! [`auto_linear`] picks among three execution paths, in this order
+//! (huggingface/candle#3857 -- NVFP4 had no execution path off CUDA):
+//!
+//!   1. `nvfp4-cuda` fused kernel ([`cuda::Nvfp4LinearCuda`]): packed and
+//!      device-resident, used only on a CUDA device with the kernel
+//!      available.
+//!   2. [`Nvfp4LinearPacked`]: a CPU operator that keeps the weight in its
+//!      packed form (~1x the checkpoint's footprint, not 8x) and decodes
+//!      each output row on the fly during `forward`, trading some compute
+//!      for memory. This is the default off CUDA -- on a CPU host or Apple
+//!      Silicon, where the dense fallback below can OOM or refuse to run,
+//!      memory is the actual blocker, not speed. There is no Metal kernel
+//!      yet; on a Metal device this path still round-trips through host
+//!      memory rather than running on-device.
+//!   3. [`nvfp4_linear`]: dequantizes to a dense tensor once at load time.
+//!      Opt in via `Nvfp4Config::force_dense_fallback` when raw forward-pass
+//!      throughput matters more than resident memory and the checkpoint
+//!      fits within `max_dense_bytes`.
 
 use candle::{DType, Result, Tensor};
 use candle_nn::{Linear, Module, VarBuilder};
@@ -230,14 +249,22 @@ pub fn dequantize_nvfp4(
     Tensor::from_vec(out, (out_dim, in_dim), &candle::Device::Cpu)
 }
 
-/// Configuration for [`nvfp4_linear`] and [`auto_linear`].
+/// Configuration for [`nvfp4_linear`], [`nvfp4_linear_packed`] and
+/// [`auto_linear`].
 #[derive(Debug, Clone, Copy)]
 pub struct Nvfp4Config {
     pub block_size: usize,
     /// Refuses to dequantize a packed weight into a dense tensor larger than
     /// this many bytes. Only applies to the CPU dequantization fallback; the
-    /// `nvfp4-cuda` fused path never expands the weight.
+    /// `nvfp4-cuda` fused path and the CPU packed path never expand the
+    /// weight.
     pub max_dense_bytes: usize,
+    /// When [`auto_linear`] can't use the `nvfp4-cuda` fused path, it
+    /// defaults to [`Nvfp4LinearPacked`] (packed, ~1x footprint). Set this to
+    /// dequantize to a dense tensor once at load time instead
+    /// ([`nvfp4_linear`]), trading resident memory for forward-pass
+    /// throughput; still bounded by `max_dense_bytes`.
+    pub force_dense_fallback: bool,
 }
 
 impl Default for Nvfp4Config {
@@ -247,6 +274,131 @@ impl Default for Nvfp4Config {
             // A generous but explicit guardrail: refuse rather than silently
             // blow past available memory on an 8x unpack.
             max_dense_bytes: 4 * 1024 * 1024 * 1024,
+            force_dense_fallback: false,
+        }
+    }
+}
+
+/// A CPU operator for a packed NVFP4 linear layer that never materializes a
+/// dense `[out_dim, in_dim]` weight: the packed weight and block scales stay
+/// in their checkpoint-native, ~1x-footprint form, and each output row is
+/// decoded on the fly during [`forward`](Module::forward). See the module
+/// docs for where this sits in [`auto_linear`]'s execution preference order.
+#[derive(Debug, Clone)]
+pub struct Nvfp4LinearPacked {
+    /// Row-major `[out_dim, in_dim / 2]`, two E2M1 nibbles per byte.
+    packed_weight: Vec<u8>,
+    /// Row-major `[out_dim, in_dim.div_ceil(block_size)]`, decoded to `f32`.
+    weight_scale: Vec<f32>,
+    weight_scale_2: f32,
+    in_dim: usize,
+    out_dim: usize,
+    block_size: usize,
+    bias: Option<Tensor>,
+}
+
+/// Builds a [`Nvfp4LinearPacked`] from a packed NVFP4 checkpoint, reading the
+/// same tensors as [`nvfp4_linear`] (packed weight, `weight_scale`,
+/// `weight_scale_2`, optional `bias`) but keeping them packed instead of
+/// dequantizing to a dense tensor.
+pub fn nvfp4_linear_packed(
+    in_dim: usize,
+    out_dim: usize,
+    bias: bool,
+    vb: VarBuilder,
+    cfg: Nvfp4Config,
+) -> Result<Nvfp4LinearPacked> {
+    let packed_weight = vb
+        .get_with_hints_dtype(
+            (out_dim, in_dim / 2),
+            nvfp4_weight_tensor_name(&vb),
+            Default::default(),
+            DType::U8,
+        )?
+        .flatten_all()?
+        .to_vec1::<u8>()?;
+    let weight_scale = vb
+        .get_with_hints_dtype(
+            (out_dim, in_dim.div_ceil(cfg.block_size)),
+            "weight_scale",
+            Default::default(),
+            DType::F8E4M3,
+        )?
+        .flatten_all()?
+        .to_vec1::<float8::F8E4M3>()?
+        .into_iter()
+        .map(|v| v.to_f32())
+        .collect();
+    let weight_scale_2 = read_scalar_f32(&vb, "weight_scale_2")?;
+    let bias = if bias {
+        Some(vb.get(out_dim, "bias")?)
+    } else {
+        None
+    };
+    Ok(Nvfp4LinearPacked {
+        packed_weight,
+        weight_scale,
+        weight_scale_2,
+        in_dim,
+        out_dim,
+        block_size: cfg.block_size,
+        bias,
+    })
+}
+
+impl Module for Nvfp4LinearPacked {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let target_dtype = xs.dtype();
+        let target_device = xs.device().clone();
+        let dims = xs.dims();
+        let Some((&last, leading)) = dims.split_last() else {
+            candle::bail!("nvfp4: input tensor must have at least one dimension")
+        };
+        if last != self.in_dim {
+            candle::bail!(
+                "nvfp4: expected last input dim {}, got {:?}",
+                self.in_dim,
+                dims
+            )
+        }
+        let batch: usize = leading.iter().product();
+
+        let xs_host = xs
+            .reshape((batch, self.in_dim))?
+            .to_device(&candle::Device::Cpu)?
+            .to_dtype(DType::F32)?;
+        let xs_vec = xs_host.to_vec2::<f32>()?;
+
+        let packed_row_len = self.in_dim / 2;
+        let n_blocks = self.in_dim.div_ceil(self.block_size);
+        let mut out = vec![0f32; batch * self.out_dim];
+        let mut row_buf = vec![0f32; self.in_dim];
+        for (o, (packed_row, scale_row)) in self
+            .packed_weight
+            .chunks(packed_row_len)
+            .zip(self.weight_scale.chunks(n_blocks))
+            .enumerate()
+        {
+            for (col, val) in row_buf.iter_mut().enumerate() {
+                let byte = packed_row[col / 2];
+                let nibble = if col % 2 == 0 { byte & 0xf } else { byte >> 4 };
+                *val = unpack_e2m1(nibble) * scale_row[col / self.block_size] * self.weight_scale_2;
+            }
+            for (b, x_row) in xs_vec.iter().enumerate() {
+                let acc: f32 = row_buf.iter().zip(x_row.iter()).map(|(w, x)| w * x).sum();
+                out[b * self.out_dim + o] = acc;
+            }
+        }
+
+        let mut out_shape = leading.to_vec();
+        out_shape.push(self.out_dim);
+        let out_tensor = Tensor::from_vec(out, (batch, self.out_dim), &candle::Device::Cpu)?
+            .reshape(out_shape)?
+            .to_device(&target_device)?
+            .to_dtype(target_dtype)?;
+        match &self.bias {
+            None => Ok(out_tensor),
+            Some(bias) => out_tensor.broadcast_add(bias),
         }
     }
 }
@@ -300,7 +452,13 @@ pub fn nvfp4_linear(
 pub enum AutoLinear {
     Dense(Linear),
     Fp8Block(Linear),
+    /// Dense NVFP4 fallback: dequantized once at load time. Only produced
+    /// when [`Nvfp4Config::force_dense_fallback`] is set; see
+    /// [`Nvfp4Packed`](Self::Nvfp4Packed) for the default off-CUDA path.
     Nvfp4(Linear),
+    /// Packed NVFP4 CPU operator: the default off-CUDA path. See
+    /// [`Nvfp4LinearPacked`].
+    Nvfp4Packed(Nvfp4LinearPacked),
     #[cfg(feature = "nvfp4-cuda")]
     Nvfp4Cuda(cuda::Nvfp4LinearCuda),
 }
@@ -309,6 +467,7 @@ impl Module for AutoLinear {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         match self {
             Self::Dense(l) | Self::Fp8Block(l) | Self::Nvfp4(l) => l.forward(xs),
+            Self::Nvfp4Packed(l) => l.forward(xs),
             #[cfg(feature = "nvfp4-cuda")]
             Self::Nvfp4Cuda(l) => l.forward(xs),
         }
@@ -322,8 +481,12 @@ impl Module for AutoLinear {
 ///
 /// On a CUDA device with the `nvfp4-cuda` feature enabled and the fused
 /// kernel available, NVFP4 layers stay packed and device-resident. Otherwise
-/// NVFP4 (and FP8) layers are dequantized to a dense tensor at load time,
-/// bounded by `cfg.max_dense_bytes`.
+/// they default to [`Nvfp4LinearPacked`], which keeps the weight packed
+/// (~1x footprint) and decodes on the fly; set
+/// `cfg.force_dense_fallback` to dequantize to a dense tensor at load time
+/// instead, bounded by `cfg.max_dense_bytes`. FP8 layers are always
+/// dequantized to a dense tensor at load time. See the module docs for the
+/// full preference order.
 pub fn auto_linear(
     in_dim: usize,
     out_dim: usize,
@@ -339,7 +502,12 @@ pub fn auto_linear(
                     in_dim, out_dim, bias, vb, cfg,
                 )?));
             }
-            Ok(AutoLinear::Nvfp4(nvfp4_linear(
+            if cfg.force_dense_fallback {
+                return Ok(AutoLinear::Nvfp4(nvfp4_linear(
+                    in_dim, out_dim, bias, vb, cfg,
+                )?));
+            }
+            Ok(AutoLinear::Nvfp4Packed(nvfp4_linear_packed(
                 in_dim, out_dim, bias, vb, cfg,
             )?))
         }
@@ -723,9 +891,89 @@ mod tests {
             vb.pp("nvfp4"),
             Nvfp4Config::default(),
         )?;
-        assert!(matches!(nvfp4, AutoLinear::Nvfp4(_)));
+        assert!(matches!(nvfp4, AutoLinear::Nvfp4Packed(_)));
         assert_eq!(nvfp4.forward(&input)?.dims(), &[1, out_dim]);
 
+        let nvfp4_dense = auto_linear(
+            in_dim,
+            out_dim,
+            false,
+            vb.pp("nvfp4"),
+            Nvfp4Config {
+                force_dense_fallback: true,
+                ..Nvfp4Config::default()
+            },
+        )?;
+        assert!(matches!(nvfp4_dense, AutoLinear::Nvfp4(_)));
+        assert_eq!(nvfp4_dense.forward(&input)?.dims(), &[1, out_dim]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn nvfp4_linear_packed_matches_dense_dequantization() -> Result<()> {
+        let device = Device::Cpu;
+        let out_dim = 2;
+        let in_dim = 32; // two blocks of 16
+        let row0: Vec<f32> = vec![
+            0., 0.5, 1., 1.5, 2., 3., 4., 6., -0.5, -1., -1.5, -2., -3., -4., -6., 0.,
+        ];
+        let packed_row = pack_row(&row0);
+        let packed_bytes: Vec<u8> = [
+            packed_row.clone(),
+            packed_row.clone(),
+            packed_row.clone(),
+            packed_row,
+        ]
+        .concat();
+        let scale_bytes: Vec<float8::F8E4M3> = [0x38u8, 0x40u8, 0x38u8, 0x40u8]
+            .into_iter()
+            .map(float8::F8E4M3::from_bits)
+            .collect();
+
+        let mut tensors = std::collections::HashMap::new();
+        tensors.insert(
+            "layer.weight".to_string(),
+            Tensor::from_vec(packed_bytes, (out_dim, in_dim / 2), &device)?,
+        );
+        tensors.insert(
+            "layer.weight_scale".to_string(),
+            Tensor::from_vec(scale_bytes, (out_dim, in_dim / BLOCK_SIZE), &device)?,
+        );
+        tensors.insert(
+            "layer.weight_scale_2".to_string(),
+            Tensor::from_vec(vec![0.5f32], (), &device)?,
+        );
+        let vb = VarBuilder::from_tensors(tensors, DType::F32, &device);
+
+        let dense = nvfp4_linear(
+            in_dim,
+            out_dim,
+            false,
+            vb.pp("layer"),
+            Nvfp4Config::default(),
+        )?;
+        let packed = nvfp4_linear_packed(
+            in_dim,
+            out_dim,
+            false,
+            vb.pp("layer"),
+            Nvfp4Config::default(),
+        )?;
+
+        // A batched, non-trivial input exercises the row/batch loops in
+        // Nvfp4LinearPacked::forward, not just the zero vector.
+        let xs = Tensor::rand(0f32, 1f32, (3, 5, in_dim), &device)?;
+        let dense_out = dense.forward(&xs)?.to_vec3::<f32>()?;
+        let packed_out = packed.forward(&xs)?.to_vec3::<f32>()?;
+
+        for (d_batch, p_batch) in dense_out.iter().zip(packed_out.iter()) {
+            for (d_row, p_row) in d_batch.iter().zip(p_batch.iter()) {
+                for (d, p) in d_row.iter().zip(p_row.iter()) {
+                    assert!((d - p).abs() < 1e-4, "{d} vs {p}");
+                }
+            }
+        }
         Ok(())
     }
 }

--- a/candle-transformers/src/quantized_nvfp4.rs
+++ b/candle-transformers/src/quantized_nvfp4.rs
@@ -1,0 +1,526 @@
+//! Loading NVIDIA ModelOpt NVFP4 (W4A16) checkpoints from safetensors.
+//!
+//! ModelOpt / compressed-tensors NVFP4 checkpoints store each packed linear
+//! weight as three tensors instead of one dense weight:
+//!   - `weight_packed`: a `U8` tensor of shape `[out_dim, in_dim / 2]`, packing
+//!     two E2M1 values per byte (low then high nibble).
+//!   - `weight_scale`: an `F8E4M3` tensor of shape `[out_dim, in_dim / block_size]`,
+//!     one scale per `block_size`-wide block of the input dimension
+//!     (`block_size` is 16 for NVFP4).
+//!   - `weight_scale_2`: a scalar `f32` tensor that scales the whole matrix.
+//!
+//! `weight[i, j] = e2m1(packed[i, j]) * e4m3(weight_scale[i, j / block_size]) * weight_scale_2`.
+//!
+//! This module never reinterprets the packed bytes as `f32`: [`dequantize_nvfp4`]
+//! decodes each nibble and scale byte explicitly through [`unpack_e2m1`] and
+//! `float8::F8E4M3::to_bits`, and [`nvfp4_linear`] refuses to materialize a
+//! dense tensor larger than an explicit byte budget. See the `nvfp4-cuda`
+//! feature's [`cuda`] submodule for a path that keeps the packed weight
+//! device-resident instead of expanding it 8x into a dense `f32` tensor.
+
+use candle::{DType, Result, Tensor};
+use candle_nn::{Linear, Module, VarBuilder};
+
+/// Number of input columns sharing one `weight_scale` byte.
+pub const BLOCK_SIZE: usize = 16;
+
+/// What backs a linear layer's weight in a checkpoint that may mix dense,
+/// block-wise FP8, and packed NVFP4 layers (as ModelOpt exports do).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backing {
+    /// A plain dense `weight` tensor.
+    Dense,
+    /// A block-wise FP8 weight (`weight` + `weight_scale_inv`), e.g. as used
+    /// by DeepSeek-V3-style checkpoints.
+    Fp8Block,
+    /// A packed NVFP4 weight (`weight_packed` + `weight_scale` + `weight_scale_2`).
+    Nvfp4,
+}
+
+/// Dequantizes a block-wise FP8 weight into a dense `[out_dim, in_dim]` `f32`
+/// tensor. `weight` is an `F8E4M3` tensor of shape `[out_dim, in_dim]` and
+/// `scale` is an `f32` tensor of shape
+/// `[ceil(out_dim / block_size), ceil(in_dim / block_size)]` holding one
+/// scale per `block_size x block_size` block of `weight`.
+pub fn dequantize_fp8_block(weight: &Tensor, scale: &Tensor, block_size: usize) -> Result<Tensor> {
+    let (out_dim, in_dim) = weight.dims2()?;
+    let (scale_rows, scale_cols) = scale.dims2()?;
+    if scale_rows != out_dim.div_ceil(block_size) || scale_cols != in_dim.div_ceil(block_size) {
+        candle::bail!(
+            "fp8: scale shape {:?} does not match weight shape {:?} for block_size {block_size}",
+            (scale_rows, scale_cols),
+            (out_dim, in_dim),
+        )
+    }
+    let weight = weight.to_dtype(DType::F32)?.to_vec2::<f32>()?;
+    let scale = scale.to_dtype(DType::F32)?.to_vec2::<f32>()?;
+    let mut out = vec![0f32; out_dim * in_dim];
+    for (row, weight_row) in weight.iter().enumerate() {
+        let scale_row = &scale[row / block_size];
+        for (col, &w) in weight_row.iter().enumerate() {
+            out[row * in_dim + col] = w * scale_row[col / block_size];
+        }
+    }
+    Tensor::from_vec(out, (out_dim, in_dim), &candle::Device::Cpu)
+}
+
+fn fp8_block_linear(
+    in_dim: usize,
+    out_dim: usize,
+    bias: bool,
+    vb: VarBuilder,
+    block_size: usize,
+) -> Result<Linear> {
+    let weight = vb.get_with_hints_dtype(
+        (out_dim, in_dim),
+        "weight",
+        Default::default(),
+        DType::F8E4M3,
+    )?;
+    let scale = vb.get_with_hints_dtype(
+        (out_dim.div_ceil(block_size), in_dim.div_ceil(block_size)),
+        "weight_scale_inv",
+        Default::default(),
+        DType::F32,
+    )?;
+    let weight = dequantize_fp8_block(&weight, &scale, block_size)?
+        .to_dtype(vb.dtype())?
+        .to_device(vb.device())?;
+    let bias = if bias {
+        Some(vb.get(out_dim, "bias")?)
+    } else {
+        None
+    };
+    Ok(Linear::new(weight, bias))
+}
+
+/// Inspects the tensor names available at `vb`'s current path to determine
+/// what backs the linear layer, without reading any tensor data.
+pub fn detect_backing(vb: &VarBuilder) -> Backing {
+    if vb.contains_tensor("weight_packed") && vb.contains_tensor("weight_scale_2") {
+        Backing::Nvfp4
+    } else if vb.contains_tensor("weight_scale_inv") {
+        Backing::Fp8Block
+    } else {
+        Backing::Dense
+    }
+}
+
+fn unpack_e2m1(nibble: u8) -> f32 {
+    const TABLE: [f32; 16] = [
+        0., 0.5, 1., 1.5, 2., 3., 4., 6., 0., -0.5, -1., -1.5, -2., -3., -4., -6.,
+    ];
+    TABLE[(nibble & 0xf) as usize]
+}
+
+/// Dequantizes a packed NVFP4 weight into a dense `[out_dim, in_dim]` `f32`
+/// tensor on the CPU.
+///
+/// `packed_weight` is a `U8` tensor of shape `[out_dim, in_dim / 2]` and
+/// `weight_scale` is an `F8E4M3` tensor of shape
+/// `[out_dim, in_dim / block_size]`. Fails without allocating if the
+/// resulting dense tensor would exceed `max_dense_bytes`, since unpacking
+/// NVFP4 expands its footprint roughly 8x (4-bit weights plus one scale byte
+/// per `block_size` values, versus 32-bit floats).
+pub fn dequantize_nvfp4(
+    packed_weight: &Tensor,
+    weight_scale: &Tensor,
+    weight_scale_2: f32,
+    block_size: usize,
+    max_dense_bytes: usize,
+) -> Result<Tensor> {
+    let (out_dim, packed_in_dim) = packed_weight.dims2()?;
+    let in_dim = packed_in_dim * 2;
+    let (scale_rows, scale_cols) = weight_scale.dims2()?;
+    if scale_rows != out_dim || scale_cols != in_dim.div_ceil(block_size) {
+        candle::bail!(
+            "nvfp4: weight_scale shape {:?} does not match packed weight shape {:?} for block_size {block_size}",
+            (scale_rows, scale_cols),
+            (out_dim, in_dim),
+        )
+    }
+    if packed_weight.dtype() != DType::U8 {
+        candle::bail!(
+            "nvfp4: weight_packed must be u8, got {:?}",
+            packed_weight.dtype()
+        )
+    }
+    if weight_scale.dtype() != DType::F8E4M3 {
+        candle::bail!(
+            "nvfp4: weight_scale must be f8e4m3, got {:?}",
+            weight_scale.dtype()
+        )
+    }
+    let dense_bytes = out_dim
+        .checked_mul(in_dim)
+        .and_then(|n| n.checked_mul(std::mem::size_of::<f32>()))
+        .ok_or_else(|| candle::Error::Msg("nvfp4: dense weight size overflows usize".into()))?;
+    if dense_bytes > max_dense_bytes {
+        candle::bail!(
+            "nvfp4: dequantizing a [{out_dim}, {in_dim}] weight would allocate {dense_bytes} bytes, \
+             exceeding the {max_dense_bytes}-byte budget; raise Nvfp4Config::max_dense_bytes or use \
+             the nvfp4-cuda fused path instead"
+        )
+    }
+
+    let packed = packed_weight.to_vec2::<u8>()?;
+    let scale = weight_scale.to_vec2::<float8::F8E4M3>()?;
+
+    let mut out = vec![0f32; out_dim * in_dim];
+    for row in 0..out_dim {
+        let packed_row = &packed[row];
+        let scale_row = &scale[row];
+        for col in 0..in_dim {
+            let byte = packed_row[col / 2];
+            let nibble = if col % 2 == 0 { byte & 0xf } else { byte >> 4 };
+            let block_scale = e4m3_to_f32(scale_row[col / block_size].to_bits());
+            out[row * in_dim + col] = unpack_e2m1(nibble) * block_scale * weight_scale_2;
+        }
+    }
+    Tensor::from_vec(out, (out_dim, in_dim), &candle::Device::Cpu)
+}
+
+fn e4m3_to_f32(byte: u8) -> f32 {
+    let sign = if byte & 0x80 == 0 { 1. } else { -1. };
+    let exponent = (byte >> 3) & 0xf;
+    let mantissa = byte & 0x7;
+    if exponent == 0 {
+        sign * mantissa as f32 / 512.
+    } else if exponent == 0xf && mantissa == 0x7 {
+        f32::NAN
+    } else {
+        sign * (1. + mantissa as f32 / 8.) * 2f32.powi(exponent as i32 - 7)
+    }
+}
+
+/// Configuration for [`nvfp4_linear`] and [`auto_linear`].
+#[derive(Debug, Clone, Copy)]
+pub struct Nvfp4Config {
+    pub block_size: usize,
+    /// Refuses to dequantize a packed weight into a dense tensor larger than
+    /// this many bytes. Only applies to the CPU dequantization fallback; the
+    /// `nvfp4-cuda` fused path never expands the weight.
+    pub max_dense_bytes: usize,
+}
+
+impl Default for Nvfp4Config {
+    fn default() -> Self {
+        Self {
+            block_size: BLOCK_SIZE,
+            // A generous but explicit guardrail: refuse rather than silently
+            // blow past available memory on an 8x unpack.
+            max_dense_bytes: 4 * 1024 * 1024 * 1024,
+        }
+    }
+}
+
+/// Builds a dense [`candle_nn::Linear`] layer from a packed NVFP4 checkpoint,
+/// reading `weight_packed` (`U8`), `weight_scale` (`F8E4M3`), `weight_scale_2`
+/// (scalar `f32`) and an optional `bias` tensor at the current `VarBuilder`
+/// path, dequantizing on the CPU.
+pub fn nvfp4_linear(
+    in_dim: usize,
+    out_dim: usize,
+    bias: bool,
+    vb: VarBuilder,
+    cfg: Nvfp4Config,
+) -> Result<Linear> {
+    let packed_weight = vb.get_with_hints_dtype(
+        (out_dim, in_dim / 2),
+        "weight_packed",
+        Default::default(),
+        DType::U8,
+    )?;
+    let weight_scale = vb.get_with_hints_dtype(
+        (out_dim, in_dim.div_ceil(cfg.block_size)),
+        "weight_scale",
+        Default::default(),
+        DType::F8E4M3,
+    )?;
+    let weight_scale_2 = vb
+        .get_with_hints_dtype((), "weight_scale_2", Default::default(), DType::F32)?
+        .to_scalar::<f32>()?;
+    let weight = dequantize_nvfp4(
+        &packed_weight,
+        &weight_scale,
+        weight_scale_2,
+        cfg.block_size,
+        cfg.max_dense_bytes,
+    )?
+    .to_dtype(vb.dtype())?
+    .to_device(vb.device())?;
+    let bias = if bias {
+        Some(vb.get(out_dim, "bias")?)
+    } else {
+        None
+    };
+    Ok(Linear::new(weight, bias))
+}
+
+/// A linear projection whose backing (dense, block-wise FP8, or packed
+/// NVFP4) was determined automatically from the checkpoint. See
+/// [`auto_linear`].
+#[derive(Debug, Clone)]
+pub enum AutoLinear {
+    Dense(Linear),
+    Fp8Block(Linear),
+    Nvfp4(Linear),
+    #[cfg(feature = "nvfp4-cuda")]
+    Nvfp4Cuda(cuda::Nvfp4LinearCuda),
+}
+
+impl Module for AutoLinear {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::Dense(l) | Self::Fp8Block(l) | Self::Nvfp4(l) => l.forward(xs),
+            #[cfg(feature = "nvfp4-cuda")]
+            Self::Nvfp4Cuda(l) => l.forward(xs),
+        }
+    }
+}
+
+/// A ModelOpt-aware weight source: detects what backs the linear layer at
+/// `vb`'s current path (dense, block-wise FP8, or packed NVFP4) and builds a
+/// compatible projection, so callers stop needing to special-case each
+/// checkpoint's tensor layout themselves.
+///
+/// On a CUDA device with the `nvfp4-cuda` feature enabled and the fused
+/// kernel available, NVFP4 layers stay packed and device-resident. Otherwise
+/// NVFP4 (and FP8) layers are dequantized to a dense tensor at load time,
+/// bounded by `cfg.max_dense_bytes`.
+pub fn auto_linear(
+    in_dim: usize,
+    out_dim: usize,
+    bias: bool,
+    vb: VarBuilder,
+    cfg: Nvfp4Config,
+) -> Result<AutoLinear> {
+    match detect_backing(&vb) {
+        Backing::Nvfp4 => {
+            #[cfg(feature = "nvfp4-cuda")]
+            if vb.device().is_cuda() && candle_nvfp4_kernels::is_available() {
+                return Ok(AutoLinear::Nvfp4Cuda(cuda::Nvfp4LinearCuda::new(
+                    in_dim, out_dim, bias, vb, cfg,
+                )?));
+            }
+            Ok(AutoLinear::Nvfp4(nvfp4_linear(
+                in_dim, out_dim, bias, vb, cfg,
+            )?))
+        }
+        Backing::Fp8Block => Ok(AutoLinear::Fp8Block(fp8_block_linear(
+            in_dim,
+            out_dim,
+            bias,
+            vb,
+            cfg.block_size,
+        )?)),
+        Backing::Dense => Ok(AutoLinear::Dense(candle_nn::linear_b(
+            in_dim, out_dim, bias, vb,
+        )?)),
+    }
+}
+
+/// Fused path: keeps the NVFP4 weight packed and device-resident, running
+/// the kernel from `candle-nvfp4-kernels` on every forward pass instead of
+/// dequantizing once at load time.
+#[cfg(feature = "nvfp4-cuda")]
+pub mod cuda {
+    use super::Nvfp4Config;
+    use candle::{DType, Module, Result, Tensor};
+    use candle_nn::VarBuilder;
+
+    #[derive(Debug, Clone)]
+    pub struct Nvfp4LinearCuda {
+        inner: candle_nvfp4_kernels::Nvfp4Linear,
+        bias: Option<Tensor>,
+    }
+
+    impl Nvfp4LinearCuda {
+        pub fn new(
+            in_dim: usize,
+            out_dim: usize,
+            bias: bool,
+            vb: VarBuilder,
+            cfg: Nvfp4Config,
+        ) -> Result<Self> {
+            let packed_weight = vb
+                .get_with_hints_dtype(
+                    (out_dim, in_dim / 2),
+                    "weight_packed",
+                    Default::default(),
+                    DType::U8,
+                )?
+                .to_vec2::<u8>()?
+                .concat();
+            let weight_scale = vb
+                .get_with_hints_dtype(
+                    (out_dim, in_dim.div_ceil(cfg.block_size)),
+                    "weight_scale",
+                    Default::default(),
+                    DType::F8E4M3,
+                )?
+                .to_vec2::<float8::F8E4M3>()?
+                .into_iter()
+                .flatten()
+                .map(|v| v.to_bits())
+                .collect::<Vec<u8>>();
+            let weight_scale_2 = vb
+                .get_with_hints_dtype((), "weight_scale_2", Default::default(), DType::F32)?
+                .to_scalar::<f32>()?;
+            let inner = candle_nvfp4_kernels::Nvfp4Linear::new(
+                &packed_weight,
+                &weight_scale,
+                weight_scale_2,
+                out_dim,
+                in_dim,
+                vb.device(),
+            )?;
+            let bias = if bias {
+                Some(vb.get(out_dim, "bias")?)
+            } else {
+                None
+            };
+            Ok(Self { inner, bias })
+        }
+    }
+
+    impl Module for Nvfp4LinearCuda {
+        fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+            let ys = self.inner.forward(xs)?;
+            match &self.bias {
+                None => Ok(ys),
+                Some(bias) => ys.broadcast_add(bias),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::Device;
+
+    fn pack_row(values: &[f32]) -> Vec<u8> {
+        // Reverse-maps a value to its nearest E2M1 code (test inputs are
+        // chosen to be exact codepoints, so nearest is exact).
+        const CODES: [f32; 16] = [
+            0., 0.5, 1., 1.5, 2., 3., 4., 6., 0., -0.5, -1., -1.5, -2., -3., -4., -6.,
+        ];
+        let nibbles: Vec<u8> = values
+            .iter()
+            .map(|v| {
+                CODES
+                    .iter()
+                    .position(|c| c == v)
+                    .unwrap_or_else(|| panic!("{v} is not an exact E2M1 codepoint"))
+                    as u8
+            })
+            .collect();
+        nibbles
+            .chunks(2)
+            .map(|pair| pair[0] | (pair[1] << 4))
+            .collect()
+    }
+
+    #[test]
+    fn e4m3_roundtrip_matches_known_values() {
+        assert_eq!(e4m3_to_f32(0x38), 1.0);
+        assert_eq!(e4m3_to_f32(0x40), 2.0);
+        assert_eq!(e4m3_to_f32(0xb8), -1.0);
+    }
+
+    #[test]
+    fn dequantize_nvfp4_matches_manual_computation() -> Result<()> {
+        let device = Device::Cpu;
+        let out_dim = 2;
+        let in_dim = 32; // two blocks of 16
+        let row0: Vec<f32> = vec![
+            0., 0.5, 1., 1.5, 2., 3., 4., 6., -0.5, -1., -1.5, -2., -3., -4., -6., 0.,
+        ];
+
+        let packed_row = pack_row(&row0);
+        let packed_bytes: Vec<u8> = [
+            packed_row.clone(),
+            packed_row.clone(),
+            packed_row.clone(),
+            packed_row,
+        ]
+        .concat();
+        let packed_weight = Tensor::from_vec(packed_bytes, (out_dim, in_dim / 2), &device)?;
+
+        // 1.0, 2.0 per row, built from raw E4M3 bit patterns (not a numeric
+        // cast, which would round 0x38/0x40 as if they were integers).
+        let scale_bytes: Vec<float8::F8E4M3> = [0x38u8, 0x40u8, 0x38u8, 0x40u8]
+            .into_iter()
+            .map(float8::F8E4M3::from_bits)
+            .collect();
+        let weight_scale = Tensor::from_vec(scale_bytes, (out_dim, in_dim / BLOCK_SIZE), &device)?;
+
+        let tensor_scale = 0.5f32;
+        let dequant = dequantize_nvfp4(
+            &packed_weight,
+            &weight_scale,
+            tensor_scale,
+            BLOCK_SIZE,
+            1 << 30,
+        )?;
+        let dequant = dequant.to_vec2::<f32>()?;
+
+        for row in 0..out_dim {
+            for col in 0..in_dim {
+                let block_scale = if col < BLOCK_SIZE { 1.0 } else { 2.0 };
+                let expected = row0[col % BLOCK_SIZE] * block_scale * tensor_scale;
+                assert!(
+                    (dequant[row][col] - expected).abs() < 1e-5,
+                    "mismatch at ({row},{col}): {} vs {expected}",
+                    dequant[row][col]
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn dequantize_nvfp4_refuses_over_budget_allocation() {
+        let device = Device::Cpu;
+        let out_dim = 4096;
+        let in_dim = 4096;
+        let packed_weight = Tensor::zeros((out_dim, in_dim / 2), DType::U8, &device).unwrap();
+        let weight_scale =
+            Tensor::zeros((out_dim, in_dim / BLOCK_SIZE), DType::F8E4M3, &device).unwrap();
+        let err =
+            dequantize_nvfp4(&packed_weight, &weight_scale, 1.0, BLOCK_SIZE, 1024).unwrap_err();
+        assert!(err.to_string().contains("budget"));
+    }
+
+    #[test]
+    fn detect_backing_reads_tensor_names() -> Result<()> {
+        let device = Device::Cpu;
+        let varmap = candle_nn::VarMap::new();
+        let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+        assert_eq!(detect_backing(&vb.pp("dense")), Backing::Dense);
+
+        let _ = vb.pp("nvfp4").get_with_hints_dtype(
+            (4, 2),
+            "weight_packed",
+            Default::default(),
+            DType::U8,
+        )?;
+        let _ = vb.pp("nvfp4").get_with_hints_dtype(
+            (),
+            "weight_scale_2",
+            Default::default(),
+            DType::F32,
+        )?;
+        assert_eq!(detect_backing(&vb.pp("nvfp4")), Backing::Nvfp4);
+
+        let _ = vb.pp("fp8").get_with_hints_dtype(
+            (2, 2),
+            "weight_scale_inv",
+            Default::default(),
+            DType::F32,
+        )?;
+        assert_eq!(detect_backing(&vb.pp("fp8")), Backing::Fp8Block);
+        Ok(())
+    }
+}

--- a/candle-transformers/src/quantized_nvfp4.rs
+++ b/candle-transformers/src/quantized_nvfp4.rs
@@ -1,19 +1,29 @@
 //! Loading NVIDIA ModelOpt NVFP4 (W4A16) checkpoints from safetensors.
 //!
-//! ModelOpt / compressed-tensors NVFP4 checkpoints store each packed linear
-//! weight as three tensors instead of one dense weight:
-//!   - `weight_packed`: a `U8` tensor of shape `[out_dim, in_dim / 2]`, packing
-//!     two E2M1 values per byte (low then high nibble).
+//! NVFP4 checkpoints store each packed linear weight as three tensors
+//! instead of one dense weight:
+//!   - the packed weight: a `U8` tensor of shape `[out_dim, in_dim / 2]`,
+//!     packing two E2M1 values per byte (low then high nibble). ModelOpt
+//!     exports this as `.weight` (e.g. `nvidia/Llama-3.3-70B-Instruct-FP4`);
+//!     compressed-tensors checkpoints (llm-compressor / vLLM) use
+//!     `.weight_packed` instead. See [`nvfp4_weight_tensor_name`].
 //!   - `weight_scale`: an `F8E4M3` tensor of shape `[out_dim, in_dim / block_size]`,
 //!     one scale per `block_size`-wide block of the input dimension
 //!     (`block_size` is 16 for NVFP4).
-//!   - `weight_scale_2`: a scalar `f32` tensor that scales the whole matrix.
+//!   - `weight_scale_2`: an `f32` tensor holding exactly one element (rank 0
+//!     or `[1]` depending on the exporter) that scales the whole matrix.
+//!     Its presence is the unambiguous signal that a layer is NVFP4-backed;
+//!     see [`detect_backing`].
 //!
 //! `weight[i, j] = e2m1(packed[i, j]) * e4m3(weight_scale[i, j / block_size]) * weight_scale_2`.
 //!
+//! Activations are not quantized in W4A16, so an `input_scale` tensor some
+//! checkpoints also carry alongside these three is intentionally never read
+//! here.
+//!
 //! This module never reinterprets the packed bytes as `f32`: [`dequantize_nvfp4`]
 //! decodes each nibble and scale byte explicitly through [`unpack_e2m1`] and
-//! `float8::F8E4M3::to_bits`, and [`nvfp4_linear`] refuses to materialize a
+//! `float8::F8E4M3::to_f32`, and [`nvfp4_linear`] refuses to materialize a
 //! dense tensor larger than an explicit byte budget. See the `nvfp4-cuda`
 //! feature's [`cuda`] submodule for a path that keeps the packed weight
 //! device-resident instead of expanding it 8x into a dense `f32` tensor.
@@ -33,7 +43,9 @@ pub enum Backing {
     /// A block-wise FP8 weight (`weight` + `weight_scale_inv`), e.g. as used
     /// by DeepSeek-V3-style checkpoints.
     Fp8Block,
-    /// A packed NVFP4 weight (`weight_packed` + `weight_scale` + `weight_scale_2`).
+    /// A packed NVFP4 weight: `weight_scale` + `weight_scale_2`, plus the
+    /// packed weight itself under `.weight` (ModelOpt) or `.weight_packed`
+    /// (compressed-tensors) -- see [`nvfp4_weight_tensor_name`].
     Nvfp4,
 }
 
@@ -96,14 +108,47 @@ fn fp8_block_linear(
 
 /// Inspects the tensor names available at `vb`'s current path to determine
 /// what backs the linear layer, without reading any tensor data.
+///
+/// `weight_scale_2` alone is the NVFP4 signal: both the ModelOpt and
+/// compressed-tensors export conventions include it, and neither a dense nor
+/// a block-wise-FP8 layer has one. The packed weight's own tensor name
+/// differs between the two conventions -- see [`nvfp4_weight_tensor_name`].
 pub fn detect_backing(vb: &VarBuilder) -> Backing {
-    if vb.contains_tensor("weight_packed") && vb.contains_tensor("weight_scale_2") {
+    if vb.contains_tensor("weight_scale_2") {
         Backing::Nvfp4
     } else if vb.contains_tensor("weight_scale_inv") {
         Backing::Fp8Block
     } else {
         Backing::Dense
     }
+}
+
+/// The tensor name holding the packed NVFP4 weight at `vb`'s current path:
+/// `weight_packed` under the compressed-tensors convention (llm-compressor /
+/// vLLM) if present, otherwise `weight` -- the ModelOpt convention, e.g.
+/// `nvidia/Llama-3.3-70B-Instruct-FP4`, which does not use `weight_packed`
+/// at all. Only meaningful once [`detect_backing`] has returned
+/// [`Backing::Nvfp4`].
+pub fn nvfp4_weight_tensor_name(vb: &VarBuilder) -> &'static str {
+    if vb.contains_tensor("weight_packed") {
+        "weight_packed"
+    } else {
+        "weight"
+    }
+}
+
+/// Reads `name` as an `f32` tensor holding exactly one element, accepting
+/// either a rank-0 scalar or a rank-1 `[1]` tensor: ModelOpt exporters have
+/// used both shapes for `weight_scale_2` across versions.
+fn read_scalar_f32(vb: &VarBuilder, name: &str) -> Result<f32> {
+    let t = vb.get_unchecked_dtype(name, DType::F32)?;
+    if t.elem_count() != 1 {
+        candle::bail!(
+            "nvfp4: {name} must hold exactly one element, got shape {:?}",
+            t.shape()
+        )
+    }
+    t.reshape(())?.to_scalar::<f32>()
 }
 
 fn unpack_e2m1(nibble: u8) -> f32 {
@@ -173,24 +218,11 @@ pub fn dequantize_nvfp4(
         for col in 0..in_dim {
             let byte = packed_row[col / 2];
             let nibble = if col % 2 == 0 { byte & 0xf } else { byte >> 4 };
-            let block_scale = e4m3_to_f32(scale_row[col / block_size].to_bits());
+            let block_scale = scale_row[col / block_size].to_f32();
             out[row * in_dim + col] = unpack_e2m1(nibble) * block_scale * weight_scale_2;
         }
     }
     Tensor::from_vec(out, (out_dim, in_dim), &candle::Device::Cpu)
-}
-
-fn e4m3_to_f32(byte: u8) -> f32 {
-    let sign = if byte & 0x80 == 0 { 1. } else { -1. };
-    let exponent = (byte >> 3) & 0xf;
-    let mantissa = byte & 0x7;
-    if exponent == 0 {
-        sign * mantissa as f32 / 512.
-    } else if exponent == 0xf && mantissa == 0x7 {
-        f32::NAN
-    } else {
-        sign * (1. + mantissa as f32 / 8.) * 2f32.powi(exponent as i32 - 7)
-    }
 }
 
 /// Configuration for [`nvfp4_linear`] and [`auto_linear`].
@@ -215,9 +247,10 @@ impl Default for Nvfp4Config {
 }
 
 /// Builds a dense [`candle_nn::Linear`] layer from a packed NVFP4 checkpoint,
-/// reading `weight_packed` (`U8`), `weight_scale` (`F8E4M3`), `weight_scale_2`
-/// (scalar `f32`) and an optional `bias` tensor at the current `VarBuilder`
-/// path, dequantizing on the CPU.
+/// reading the packed weight ([`nvfp4_weight_tensor_name`], `U8`),
+/// `weight_scale` (`F8E4M3`), `weight_scale_2` (one-element `f32`) and an
+/// optional `bias` tensor at the current `VarBuilder` path, dequantizing on
+/// the CPU.
 pub fn nvfp4_linear(
     in_dim: usize,
     out_dim: usize,
@@ -227,7 +260,7 @@ pub fn nvfp4_linear(
 ) -> Result<Linear> {
     let packed_weight = vb.get_with_hints_dtype(
         (out_dim, in_dim / 2),
-        "weight_packed",
+        nvfp4_weight_tensor_name(&vb),
         Default::default(),
         DType::U8,
     )?;
@@ -237,9 +270,7 @@ pub fn nvfp4_linear(
         Default::default(),
         DType::F8E4M3,
     )?;
-    let weight_scale_2 = vb
-        .get_with_hints_dtype((), "weight_scale_2", Default::default(), DType::F32)?
-        .to_scalar::<f32>()?;
+    let weight_scale_2 = read_scalar_f32(&vb, "weight_scale_2")?;
     let weight = dequantize_nvfp4(
         &packed_weight,
         &weight_scale,
@@ -325,7 +356,7 @@ pub fn auto_linear(
 /// dequantizing once at load time.
 #[cfg(feature = "nvfp4-cuda")]
 pub mod cuda {
-    use super::Nvfp4Config;
+    use super::{nvfp4_weight_tensor_name, read_scalar_f32, Nvfp4Config};
     use candle::{DType, Module, Result, Tensor};
     use candle_nn::VarBuilder;
 
@@ -346,12 +377,12 @@ pub mod cuda {
             let packed_weight = vb
                 .get_with_hints_dtype(
                     (out_dim, in_dim / 2),
-                    "weight_packed",
+                    nvfp4_weight_tensor_name(&vb),
                     Default::default(),
                     DType::U8,
                 )?
-                .to_vec2::<u8>()?
-                .concat();
+                .flatten_all()?
+                .to_vec1::<u8>()?;
             let weight_scale = vb
                 .get_with_hints_dtype(
                     (out_dim, in_dim.div_ceil(cfg.block_size)),
@@ -359,14 +390,12 @@ pub mod cuda {
                     Default::default(),
                     DType::F8E4M3,
                 )?
-                .to_vec2::<float8::F8E4M3>()?
+                .flatten_all()?
+                .to_vec1::<float8::F8E4M3>()?
                 .into_iter()
-                .flatten()
                 .map(|v| v.to_bits())
                 .collect::<Vec<u8>>();
-            let weight_scale_2 = vb
-                .get_with_hints_dtype((), "weight_scale_2", Default::default(), DType::F32)?
-                .to_scalar::<f32>()?;
+            let weight_scale_2 = read_scalar_f32(&vb, "weight_scale_2")?;
             let inner = candle_nvfp4_kernels::Nvfp4Linear::new(
                 &packed_weight,
                 &weight_scale,
@@ -420,13 +449,6 @@ mod tests {
             .chunks(2)
             .map(|pair| pair[0] | (pair[1] << 4))
             .collect()
-    }
-
-    #[test]
-    fn e4m3_roundtrip_matches_known_values() {
-        assert_eq!(e4m3_to_f32(0x38), 1.0);
-        assert_eq!(e4m3_to_f32(0x40), 2.0);
-        assert_eq!(e4m3_to_f32(0xb8), -1.0);
     }
 
     #[test]
@@ -500,19 +522,42 @@ mod tests {
         let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
         assert_eq!(detect_backing(&vb.pp("dense")), Backing::Dense);
 
-        let _ = vb.pp("nvfp4").get_with_hints_dtype(
+        // ModelOpt convention: the packed weight is `.weight`, there is no
+        // `.weight_packed` (e.g. nvidia/Llama-3.3-70B-Instruct-FP4).
+        let _ = vb.pp("modelopt").get_with_hints_dtype(
             (4, 2),
-            "weight_packed",
+            "weight",
             Default::default(),
             DType::U8,
         )?;
-        let _ = vb.pp("nvfp4").get_with_hints_dtype(
+        let _ = vb.pp("modelopt").get_with_hints_dtype(
             (),
             "weight_scale_2",
             Default::default(),
             DType::F32,
         )?;
-        assert_eq!(detect_backing(&vb.pp("nvfp4")), Backing::Nvfp4);
+        assert_eq!(detect_backing(&vb.pp("modelopt")), Backing::Nvfp4);
+        assert_eq!(nvfp4_weight_tensor_name(&vb.pp("modelopt")), "weight");
+
+        // compressed-tensors convention (llm-compressor / vLLM): the packed
+        // weight is `.weight_packed`, alongside `.weight_scale_2`.
+        let _ = vb.pp("compressed_tensors").get_with_hints_dtype(
+            (4, 2),
+            "weight_packed",
+            Default::default(),
+            DType::U8,
+        )?;
+        let _ = vb.pp("compressed_tensors").get_with_hints_dtype(
+            (),
+            "weight_scale_2",
+            Default::default(),
+            DType::F32,
+        )?;
+        assert_eq!(detect_backing(&vb.pp("compressed_tensors")), Backing::Nvfp4);
+        assert_eq!(
+            nvfp4_weight_tensor_name(&vb.pp("compressed_tensors")),
+            "weight_packed"
+        );
 
         let _ = vb.pp("fp8").get_with_hints_dtype(
             (2, 2),
@@ -521,6 +566,79 @@ mod tests {
             DType::F32,
         )?;
         assert_eq!(detect_backing(&vb.pp("fp8")), Backing::Fp8Block);
+        Ok(())
+    }
+
+    #[test]
+    fn read_scalar_f32_accepts_rank_0_or_rank_1() -> Result<()> {
+        let device = Device::Cpu;
+        let mut tensors = std::collections::HashMap::new();
+        tensors.insert(
+            "rank0.s".to_string(),
+            Tensor::from_vec(vec![0.25f32], (), &device)?,
+        );
+        tensors.insert(
+            "rank1.s".to_string(),
+            Tensor::from_vec(vec![0.25f32], 1, &device)?,
+        );
+        tensors.insert(
+            "not_scalar.s".to_string(),
+            Tensor::from_vec(vec![0.25f32, 0.5], 2, &device)?,
+        );
+        let vb = VarBuilder::from_tensors(tensors, DType::F32, &device);
+
+        assert_eq!(read_scalar_f32(&vb.pp("rank0"), "s")?, 0.25);
+        assert_eq!(read_scalar_f32(&vb.pp("rank1"), "s")?, 0.25);
+        assert!(read_scalar_f32(&vb.pp("not_scalar"), "s").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn nvfp4_linear_reads_the_modelopt_naming_convention() -> Result<()> {
+        // A layer using ModelOpt's naming (packed weight under `.weight`,
+        // no `.weight_packed`) must load through the same auto_linear/
+        // nvfp4_linear path as the compressed-tensors naming; this is what
+        // Backing::Nvfp4 promises once detect_backing returns it.
+        let device = Device::Cpu;
+        let out_dim = 2;
+        let in_dim = 32;
+        let row0: Vec<f32> = vec![
+            0., 0.5, 1., 1.5, 2., 3., 4., 6., -0.5, -1., -1.5, -2., -3., -4., -6., 0.,
+        ];
+        let packed_row = pack_row(&row0);
+        let packed_bytes: Vec<u8> = [
+            packed_row.clone(),
+            packed_row.clone(),
+            packed_row.clone(),
+            packed_row,
+        ]
+        .concat();
+        let scale_bytes: Vec<float8::F8E4M3> = [0x38u8, 0x38u8, 0x38u8, 0x38u8]
+            .into_iter()
+            .map(float8::F8E4M3::from_bits)
+            .collect();
+
+        let mut tensors = std::collections::HashMap::new();
+        tensors.insert(
+            "layer.weight".to_string(),
+            Tensor::from_vec(packed_bytes, (out_dim, in_dim / 2), &device)?,
+        );
+        tensors.insert(
+            "layer.weight_scale".to_string(),
+            Tensor::from_vec(scale_bytes, (out_dim, in_dim / BLOCK_SIZE), &device)?,
+        );
+        tensors.insert(
+            "layer.weight_scale_2".to_string(),
+            Tensor::from_vec(vec![0.5f32], (), &device)?,
+        );
+        let vb = VarBuilder::from_tensors(tensors, DType::F32, &device);
+        let layer = vb.pp("layer");
+
+        assert_eq!(detect_backing(&layer), Backing::Nvfp4);
+        assert_eq!(nvfp4_weight_tensor_name(&layer), "weight");
+        let linear = nvfp4_linear(in_dim, out_dim, false, layer, Nvfp4Config::default())?;
+        let output = linear.forward(&Tensor::zeros((1, in_dim), DType::F32, &device)?)?;
+        assert_eq!(output.dims(), &[1, out_dim]);
         Ok(())
     }
 }

--- a/candle-transformers/src/quantized_nvfp4.rs
+++ b/candle-transformers/src/quantized_nvfp4.rs
@@ -241,7 +241,11 @@ pub fn dequantize_nvfp4(
         let scale_row = &scale[row];
         for col in 0..in_dim {
             let byte = packed_row[col / 2];
-            let nibble = if col % 2 == 0 { byte & 0xf } else { byte >> 4 };
+            let nibble = if col.is_multiple_of(2) {
+                byte & 0xf
+            } else {
+                byte >> 4
+            };
             let block_scale = scale_row[col / block_size].to_f32();
             out[row * in_dim + col] = unpack_e2m1(nibble) * block_scale * weight_scale_2;
         }
@@ -391,7 +395,11 @@ impl Module for Nvfp4LinearPacked {
         {
             for (col, val) in row_buf.iter_mut().enumerate() {
                 let byte = packed_row[col / 2];
-                let nibble = if col % 2 == 0 { byte & 0xf } else { byte >> 4 };
+                let nibble = if col.is_multiple_of(2) {
+                    byte & 0xf
+                } else {
+                    byte >> 4
+                };
                 let block_scale = scale_row[col / self.block_size].to_f32();
                 *val = unpack_e2m1(nibble) * block_scale * self.weight_scale_2;
             }

--- a/candle-transformers/src/quantized_nvfp4.rs
+++ b/candle-transformers/src/quantized_nvfp4.rs
@@ -288,8 +288,11 @@ impl Default for Nvfp4Config {
 pub struct Nvfp4LinearPacked {
     /// Row-major `[out_dim, in_dim / 2]`, two E2M1 nibbles per byte.
     packed_weight: Vec<u8>,
-    /// Row-major `[out_dim, in_dim.div_ceil(block_size)]`, decoded to `f32`.
-    weight_scale: Vec<f32>,
+    /// Row-major `[out_dim, in_dim.div_ceil(block_size)]`, kept as raw
+    /// `F8E4M3` bytes (not decoded to `f32`) so this struct's footprint
+    /// matches the checkpoint's, not 4x it; decoded per block in
+    /// `forward`.
+    weight_scale: Vec<float8::F8E4M3>,
     weight_scale_2: f32,
     in_dim: usize,
     out_dim: usize,
@@ -325,10 +328,7 @@ pub fn nvfp4_linear_packed(
             DType::F8E4M3,
         )?
         .flatten_all()?
-        .to_vec1::<float8::F8E4M3>()?
-        .into_iter()
-        .map(|v| v.to_f32())
-        .collect();
+        .to_vec1::<float8::F8E4M3>()?;
     let weight_scale_2 = read_scalar_f32(&vb, "weight_scale_2")?;
     let bias = if bias {
         Some(vb.get(out_dim, "bias")?)
@@ -382,7 +382,8 @@ impl Module for Nvfp4LinearPacked {
             for (col, val) in row_buf.iter_mut().enumerate() {
                 let byte = packed_row[col / 2];
                 let nibble = if col % 2 == 0 { byte & 0xf } else { byte >> 4 };
-                *val = unpack_e2m1(nibble) * scale_row[col / self.block_size] * self.weight_scale_2;
+                let block_scale = scale_row[col / self.block_size].to_f32();
+                *val = unpack_e2m1(nibble) * block_scale * self.weight_scale_2;
             }
             for (b, x_row) in xs_vec.iter().enumerate() {
                 let acc: f32 = row_buf.iter().zip(x_row.iter()).map(|(w, x)| w * x).sum();
@@ -448,7 +449,12 @@ pub fn nvfp4_linear(
 /// A linear projection whose backing (dense, block-wise FP8, or packed
 /// NVFP4) was determined automatically from the checkpoint. See
 /// [`auto_linear`].
+///
+/// `#[non_exhaustive]`: a Metal-backed NVFP4 variant is expected future work
+/// (huggingface/candle#3857), and this should not be a breaking change for
+/// downstream matches when it lands.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum AutoLinear {
     Dense(Linear),
     Fp8Block(Linear),

--- a/candle-transformers/src/quantized_nvfp4.rs
+++ b/candle-transformers/src/quantized_nvfp4.rs
@@ -673,10 +673,10 @@ mod tests {
         );
 
         // NVFP4, ModelOpt naming: `.weight` (packed) + `.weight_scale` +
-        // `.weight_scale_2`, no `.weight_packed`.
-        let row: Vec<f32> = vec![
-            0., 0.5, 1., 1.5, 2., 3., 4., 6., 0., 0., 0., 0., 0., 0., 0., 0.,
-        ];
+        // `.weight_scale_2`, no `.weight_packed`. `row` must have exactly
+        // `in_dim` values: it's one row of the packed weight, not a full
+        // BLOCK_SIZE-wide block (in_dim=4 here is smaller than BLOCK_SIZE).
+        let row: Vec<f32> = vec![0., 0.5, 1., 1.5];
         let packed_row = pack_row(&row);
         tensors.insert(
             "nvfp4.weight".to_string(),

--- a/candle-transformers/src/quantized_nvfp4.rs
+++ b/candle-transformers/src/quantized_nvfp4.rs
@@ -284,6 +284,16 @@ impl Default for Nvfp4Config {
 /// in their checkpoint-native, ~1x-footprint form, and each output row is
 /// decoded on the fly during [`forward`](Module::forward). See the module
 /// docs for where this sits in [`auto_linear`]'s execution preference order.
+///
+/// Unlike [`nvfp4_linear`], `forward` here ignores the `VarBuilder`'s dtype
+/// entirely: decoding and the matmul both run in `f32`, and only the output
+/// is rounded to the input's dtype at the very end. [`nvfp4_linear`]
+/// instead rounds the dense weight to the `VarBuilder`'s dtype (e.g. `bf16`)
+/// once at load time, so every subsequent matmul runs at that lower
+/// precision. On a reduced-precision checkpoint the two paths therefore
+/// aren't bit-identical -- this one is the more accurate of the two, since
+/// it defers rounding instead of compounding it into the weight -- see
+/// `nvfp4_linear_packed_precision_differs_from_dense_at_reduced_precision`.
 #[derive(Debug, Clone)]
 pub struct Nvfp4LinearPacked {
     /// Row-major `[out_dim, in_dim / 2]`, two E2M1 nibbles per byte.
@@ -980,6 +990,141 @@ mod tests {
                 }
             }
         }
+        Ok(())
+    }
+
+    /// Covers the precision note on [`Nvfp4LinearPacked`]'s docs: at a
+    /// reduced-precision `VarBuilder` dtype, `nvfp4_linear` rounds the dense
+    /// weight to that dtype once at load time (so rounding error compounds
+    /// into every accumulation of the matmul), while `Nvfp4LinearPacked`
+    /// always computes in `f32` and rounds only the final output. Neither is
+    /// a bug, but they aren't bit-identical, and the `f32`-only parity test
+    /// above doesn't exercise this at all.
+    #[test]
+    fn nvfp4_linear_packed_precision_differs_from_dense_at_reduced_precision() -> Result<()> {
+        let device = Device::Cpu;
+        let out_dim = 2;
+        let in_dim = 32; // two blocks of 16
+        let row0: Vec<f32> = vec![
+            0., 0.5, 1., 1.5, 2., 3., 4., 6., -0.5, -1., -1.5, -2., -3., -4., -6., 0.,
+        ];
+        let packed_row = pack_row(&row0);
+        let packed_bytes: Vec<u8> = [
+            packed_row.clone(),
+            packed_row.clone(),
+            packed_row.clone(),
+            packed_row,
+        ]
+        .concat();
+        let scale_bytes: Vec<float8::F8E4M3> = [0x38u8, 0x40u8, 0x38u8, 0x40u8]
+            .into_iter()
+            .map(float8::F8E4M3::from_bits)
+            .collect();
+
+        let mut tensors = std::collections::HashMap::new();
+        tensors.insert(
+            "layer.weight".to_string(),
+            Tensor::from_vec(packed_bytes, (out_dim, in_dim / 2), &device)?,
+        );
+        tensors.insert(
+            "layer.weight_scale".to_string(),
+            Tensor::from_vec(scale_bytes, (out_dim, in_dim / BLOCK_SIZE), &device)?,
+        );
+        // A non-power-of-two tensor scale: a power-of-two scale wouldn't
+        // cost any f16 mantissa bits and would defeat the point of this
+        // test, since E2M1 codepoints are already exact in f16.
+        tensors.insert(
+            "layer.weight_scale_2".to_string(),
+            Tensor::from_vec(vec![1f32 / 3.], (), &device)?,
+        );
+        let vb_f32 = VarBuilder::from_tensors(tensors.clone(), DType::F32, &device);
+        // candle-core's default CPU matmul only supports F16/F32/F64, not
+        // BF16 -- nvfp4_linear's dense path would fail outright at BF16
+        // here regardless of anything in this module, so this test uses
+        // F16 to isolate the rounding-order question it's actually about.
+        let vb_f16 = VarBuilder::from_tensors(tensors, DType::F16, &device);
+
+        // Nvfp4LinearPacked never reads vb.dtype() (see nvfp4_linear_packed):
+        // building it from an f32 VarBuilder is enough, the reduced
+        // precision below comes entirely from the input/output dtype.
+        let packed = nvfp4_linear_packed(
+            in_dim,
+            out_dim,
+            false,
+            vb_f32.pp("layer"),
+            Nvfp4Config::default(),
+        )?;
+        // nvfp4_linear does read vb.dtype() and rounds the dense weight to
+        // it, so this one needs the f16 VarBuilder.
+        let dense_f16 = nvfp4_linear(
+            in_dim,
+            out_dim,
+            false,
+            vb_f16.pp("layer"),
+            Nvfp4Config::default(),
+        )?;
+
+        let xs_f16 = Tensor::rand(0f32, 1f32, (3, 5, in_dim), &device)?.to_dtype(DType::F16)?;
+        // What Nvfp4LinearPacked::forward computes with internally: xs_f16
+        // upconverted to f32, losslessly (f16 -> f32 never rounds).
+        let xs_ref = xs_f16.to_dtype(DType::F32)?;
+
+        // True f32 reference: same dequantized weight and input as both
+        // paths compute from, no rounding anywhere.
+        let reference = packed.forward(&xs_ref)?.to_vec3::<f32>()?;
+
+        // Packed's only rounding step is the final output cast to f16, so
+        // this must match `reference` rounded to f16 exactly.
+        let packed_out = packed
+            .forward(&xs_f16)?
+            .to_dtype(DType::F32)?
+            .to_vec3::<f32>()?;
+        let rounded_reference = Tensor::new(reference.clone(), &device)?
+            .to_dtype(DType::F16)?
+            .to_dtype(DType::F32)?
+            .to_vec3::<f32>()?;
+        for (p_batch, r_batch) in packed_out.iter().zip(rounded_reference.iter()) {
+            for (p_row, r_row) in p_batch.iter().zip(r_batch.iter()) {
+                for (p, r) in p_row.iter().zip(r_row.iter()) {
+                    assert_eq!(
+                        p, r,
+                        "packed's f16 output should equal the f32 reference rounded once at the end"
+                    );
+                }
+            }
+        }
+
+        // Dense rounds the weight to f16 before the matmul, so its error
+        // compounds across all in_dim=32 accumulations instead of rounding
+        // once at the end like the packed path does. Compare each against
+        // the same f32 reference rather than asserting an absolute
+        // threshold, since the right magnitude depends on the random input:
+        // dense's compounded error must exceed packed's single
+        // rounding-only error, not just be nonzero.
+        let dense_out = dense_f16
+            .forward(&xs_f16)?
+            .to_dtype(DType::F32)?
+            .to_vec3::<f32>()?;
+        let mut dense_max_abs_diff = 0f32;
+        let mut packed_max_abs_diff = 0f32;
+        for ((d_batch, p_batch), r_batch) in dense_out
+            .iter()
+            .zip(packed_out.iter())
+            .zip(reference.iter())
+        {
+            for ((d_row, p_row), r_row) in d_batch.iter().zip(p_batch.iter()).zip(r_batch.iter()) {
+                for ((d, p), r) in d_row.iter().zip(p_row.iter()).zip(r_row.iter()) {
+                    dense_max_abs_diff = dense_max_abs_diff.max((d - r).abs());
+                    packed_max_abs_diff = packed_max_abs_diff.max((p - r).abs());
+                }
+            }
+        }
+        assert!(
+            dense_max_abs_diff > packed_max_abs_diff,
+            "expected dense's compounded f16 rounding ({dense_max_abs_diff}) to diverge \
+             from the f32 reference more than packed's single final rounding \
+             ({packed_max_abs_diff})"
+        );
         Ok(())
     }
 }

--- a/candle-transformers/src/quantized_nvfp4.rs
+++ b/candle-transformers/src/quantized_nvfp4.rs
@@ -466,14 +466,14 @@ mod tests {
         )?;
         let dequant = dequant.to_vec2::<f32>()?;
 
-        for row in 0..out_dim {
+        for (row, dequant_row) in dequant.iter().enumerate().take(out_dim) {
             for col in 0..in_dim {
                 let block_scale = if col < BLOCK_SIZE { 1.0 } else { 2.0 };
                 let expected = row0[col % BLOCK_SIZE] * block_scale * tensor_scale;
                 assert!(
-                    (dequant[row][col] - expected).abs() < 1e-5,
+                    (dequant_row[col] - expected).abs() < 1e-5,
                     "mismatch at ({row},{col}): {} vs {expected}",
-                    dequant[row][col]
+                    dequant_row[col]
                 );
             }
         }

--- a/candle-transformers/src/quantized_nvfp4.rs
+++ b/candle-transformers/src/quantized_nvfp4.rs
@@ -54,7 +54,9 @@ use candle_nn::{Linear, Module, VarBuilder};
 pub const BLOCK_SIZE: usize = 16;
 
 /// What backs a linear layer's weight in a checkpoint that may mix dense,
-/// block-wise FP8, and packed NVFP4 layers (as ModelOpt exports do).
+/// block-wise FP8, per-tensor FP8, and packed NVFP4 layers (as ModelOpt
+/// mixed-precision exports do -- e.g. a Qwen 3.5 MoE checkpoint with NVFP4
+/// experts and per-tensor-FP8 attention projections).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Backing {
     /// A plain dense `weight` tensor.
@@ -62,6 +64,13 @@ pub enum Backing {
     /// A block-wise FP8 weight (`weight` + `weight_scale_inv`), e.g. as used
     /// by DeepSeek-V3-style checkpoints.
     Fp8Block,
+    /// A per-tensor FP8 weight (`weight` in `F8E4M3` + a single scalar
+    /// `weight_scale`, e.g. `amax / 448` as ModelOpt's exporter writes it),
+    /// as used by ModelOpt's attention projections in mixed-precision NVFP4
+    /// checkpoints. An optional `input_scale` may also be present for
+    /// activation quantization; this module never reads it, since
+    /// [`fp8_tensor_linear`] only dequantizes the weight.
+    Fp8Tensor,
     /// A packed NVFP4 weight: `weight_scale` + `weight_scale_2`, plus the
     /// packed weight itself under `.weight` (ModelOpt) or `.weight_packed`
     /// (compressed-tensors) -- see [`nvfp4_weight_tensor_name`].
@@ -125,20 +134,66 @@ fn fp8_block_linear(
     Ok(Linear::new(weight, bias))
 }
 
-/// Inspects the tensor names available at `vb`'s current path to determine
-/// what backs the linear layer, without reading any tensor data.
+/// Dequantizes a per-tensor FP8 weight: a single scalar `weight_scale`
+/// applies to the whole `[out_dim, in_dim]` `F8E4M3` weight, unlike
+/// [`fp8_block_linear`]'s per-block scale grid. The scale multiplication
+/// runs on-device via [`Tensor::affine`] rather than round-tripping through
+/// the host like [`dequantize_fp8_block`] does, since there's no per-element
+/// scale lookup to do.
 ///
-/// `weight_scale_2` alone is the NVFP4 signal: both the ModelOpt and
-/// compressed-tensors export conventions include it, and neither a dense nor
-/// a block-wise-FP8 layer has one. The packed weight's own tensor name
-/// differs between the two conventions -- see [`nvfp4_weight_tensor_name`].
-pub fn detect_backing(vb: &VarBuilder) -> Backing {
-    if vb.contains_tensor("weight_scale_2") {
-        Backing::Nvfp4
-    } else if vb.contains_tensor("weight_scale_inv") {
-        Backing::Fp8Block
+/// An `input_scale` tensor some checkpoints carry alongside `weight` and
+/// `weight_scale` (for activation quantization) is intentionally never read
+/// here: this dequantizes the weight only. A future activation-quantized
+/// path would read it under this same [`Backing::Fp8Tensor`] detection.
+fn fp8_tensor_linear(in_dim: usize, out_dim: usize, bias: bool, vb: VarBuilder) -> Result<Linear> {
+    let weight = vb.get_with_hints_dtype(
+        (out_dim, in_dim),
+        "weight",
+        Default::default(),
+        DType::F8E4M3,
+    )?;
+    let scale = read_scalar_f32(&vb, "weight_scale")?;
+    let weight = weight
+        .to_dtype(vb.dtype())?
+        .affine(scale as f64, 0.)?
+        .to_device(vb.device())?;
+    let bias = if bias {
+        Some(vb.get(out_dim, "bias")?)
     } else {
-        Backing::Dense
+        None
+    };
+    Ok(Linear::new(weight, bias))
+}
+
+/// Inspects the tensor names available at `vb`'s current path to determine
+/// what backs the linear layer, without reading any tensor data. Refuses
+/// (rather than silently degrading to [`Backing::Dense`]) when a layer
+/// carries quantization tensors none of the recognized backings account
+/// for, since a dense read of quantized bytes fails silently: the model
+/// loads, runs, and answers wrong.
+///
+/// `weight_scale_2` must be checked first: an NVFP4 layer also carries a
+/// per-block `weight_scale`, so checking that before `weight_scale_2` would
+/// misclassify NVFP4 as [`Backing::Fp8Tensor`]. Similarly,
+/// `weight_zero_point` (e.g. GPTQ/AWQ-style zero-point quantization, not
+/// handled by any `Backing` here) must be checked before `weight_scale`,
+/// since those layouts carry both.
+pub fn detect_backing(vb: &VarBuilder) -> Result<Backing> {
+    if vb.contains_tensor("weight_scale_2") {
+        Ok(Backing::Nvfp4)
+    } else if vb.contains_tensor("weight_scale_inv") {
+        Ok(Backing::Fp8Block)
+    } else if vb.contains_tensor("weight_zero_point") {
+        candle::bail!(
+            "unrecognized quantized weight layout: found weight_zero_point, \
+             which none of Backing::{{Nvfp4,Fp8Block,Fp8Tensor}} account for \
+             (e.g. GPTQ/AWQ-style zero-point quantization); refusing to fall \
+             back to a dense read that would silently drop it"
+        )
+    } else if vb.contains_tensor("weight_scale") {
+        Ok(Backing::Fp8Tensor)
+    } else {
+        Ok(Backing::Dense)
     }
 }
 
@@ -476,6 +531,8 @@ pub fn nvfp4_linear(
 pub enum AutoLinear {
     Dense(Linear),
     Fp8Block(Linear),
+    /// Per-tensor FP8: see [`Backing::Fp8Tensor`] / [`fp8_tensor_linear`].
+    Fp8Tensor(Linear),
     /// Dense NVFP4 fallback: dequantized once at load time. Only produced
     /// when [`Nvfp4Config::force_dense_fallback`] is set; see
     /// [`Nvfp4Packed`](Self::Nvfp4Packed) for the default off-CUDA path.
@@ -490,7 +547,9 @@ pub enum AutoLinear {
 impl Module for AutoLinear {
     fn forward(&self, xs: &Tensor) -> Result<Tensor> {
         match self {
-            Self::Dense(l) | Self::Fp8Block(l) | Self::Nvfp4(l) => l.forward(xs),
+            Self::Dense(l) | Self::Fp8Block(l) | Self::Fp8Tensor(l) | Self::Nvfp4(l) => {
+                l.forward(xs)
+            }
             Self::Nvfp4Packed(l) => l.forward(xs),
             #[cfg(feature = "nvfp4-cuda")]
             Self::Nvfp4Cuda(l) => l.forward(xs),
@@ -499,18 +558,23 @@ impl Module for AutoLinear {
 }
 
 /// A ModelOpt-aware weight source: detects what backs the linear layer at
-/// `vb`'s current path (dense, block-wise FP8, or packed NVFP4) and builds a
-/// compatible projection, so callers stop needing to special-case each
-/// checkpoint's tensor layout themselves.
+/// `vb`'s current path (dense, block-wise FP8, per-tensor FP8, or packed
+/// NVFP4) and builds a compatible projection, so callers stop needing to
+/// special-case each checkpoint's tensor layout themselves -- including a
+/// mixed-precision checkpoint that uses more than one of these per layer
+/// (e.g. NVFP4 experts alongside per-tensor-FP8 attention projections).
 ///
 /// On a CUDA device with the `nvfp4-cuda` feature enabled and the fused
 /// kernel available, NVFP4 layers stay packed and device-resident. Otherwise
 /// they default to [`Nvfp4LinearPacked`], which keeps the weight packed
 /// (~1x footprint) and decodes on the fly; set
 /// `cfg.force_dense_fallback` to dequantize to a dense tensor at load time
-/// instead, bounded by `cfg.max_dense_bytes`. FP8 layers are always
-/// dequantized to a dense tensor at load time. See the module docs for the
-/// full preference order.
+/// instead, bounded by `cfg.max_dense_bytes`. FP8 layers (block-wise or
+/// per-tensor) are always dequantized to a dense tensor at load time. A
+/// layer whose quantization tensors none of these backings recognize fails
+/// to load ([`detect_backing`]) rather than silently falling back to a
+/// dense read of quantized bytes. See the module docs for the full
+/// preference order.
 pub fn auto_linear(
     in_dim: usize,
     out_dim: usize,
@@ -518,7 +582,7 @@ pub fn auto_linear(
     vb: VarBuilder,
     cfg: Nvfp4Config,
 ) -> Result<AutoLinear> {
-    match detect_backing(&vb) {
+    match detect_backing(&vb)? {
         Backing::Nvfp4 => {
             #[cfg(feature = "nvfp4-cuda")]
             if vb.device().is_cuda() && candle_nvfp4_kernels::is_available() {
@@ -541,6 +605,9 @@ pub fn auto_linear(
             bias,
             vb,
             cfg.block_size,
+        )?)),
+        Backing::Fp8Tensor => Ok(AutoLinear::Fp8Tensor(fp8_tensor_linear(
+            in_dim, out_dim, bias, vb,
         )?)),
         Backing::Dense => Ok(AutoLinear::Dense(candle_nn::linear_b(
             in_dim, out_dim, bias, vb,
@@ -717,7 +784,7 @@ mod tests {
         let device = Device::Cpu;
         let varmap = candle_nn::VarMap::new();
         let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
-        assert_eq!(detect_backing(&vb.pp("dense")), Backing::Dense);
+        assert_eq!(detect_backing(&vb.pp("dense"))?, Backing::Dense);
 
         // ModelOpt convention: the packed weight is `.weight`, there is no
         // `.weight_packed` (e.g. nvidia/Llama-3.3-70B-Instruct-FP4).
@@ -733,7 +800,7 @@ mod tests {
             Default::default(),
             DType::F32,
         )?;
-        assert_eq!(detect_backing(&vb.pp("modelopt")), Backing::Nvfp4);
+        assert_eq!(detect_backing(&vb.pp("modelopt"))?, Backing::Nvfp4);
         assert_eq!(nvfp4_weight_tensor_name(&vb.pp("modelopt")), "weight");
 
         // compressed-tensors convention (llm-compressor / vLLM): the packed
@@ -750,19 +817,52 @@ mod tests {
             Default::default(),
             DType::F32,
         )?;
-        assert_eq!(detect_backing(&vb.pp("compressed_tensors")), Backing::Nvfp4);
+        assert_eq!(
+            detect_backing(&vb.pp("compressed_tensors"))?,
+            Backing::Nvfp4
+        );
         assert_eq!(
             nvfp4_weight_tensor_name(&vb.pp("compressed_tensors")),
             "weight_packed"
         );
 
-        let _ = vb.pp("fp8").get_with_hints_dtype(
+        let _ = vb.pp("fp8_block").get_with_hints_dtype(
             (2, 2),
             "weight_scale_inv",
             Default::default(),
             DType::F32,
         )?;
-        assert_eq!(detect_backing(&vb.pp("fp8")), Backing::Fp8Block);
+        assert_eq!(detect_backing(&vb.pp("fp8_block"))?, Backing::Fp8Block);
+
+        // Per-tensor FP8 (ModelOpt's attention projections in a
+        // mixed-precision NVFP4 checkpoint): `weight_scale` alone, no
+        // `weight_scale_2` and no `weight_scale_inv`.
+        let _ = vb.pp("fp8_tensor").get_with_hints_dtype(
+            (),
+            "weight_scale",
+            Default::default(),
+            DType::F32,
+        )?;
+        assert_eq!(detect_backing(&vb.pp("fp8_tensor"))?, Backing::Fp8Tensor);
+
+        // weight_zero_point (e.g. GPTQ/AWQ-style) is not any recognized
+        // Backing and must fail loudly, even though it's typically paired
+        // with a weight_scale tensor that would otherwise match Fp8Tensor.
+        let _ = vb.pp("zero_point").get_with_hints_dtype(
+            (),
+            "weight_scale",
+            Default::default(),
+            DType::F32,
+        )?;
+        let _ = vb.pp("zero_point").get_with_hints_dtype(
+            (),
+            "weight_zero_point",
+            Default::default(),
+            DType::F32,
+        )?;
+        let err = detect_backing(&vb.pp("zero_point")).unwrap_err();
+        assert!(err.to_string().contains("weight_zero_point"));
+
         Ok(())
     }
 
@@ -833,7 +933,7 @@ mod tests {
         let vb = VarBuilder::from_tensors(tensors, DType::F32, &device);
         let layer = vb.pp("layer");
 
-        assert_eq!(detect_backing(&layer), Backing::Nvfp4);
+        assert_eq!(detect_backing(&layer)?, Backing::Nvfp4);
         assert_eq!(nvfp4_weight_tensor_name(&layer), "weight");
         let linear = nvfp4_linear(in_dim, out_dim, false, layer, Nvfp4Config::default())?;
         let output = linear.forward(&Tensor::zeros((1, in_dim), DType::F32, &device)?)?;
@@ -891,6 +991,20 @@ mod tests {
             Tensor::from_vec(vec![1f32], (), &device)?,
         );
 
+        // Per-tensor FP8 (ModelOpt attention projections): `.weight` +
+        // scalar `.weight_scale`, no `.weight_scale_2` and no
+        // `.weight_scale_inv` -- the third layout mixed into ModelOpt's
+        // mixed-precision checkpoints alongside dense, block-wise FP8, and
+        // NVFP4 (huggingface/candle#3858 review).
+        tensors.insert(
+            "fp8_tensor.weight".to_string(),
+            Tensor::zeros((out_dim, in_dim), DType::F8E4M3, &device)?,
+        );
+        tensors.insert(
+            "fp8_tensor.weight_scale".to_string(),
+            Tensor::from_vec(vec![1f32], (), &device)?,
+        );
+
         let vb = VarBuilder::from_tensors(tensors, DType::F32, &device);
         let input = Tensor::zeros((1, in_dim), DType::F32, &device)?;
 
@@ -907,6 +1021,16 @@ mod tests {
         let fp8 = auto_linear(in_dim, out_dim, false, vb.pp("fp8"), Nvfp4Config::default())?;
         assert!(matches!(fp8, AutoLinear::Fp8Block(_)));
         assert_eq!(fp8.forward(&input)?.dims(), &[1, out_dim]);
+
+        let fp8_tensor = auto_linear(
+            in_dim,
+            out_dim,
+            false,
+            vb.pp("fp8_tensor"),
+            Nvfp4Config::default(),
+        )?;
+        assert!(matches!(fp8_tensor, AutoLinear::Fp8Tensor(_)));
+        assert_eq!(fp8_tensor.forward(&input)?.dims(), &[1, out_dim]);
 
         let nvfp4 = auto_linear(
             in_dim,
@@ -931,6 +1055,52 @@ mod tests {
         assert!(matches!(nvfp4_dense, AutoLinear::Nvfp4(_)));
         assert_eq!(nvfp4_dense.forward(&input)?.dims(), &[1, out_dim]);
 
+        Ok(())
+    }
+
+    /// Regression coverage for huggingface/candle#3858: `fp8_tensor_linear`
+    /// must actually multiply by `weight_scale`, not just successfully load
+    /// an `F8E4M3` tensor and drop the scale on the floor. A weight of all
+    /// 1.0s and a non-1.0 scale makes a dropped scale obvious: forgetting it
+    /// gives `sum(x)`, applying it gives `scale * sum(x)`.
+    #[test]
+    fn fp8_tensor_linear_applies_weight_scale() -> Result<()> {
+        let device = Device::Cpu;
+        let out_dim = 1;
+        let in_dim = 4;
+        let scale = 2.5f32;
+
+        let mut tensors = std::collections::HashMap::new();
+        tensors.insert(
+            "layer.weight".to_string(),
+            // 0x38 is F8E4M3's bit pattern for 1.0, exact.
+            Tensor::from_vec(
+                vec![float8::F8E4M3::from_bits(0x38); out_dim * in_dim],
+                (out_dim, in_dim),
+                &device,
+            )?,
+        );
+        tensors.insert(
+            "layer.weight_scale".to_string(),
+            Tensor::from_vec(vec![scale], (), &device)?,
+        );
+        let vb = VarBuilder::from_tensors(tensors, DType::F32, &device);
+        let layer = vb.pp("layer");
+
+        assert_eq!(detect_backing(&layer)?, Backing::Fp8Tensor);
+        let linear = fp8_tensor_linear(in_dim, out_dim, false, layer)?;
+
+        let xs = Tensor::ones((1, in_dim), DType::F32, &device)?;
+        let out = linear.forward(&xs)?.to_vec2::<f32>()?;
+        // With the weight all 1.0 and x all 1.0: sum(x) = in_dim. Applying
+        // the scale gives in_dim * scale; dropping it (the #3858 bug) would
+        // give plain in_dim instead.
+        let expected = in_dim as f32 * scale;
+        assert!(
+            (out[0][0] - expected).abs() < 1e-5,
+            "{} vs {expected} (weight_scale dropped?)",
+            out[0][0]
+        );
         Ok(())
     }
 

--- a/candle-transformers/src/quantized_nvfp4.rs
+++ b/candle-transformers/src/quantized_nvfp4.rs
@@ -140,14 +140,19 @@ pub fn nvfp4_weight_tensor_name(vb: &VarBuilder) -> &'static str {
 /// Reads `name` as an `f32` tensor holding exactly one element, accepting
 /// either a rank-0 scalar or a rank-1 `[1]` tensor: ModelOpt exporters have
 /// used both shapes for `weight_scale_2` across versions.
+///
+/// Tries the shapes with ordinary, shape-checked reads rather than
+/// `get_unchecked`, since some `SimpleBackend`s reject it outright (e.g.
+/// `VarMap`, used to build a randomly-initialized `VarBuilder`). Note this
+/// module still isn't reachable from a `ShardedVarBuilder` (used for
+/// tensor-parallel loading): that's a different `VarBuilderArgs<B>`
+/// instantiation than the concrete `VarBuilder` these functions take, so
+/// it's a type-level gap this fix doesn't close.
 fn read_scalar_f32(vb: &VarBuilder, name: &str) -> Result<f32> {
-    let t = vb.get_unchecked_dtype(name, DType::F32)?;
-    if t.elem_count() != 1 {
-        candle::bail!(
-            "nvfp4: {name} must hold exactly one element, got shape {:?}",
-            t.shape()
-        )
+    if let Ok(t) = vb.get_with_hints_dtype((), name, Default::default(), DType::F32) {
+        return t.to_scalar::<f32>();
     }
+    let t = vb.get_with_hints_dtype(1, name, Default::default(), DType::F32)?;
     t.reshape(())?.to_scalar::<f32>()
 }
 
@@ -596,9 +601,11 @@ mod tests {
     #[test]
     fn nvfp4_linear_reads_the_modelopt_naming_convention() -> Result<()> {
         // A layer using ModelOpt's naming (packed weight under `.weight`,
-        // no `.weight_packed`) must load through the same auto_linear/
-        // nvfp4_linear path as the compressed-tensors naming; this is what
-        // Backing::Nvfp4 promises once detect_backing returns it.
+        // no `.weight_packed`) must load through nvfp4_linear the same way
+        // as the compressed-tensors naming; this is what nvfp4_weight_tensor_name
+        // promises once detect_backing returns Backing::Nvfp4. See
+        // auto_linear_dispatches_by_detected_backing for the auto_linear
+        // entry point built on top of this.
         let device = Device::Cpu;
         let out_dim = 2;
         let in_dim = 32;
@@ -639,6 +646,86 @@ mod tests {
         let linear = nvfp4_linear(in_dim, out_dim, false, layer, Nvfp4Config::default())?;
         let output = linear.forward(&Tensor::zeros((1, in_dim), DType::F32, &device)?)?;
         assert_eq!(output.dims(), &[1, out_dim]);
+        Ok(())
+    }
+
+    #[test]
+    fn auto_linear_dispatches_by_detected_backing() -> Result<()> {
+        let device = Device::Cpu;
+        let in_dim = 4;
+        let out_dim = 2;
+        let mut tensors = std::collections::HashMap::new();
+
+        // Dense: a plain `.weight`, nothing else.
+        tensors.insert(
+            "dense.weight".to_string(),
+            Tensor::zeros((out_dim, in_dim), DType::F32, &device)?,
+        );
+
+        // Block-wise FP8 (DeepSeek-style): `.weight` + `.weight_scale_inv`.
+        tensors.insert(
+            "fp8.weight".to_string(),
+            Tensor::zeros((out_dim, in_dim), DType::F8E4M3, &device)?,
+        );
+        tensors.insert(
+            "fp8.weight_scale_inv".to_string(),
+            Tensor::from_vec(vec![1f32], (1, 1), &device)?,
+        );
+
+        // NVFP4, ModelOpt naming: `.weight` (packed) + `.weight_scale` +
+        // `.weight_scale_2`, no `.weight_packed`.
+        let row: Vec<f32> = vec![
+            0., 0.5, 1., 1.5, 2., 3., 4., 6., 0., 0., 0., 0., 0., 0., 0., 0.,
+        ];
+        let packed_row = pack_row(&row);
+        tensors.insert(
+            "nvfp4.weight".to_string(),
+            Tensor::from_vec(
+                [packed_row.clone(), packed_row].concat(),
+                (out_dim, in_dim / 2),
+                &device,
+            )?,
+        );
+        tensors.insert(
+            "nvfp4.weight_scale".to_string(),
+            Tensor::from_vec(
+                vec![float8::F8E4M3::from_bits(0x38); out_dim],
+                (out_dim, in_dim.div_ceil(BLOCK_SIZE)),
+                &device,
+            )?,
+        );
+        tensors.insert(
+            "nvfp4.weight_scale_2".to_string(),
+            Tensor::from_vec(vec![1f32], (), &device)?,
+        );
+
+        let vb = VarBuilder::from_tensors(tensors, DType::F32, &device);
+        let input = Tensor::zeros((1, in_dim), DType::F32, &device)?;
+
+        let dense = auto_linear(
+            in_dim,
+            out_dim,
+            false,
+            vb.pp("dense"),
+            Nvfp4Config::default(),
+        )?;
+        assert!(matches!(dense, AutoLinear::Dense(_)));
+        assert_eq!(dense.forward(&input)?.dims(), &[1, out_dim]);
+
+        let fp8 = auto_linear(in_dim, out_dim, false, vb.pp("fp8"), Nvfp4Config::default())?;
+        assert!(matches!(fp8, AutoLinear::Fp8Block(_)));
+        assert_eq!(fp8.forward(&input)?.dims(), &[1, out_dim]);
+
+        let nvfp4 = auto_linear(
+            in_dim,
+            out_dim,
+            false,
+            vb.pp("nvfp4"),
+            Nvfp4Config::default(),
+        )?;
+        assert!(matches!(nvfp4, AutoLinear::Nvfp4(_)));
+        assert_eq!(nvfp4.forward(&input)?.dims(), &[1, out_dim]);
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Closes #3857.

NVFP4 (ModelOpt / compressed-tensors W4A16) currently has no execution
path off CUDA hardware in candle: the CUDA-only `candle-nvfp4-kernels`
crate provides a fused, device-resident operator, but any non-CUDA
host (CPU, Apple Silicon) has no way to run an NVFP4 checkpoint except
dequantizing every packed weight to a dense `f32` tensor at load time
— an 8x footprint expansion that OOMs or fails outright on exactly the
hosts this issue is about. As the issue states: memory is the
blocker, not speed.

This PR adds:

- `candle-nvfp4-kernels`: a CUDA crate exposing a fused NVFP4 linear
  operator (`Nvfp4Linear`) that keeps the packed weight
  device-resident and never materializes a dense tensor.
- `candle_transformers::quantized_nvfp4`: a ModelOpt/compressed-tensors
  aware weight source —
  - `detect_backing()` distinguishes dense, block-wise FP8, and packed
    NVFP4 layers from a `VarBuilder`'s tensor names alone, so mixed
    checkpoints load layer by layer.
  - `dequantize_nvfp4()` decodes packed E2M1 nibbles and E4M3 block
    scales explicitly (never via a numeric dtype cast), bounded by an
    explicit `max_dense_bytes` budget so an 8x unpack fails loudly
    instead of exceeding available memory.
  - **`Nvfp4LinearPacked`** (new in this PR): a CPU operator that keeps
    the packed weight and block scales resident in their
    checkpoint-native, ~1x-footprint form and decodes each output row
    on the fly during `forward`, instead of pre-expanding the whole
    matrix to dense `f32`. This is what actually resolves #3857 for
    non-CUDA hosts.
  - `auto_linear()` ties detection and construction together with an
    explicit execution preference order:
    1. `nvfp4-cuda` fused kernel — CUDA device, packed and
       device-resident.
    2. `Nvfp4LinearPacked` — the new default off CUDA: packed, ~1x
       footprint, decoded on the fly.
    3. Dense dequantization (`nvfp4_linear`) — opt-in via
       `Nvfp4Config::force_dense_fallback`, for callers who'd rather
       trade memory for forward-pass throughput and know the
       checkpoint fits within `max_dense_bytes`.

A Metal backend is still future work (tracked by the sibling-crate gap
noted in #3857) — `Nvfp4LinearPacked` is device-agnostic CPU code, so
on a Metal device it currently round-trips through host memory rather
than running on-device. That's a reasonable interim step: it turns an
outright failure/OOM into a working (if not fully accelerated) path,
and a future Metal kernel can slot into the same preference order
without changing `auto_linear`'s public API.

## Why a new operator instead of just relaxing the dense fallback

Raising or removing `max_dense_bytes` doesn't fix the underlying
problem — a 70B-parameter NVFP4 checkpoint still needs ~8x its packed
size in RAM once dequantized, whether or not you allow the allocation.
`Nvfp4LinearPacked` avoids the expansion entirely by never storing a
dense copy of the weight, at the cost of decoding each row on every
forward pass instead of once at load time. That tradeoff matches what
the issue asks for explicitly: "Memory is the blocker, not speed."

## Test plan

- [x] `cargo test -p candle-transformers quantized_nvfp4` — unit tests
      cover `detect_backing`, both ModelOpt and compressed-tensors
      naming conventions, the `max_dense_bytes` budget guard, and a
      new test asserting `Nvfp4LinearPacked` matches
      `dequantize_nvfp4`'s dense output on a batched, multi-dimensional
      input.
- [x] `cargo build -p candle-transformers -p candle-nvfp4-kernels`
- [x] `cargo fmt --check` / `cargo clippy --tests -- -D warnings` on
      the touched crates.
- [ ] CUDA fused path (`--features nvfp4-cuda`) exercised on a GPU
      runner — not available in this environment; the CUDA kernel
      itself is unchanged by this PR.