### PR TITLE
Fix repeat with zero factors

### DIFF
--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -696,9 +696,11 @@ impl Tensor {
             self.clone()
         };
         for (idx, &repeat) in repeats.iter().enumerate() {
-            if repeat > 1 {
-                inp = Tensor::cat(&vec![&inp; repeat], idx)?
-            }
+            inp = match repeat {
+                0 => inp.narrow(idx, 0, 0)?,
+                1 => inp,
+                repeat => Tensor::cat(&vec![&inp; repeat], idx)?,
+            };
         }
         Ok(inp)
     }

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -1761,6 +1761,34 @@ fn randn(device: &Device) -> Result<()> {
     Ok(())
 }
 
+fn repeat_with_zero_factor(device: &Device) -> Result<()> {
+    let tensor = Tensor::new(&[[1u32, 2], [3, 4]], device)?;
+
+    let repeated_rows = tensor.repeat((0, 2))?;
+    assert_eq!(repeated_rows.dims(), &[0, 4]);
+    assert_eq!(repeated_rows.elem_count(), 0);
+
+    let repeated_columns = tensor.repeat((2, 0))?;
+    assert_eq!(repeated_columns.dims(), &[4, 0]);
+    assert_eq!(repeated_columns.elem_count(), 0);
+
+    Ok(())
+}
+
+fn meshgrid_with_empty_axis(device: &Device) -> Result<()> {
+    let empty_axis = Tensor::from_vec(Vec::<f32>::new(), 0, device)?;
+    let coordinates = Tensor::new(&[10f32, 20., 30.], device)?;
+
+    let grids = Tensor::meshgrid(&[&empty_axis, &coordinates], false)?;
+    assert_eq!(grids.len(), 2);
+    for grid in grids {
+        assert_eq!(grid.dims(), &[0, 3]);
+        assert_eq!(grid.elem_count(), 0);
+    }
+
+    Ok(())
+}
+
 fn zero_dim(device: &Device) -> Result<()> {
     let t = Tensor::zeros((4, 0, 1), DType::F32, device)?;
     assert_eq!(t.dims3()?, (4, 0, 1));
@@ -1830,6 +1858,18 @@ test_device!(clamp, clamp_cpu, clamp_gpu, clamp_metal);
 test_device!(asort, asort_cpu, asort_gpu, asort_metal);
 test_device!(asort_big, asort_big_cpu, asort_big_gpu, asort_big_metal);
 test_device!(var, var_cpu, var_gpu, var_metal);
+test_device!(
+    repeat_with_zero_factor,
+    repeat_with_zero_factor_cpu,
+    repeat_with_zero_factor_gpu,
+    repeat_with_zero_factor_metal
+);
+test_device!(
+    meshgrid_with_empty_axis,
+    meshgrid_with_empty_axis_cpu,
+    meshgrid_with_empty_axis_gpu,
+    meshgrid_with_empty_axis_metal
+);
 test_device!(zero_dim, zero_dim_cpu, zero_dim_gpu, zero_dim_metal);
 
 fn tensor_send_sync(device: &Device) -> Result<()> {

--- a/candle-examples/examples/colpali/main.rs
+++ b/candle-examples/examples/colpali/main.rs
@@ -107,7 +107,7 @@ impl PageRetriever {
                 .images_to_tensor(batch, self.config.vision_config.image_size)?
                 .to_device(&self.device)?
                 .to_dtype(dtype)?;
-            let dummy_input = dummy_input.repeat((page_images.dims()[0], 0))?;
+            let dummy_input = dummy_input.repeat((page_images.dims()[0], 1))?;
 
             let image_embeddings = self.model.forward_images(&page_images, &dummy_input)?;
             let text_embeddings = self.model.forward_text(&input)?;


### PR DESCRIPTION
`Tensor::repeat` treated a zero repeat factor as one.

```rust
let tensor = Tensor::new(&[[1u32, 2], [3, 4]], &Device::Cpu)?;
let repeated = tensor.repeat((0, 2))?;
assert_eq!(repeated.dims(), &[0, 4]);
```

Before this fix, the result shape was `[2, 4]`.

The fix returns an empty view for zero factors, updates ColPali to use `1` when preserving a dimension, and adds regression tests for `repeat` and empty-axis `meshgrid`.
