### PR TITLE
fix(cuda): name the missing kernel and module in symbol-lookup errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ candle-transformers = { path = "./candle-transformers", version = "0.11.0" }
 candle-ug = { path = "./candle-ug", version = "0.11.0" }
 clap = { version = "4.2.4", features = ["derive"] }
 criterion = { version = "0.8", default-features = false }
-cudarc = { version = "0.19.8", features = [
+cudarc = { version = "0.19.9", features = [
     "std",
     "cublas",
     "cublaslt",

--- a/candle-core/src/cuda_backend/device.rs
+++ b/candle-core/src/cuda_backend/device.rs
@@ -341,7 +341,7 @@ impl CudaDevice {
     ) -> Result<CudaFunc> {
         let ms = self.custom_modules.read().unwrap();
         if let Some(mdl) = ms.get(module_name).as_ref() {
-            let func = mdl.load_function(fn_name).w()?;
+            let func = load_function(mdl, fn_name, module_name)?;
             return Ok(CudaFunc {
                 func,
                 stream: self.stream.clone(),
@@ -351,7 +351,7 @@ impl CudaDevice {
         let mut ms = self.custom_modules.write().unwrap();
         let cuda_module = self.context.load_module(ptx.into()).w()?;
         ms.insert(module_name.to_string(), cuda_module.clone());
-        let func = cuda_module.load_function(fn_name).w()?;
+        let func = load_function(&cuda_module, fn_name, module_name)?;
         Ok(CudaFunc {
             func,
             stream: self.stream.clone(),
@@ -360,8 +360,8 @@ impl CudaDevice {
 
     pub fn get_or_load_func(&self, fn_name: &str, mdl: &kernels::Module) -> Result<CudaFunc> {
         let ms = self.modules.read().unwrap();
-        if let Some(mdl) = ms.mdls[mdl.index()].as_ref() {
-            let func = mdl.load_function(fn_name).w()?;
+        if let Some(cuda_module) = ms.mdls[mdl.index()].as_ref() {
+            let func = load_function(cuda_module, fn_name, mdl.name())?;
             return Ok(CudaFunc {
                 func,
                 stream: self.stream.clone(),
@@ -371,7 +371,7 @@ impl CudaDevice {
         let mut ms = self.modules.write().unwrap();
         let cuda_module = self.context.load_module(mdl.ptx().into()).w()?;
         ms.mdls[mdl.index()] = Some(cuda_module.clone());
-        let func = cuda_module.load_function(fn_name).w()?;
+        let func = load_function(&cuda_module, fn_name, mdl.name())?;
         Ok(CudaFunc {
             func,
             stream: self.stream.clone(),
@@ -381,6 +381,21 @@ impl CudaDevice {
     pub fn cublas_handle(&self) -> Arc<cudarc::cublas::CudaBlas> {
         self.blas.clone()
     }
+}
+
+fn load_function(
+    module: &Arc<cudarc::driver::CudaModule>,
+    fn_name: &str,
+    module_name: &str,
+) -> Result<CudaFunction> {
+    module.load_function(fn_name).map_err(|source| {
+        CudaError::MissingKernel {
+            kernel_name: fn_name.to_string(),
+            module_name: module_name.to_string(),
+            source,
+        }
+        .into()
+    })
 }
 
 impl CudaDevice {

--- a/candle-core/src/cuda_backend/error.rs
+++ b/candle-core/src/cuda_backend/error.rs
@@ -15,8 +15,15 @@ pub enum CudaError {
     #[error(transparent)]
     Curand(#[from] cudarc::curand::result::CurandError),
 
-    #[error("missing kernel '{module_name}'")]
-    MissingKernel { module_name: String },
+    #[error(
+        "cuda: kernel `{kernel_name}` not found in module `{module_name}` (this kernel may not be compiled for the target architecture)"
+    )]
+    MissingKernel {
+        kernel_name: String,
+        module_name: String,
+        #[source]
+        source: cudarc::driver::DriverError,
+    },
 
     #[error("unsupported dtype {dtype:?} for {op}")]
     UnsupportedDtype { dtype: DType, op: &'static str },

--- a/candle-kernels/src/lib.rs
+++ b/candle-kernels/src/lib.rs
@@ -35,6 +35,7 @@ pub const ALL_IDS: [Id; 11] = [
 pub struct Module {
     index: usize,
     ptx: &'static str,
+    name: &'static str,
 }
 
 impl Module {
@@ -44,6 +45,10 @@ impl Module {
 
     pub fn ptx(&self) -> &'static str {
         self.ptx
+    }
+
+    pub fn name(&self) -> &'static str {
+        self.name
     }
 }
 
@@ -59,24 +64,25 @@ const fn module_index(id: Id) -> usize {
 }
 
 macro_rules! mdl {
-    ($cst:ident, $id:ident) => {
+    ($cst:ident, $id:ident, $name:literal) => {
         pub const $cst: Module = Module {
             index: module_index(Id::$id),
             ptx: ptx::$cst,
+            name: $name,
         };
     };
 }
 
-mdl!(AFFINE, Affine);
-mdl!(BINARY, Binary);
-mdl!(CAST, Cast);
-mdl!(CONV, Conv);
-mdl!(FILL, Fill);
-mdl!(INDEXING, Indexing);
-mdl!(QUANTIZED, Quantized);
-mdl!(REDUCE, Reduce);
-mdl!(SORT, Sort);
-mdl!(TERNARY, Ternary);
-mdl!(UNARY, Unary);
+mdl!(AFFINE, Affine, "affine");
+mdl!(BINARY, Binary, "binary");
+mdl!(CAST, Cast, "cast");
+mdl!(CONV, Conv, "conv");
+mdl!(FILL, Fill, "fill");
+mdl!(INDEXING, Indexing, "indexing");
+mdl!(QUANTIZED, Quantized, "quantized");
+mdl!(REDUCE, Reduce, "reduce");
+mdl!(SORT, Sort, "sort");
+mdl!(TERNARY, Ternary, "ternary");
+mdl!(UNARY, Unary, "unary");
 
 pub mod ffi;


### PR DESCRIPTION
### What

`CudaDevice::get_or_load_func` surfaces a bare cudarc `"named symbol not
found"` when a kernel lookup fails, with no indication of *which* kernel or
module was being looked up.

This is a real diagnostic gap: dtypes like `F8E4M3` have kernels with
non-uniform architecture guards, so on some devices (e.g. `sm_86`) certain
ops work while others fail lookup — a supported, expected configuration
rather than an exceptional one. Without the kernel name, "symbol not found"
gives no signal for diagnosing which op/dtype combination is missing.

### Changes

- `candle-kernels::Module` now carries a human-readable `name` (e.g.
  `"affine"`, `"binary"`, …) alongside its PTX source, exposed via
  `Module::name()`.
- `CudaError::MissingKernel` now carries `kernel_name`, `module_name`, and
  keeps the underlying `DriverError` in the source chain via `#[source]`,
  instead of just `module_name`. New message:
