### PR TITLE
Metal: bound-check K-quant mul_mv stores and fix the Q2K dispatch

### DIFF
--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -24,6 +24,47 @@ pub enum GgmlDType {
     BF16,
 }
 
+/// Threadgroup geometry for the `kernel_mul_mv_*_f32` family: `(nth0, nth1, align)`.
+///
+/// `align` must equal the number of `dst` rows a single threadgroup writes, because
+/// the caller dispatches `ceil(ne01 / align)` threadgroups. An `align` smaller than
+/// the kernel's real row stride over-dispatches, and the surplus threadgroups compute
+/// rows past `ne01` — reading `src0` out of bounds on the way, since every one of these
+/// kernels derives its `src0` base pointer from the row index before any bound check.
+///
+/// Row stride per kernel, from `metal_src/quantized.metal` (`N_DST` 4, `N_SIMDGROUP` 2):
+///
+/// | kernel | row index          | rows/simdgroup | simdgroups | stride |
+/// |--------|--------------------|----------------|------------|--------|
+/// | q2_K   | `(r0*2+sgitg)*4`   | 4              | 2          | 8      |
+/// | q3_K   | `(r0*2+sgitg)*2`   | 2              | 2          | 4      |
+/// | q4_K   | `r0*4`             | 4              | 1          | 4      |
+/// | q5_K   | `(r0*2+sgitg)*2`   | 2              | 2          | 4      |
+/// | q6_K   | `2*r0+sgitg`       | 1              | 2          | 2      |
+pub(crate) fn mul_mv_dispatch_geometry(dtype: GgmlDType) -> (usize, usize, usize) {
+    match dtype {
+        GgmlDType::Q4_0
+        | GgmlDType::Q4_1
+        | GgmlDType::Q5_0
+        | GgmlDType::Q5_1
+        | GgmlDType::Q8_0
+        | GgmlDType::Q8_1 => (8, 8, 8),
+        // Fixing a bug in Metal for GGML
+        // https://github.com/ggerganov/llama.cpp/blob/b8109bc0139f15a5b321909f47510b89dca47ffc/ggml-metal.m#L1576
+        //
+        // `align` was 4 here, but the kernel row stride is 8:
+        // `first_row = (r0 * N_SIMDGROUP + sgitg) * N_DST` with two simdgroups per
+        // threadgroup (nth0 * nth1 = 64 threads).
+        GgmlDType::Q2K => (2, 32, 8),
+        GgmlDType::Q4K => (4, 8, 4),
+        GgmlDType::Q3K | GgmlDType::Q5K => (2, 32, 4),
+        GgmlDType::Q6K => (2, 32, 2),
+        // Original implem uses rows
+        GgmlDType::F16 | GgmlDType::BF16 | GgmlDType::Q8K => (32, 1, 8),
+        GgmlDType::F32 => (32, 1, 8),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn call_quantized_matmul_mv_t(
     device: &Device,
@@ -61,58 +102,7 @@ pub fn call_quantized_matmul_mv_t(
     let r2: u32 = (ne12 / ne02) as u32;
     let r3: u32 = (ne13 / ne03) as u32;
 
-    let (nth0, nth1, align) = match dtype {
-        GgmlDType::Q4_0
-        | GgmlDType::Q4_1
-        | GgmlDType::Q5_0
-        | GgmlDType::Q5_1
-        | GgmlDType::Q8_0
-        | GgmlDType::Q8_1 => {
-            let nth0 = 8;
-            let nth1 = 8;
-            let align = 8;
-            (nth0, nth1, align)
-        }
-        GgmlDType::Q2K => {
-            // Fixing a bug in Metal for GGML
-            // https://github.com/ggerganov/llama.cpp/blob/b8109bc0139f15a5b321909f47510b89dca47ffc/ggml-metal.m#L1576
-            let nth0 = 2;
-            let nth1 = 32;
-            let align = 4;
-            (nth0, nth1, align)
-        }
-        GgmlDType::Q4K => {
-            let nth0 = 4;
-            let nth1 = 8;
-            let align = 4;
-            (nth0, nth1, align)
-        }
-        GgmlDType::Q3K | GgmlDType::Q5K => {
-            let nth0 = 2;
-            let nth1 = 32;
-            let align = 4;
-            (nth0, nth1, align)
-        }
-        GgmlDType::Q6K => {
-            let nth0 = 2;
-            let nth1 = 32;
-            let align = 2;
-            (nth0, nth1, align)
-        }
-        GgmlDType::F16 | GgmlDType::BF16 | GgmlDType::Q8K => {
-            // Original implem uses rows
-            let nth0 = 32;
-            let nth1 = 1;
-            let align = 8;
-            (nth0, nth1, align)
-        }
-        GgmlDType::F32 => {
-            let nth0 = 32;
-            let nth1 = 1;
-            let align = 8;
-            (nth0, nth1, align)
-        }
-    };
+    let (nth0, nth1, align) = mul_mv_dispatch_geometry(dtype);
     let thread_groups_count = MTLSize {
         width: divide(ne01 as usize, align),
         height: ne11 as usize,

--- a/candle-metal-kernels/src/kernels/quantized.rs
+++ b/candle-metal-kernels/src/kernels/quantized.rs
@@ -27,10 +27,12 @@ pub enum GgmlDType {
 /// Threadgroup geometry for the `kernel_mul_mv_*_f32` family: `(nth0, nth1, align)`.
 ///
 /// `align` must equal the number of `dst` rows a single threadgroup writes, because
-/// the caller dispatches `ceil(ne01 / align)` threadgroups. An `align` smaller than
-/// the kernel's real row stride over-dispatches, and the surplus threadgroups compute
-/// rows past `ne01` — reading `src0` out of bounds on the way, since every one of these
-/// kernels derives its `src0` base pointer from the row index before any bound check.
+/// the caller dispatches `ceil(ne01 / align)` threadgroups. Either direction is a bug:
+/// an `align` smaller than the kernel's real row stride over-dispatches, and the surplus
+/// threadgroups compute rows past `ne01` — reading `src0` out of bounds on the way, since
+/// every one of these kernels derives its `src0` base pointer from the row index before
+/// any bound check. An `align` larger than the stride under-dispatches and leaves rows
+/// never written at all.
 ///
 /// Row stride per kernel, from `metal_src/quantized.metal` (`N_DST` 4, `N_SIMDGROUP` 2):
 ///
@@ -41,6 +43,11 @@ pub enum GgmlDType {
 /// | q4_K   | `r0*4`             | 4              | 1          | 4      |
 /// | q5_K   | `(r0*2+sgitg)*2`   | 2              | 2          | 4      |
 /// | q6_K   | `2*r0+sgitg`       | 1              | 2          | 2      |
+///
+/// The `F32` and `F16`/`BF16`/`Q8K` arms below violate this rule in the under-dispatch
+/// direction: `kernel_mul_mv_impl` takes `r0 = tgpig.x`, one row per threadgroup, so
+/// their stride is 1 while `align` is 8 — at `ne01 = 12` only 2 of 12 rows are written.
+/// That is the subject of #3856 and is left untouched here to avoid duplicating it.
 pub(crate) fn mul_mv_dispatch_geometry(dtype: GgmlDType) -> (usize, usize, usize) {
     match dtype {
         GgmlDType::Q4_0

--- a/candle-metal-kernels/src/metal_src/quantized.metal
+++ b/candle-metal-kernels/src/metal_src/quantized.metal
@@ -4663,7 +4663,7 @@ void kernel_mul_mv_q2_K_f32_impl(
 
     for (int row = 0; row < N_DST; ++row) {
         all_sum = simd_sum(sumf[row]);
-        if (tiisg == 0) {
+        if (tiisg == 0 && first_row + row < ne01) {
             dst[r1*ne0 + im*ne0*ne1 + first_row + row] = all_sum;
         }
     }
@@ -4851,7 +4851,9 @@ void kernel_mul_mv_q3_K_f32_impl(
     }
     if (tiisg == 0) {
         for (int row = 0; row < 2; ++row) {
-            dst[r1*ne0 + im*ne0*ne1 + first_row + row] = sumf1[row];
+            if (first_row + row < ne01) {
+                dst[r1*ne0 + im*ne0*ne1 + first_row + row] = sumf1[row];
+            }
         }
     }
 }
@@ -4992,7 +4994,7 @@ void kernel_mul_mv_q4_K_f32_impl(
 
     for (int row = 0; row < N_DST; ++row) {
         all_sum = simd_sum(sumf[row]);
-        if (tiisg == 0) {
+        if (tiisg == 0 && first_row + row < ne01) {
             dst[r1*ne0 + im*ne0*ne1 + first_row + row] = all_sum;
         }
     }
@@ -5149,7 +5151,7 @@ void kernel_mul_mv_q5_K_f32_impl(
 
     for (int row = 0; row < 2; ++row) {
         const float tot = simd_sum(sumf[row]);
-        if (tiisg == 0) {
+        if (tiisg == 0 && first_row + row < ne01) {
             dst[r1*ne0 + im*ne0*ne1 + first_row + row] = tot;
         }
     }
@@ -5260,7 +5262,7 @@ void kernel_mul_mv_q6_K_f32_impl(
     }
 
     const float tot = simd_sum(sumf);
-    if (tiisg == 0) {
+    if (tiisg == 0 && row < ne01) {
         dst[r1*ne0 + im*ne0*ne1 + row] = tot;
     }
 }

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2599,14 +2599,15 @@ fn kquant_mul_mv_store_overrun_survey() {
 
     // (dtype, block bytes from the static_asserts in quantized.metal)
     let family = [
-        (GgmlDType::Q2K, 2 * 2 + QK_K / 16 + QK_K / 4),          // 84
-        (GgmlDType::Q3K, 2 + QK_K / 4 + QK_K / 8 + 12),          // 110
-        (GgmlDType::Q4K, 2 * 2 + 12 + QK_K / 2),                 // 144
-        (GgmlDType::Q5K, 2 * 2 + 12 + QK_K / 2 + QK_K / 8),      // 176
-        (GgmlDType::Q6K, 2 + QK_K / 16 + 3 * QK_K / 4),          // 210
+        (GgmlDType::Q2K, 2 * 2 + QK_K / 16 + QK_K / 4), // 84
+        (GgmlDType::Q3K, 2 + QK_K / 4 + QK_K / 8 + 12), // 110
+        (GgmlDType::Q4K, 2 * 2 + 12 + QK_K / 2),        // 144
+        (GgmlDType::Q5K, 2 * 2 + 12 + QK_K / 2 + QK_K / 8), // 176
+        (GgmlDType::Q6K, 2 + QK_K / 16 + 3 * QK_K / 4), // 210
     ];
 
     let mut report = String::new();
+    let mut failures: Vec<String> = Vec::new();
     for (dtype, block_bytes) in family {
         for n in [8usize, 10, 12, 16, 17] {
             let k = QK_K;
@@ -2621,8 +2622,16 @@ fn kquant_mul_mv_store_overrun_survey() {
             let dst = new_buffer(&device, &vec![SENTINEL; dst_len]);
 
             call_quantized_matmul_mv_t(
-                &device, &encoder, &kernels, dtype, (1, 1, n, k),
-                &activations, 0, &weights, 0, &dst,
+                &device,
+                &encoder,
+                &kernels,
+                dtype,
+                (1, 1, n, k),
+                &activations,
+                0,
+                &weights,
+                0,
+                &dst,
             )
             .unwrap();
             drop(encoder);
@@ -2634,7 +2643,162 @@ fn kquant_mul_mv_store_overrun_survey() {
             report.push_str(&format!(
                 "{dtype:?}\tne01={n}\toverrun={over}\tin_range_ok={in_range_ok}\n"
             ));
+            if over != 0 || !in_range_ok {
+                failures.push(format!(
+                    "{dtype:?} ne01={n} overrun={over} in_range_ok={in_range_ok}"
+                ));
+            }
         }
     }
     println!("\n--- K-quant mul_mv store overrun survey ---\n{report}");
+    assert!(
+        failures.is_empty(),
+        "K-quant mul_mv kernels stored outside [0, ne01):\n{}",
+        failures.join("\n")
+    );
+}
+
+/// Bounding the store is not on its own sufficient, because these kernels compute their
+/// `src0` base pointer from the row index *before* anything checks that index against
+/// `ne01`: q2_K at `quantized.metal:4596` (`first_row`) -> `:4597` (`ib_row`) -> `:4604`
+/// (`x`), q6_K at `:5215` -> `:5222`. The already-guarded legacy template does the same at
+/// `:2334` -> `:2339` -> `:2341`, which is exactly why its store guard at `:2374` bounds
+/// the write but leaves the read unbounded. So while Q2K's `align` is smaller than the
+/// kernel's row stride, the surplus threadgroups keep reading weight rows past `ne01`
+/// however well the store is guarded.
+///
+/// The weights buffer is deliberately over-allocated so the overread lands inside our own
+/// allocation and the test stays well-defined, rather than depending on whatever happens to
+/// follow a tightly-sized buffer. Rows `[0, n)` are byte-identical across the two runs and
+/// only the rows past `n` differ, so any difference in the output can only have come from
+/// reading past `ne01`.
+#[test]
+fn q2k_mul_mv_output_does_not_depend_on_rows_past_ne01() {
+    const QK_K: usize = 256;
+    const BLOCK_Q2K_BYTES: usize = QK_K / 16 + QK_K / 4 + 2 + 2; // 84
+    const SENTINEL: f32 = -1234.0;
+
+    let (b, m, n, k) = (1usize, 1usize, 12usize, QK_K);
+    let blocks_per_row = k / QK_K;
+    // Far past the furthest row the over-dispatch can reach (8 * ceil(12/4) = 24).
+    let rows_alloc = 4 * n;
+    let dst_len = 4 * n;
+
+    let run = |poison: u8| -> Vec<f32> {
+        let device = device();
+        let kernels = Kernels::new();
+        let commands = commands(&device);
+        let encoder = commands.command_encoder().unwrap();
+
+        let mut w = vec![0u8; rows_alloc * blocks_per_row * BLOCK_Q2K_BYTES];
+        // Rows [0, n) stay all-zero, so d == dmin == 0 and the correct output is exactly 0.
+        // Only the rows the kernel has no business reading carry the poison.
+        w[n * blocks_per_row * BLOCK_Q2K_BYTES..].fill(poison);
+
+        let weights = new_buffer(&device, &w);
+        let activations = new_buffer(&device, &vec![1f32; m * k]);
+        let dst = new_buffer(&device, &vec![SENTINEL; dst_len]);
+
+        call_quantized_matmul_mv_t(
+            &device,
+            &encoder,
+            &kernels,
+            GgmlDType::Q2K,
+            (b, m, n, k),
+            &activations,
+            0,
+            &weights,
+            0,
+            &dst,
+        )
+        .unwrap();
+        drop(encoder);
+        commands.wait_until_completed().unwrap();
+        read_to_vec(&dst, dst_len)
+    };
+
+    let zeroed = run(0x00);
+    let poisoned = run(0x5a);
+
+    for (label, out) in [("zeroed", &zeroed), ("poisoned", &poisoned)] {
+        assert_eq!(
+            &out[..n],
+            &vec![0f32; n][..],
+            "the in-range output rows are wrong in the {label} run, \
+             which is a different bug from the one under test"
+        );
+    }
+
+    // Compare bit patterns: the poisoned weights can dequantize to NaN, and NaN != NaN
+    // would make a value comparison silently pass.
+    let differing: Vec<usize> = (0..dst_len)
+        .filter(|&i| zeroed[i].to_bits() != poisoned[i].to_bits())
+        .collect();
+    assert!(
+        differing.is_empty(),
+        "kernel_mul_mv_q2_K_f32 output changed when only weight rows >= ne01 = {n} changed, \
+         so it read past ne01: indices {:?} (zeroed {:?} vs poisoned {:?})",
+        differing,
+        differing.iter().map(|&i| zeroed[i]).collect::<Vec<_>>(),
+        differing.iter().map(|&i| poisoned[i]).collect::<Vec<_>>(),
+    );
+}
+
+/// `align` is the number of `dst` rows one threadgroup writes, and the dispatch is
+/// `ceil(ne01 / align)` threadgroups, so `align` must equal the kernel's real row stride.
+///
+/// This has to be asserted directly rather than through the output, because once the
+/// K-quant kernels bound-check their stores an `align` that is too small no longer
+/// corrupts anything observable — the surplus threadgroups compute rows that are then
+/// discarded. `kquant_mul_mv_store_overrun_survey` reports `overrun=0` either way. Without
+/// this test, re-introducing the dispatch mismatch would be undetectable.
+///
+/// The stride is derived from the thread geometry the function itself returns plus the
+/// kernel's rows-per-simdgroup, so changing `nth0`/`nth1` is caught here too.
+/// `N_DST` is 4 and `N_SIMDGROUP` is 2, neither `#undef`d anywhere in `quantized.metal`.
+#[test]
+fn mul_mv_dispatch_align_matches_kernel_row_stride() {
+    const SIMDGROUP_SIZE: usize = 32;
+
+    // (dtype, rows written per simdgroup, the kernel's row expression)
+    let kernels = [
+        (
+            GgmlDType::Q2K,
+            4,
+            "first_row = (r0 * N_SIMDGROUP + sgitg) * N_DST",
+        ),
+        (
+            GgmlDType::Q3K,
+            2,
+            "first_row = (r0 * N_SIMDGROUP + sgitg) * 2",
+        ),
+        (GgmlDType::Q4K, 4, "first_row = r0 * N_DST"),
+        (
+            GgmlDType::Q5K,
+            2,
+            "first_row = (r0 * N_SIMDGROUP + sgitg) * 2",
+        ),
+        (GgmlDType::Q6K, 1, "row = 2 * r0 + sgitg"),
+    ];
+
+    for (dtype, rows_per_simdgroup, row_expr) in kernels {
+        let (nth0, nth1, align) = mul_mv_dispatch_geometry(dtype);
+        let threads = nth0 * nth1;
+        assert_eq!(
+            threads % SIMDGROUP_SIZE,
+            0,
+            "{dtype:?}: {nth0}x{nth1} = {threads} threads is not a whole number of simdgroups"
+        );
+        let stride = (threads / SIMDGROUP_SIZE) * rows_per_simdgroup;
+        assert_eq!(
+            align,
+            stride,
+            "{dtype:?}: align is {align} but the kernel writes {stride} rows per threadgroup \
+             ({row_expr}, {} simdgroups x {rows_per_simdgroup} rows). Dispatching \
+             ceil(ne01/{align}) threadgroups of {stride} rows over-dispatches by {}x and the \
+             surplus threadgroups read src0 past ne01.",
+            threads / SIMDGROUP_SIZE,
+            stride / align.max(1),
+        );
+    }
 }

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2580,3 +2580,61 @@ fn q2k_mul_mv_writes_past_ne01() {
         clobbered
     );
 }
+
+/// Same canary as `q2k_mul_mv_writes_past_ne01`, run across the K-quant family and
+/// several `ne01`, to separate two distinct effects:
+///
+///   a) EVERY K-quant mv kernel stores without the `first_row + row < ne01` guard that
+///      the legacy quants have, so any `ne01` that is not a multiple of the kernel's
+///      row stride overruns by up to `stride - 1` rows;
+///   b) Q2K ADDITIONALLY has a dispatch-table mismatch (kernel stride 8, `align` 4),
+///      so it over-dispatches 2x and overruns by ~ne01 rows even when ne01 IS a
+///      multiple of the stride.
+///
+/// Reports rather than asserts, so one run prints the whole picture.
+#[test]
+fn kquant_mul_mv_store_overrun_survey() {
+    const QK_K: usize = 256;
+    const SENTINEL: f32 = -1234.0;
+
+    // (dtype, block bytes from the static_asserts in quantized.metal)
+    let family = [
+        (GgmlDType::Q2K, 2 * 2 + QK_K / 16 + QK_K / 4),          // 84
+        (GgmlDType::Q3K, 2 + QK_K / 4 + QK_K / 8 + 12),          // 110
+        (GgmlDType::Q4K, 2 * 2 + 12 + QK_K / 2),                 // 144
+        (GgmlDType::Q5K, 2 * 2 + 12 + QK_K / 2 + QK_K / 8),      // 176
+        (GgmlDType::Q6K, 2 + QK_K / 16 + 3 * QK_K / 4),          // 210
+    ];
+
+    let mut report = String::new();
+    for (dtype, block_bytes) in family {
+        for n in [8usize, 10, 12, 16, 17] {
+            let k = QK_K;
+            let device = device();
+            let kernels = Kernels::new();
+            let commands = commands(&device);
+            let encoder = commands.command_encoder().unwrap();
+
+            let weights = new_buffer(&device, &vec![0u8; n * (k / QK_K) * block_bytes]);
+            let activations = new_buffer(&device, &vec![1f32; k]);
+            let dst_len = 4 * n;
+            let dst = new_buffer(&device, &vec![SENTINEL; dst_len]);
+
+            call_quantized_matmul_mv_t(
+                &device, &encoder, &kernels, dtype, (1, 1, n, k),
+                &activations, 0, &weights, 0, &dst,
+            )
+            .unwrap();
+            drop(encoder);
+            commands.wait_until_completed().unwrap();
+
+            let out: Vec<f32> = read_to_vec(&dst, dst_len);
+            let in_range_ok = out[..n].iter().all(|&v| v == 0.0);
+            let over = (n..dst_len).filter(|&i| out[i] != SENTINEL).count();
+            report.push_str(&format!(
+                "{dtype:?}\tne01={n}\toverrun={over}\tin_range_ok={in_range_ok}\n"
+            ));
+        }
+    }
+    println!("\n--- K-quant mul_mv store overrun survey ---\n{report}");
+}

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2491,3 +2491,92 @@ fn residency_set_batch_insert_remove() {
     set.remove_batch(std::iter::empty());
     assert_eq!(raw.allocationCount(), base);
 }
+
+// ---------------------------------------------------------------------------
+// Reproduction: `kernel_mul_mv_q2_K_f32` stores past `ne01`.
+//
+// `kernel_mul_mv_q2_K_f32_impl` computes
+//     first_row = (r0 * N_SIMDGROUP + sgitg) * N_DST
+// with N_SIMDGROUP == 2 and N_DST == 4, so one threadgroup owns 8 consecutive
+// output rows, and it stores WITHOUT the `first_row + row < ne01` bound check
+// that the legacy-quant kernels in the same file do have (quantized.metal:2374
+// and :2551).
+//
+// `call_quantized_matmul_mv_t` meanwhile dispatches `ceil(ne01 / align)`
+// threadgroups with `align = 4` for Q2K, so it launches twice as many
+// threadgroups as the kernel's row stride calls for. The highest one starts at
+// row `8 * ceil(ne01 / 4) - 4` and writes 4 rows from there — roughly `ne01`
+// f32 values past the end of the output.
+//
+// Q2K is the only entry in the file where the two disagree:
+//
+//   kernel   rows written per threadgroup   `align` in the dispatch table
+//   q2_K     (r0 * 2 + sgitg) * 4  =  8     4     <-- mismatch
+//   q3_K     (r0 * 2 + sgitg) * 2  =  4     4
+//   q4_K      r0 * 4               =  4     4
+//   q5_K     (r0 * 2 + sgitg) * 2  =  4     4
+//   q6_K      2 * r0 + sgitg       =  2     2
+//
+// The test needs no quantizer: an all-zero block_q2_K has d == dmin == 0, so
+// every dequantized weight is 0 and the whole correct output is exactly 0.0.
+// The interesting part is the canary region after it.
+#[test]
+fn q2k_mul_mv_writes_past_ne01() {
+    // block_q2_K = scales[QK_K/16] + qs[QK_K/4] + half d + half dmin
+    const QK_K: usize = 256;
+    const BLOCK_Q2K_BYTES: usize = QK_K / 16 + QK_K / 4 + 2 + 2; // 84
+    const SENTINEL: f32 = -1234.0;
+
+    // ne01 = 12 output rows: not a multiple of the kernel's 8-row stride, and
+    // small enough that the overrun is easy to read off.
+    let (b, m, n, k) = (1usize, 1usize, 12usize, QK_K);
+
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+
+    // src0: the quantized weights, all-zero blocks.
+    let weights = new_buffer(&device, &vec![0u8; n * (k / QK_K) * BLOCK_Q2K_BYTES]);
+    // src1: the activation vector.
+    let activations = new_buffer(&device, &vec![1f32; m * k]);
+    // dst: 4x the space actually needed, pre-filled with a sentinel so that any
+    // store outside [0, n) is visible instead of silently corrupting whatever
+    // the buffer pool happens to hand out next.
+    let dst_len = 4 * n;
+    let dst = new_buffer(&device, &vec![SENTINEL; dst_len]);
+
+    call_quantized_matmul_mv_t(
+        &device,
+        &encoder,
+        &kernels,
+        GgmlDType::Q2K,
+        (b, m, n, k),
+        &activations,
+        0,
+        &weights,
+        0,
+        &dst,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let out: Vec<f32> = read_to_vec(&dst, dst_len);
+
+    // The computed rows themselves are fine.
+    assert_eq!(
+        &out[..n],
+        &vec![0f32; n][..],
+        "the in-range output rows are wrong, which is a different bug from the one under test"
+    );
+
+    // Everything past row n must be untouched.
+    let clobbered: Vec<usize> = (n..dst_len).filter(|&i| out[i] != SENTINEL).collect();
+    assert!(
+        clobbered.is_empty(),
+        "kernel_mul_mv_q2_K_f32 wrote {} f32 values past ne01 = {n}: indices {:?}",
+        clobbered.len(),
+        clobbered
+    );
+}


### PR DESCRIPTION
## Problem

On Metal, the five reachable K-quant `mul_mv` kernels store past the end of `dst`. For Q2K
the overrun is as large as the output itself: at `ne01 = 12`, `kernel_mul_mv_q2_K_f32`
writes 12 `f32` values past the end.

`candle-metal-kernels` is `exclude`d from the workspace (`Cargo.toml:19`), so the tests
have to be run from the crate directory:

```
cd candle-metal-kernels
cargo test q2k_mul_mv_writes_past_ne01
```

Overrun in `f32` elements past `ne01` on the unpatched tree, measured on an Apple M4,
macOS 26.2, debug profile. Every cell matches `stride * ceil(ne01 / align) - ne01`:

| dtype | ne01=8 | 10 | 12 | 16 | 17 |
|-------|-------:|---:|---:|---:|---:|
| Q2K   | 8      | 14 | 12 | 16 | 23 |
| Q3K   | 0      |  2 |  0 |  0 |  3 |
| Q4K   | 0      |  2 |  0 |  0 |  3 |
| Q5K   | 0      |  2 |  0 |  0 |  3 |
| Q6K   | 0      |  0 |  0 |  0 |  1 |

The in-range rows are correct in every case; this is purely a write outside `[0, ne01)`.

Reported by @oetiker in #3863, with a self-contained reproduction branch. The two test
commits here are theirs, cherry-picked.

## Root cause

Two independent defects.

**1. The K-quant stores are not bound-checked.** The legacy quant kernels carry
`if (tiisg == 0 && first_row + row < ne01)` (`quantized.metal:2374` for
q4_0/q4_1/q5_0/q5_1, `:2551` for q8_0). The K-quant kernels store unconditionally:
`:4667` q2_K, `:4854` q3_K, `:4996` q4_K, `:5153` q5_K, `:5264` q6_K. Any `ne01` that is
not a multiple of the kernel's row stride overruns by up to `stride - 1` rows.

The comment at `:2308-2311` still says the template "does not guard against the number of
rows not being divisible by N_DST", which stopped being true when `:2374` was added. The
guard looks like it was retrofitted there and never propagated to the K-quants.

**2. Q2K's dispatch disagrees with its own kernel.** `kernel_mul_mv_q2_K_f32_impl` uses
`first_row = (r0 * N_SIMDGROUP + sgitg) * N_DST` (`:4596`) with `N_DST` 4 and
`N_SIMDGROUP` 2, and `nth0 * nth1 = 64` threads is two simdgroups, so one threadgroup
covers 8 rows. `call_quantized_matmul_mv_t` dispatched `ceil(ne01 / 4)` — twice the
threadgroups needed. Q2K is the only dtype where the table and the kernel disagree:

| kernel | row index | rows/simdgroup | simdgroups | stride | old `align` |
|--------|-----------|---------------:|-----------:|-------:|------------:|
| q2_K   | `(r0*2+sgitg)*4` | 4 | 2 | 8 | **4** |
| q3_K   | `(r0*2+sgitg)*2` | 2 | 2 | 4 | 4 |
| q4_K   | `r0*4`           | 4 | 1 | 4 | 4 |
| q5_K   | `(r0*2+sgitg)*2` | 2 | 2 | 4 | 4 |
| q6_K   | `2*r0+sgitg`     | 1 | 2 | 2 | 2 |

## On whether these are alternatives

@oetiker deliberately left this unpatched, on the grounds that the two fixes are not
equivalent and the choice looked like a maintainer's call. That framing deserves a direct
answer rather than a silent decision, so: I don't think it is a choice, and the reason is a
third thing that isn't in the issue.

Every one of these kernels derives its `src0` base pointer from the row index *before*
anything bounds-checks that index — q2_K at `:4596` → `:4597` → `:4604`, q6_K at `:5215` →
`:5222`. The surplus threadgroups therefore do not only store out of bounds, they read out
of bounds, and a store guard cannot bound a read.

The clearest evidence is the template that is already guarded. `mul_vec_q_n_f32_impl`
computes `offset0` from `first_row` at `:2339` and reads `x + ib + row*nb` at `:2366`,
with the guard only at the store on `:2374`. So "a store guard leaves the read unbounded"
is not a prediction about a hypothetical fix — it is a property of the fix this file
already carries.

With a correct dispatch that read is bounded by `stride - 1` rows, the same tail every
kernel here already tolerates. With Q2K's 2x over-dispatch it is not: it reads roughly
`ne01` rows past the weights. That is why the dispatch change is in this PR as a
correctness fix rather than as the ~2x launch saving it also happens to be.

Demonstrated rather than asserted: `q2k_mul_mv_output_does_not_depend_on_rows_past_ne01`
over-allocates `src0`, keeps rows `[0, ne01)` byte-identical between two runs, and poisons
only the rows past `ne01`. On the unpatched tree the output changes — `dst[12..24]` reads
`520320.0` under one poison byte and `0.0` under the other. The output depends on weight
rows the kernel should never have touched. (The buffer is over-allocated deliberately, so
the overread lands inside a real allocation and the test itself stays well-defined.)

One limit, stated plainly: that test proves the read happens, but it cannot prove the read
*survives* a store guard, because a guarded kernel discards the values and the read stops
being observable through `dst`. That half rests on the source (`:4604`, `:5222`, `:2339`).
I tried `MTL_SHADER_VALIDATION=1` and it did not flag anything, which I'm treating as
inconclusive rather than as evidence of absence. If you know a reliable way to observe a
discarded device-memory read on Metal, I'd like to add it as a test.

If you read it the other way and want these as two PRs, I'm happy to split it — say which
you'd rather review first and I'll cut it that way. My only concern with landing the guard
on its own is the ordering: after it, nothing observable detects the dispatch mismatch (the
table in Testing below shows my own overread test going green while the bug is still
there), so a follow-up PR would have no failing test to point at.

## Fix

- Add the `:2374` guard to the five K-quant stores. q6_K needs `row < ne01` rather than
  `first_row + row < ne01` because it stores `dst[... + row]` with `row = 2*r0 + sgitg`
  (`:5264`), so the guard is the same idea in a different shape. Cost is one compare in
  the `tiisg == 0` tail.
- Set Q2K's `align` to 8 so the dispatch matches the kernel's row stride. Only the Q2K arm
  changes; `align` is selected per dtype, so no other dtype's launch geometry moves.

Deliberately untouched:

- The ten `kernel_mul_mv_iq*` kernels share the unguarded store, and `iq4_nl:6238` guards
  in its loop condition while its otherwise-identical twin `iq4_xs:6333` does not. But
  `GgmlDType` has no iq variants and no Rust code references those kernels, so they are
  unreachable from candle. Left alone rather than widening the diff into dead code.
- The CUDA and CPU paths. This is a Metal kernel and a Metal dispatch table; neither is
  shared.
- Pre-existing clippy findings in this crate. `cargo clippy --all-targets` reports the
  same 13 locations on this branch as on `main`, none in the changed code.

One part is separable: extracting the geometry table into `mul_mv_dispatch_geometry` is
what makes defect 2 testable at all (see below), but if you'd rather have a one-line
`align` change, say so and I'll drop the extraction.

## Testing

**The threadgroup-count assertion is the important one.** Once the stores are guarded, an
`align` that is too small stops being observable: the surplus threadgroups compute rows
that are then discarded, and every output-correctness test goes green. I measured this
rather than assuming it — with the guards in and `align` back at 4, three of the four
tests pass, *including the overread test above*. Only
`mul_mv_dispatch_align_matches_kernel_row_stride` catches it:

| test | unpatched | store guard only | this PR |
|------|-----------|------------------|---------|
| `q2k_mul_mv_writes_past_ne01` (@oetiker) | fail | pass | pass |
| `kquant_mul_mv_store_overrun_survey` (@oetiker) | fail | pass | pass |
| `q2k_mul_mv_output_does_not_depend_on_rows_past_ne01` | fail | **pass** | pass |
| `mul_mv_dispatch_align_matches_kernel_row_stride` | fail | **fail** | pass |

So without that assertion, landing the store guard alone would make the dispatch mismatch
permanently undetectable — it would look fixed and stay broken. The assertion derives the
expected stride from the thread geometry the function itself returns, so changing
`nth0`/`nth1` is caught too, not just a hand-edited `align`.

Red to green, from the crate directory on an Apple M4, macOS 26.2, debug profile:

- `q2k_mul_mv_writes_past_ne01`: 10/10 fail unpatched, 10/10 pass patched.
- `q2k_mul_mv_output_does_not_depend_on_rows_past_ne01`: 10/10 fail unpatched, 10/10 pass
  patched. Deterministic, not flaky.
- `kquant_mul_mv_store_overrun_survey` now asserts instead of only printing; it reported
  the table above and passed silently, which is why it needed the assertion.
- Full crate suite: 65 passed, 0 failed.
- `cargo fmt -- --check` clean. The cherry-picked test commits needed reformatting; that
  is the only reason `tests.rs` shows formatting churn.

Worth flagging: none of this runs in CI. `candle-metal-kernels` is excluded from the
workspace, so `cargo test --workspace` never reaches it, and the Metal job in
`rust-ci.yml` only runs `cargo check`. These tests protect the code only for someone
running them locally in the crate directory.
