### PR TITLE
fix(models): centralize the additive causal mask, build it batch-independently

### DIFF
--- a/candle-transformers/src/models/glm4_new.rs
+++ b/candle-transformers/src/models/glm4_new.rs
@@ -329,41 +329,20 @@ impl Model {
         }
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| {
-                    let past_ok = j <= i + offset;
-                    let sw_ok = match sw {
-                        Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
-                        None => true,
-                    };
-                    if past_ok && sw_ok {
-                        0.
-                    } else {
-                        minf
-                    }
-                })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
-        let (b, l) = input.dims2()?;
+        let (_b, l) = input.dims2()?;
         let mut h = self.embed_tokens.forward(input)?;
 
         let causal = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(crate::utils::build_additive_causal_mask(
+                l,
+                offset,
+                None,
+                &self.device,
+                self.dtype,
+            )?)
         };
 
         for layer in &mut self.layers {

--- a/candle-transformers/src/models/quantized_glm4.rs
+++ b/candle-transformers/src/models/quantized_glm4.rs
@@ -427,42 +427,21 @@ impl ModelWeights {
         })
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| {
-                    let past_ok = j <= i + offset;
-                    let sw_ok = match sw {
-                        Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
-                        None => true,
-                    };
-                    if past_ok && sw_ok {
-                        0.
-                    } else {
-                        minf
-                    }
-                })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
         let _enter = self.span.enter();
-        let (b, l) = input.dims2()?;
+        let (_b, l) = input.dims2()?;
         let mut h = self.embed_tokens.forward(input)?;
 
         let causal_mask = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(crate::utils::build_additive_causal_mask(
+                l,
+                offset,
+                None,
+                &self.device,
+                self.dtype,
+            )?)
         };
 
         for layer in &mut self.layers {

--- a/candle-transformers/src/models/quantized_qwen3.rs
+++ b/candle-transformers/src/models/quantized_qwen3.rs
@@ -535,42 +535,21 @@ impl ModelWeights {
         })
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| {
-                    let past_ok = j <= i + offset;
-                    let sw_ok = match sw {
-                        Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
-                        None => true,
-                    };
-                    if past_ok && sw_ok {
-                        0.
-                    } else {
-                        minf
-                    }
-                })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
         let _enter = self.span.enter();
-        let (b, l) = input.dims2()?;
+        let (_b, l) = input.dims2()?;
         let mut h = self.embed_tokens.forward(input)?;
         // Skip mask materialization when using CPU flash attention
         let causal_mask = if l == 1 || self.device.is_cpu() {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(crate::utils::build_additive_causal_mask(
+                l,
+                offset,
+                None,
+                &self.device,
+                self.dtype,
+            )?)
         };
         for layer in &mut self.layers {
             h = layer.forward(&h, causal_mask.as_ref(), offset)?;

--- a/candle-transformers/src/models/quantized_qwen3_moe.rs
+++ b/candle-transformers/src/models/quantized_qwen3_moe.rs
@@ -391,41 +391,20 @@ impl GGUFQWenMoE {
         })
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| {
-                    let past_ok = j <= i + offset;
-                    let sw_ok = match sw {
-                        Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
-                        None => true,
-                    };
-                    if past_ok && sw_ok {
-                        0.
-                    } else {
-                        minf
-                    }
-                })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     pub fn forward(&mut self, x: &Tensor, offset: usize) -> Result<Tensor> {
         let mut xs = self.tok_embeddings.forward(x)?;
-        let (b, l) = x.dims2()?;
+        let (_b, l) = x.dims2()?;
 
         let causal_mask = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(crate::utils::build_additive_causal_mask(
+                l,
+                offset,
+                None,
+                &self.device,
+                self.dtype,
+            )?)
         };
 
         for layer in self.layers.iter_mut() {

--- a/candle-transformers/src/models/qwen3.rs
+++ b/candle-transformers/src/models/qwen3.rs
@@ -396,37 +396,6 @@ impl DecoderLayer {
     }
 }
 
