### PR TITLE
feat(metal): add head_dim=48 support in Metal SDPA kernel

### DIFF
--- a/candle-metal-kernels/src/kernels/sdpa.rs
+++ b/candle-metal-kernels/src/kernels/sdpa.rs
@@ -74,11 +74,11 @@ pub fn call_sdpa_full(
     }
 
     let bd = q_shape[q_shape.len() - 1];
-    if ![32, 64, 72, 80, 96, 128, 256, 512].contains(&bd) {
+    if ![32, 48, 64, 72, 80, 96, 128, 256, 512].contains(&bd) {
         return Err(MetalKernelError::SdpaHeadSizeMismatch {
             variation: "full",
             got: bd,
-            expected: vec![32, 64, 72, 80, 96, 128, 256, 512],
+            expected: vec![32, 48, 64, 72, 80, 96, 128, 256, 512],
         });
     };
 

--- a/candle-metal-kernels/src/metal_src/scaled_dot_product_attention.metal
+++ b/candle-metal-kernels/src/metal_src/scaled_dot_product_attention.metal
@@ -2319,6 +2319,7 @@ template <
     instantiate_attn(iname, itype, 32, 32,  80, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  72, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  64, 4, 1, mname, mtype) \
+    instantiate_attn(iname, itype, 32, 32,  48, 4, 1, mname, mtype) \
     instantiate_attn(iname, itype, 32, 32,  32, 4, 1, mname, mtype)
 
 #define instantiate_attn_mask_helper(iname, itype) \

--- a/candle-nn/src/ops.rs
+++ b/candle-nn/src/ops.rs
@@ -1076,7 +1076,8 @@ impl candle::CustomOp3 for Sdpa {
         let k_seq = k_l.dim(2)?;
 
         let mut implementation_supports_use_case = q_head == k_head;
-        let supported_head_dim = q_head == 32
+        let supported_full_head_dim = q_head == 32
+            || q_head == 48
             || q_head == 64
             || q_head == 72
             || q_head == 80
@@ -1084,19 +1085,22 @@ impl candle::CustomOp3 for Sdpa {
             || q_head == 128
             || q_head == 256
             || q_head == 512;
+        let supported_vector_head_dim =
+            q_head == 32 || q_head == 64 || q_head == 96 || q_head == 128 || q_head == 256 || q_head == 512;
+        let supported_head_dim = supported_full_head_dim;
 
         let supports_sdpa_full_mask = self.mask.is_none() || q_seq <= k_seq;
         // F32 full attention at head_dim=512 exceeds 32KB Metal threadgroup memory
         let supports_sdpa_full_dtype = !(q_head == 512 && q.dtype() == DType::F32);
+        let supports_sdpa_vector = q_seq == 1 && supported_vector_head_dim && q_seq <= k_seq;
         let supports_sdpa_full =
-            q_seq > 1 && supported_head_dim && supports_sdpa_full_mask && supports_sdpa_full_dtype;
-        let supports_sdpa_vector = q_seq == 1 && supported_head_dim && q_seq <= k_seq;
+            (q_seq > 1 || !supports_sdpa_vector) && supported_full_head_dim && supports_sdpa_full_mask && supports_sdpa_full_dtype;
 
         implementation_supports_use_case &= supports_sdpa_full || supports_sdpa_vector;
 
         if !supported_head_dim {
             candle::bail!(
-                "Meta SDPA does not support q head dim {q_head}: q dims {:?}, k dims {:?}, v dims {:?}.",
+                "Metal SDPA does not support q head dim {q_head}: q dims {:?}, k dims {:?}, v dims {:?}.",
                 q_l.dims(),
                 k_l.dims(),
                 v_l.dims()
@@ -1104,7 +1108,7 @@ impl candle::CustomOp3 for Sdpa {
         }
         if !implementation_supports_use_case {
             candle::bail!(
-                "Meta SDPA does not support q dims {:?}, k dims {:?}, v dims {:?}.",
+                "Metal SDPA does not support q dims {:?}, k dims {:?}, v dims {:?}.",
                 q_l.dims(),
                 k_l.dims(),
                 v_l.dims()

--- a/candle-nn/tests/sdpa.rs
+++ b/candle-nn/tests/sdpa.rs
@@ -49,6 +49,35 @@ mod metal_sdpa_tests {
     }
 
     #[test]
+    fn sdpa_full_headdim_48() -> Result<()> {
+        const BS: usize = 2;
+        const R: usize = 16;
+        const L: usize = 16;
+        const DK: usize = 48;
+        const H: usize = 4;
+
+        let scale: f64 = f64::from(DK as u32).sqrt().recip();
+        let device = Device::new_metal(0)?;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(4848);
+        let q = randn(&mut rng, (BS, H, R, DK), &device)?;
+        let k = randn(&mut rng, (BS, H, L, DK), &device)?;
+        let v = randn(&mut rng, (BS, H, L, DK), &device)?;
+        let ground_truth = {
+            let att = (q.clone() * scale)?.matmul(&k.clone().t()?)?;
+            let att = candle_nn::ops::softmax_last_dim(&att.to_dtype(DType::F32)?)?
+                .to_dtype(q.dtype())?;
+            att.matmul(&v.clone())?
+        };
+        let sdpa_output = candle_nn::ops::sdpa(&q, &k, &v, None, false, scale as f32, 1.)?;
+        assert_eq!(ground_truth.shape(), sdpa_output.shape());
+        let error: f32 = ((&ground_truth - &sdpa_output)?.abs()? / &ground_truth.abs()?)?
+            .sum_all()?
+            .to_scalar()?;
+        assert!(error <= 0.02, "{}", error);
+        Ok(())
+    }
+
+    #[test]
     fn sdpa_vector() -> Result<()> {
         // Allow vectorized, seqlen = 1
         const BS: usize = 4;


### PR DESCRIPTION
## Description

This PR adds support for `head_dim = 48` in the Metal SDPA full attention kernel (`steel_attention`).

### Motivation
Models like Whisper and certain audio/ASR architectures use non-standard attention head dimensions (such as `head_dim = 48`). Currently, Metal SDPA rejects `head_dim = 48`, requiring either fallback to explicit matmul or custom workarounds.

### Changes
1. **Metal Shader**: Added `instantiate_attn(iname, itype, 32, 32, 48, 4, 1, mname, mtype)` to `scaled_dot_product_attention.metal` for `float16`, `bfloat16`, and `float32`.
2. **Rust Dispatch**: Included `48` in the valid `head_dim` list in `candle_metal_kernels::call_sdpa_full`.
3. **Fallback Logic**: For `q_seq == 1` when `head_dim` is not supported by the vector kernel (e.g. 48, 72, 80), allow fallback to the full steel attention kernel instead of failing.
4. **Typo Fix**: Fixed `"Meta SDPA"` -> `"Metal SDPA"` in error messages in `candle-nn/src/ops.rs`.
5. **Tests**: Added unit test `sdpa_full_headdim_48` in `candle-nn/tests/sdpa.rs`.

### Testing
- Ran `cargo test -p candle-nn --test sdpa --features metal`, all 6 tests passed including `sdpa_full_headdim_48`.