### PR TITLE
gguf: reject zero alignment instead of panicking with divide-by-zero

### DIFF
--- a/candle-core/src/quantized/gguf_file.rs
+++ b/candle-core/src/quantized/gguf_file.rs
@@ -557,6 +557,11 @@ impl Content {
             Some(Value::I32(v)) if *v >= 0 => *v as u64,
             _ => DEFAULT_ALIGNMENT,
         };
+        if alignment == 0 {
+            crate::bail!(
+                "gguf: invalid alignment {alignment} in general.alignment (must be non-zero)"
+            )
+        }
         let tensor_data_offset = position.div_ceil(alignment) * alignment;
         Ok(Self {
             magic,


### PR DESCRIPTION
## What

`gguf_file::Content::read` panics with "attempt to divide by zero" when
the metadata key `general.alignment` is 0: `position.div_ceil(alignment)`
at `candle-core/src/quantized/gguf_file.rs`. A hostile model file (57
bytes: header + one KV `general.alignment = 0`) crashes the process with
a Rust panic instead of a structured error.

Other GGUF readers reject zero alignment (llama.cpp: "alignment must be
power of two"; ember: "invalid GGUF alignment 0"). This fix returns a
structured error.

## Repro

57-byte GGUF: header (0 tensors, 1 KV), KV `general.alignment` = u32 0.

Before: `thread 'main' panicked at
candle-core-0.11.0/src/quantized/gguf_file.rs:560: attempt to divide by
zero` (verified on crates.io 0.11.0, latest).

After: `gguf: invalid alignment 0 in general.alignment (must be
non-zero)`.

## Notes

Found by differential fuzzing of GGUF model loaders. Availability
defect (panic), no memory-safety claim. Reproducer and report archived
with the research corpus (research/embersec/comparative/disclosure/).
