### PR TITLE
Fix CPU argsort for offset tensor views

### DIFF
--- a/candle-core/src/sort.rs
+++ b/candle-core/src/sort.rs
@@ -8,7 +8,11 @@ struct ArgSort {
 }
 
 impl ArgSort {
-    fn asort<T: crate::WithDType>(&self, vs: &[T], layout: &crate::Layout) -> Vec<u32> {
+    fn asort<T: crate::WithDType>(&self, vs: &[T], layout: &crate::Layout) -> Result<Vec<u32>> {
+        let vs = match layout.contiguous_offsets() {
+            None => crate::bail!("input has to be contiguous"),
+            Some((o1, o2)) => &vs[o1..o2],
+        };
         #[allow(clippy::uninit_vec)]
         // Safety: indexes are set later in the parallelized section.
         let mut sort_indexes = unsafe {
@@ -48,7 +52,7 @@ impl ArgSort {
                     })
                 });
         }
-        sort_indexes
+        Ok(sort_indexes)
     }
 }
 
@@ -114,16 +118,16 @@ impl crate::CustomOp1 for ArgSort {
         layout: &crate::Layout,
     ) -> Result<(crate::CpuStorage, crate::Shape)> {
         let sort_indexes = match storage {
-            crate::CpuStorage::U8(vs) => self.asort(vs, layout),
-            crate::CpuStorage::U32(vs) => self.asort(vs, layout),
-            crate::CpuStorage::I16(vs) => self.asort(vs, layout),
-            crate::CpuStorage::I32(vs) => self.asort(vs, layout),
-            crate::CpuStorage::I64(vs) => self.asort(vs, layout),
-            crate::CpuStorage::BF16(vs) => self.asort(vs, layout),
-            crate::CpuStorage::F16(vs) => self.asort(vs, layout),
-            crate::CpuStorage::F32(vs) => self.asort(vs, layout),
-            crate::CpuStorage::F64(vs) => self.asort(vs, layout),
-            crate::CpuStorage::F8E4M3(vs) => self.asort(vs, layout),
+            crate::CpuStorage::U8(vs) => self.asort(vs, layout)?,
+            crate::CpuStorage::U32(vs) => self.asort(vs, layout)?,
+            crate::CpuStorage::I16(vs) => self.asort(vs, layout)?,
+            crate::CpuStorage::I32(vs) => self.asort(vs, layout)?,
+            crate::CpuStorage::I64(vs) => self.asort(vs, layout)?,
+            crate::CpuStorage::BF16(vs) => self.asort(vs, layout)?,
+            crate::CpuStorage::F16(vs) => self.asort(vs, layout)?,
+            crate::CpuStorage::F32(vs) => self.asort(vs, layout)?,
+            crate::CpuStorage::F64(vs) => self.asort(vs, layout)?,
+            crate::CpuStorage::F8E4M3(vs) => self.asort(vs, layout)?,
             // Dummy types don't support sorting
             crate::CpuStorage::F6E2M3(_) => {
                 return Err(

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -216,6 +216,15 @@ fn asort(device: &Device) -> Result<()> {
         sorted.to_vec2::<f32>()?,
         [[5.0, 4.0, 3.0, 1.1, 1.0], [8.0, 7.0, 2.1, 2.0, 1.0]]
     );
+
+    let offset_view = Tensor::new(&[[1f32, 2., 3.], [30., 10., 20.]], device)?.narrow(0, 1, 1)?;
+    let (sorted, indexes) = offset_view.sort_last_dim(true)?;
+    assert_eq!(indexes.to_vec2::<u32>()?, [[1, 2, 0]]);
+    assert_eq!(sorted.to_vec2::<f32>()?, [[10., 20., 30.]]);
+
+    let (sorted, indexes) = offset_view.sort_last_dim(false)?;
+    assert_eq!(indexes.to_vec2::<u32>()?, [[0, 2, 1]]);
+    assert_eq!(sorted.to_vec2::<f32>()?, [[30., 20., 10.]]);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- make CPU `arg_sort_last_dim` sort only the tensor view's contiguous storage window
- add ascending and descending regression coverage for a narrowed tensor with a non-zero offset

This matches the existing CUDA path, which already applies `Layout::contiguous_offsets()` before sorting.

Fixes #3874

## Tests

- `cargo test -p candle-core --test tensor_tests`
- `cargo clippy -p candle-core --tests -- -D warnings`
- `cargo fmt --all -- --check`
