### PR TITLE
Fix Metal rank-5+ strided reduce reading out of bounds

### DIFF
--- a/candle-core/tests/grad_tests.rs
+++ b/candle-core/tests/grad_tests.rs
@@ -38,6 +38,24 @@ fn sum_grad(device: &Device) -> Result<()> {
     Ok(())
 }
 
+fn expand_grad(device: &Device) -> Result<()> {
+    // Computing the gradient sums over a middle dim of a 5D tensor, which
+    // takes the strided-index fallback path in the Metal reduce kernels,
+    // see issue #3847.
+    let data: Vec<f32> = (0..24).map(|v| v as f32).collect();
+    let x = Var::from_vec(data, (1, 1, 4, 6), device)?;
+    let e = x.as_tensor().unsqueeze(2)?.expand((1, 1, 3, 4, 6))?;
+    let loss = (e.sqr()?.sum_all()? * 0.5)?;
+    let grads = loss.backward()?;
+    let grad_x = grads.get(&x).context("no grad for x")?;
+    // loss = 0.5 * sum over the 3 broadcast copies of x^2, so dloss/dx = 3.x
+    assert_eq!(
+        grad_x.flatten_all()?.to_vec1::<f32>()?,
+        (0..24).map(|v| 3. * v as f32).collect::<Vec<f32>>()
+    );
+    Ok(())
+}
+
 fn matmul_grad(device: &Device) -> Result<()> {
     let data: Vec<_> = (0..12).map(|i| i as f32).collect();
     let x = Var::from_slice(&data, (2, 2, 3), device)?;
@@ -587,6 +605,12 @@ test_device!(
     simple_grad_metal
 );
 test_device!(sum_grad, sum_grad_cpu, sum_grad_gpu, sum_grad_metal);
+test_device!(
+    expand_grad,
+    expand_grad_cpu,
+    expand_grad_gpu,
+    expand_grad_metal
+);
 test_device!(
     matmul_grad,
     matmul_grad_cpu,

--- a/candle-metal-kernels/src/metal_src/reduce.metal
+++ b/candle-metal-kernels/src/metal_src/reduce.metal
@@ -82,7 +82,7 @@ METAL_FUNC IndexT get_strided_idx_fallback(
 
     IndexT strided_i = 0;
     for (IndexT d = D; d < num_dims; d++) {
-        IndexT dim_idx = num_dims - 1 - d;
+        IndexT dim_idx = num_dims - 1 - (d - D);
         IndexT dim = dims[dim_idx];
         strided_i += (idx % dim) * strides[dim_idx];
         idx /= dim;


### PR DESCRIPTION
Fixes #3847.

`get_strided_idx_fallback` in `reduce.metal` decomposes the linear index over the wrong dimensions. This affects all strided reduces (sum/min/max/argmin/argmax) on rank-5+ inputs.

Concrete example from the issue's repro: the backward of an interior-dim broadcast on a
`(1, 1, 2, 512, 64)` tensor is a rank-5 strided sum with kernel dims
`[1, 1, 512, 64, 2]` / strides `[65536, 65536, 64, 1, 32768]`. The fallback maps logical
index 65535 to storage offset 63 + 32704 + 65536 = 98303 (should be 65535) in a 65536-element buffer.

The `expand_grad` test is distilled from this repro; on an M4 Max it fails before the fix and passes after.