-/// Builds the additive causal attention mask of shape `(1, 1, tgt, tgt + offset)`.
-fn build_causal_mask(
-    tgt: usize,
-    offset: usize,
-    sw: Option<usize>,
-    device: &Device,
-    dtype: DType,
-) -> Result<Tensor> {
-    let minf = f32::NEG_INFINITY;
-    let mask: Vec<_> = (0..tgt)
-        .flat_map(|i| {
-            (0..(tgt + offset)).map(move |j| {
-                let past_ok = j <= i + offset;
-                // Within the window iff `(i + offset) - j <= w`, rearranged to
-                // `j + w >= i + offset` to stay in `usize` (no signed casts, no
-                // subtraction underflow when `j > i + offset`).
-                let sw_ok = match sw {
-                    Some(w) => j + w >= i + offset,
-                    None => true,
-                };
-                if past_ok && sw_ok {
-                    0.
-                } else {
-                    minf
-                }
-            })
-        })
-        .collect();
-    Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), device)?.to_dtype(dtype)
-}
-
 #[derive(Debug, Clone)]
 pub struct Model {
     embed_tokens: candle_nn::Embedding,
@@ -480,7 +449,7 @@ impl Model {
         #[cfg(feature = "flash-attn")]
         let needs_mask = self.device.is_cpu() && l > 1;
         let causal = if needs_mask {
-            Some(build_causal_mask(
+            Some(crate::utils::build_additive_causal_mask(
                 l,
                 offset,
                 None,
@@ -525,65 +494,5 @@ impl ModelForCausalLM {
 
     pub fn clear_kv_cache(&mut self) {
         self.base.clear_kv_cache();
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // Regression test for https://github.com/huggingface/candle/issues/3582
-    #[test]
-    fn causal_mask_is_batch_independent_and_broadcasts() {
-        let device = Device::Cpu;
-        let neg = f32::NEG_INFINITY;
-
-        let mask = build_causal_mask(3, 0, None, &device, DType::F32).unwrap();
-        assert_eq!(
-            mask.dims(),
-            &[1, 1, 3, 3],
-            "mask must carry a leading batch dim of 1 so broadcast_add applies it to every row",
-        );
-
-        // Broadcasting onto a 2-sequence batch must mask both rows identically and causally.
-        let scores = Tensor::zeros((2, 1, 3, 3), DType::F32, &device).unwrap();
-        let masked = scores
-            .broadcast_add(&mask)
-            .unwrap()
-            .squeeze(1)
-            .unwrap()
-            .to_vec3::<f32>()
-            .unwrap();
-
-        assert_eq!(
-            masked[0], masked[1],
-            "both batch rows must receive the same causal mask",
-        );
-        assert_eq!(masked[0][0], vec![0.0, neg, neg]);
-        assert_eq!(masked[0][1], vec![0.0, 0.0, neg]);
-        assert_eq!(masked[0][2], vec![0.0, 0.0, 0.0]);
-    }
-
-    #[test]
-    fn causal_mask_respects_sliding_window() {
-        // With a sliding window of `w`, query i may attend to key j only when it is
-        // both causal (j <= i + offset) and within the window (i + offset - j <= w).
-        let device = Device::Cpu;
-        let neg = f32::NEG_INFINITY;
-
-        let mask = build_causal_mask(4, 0, Some(1), &device, DType::F32)
-            .unwrap()
-            .squeeze(0)
-            .unwrap()
-            .squeeze(0)
-            .unwrap()
-            .to_vec2::<f32>()
-            .unwrap();
-
-        // window = 1: each query sees itself and the single preceding position.
-        assert_eq!(mask[0], vec![0.0, neg, neg, neg]);
-        assert_eq!(mask[1], vec![0.0, 0.0, neg, neg]);
-        assert_eq!(mask[2], vec![neg, 0.0, 0.0, neg]);
-        assert_eq!(mask[3], vec![neg, neg, 0.0, 0.0]);
     }
 }

--- a/candle-transformers/src/models/qwen3_moe.rs
+++ b/candle-transformers/src/models/qwen3_moe.rs
@@ -299,41 +299,20 @@ impl Model {
         }
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| {
-                    let past_ok = j <= i + offset;
-                    let sw_ok = match sw {
-                        Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
-                        None => true,
-                    };
-                    if past_ok && sw_ok {
-                        0.
-                    } else {
-                        minf
-                    }
-                })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
-        let (b, l) = input.dims2()?;
+        let (_b, l) = input.dims2()?;
         let mut h = self.embed_tokens.forward(input)?;
 
         let causal = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(crate::utils::build_additive_causal_mask(
+                l,
+                offset,
+                None,
+                &self.device,
+                self.dtype,
+            )?)
         };
 
         for layer in &mut self.layers {

--- a/candle-transformers/src/models/smol/quantized_smollm3.rs
+++ b/candle-transformers/src/models/smol/quantized_smollm3.rs
@@ -738,14 +738,20 @@ impl QuantizedModelForCausalLM {
     }
 
     pub fn forward(&mut self, input_ids: &Tensor, offset: usize) -> Result<Tensor> {
-        let (batch_size, seq_len) = input_ids.dims2()?;
+        let (_batch_size, seq_len) = input_ids.dims2()?;
 
         // Embed tokens
         let mut hidden_states = self.embed_tokens.forward(input_ids)?;
 
         // Skip mask materialization when using CPU flash attention
         let mask = if seq_len > 1 && !(self.use_flash_attn && self.device.is_cpu()) {
-            Some(self.create_causal_mask(batch_size, seq_len, offset)?)
+            Some(crate::utils::build_additive_causal_mask(
+                seq_len,
+                offset,
+                None,
+                &self.device,
+                DType::F32,
+            )?)
         } else {
             None
         };
@@ -763,31 +769,6 @@ impl QuantizedModelForCausalLM {
         let logits = last_hidden.apply(&self.lm_head)?;
 
         Ok(logits)
-    }
-
-    fn create_causal_mask(
-        &self,
-        batch_size: usize,
-        tgt_len: usize,
-        offset: usize,
-    ) -> Result<Tensor> {
-        let mask: Vec<_> = (0..tgt_len)
-            .flat_map(|i| {
-                (0..tgt_len + offset).map(move |j| {
-                    if j <= i + offset {
-                        0f32
-                    } else {
-                        f32::NEG_INFINITY
-                    }
-                })
-            })
-            .collect();
-
-        Tensor::from_slice(
-            &mask,
-            (batch_size, 1, tgt_len, tgt_len + offset),
-            &self.device,
-        )
     }
 
     pub fn clear_kv_cache(&mut self) {

--- a/candle-transformers/src/models/smol/smollm3.rs
+++ b/candle-transformers/src/models/smol/smollm3.rs
@@ -393,42 +393,21 @@ impl Model {
         }
     }
 
-    fn causal_mask(
-        &self,
-        b: usize,
-        tgt: usize,
-        offset: usize,
-        sw: Option<usize>,
-    ) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| {
-                    let past_ok = j <= i + offset;
-                    let sw_ok = match sw {
-                        Some(w) => (i + offset) as i64 - j as i64 <= w as i64,
-                        None => true,
-                    };
-                    if past_ok && sw_ok {
-                        0.
-                    } else {
-                        minf
-                    }
-                })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     pub fn forward(&mut self, input: &Tensor, offset: usize) -> Result<Tensor> {
-        let (b, l) = input.dims2()?;
+        let (_b, l) = input.dims2()?;
 
         let mut h = self.embed_tokens.forward(input)?;
 
         let causal = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, offset, None)?)
+            Some(crate::utils::build_additive_causal_mask(
+                l,
+                offset,
+                None,
+                &self.device,
+                self.dtype,
+            )?)
         };
 
         for layer in &mut self.layers {

--- a/candle-transformers/src/models/z_image/text_encoder.rs
+++ b/candle-transformers/src/models/z_image/text_encoder.rs
@@ -399,17 +399,6 @@ impl ZImageTextEncoder {
         })
     }
 
-    /// Create causal attention mask
-    fn causal_mask(&self, b: usize, tgt: usize, offset: usize) -> Result<Tensor> {
-        let minf = f32::NEG_INFINITY;
-        let mask: Vec<_> = (0..tgt)
-            .flat_map(|i| {
-                (0..(tgt + offset)).map(move |j| if j <= i + offset { 0.0 } else { minf })
-            })
-            .collect();
-        Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?.to_dtype(self.dtype)
-    }
-
     /// Encode text, returning second-to-last layer hidden states
     ///
     /// # Arguments
@@ -420,13 +409,19 @@ impl ZImageTextEncoder {
     ///
     /// **Important**: Returns raw output from layer[-2] WITHOUT final RMSNorm
     pub fn forward(&self, input_ids: &Tensor) -> Result<Tensor> {
-        let (b, l) = input_ids.dims2()?;
+        let (_b, l) = input_ids.dims2()?;
         let mut hidden_states = self.embed_tokens.forward(input_ids)?;
 
         let causal = if l == 1 {
             None
         } else {
-            Some(self.causal_mask(b, l, 0)?)
+            Some(crate::utils::build_additive_causal_mask(
+                l,
+                0,
+                None,
+                &self.device,
+                self.dtype,
+            )?)
         };
 
         // num_hidden_layers = 36, second-to-last layer index = 34

--- a/candle-transformers/src/utils.rs
+++ b/candle-transformers/src/utils.rs
@@ -1,6 +1,6 @@
 //! Shared utilities: repeat_kv, repeat_penalty, causal mask.
 
-use candle::{Device, Result, Tensor};
+use candle::{DType, Device, Result, Tensor};
 
 /// Build a causal attention mask of shape `(seq_len, kv_len)` where
 /// `kv_len = index_pos + seq_len`.
@@ -20,6 +20,49 @@ pub fn build_causal_mask(seq_len: usize, index_pos: usize, device: &Device) -> R
         .flat_map(|i| (0..kv_len).map(move |j| u8::from(j > index_pos + i)))
         .collect();
     Tensor::from_slice(&mask, (seq_len, kv_len), device)
+}
+
+/// Build an *additive* causal attention mask of shape `(1, 1, tgt, tgt + offset)`,
+/// where masked positions are `-inf` and visible ones are `0`.
+///
+/// This is the counterpart to [`build_causal_mask`] for models that apply the mask
+/// with `scores.broadcast_add(&mask)` rather than by selecting on a `u8` mask.
+///
+/// The buffer holds `tgt * (tgt + offset)` values and does not depend on the batch
+/// size, so the leading dim stays `1` and is broadcast over the batch by the caller.
+/// Shaping it `(b, 1, ..)` instead claims `b` times more elements than the buffer
+/// holds, which `Tensor::from_slice` does not reject; see
+/// https://github.com/huggingface/candle/issues/3582.
+///
+/// `sw` optionally restricts each query to a sliding window of `sw` preceding keys.
+pub fn build_additive_causal_mask(
+    tgt: usize,
+    offset: usize,
+    sw: Option<usize>,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    let minf = f32::NEG_INFINITY;
+    let mask: Vec<_> = (0..tgt)
+        .flat_map(|i| {
+            (0..(tgt + offset)).map(move |j| {
+                let past_ok = j <= i + offset;
+                // Within the window iff `(i + offset) - j <= w`, rearranged to
+                // `j + w >= i + offset` to stay in `usize` (no signed casts, no
+                // subtraction underflow when `j > i + offset`).
+                let sw_ok = match sw {
+                    Some(w) => j + w >= i + offset,
+                    None => true,
+                };
+                if past_ok && sw_ok {
+                    0.
+                } else {
+                    minf
+                }
+            })
+        })
+        .collect();
+    Tensor::from_slice(&mask, (1, 1, tgt, tgt + offset), device)?.to_dtype(dtype)
 }
 
 pub fn apply_repeat_penalty(logits: &Tensor, penalty: f32, context: &[u32]) -> Result<Tensor> {
@@ -54,5 +97,85 @@ pub fn repeat_kv(xs: Tensor, n_rep: usize) -> Result<Tensor> {
         // strided copy.
         // https://github.com/huggingface/candle/pull/2043
         Tensor::cat(&vec![&xs; n_rep], 2)?.reshape((b_sz, n_kv_head * n_rep, seq_len, head_dim))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression test for https://github.com/huggingface/candle/issues/3582
+    #[test]
+    fn additive_causal_mask_is_batch_independent_and_broadcasts() {
+        let device = Device::Cpu;
+        let neg = f32::NEG_INFINITY;
+
+        let mask = build_additive_causal_mask(3, 0, None, &device, DType::F32).unwrap();
+        assert_eq!(
+            mask.dims(),
+            &[1, 1, 3, 3],
+            "mask must carry a leading batch dim of 1 so broadcast_add applies it to every row",
+        );
+
+        // Broadcasting onto a 2-sequence batch must mask both rows identically and causally.
+        let scores = Tensor::zeros((2, 1, 3, 3), DType::F32, &device).unwrap();
+        let masked = scores
+            .broadcast_add(&mask)
+            .unwrap()
+            .squeeze(1)
+            .unwrap()
+            .to_vec3::<f32>()
+            .unwrap();
+
+        assert_eq!(
+            masked[0], masked[1],
+            "both batch rows must receive the same causal mask",
+        );
+        assert_eq!(masked[0][0], vec![0.0, neg, neg]);
+        assert_eq!(masked[0][1], vec![0.0, 0.0, neg]);
+        assert_eq!(masked[0][2], vec![0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn additive_causal_mask_handles_kv_cache_offset() {
+        // With `offset` cached keys the mask is rectangular: every query attends to
+        // all cached prefix keys, then the usual causal triangle over the new tokens.
+        let device = Device::Cpu;
+        let neg = f32::NEG_INFINITY;
+
+        let mask = build_additive_causal_mask(2, 2, None, &device, DType::F32)
+            .unwrap()
+            .squeeze(0)
+            .unwrap()
+            .squeeze(0)
+            .unwrap()
+            .to_vec2::<f32>()
+            .unwrap();
+
+        assert_eq!(mask[0], vec![0.0, 0.0, 0.0, neg]);
+        assert_eq!(mask[1], vec![0.0, 0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn additive_causal_mask_respects_sliding_window() {
+        // With a sliding window of `w`, query i may attend to key j only when it is
+        // both causal (j <= i + offset) and within the window (i + offset - j <= w).
+        let device = Device::Cpu;
+        let neg = f32::NEG_INFINITY;
+
+        let mask = build_additive_causal_mask(4, 0, Some(1), &device, DType::F32)
+            .unwrap()
+            .squeeze(0)
+            .unwrap()
+            .squeeze(0)
+            .unwrap()
+            .to_vec2::<f32>()
+            .unwrap();
+
+        // window = 1: each query sees itself and the single preceding position.
+        assert_eq!(mask[0], vec![0.0, neg, neg, neg]);
+        assert_eq!(mask[1], vec![0.0, 0.0, neg, neg]);
+        assert_eq!(mask[2], vec![neg, 0.0, 0.0, neg]);
+        assert_eq!(mask[3], vec![neg, neg, 0.0, 0.0]);
     }
 }


### PR DESCRIPTION
Follow-up to #3586, which fixed this in `qwen3`. That PR noted the same pattern in sibling models and offered to fix them separately. This is that sweep, with the shared logic moved into `crate::utils` next to `build_causal_mask`, following #3437.

## The bug

These mask builders fill the additive buffer with `tgt * (tgt + offset)` elements, independent of the batch, but shape the tensor `(b, 1, tgt, tgt + offset)`:

```rust
let mask: Vec<_> = (0..tgt)
    .flat_map(|i| (0..(tgt + offset)).map(move |j| /* ... */))
    .collect();                       // len = tgt * (tgt + offset), independent of b
Tensor::from_slice(&mask, (b, 1, tgt, tgt + offset), &self.device)?
```

`Tensor::from_slice` does not validate the element count against the shape. The blanket impl discards `el_count`:

```rust
impl<S: Into<Shape>> ShapeWithOneHole for S {
    fn into_shape(self, _el_count: usize) -> Result<Shape> {
        Ok(self.into())
    }
}
```

So the oversized tensor is built silently and only misbehaves when read. The failure mode depends on the backend:

- CPU: panics with `range end index 18 out of range for slice of length 9` in `cpu_backend/utils.rs`.
- Metal/CUDA: reads past the buffer, so every batch row after the first gets a garbage mask and the model returns wrong output. That is what #3582 reported.

## Scope

Eight models carry the pattern: `qwen3_moe`, `quantized_qwen3`, `quantized_qwen3_moe`, `glm4_new`, `quantized_glm4`, `smol/smollm3`, `smol/quantized_smollm3` and `z_image/text_encoder`. In `smol/quantized_smollm3` the function is called `create_causal_mask` and `z_image/text_encoder` has no sliding window, but the defect is the same.

These are more exposed than `qwen3` was. There the mask path was gated to CPU-only under the `flash-attn` feature. These gate only on `l == 1`, so the broken mask is built on every multi-token forward on every backend.

I checked this is the whole set by parsing every `Tensor::from_slice` and `from_vec` call in `candle-transformers` and looking for a batch-like leading dim, rather than grepping line by line. A line grep is how `smol/quantized_smollm3` got missed when #3586 listed the siblings, since its call is split across lines. All eight hits are this bug and there are no other batch-leading constructions in the crate.

## The fix

Rather than copy the corrected builder into eight more files, this adds `utils::build_additive_causal_mask` next to the existing `utils::build_causal_mask`, in the same spirit as #3437. It returns `(1, 1, tgt, tgt + offset)` and is broadcast over the batch by the existing `broadcast_add`.

The existing `build_causal_mask` is not reusable here: it returns a `u8` `(seq_len, kv_len)` mask for models that select on it, whereas these nine add an `f32`/`-inf` mask and need a `dtype`. So this is a sibling of it, not a replacement.

All nine models now call the shared helper, including `qwen3`, which drops the per-model copy added in #3586. Net effect is 306 lines deleted against 189 added.

The sliding-window check uses `usize` arithmetic (`j + w >= i + offset`) as in #3586, which drops the signed casts. I kept the `sw` parameter even though every call site currently passes `None`: `qwen3` bails with `"sliding window is not supported"` at construction, so it is the seam for when that lands, and removing it would be a second unrelated change.

## Tests

The tests move with the helper into `utils`: mask shape and batch broadcast, the KV cache offset case, and the sliding window.

They are not vacuous: putting `(2, 1, tgt, tgt + offset)` back in the helper fails all three.

`cargo test -p candle-transformers`, `cargo clippy -p candle-transformers --all-targets` and `cargo fmt --all -- --check` are clean.
