### PR TITLE
Avoid copying a rank-2 rhs in broadcast_matmul

### DIFF
--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -1562,6 +1562,21 @@ impl Tensor {
                 .broadcast_as(&l_shape)?
                 .contiguous()?
                 .matmul(&rhs.broadcast_as(&r_shape)?.contiguous()?),
+            // A rank-2 rhs is only broadcast over the batch dimensions, so the whole product is
+            // a single 2D matmul once the leading dims of lhs are folded into its row dimension.
+            // Broadcasting the rhs instead would copy it `batch` times -- for an lm_head that is
+            // the entire vocabulary matrix, per call. Same trick, and same contiguity guard, as
+            // `candle_nn::Linear::forward`.
+            (false, true) if rhs.rank() == 2 && lhs.is_contiguous() => {
+                let (lhs_dims, rhs_dims) = (lhs.dims(), rhs.dims());
+                let (m, k) = (lhs_dims[lhs.rank() - 2], lhs_dims[lhs.rank() - 1]);
+                let n = rhs_dims[1];
+                let batch: usize = lhs_dims[..lhs.rank() - 2].iter().product();
+                let mut out_dims = lhs_dims.to_vec();
+                out_dims.pop();
+                out_dims.push(n);
+                lhs.reshape((batch * m, k))?.matmul(rhs)?.reshape(out_dims)
+            }
             (false, true) => lhs.matmul(&rhs.broadcast_as(&r_shape)?.contiguous()?),
             (true, false) => lhs.broadcast_as(&l_shape)?.contiguous()?.matmul(rhs),
             (false, false) => lhs.matmul(rhs),

--- a/candle-core/tests/matmul_tests.rs
+++ b/candle-core/tests/matmul_tests.rs
@@ -149,6 +149,35 @@ fn zero_matmul_device_validation(device: &Device) -> Result<()> {
     Ok(())
 }
 
+// A rank-2 rhs is broadcast over the batch dims only, which `broadcast_matmul` folds into a
+// single 2D matmul instead of copying the rhs. Check the folded path against the per-batch
+// products it stands for, contiguous lhs (folded) and non-contiguous lhs (fallback) alike.
+fn broadcast_matmul_rank2_rhs(device: &Device) -> Result<()> {
+    let rhs = Tensor::randn(0f32, 1f32, (5, 2), device)?;
+    for lhs in [
+        Tensor::randn(0f32, 1f32, (3, 4, 5), device)?,
+        Tensor::randn(0f32, 1f32, (3, 6, 4, 5), device)?,
+        Tensor::randn(0f32, 1f32, (1, 1, 5), device)?,
+        Tensor::randn(0f32, 1f32, (3, 5, 4), device)?.transpose(1, 2)?,
+    ] {
+        let out = lhs.broadcast_matmul(&rhs)?;
+        let mut dims = lhs.dims().to_vec();
+        let n = dims.len();
+        dims[n - 1] = 2;
+        assert_eq!(out.dims(), dims.as_slice());
+        // Same product, computed the way the doc comment describes it.
+        let batch: usize = lhs.dims()[..n - 2].iter().product();
+        let (m, k) = (lhs.dims()[n - 2], lhs.dims()[n - 1]);
+        let flat = lhs.reshape((batch, m, k))?;
+        let out = out.reshape((batch, m, 2))?;
+        for b in 0..batch {
+            let diff = (out.i(b)? - flat.i(b)?.matmul(&rhs)?)?.sqr()?.sum_all()?;
+            assert!(diff.to_vec0::<f32>()? < 1e-6);
+        }
+    }
+    Ok(())
+}
+
 #[test]
 fn tensor_dot() -> Result<()> {
     let lhs = Tensor::new(&[1., 2., 3.], &Device::Cpu)?;
@@ -226,6 +255,12 @@ test_device!(
     zero_matmul_device_validation_cpu,
     zero_matmul_device_validation_gpu,
     zero_matmul_device_validation_metal
+);
+test_device!(
+    broadcast_matmul_rank2_rhs,
+    broadcast_matmul_rank2_rhs_cpu,
+    broadcast_matmul_rank2_rhs_gpu,
+    broadcast_matmul_rank2_rhs_metal
 );
 test_device!(squeeze_mm, squeeze_mm_cpu, squeeze_mm_gpu, squeeze_mm_metal);
 test_device!(mm_layout, mm_layout_cpu, mm_layout_gpu, mm_layout_metal);


### PR DESCRIPTION
Fixes #3871.

## Summary

`Tensor::broadcast_matmul` on a `(b, m, k) @ (k, n)` product takes the `(false, true)` arm and runs
`lhs.matmul(&rhs.broadcast_as(&r_shape)?.contiguous()?)`, so it builds a `(b, k, n)` copy of the rhs
on every call — when the rhs is a weight matrix, a full copy of the weights, per call. And since the
rhs is usually a transposed view (`w.t()`), that copy is a strided gather rather than a memcpy.

`candle_nn::Linear::forward` already avoids this deliberately, by folding the leading dims of `x`
into its row dimension, so models built on `Linear` (including the ones in `candle_transformers`) do
not pay it. The primitive still has the trap: write the mathematically identical
`h.broadcast_matmul(&w.t()?)` in your own code and you silently get an `O(k*n)` copy per call, with
nothing at the call site to suggest it.

## Fix

A rank-2 rhs is only broadcast over the batch dims, so the whole product is one 2D matmul once the
leading dims of the lhs are folded into its row dimension. This moves that fold into the primitive,
under the same `is_contiguous()` guard `Linear::forward` uses — `reshape` on a non-contiguous lhs
would itself copy, so the fallback path is kept for that case.

## Measurements

Reproducer from the issue, CPU only, `--release`, best of 5, Apple M3 Max, rustc 1.95:

| lhs | rhs | dtype | before | after |
|---|---|---|---|---|
| `(1, 1, 2560)` | `(151936, 2560)ᵀ` | f16 | 1495.8 ms | 11.5 ms |
| `(1, 1, 2560)` | `(151936, 2560)ᵀ` | f32 | 1903.8 ms | 52.8 ms |
| `(1, 8, 2560)` | `(151936, 2560)ᵀ` | f16 | 1417.3 ms | 14.8 ms |

Those CPU numbers are dominated by a single-threaded strided copy, so do not read the ratio as a GPU
ratio. What holds on any backend is the shape of the cost: `O(b*k*n)` bytes written then read back
per call, for a product that only needs to read `O(k*n)` bytes once. The issue has an L40S decode
loop where that made the head phase cost twice all 36 transformer blocks combined.

f16 accuracy improves as a side effect, the folded path being the 2D matmul rather than the batched
one. Error against the f32 product of the same inputs, `32768 x 2560` f16, relative to `max |out|`:
`1.38e-2` before, `1.18e-3` after.

## Scope

Only the `(false, true)` arm with a rank-2 rhs. A rhs of rank > 2 whose batch dims are all 1 still
takes the copy path, and `(true, false)` / `(true, true)` still concretise — the pre-existing TODO
covers those too and they do not have a one-line answer. Happy to look at the general case in a
follow-up if you would rather have it in one go.

## Tests

* `cargo test -p candle-core --release` and `cargo test -p candle-nn --release` pass in full,
  `grad_tests` included (`reshape` and `matmul` are both differentiable, so autograd is unaffected).
* `cargo test -p candle-core --release --features metal --test matmul_tests` passes on the M3 Max,
  new test included. No CUDA hardware here, so the `_gpu` variants are untested.
* `cargo fmt --all -- --check` is clean, as is
  `cargo clippy -p candle-core -p candle-nn --tests --benches -- -D warnings`.
* The added `broadcast_matmul_rank2_rhs` checks the folded result against the per-batch products it
  stands for, over rank-3 and rank-4 lhs, `m = 1`, and a non-contiguous lhs that has to fall back.
  It fails if the fold mixes rows across batches (checked by mutating the reshape).
* Checked separately against the old path, on rank-3 and rank-4 lhs: values bit-identical, gradients
  w.r.t. both operands equal up to float rounding, and zero-sized operands (`b`, `m`, `k` or `n` set
  to 0) keep the shapes they had before.
