### PR TITLE
fix(metal): surface command buffer errors that occur during execution

### DIFF
--- a/candle-metal-kernels/src/metal/commands.rs
+++ b/candle-metal-kernels/src/metal/commands.rs
@@ -328,11 +328,6 @@ impl Commands {
             _ => unreachable!(),
         }
 
-        // The status matched above is the status *before* waiting. A buffer that was still
-        // NotEnqueued/Enqueued/Committed/Scheduled can fail during execution -- the GPU aborts
-        // it, and every buffer queued behind it is nopped -- ending in `Error`. Without this
-        // second check the failure is silently swallowed and the caller goes on to read output
-        // buffers the GPU never wrote, turning a hard error into wrong numbers.
         if cb.status() == MTLCommandBufferStatus::Error {
             return Err(Self::cb_error(cb));
         }

--- a/candle-metal-kernels/src/metal/commands.rs
+++ b/candle-metal-kernels/src/metal/commands.rs
@@ -324,17 +324,28 @@ impl Commands {
                 cb.wait_until_completed();
             }
             MTLCommandBufferStatus::Completed => {}
-            MTLCommandBufferStatus::Error => {
-                let msg = cb
-                    .error()
-                    .map(|e| e.to_string())
-                    .unwrap_or_else(|| "unknown error".to_string());
-                return Err(MetalKernelError::CommandBufferError(msg));
-            }
+            MTLCommandBufferStatus::Error => return Err(Self::cb_error(cb)),
             _ => unreachable!(),
         }
 
+        // The status matched above is the status *before* waiting. A buffer that was still
+        // NotEnqueued/Enqueued/Committed/Scheduled can fail during execution -- the GPU aborts
+        // it, and every buffer queued behind it is nopped -- ending in `Error`. Without this
+        // second check the failure is silently swallowed and the caller goes on to read output
+        // buffers the GPU never wrote, turning a hard error into wrong numbers.
+        if cb.status() == MTLCommandBufferStatus::Error {
+            return Err(Self::cb_error(cb));
+        }
+
         Ok(())
+    }
+
+    fn cb_error(cb: &CommandBuffer) -> MetalKernelError {
+        let msg = cb
+            .error()
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "unknown error".to_string());
+        MetalKernelError::CommandBufferError(msg)
     }
 
     fn end_encoding(&self, encoder: ComputeCommandEncoder) {


### PR DESCRIPTION
Closes #3850.

### The bug

`Commands::ensure_completed` inspects a command buffer's status, and then, for the
not-yet-finished states, waits:

```rust
fn ensure_completed(cb: &CommandBuffer) -> Result<(), MetalKernelError> {
    match cb.status() {
        NotEnqueued | Enqueued  => { cb.commit(); cb.wait_until_completed(); }
        Committed | Scheduled   => { cb.wait_until_completed(); }
        Completed               => {}
        Error                   => { /* ...reported... */ }
        _ => unreachable!(),
    }
    Ok(())        // status never re-checked
}
```

The status that is matched is the status *before* the wait. A buffer that was
`Committed` or `Scheduled` at the moment of the check can fail during
execution — the GPU aborts it, and every buffer queued behind it is nopped —
ending in `Error`. That transition happens inside `wait_until_completed()`, after
the match arm has already been chosen, so nothing looks at it and the function
returns `Ok`.

The `Error` arm therefore only ever fires for a buffer that had *already* failed
before `ensure_completed` looked at it. In the CPU-readback path
(`flush_and_wait_current`) the buffer is freshly committed, so its pre-wait status
is `Committed` — never `Error` — and any execution failure is discarded. The
caller then reads output buffers the GPU never wrote.

This also covers the gap #3850 notes in `flush_and_wait`: it error-checks
`to_wait[..len-1]` explicitly, but the last buffer goes through
`ensure_completed` and so was only ever checked before its wait.

### Why it matters

It turns a hard, diagnosable failure into wrong numbers. A GPU out-of-memory —
routine when a model does not fit — comes back as garbled output and **exit status
0**, with nothing anywhere saying the GPU aborted.

It is also a force multiplier on every other Metal bug: any kernel fault that
aborts the command buffer is reported as bad output rather than as a fault, so an
investigation starts by suspecting the numerics instead of the abort.

### The fix

Re-check the status after waiting, and factor the error construction so both
sites share it:

```rust
        MTLCommandBufferStatus::Error => return Err(Self::cb_error(cb)),
        _ => unreachable!(),
    }

    // The status matched above is the status *before* waiting. A buffer that was still
    // NotEnqueued/Enqueued/Committed/Scheduled can fail during execution -- the GPU aborts
    // it, and every buffer queued behind it is nopped -- ending in `Error`. Without this
    // second check the failure is silently swallowed and the caller goes on to read output
    // buffers the GPU never wrote, turning a hard error into wrong numbers.
    if cb.status() == MTLCommandBufferStatus::Error {
        return Err(Self::cb_error(cb));
    }

    Ok(())
}
```

No API change and no new error variant — `MetalKernelError::CommandBufferError`
already exists and already carries the message from `cb.error()`. The only
behavioural difference is that a failure which previously returned `Ok` now
returns that error.

### Testing, and what I did *not* test

- Compiles clean: `cargo check -p candle-metal-kernels` on macOS (M1 Max, macOS
  26.6), against `main` at `6f74e7c3`.
- **No automated test.** Provoking this needs a command buffer that fails *during*
  execution, which in practice means a real GPU OOM or a deliberately faulting
  kernel — neither belongs in the test suite. The change is a status re-read on a
  path that previously had none, so regression risk is confined to callers that
  were relying on errors being swallowed.
- **I have not re-verified the runtime symptom against this patch.** The symptom
  in #3850 — `kIOGPUCommandBufferCallbackErrorOutOfMemory` on a 32B quantized GGUF
  emitting garbled output with exit 0 on Metal, while the same weights and prompt
  decoded correctly on CPU — is as reported there. What I confirmed for this PR is
  the cherry-pick onto current `main` and the compile.

Happy to rework any of it.
