### PR TITLE
perf(quantized): reuse scratch buffer during sequential GGUF tensor loading

### DIFF
--- a/candle-core/src/quantized/gguf_file.rs
+++ b/candle-core/src/quantized/gguf_file.rs
@@ -91,6 +91,21 @@ impl TensorInfo {
         tensor_data_offset: u64,
         device: &Device,
     ) -> Result<QTensor> {
+        let mut scratch = Vec::new();
+        self.read_into(reader, tensor_data_offset, device, &mut scratch)
+    }
+
+    /// Read with a reusable scratch buffer instead of a per-tensor heap allocation.
+    ///
+    /// The scratch buffer is resized only when necessary to accommodate the tensor size,
+    /// reducing heap fragmentation and peak memory when reading multiple tensors in sequence.
+    pub fn read_into<R: std::io::Seek + std::io::Read>(
+        &self,
+        reader: &mut R,
+        tensor_data_offset: u64,
+        device: &Device,
+        scratch: &mut Vec<u8>,
+    ) -> Result<QTensor> {
         let tensor_elems = self.shape.elem_count();
         let block_size = self.ggml_dtype.block_size();
         if !tensor_elems.is_multiple_of(block_size) {
@@ -107,12 +122,15 @@ impl TensorInfo {
                 "tensor needs {size_in_bytes} bytes at offset {tensor_start}, only {remaining} remaining in file"
             )
         }
-        let mut raw_data = vec![0u8; size_in_bytes];
+        if scratch.len() < size_in_bytes {
+            scratch.resize(size_in_bytes, 0);
+        }
+        let raw_data = &mut scratch[..size_in_bytes];
         reader.seek(std::io::SeekFrom::Start(tensor_start))?;
-        reader.read_exact(&mut raw_data)?;
+        reader.read_exact(raw_data)?;
         super::ggml_file::qtensor_from_ggml(
             self.ggml_dtype,
-            &raw_data,
+            raw_data,
             self.shape.dims().to_vec(),
             device,
         )
@@ -577,6 +595,23 @@ impl Content {
             None => crate::bail!("cannot find tensor info for {name}"),
         };
         tensor_info.read(reader, self.tensor_data_offset, device)
+    }
+
+    /// Read a tensor with a reusable scratch buffer.
+    ///
+    /// See [`TensorInfo::read_into`] for details.
+    pub fn tensor_into<R: std::io::Seek + std::io::Read>(
+        &self,
+        reader: &mut R,
+        name: &str,
+        device: &Device,
+        scratch: &mut Vec<u8>,
+    ) -> Result<QTensor> {
+        let tensor_info = match self.tensor_infos.get(name) {
+            Some(tensor_info) => tensor_info,
+            None => crate::bail!("cannot find tensor info for {name}"),
+        };
+        tensor_info.read_into(reader, self.tensor_data_offset, device, scratch)
     }
 }
 

--- a/candle-core/tests/gguf_tests.rs
+++ b/candle-core/tests/gguf_tests.rs
@@ -128,6 +128,40 @@ fn rejects_tensor_size_exceeding_file() {
 }
 
 #[test]
+fn read_tensor_into_reuses_scratch() {
+    // Single F32 tensor with 4 elements [1.0, 2.0, 3.0, 4.0]
+    let mut buf = header(1, 0);
+    buf.extend(length_prefixed(b"t"));
+    buf.extend_from_slice(&1u32.to_le_bytes()); // n dims
+    buf.extend_from_slice(&4u64.to_le_bytes()); // 4 elements
+    buf.extend_from_slice(&0u32.to_le_bytes()); // F32
+    buf.extend_from_slice(&0u64.to_le_bytes()); // offset = 0
+    // Pad to alignment (32 bytes default)
+    let header_len = buf.len();
+    let aligned_len = (header_len + 31) & !31;
+    buf.resize(aligned_len, 0);
+    // Data: 4 * f32 = 16 bytes
+    for f in [1.0f32, 2.0, 3.0, 4.0] {
+        buf.extend_from_slice(&f.to_le_bytes());
+    }
+
+    let mut cursor = Cursor::new(buf);
+    let content = Content::read(&mut cursor).expect("header should parse");
+
+    let mut scratch = Vec::new();
+    let qtensor = content
+        .tensor_into(&mut cursor, "t", &Device::Cpu, &mut scratch)
+        .expect("tensor should load");
+    assert_eq!(qtensor.shape().dims(), &[4]);
+    assert_eq!(scratch.len(), 16);
+    let dequant = qtensor.dequantize(&Device::Cpu).expect("dequantize");
+    assert_eq!(
+        dequant.to_vec1::<f32>().expect("to_vec"),
+        &[1.0, 2.0, 3.0, 4.0]
+    );
+}
+
+#[test]
 fn rejects_string_length_above_remaining_file_bytes() {
     let mut buf = header(1, 0);
     buf.extend_from_slice(&(1u64 << 20).to_le_bytes()); // 1 MB, below cap, above file size

--- a/candle-transformers/src/quantized_var_builder.rs
+++ b/candle-transformers/src/quantized_var_builder.rs
@@ -20,9 +20,24 @@ impl VarBuilder {
     pub fn from_gguf<P: AsRef<std::path::Path>>(p: P, device: &Device) -> Result<Self> {
         let mut file = std::fs::File::open(p)?;
         let content = candle::quantized::gguf_file::Content::read(&mut file)?;
+        let max_tensor_bytes = content
+            .tensor_infos
+            .values()
+            .map(|ti| {
+                let elems = ti.shape.elem_count();
+                let bs = ti.ggml_dtype.block_size();
+                if bs == 0 {
+                    0
+                } else {
+                    elems / bs * ti.ggml_dtype.type_size()
+                }
+            })
+            .max()
+            .unwrap_or(0);
+        let mut scratch: Vec<u8> = Vec::with_capacity(max_tensor_bytes);
         let mut data = std::collections::HashMap::new();
         for tensor_name in content.tensor_infos.keys() {
-            let tensor = content.tensor(&mut file, tensor_name, device)?;
+            let tensor = content.tensor_into(&mut file, tensor_name, device, &mut scratch)?;
             data.insert(tensor_name.to_string(), Arc::new(tensor));
         }
         Ok(Self {
@@ -35,9 +50,24 @@ impl VarBuilder {
     pub fn from_gguf_buffer(buffer: &[u8], device: &Device) -> Result<Self> {
         let mut cursor = std::io::Cursor::new(buffer);
         let content = candle::quantized::gguf_file::Content::read(&mut cursor)?;
+        let max_tensor_bytes = content
+            .tensor_infos
+            .values()
+            .map(|ti| {
+                let elems = ti.shape.elem_count();
+                let bs = ti.ggml_dtype.block_size();
+                if bs == 0 {
+                    0
+                } else {
+                    elems / bs * ti.ggml_dtype.type_size()
+                }
+            })
+            .max()
+            .unwrap_or(0);
+        let mut scratch: Vec<u8> = Vec::with_capacity(max_tensor_bytes);
         let mut data = std::collections::HashMap::new();
         for tensor_name in content.tensor_infos.keys() {
-            let tensor = content.tensor(&mut cursor, tensor_name, device)?;
+            let tensor = content.tensor_into(&mut cursor, tensor_name, device, &mut scratch)?;
             data.insert(tensor_name.to_string(), Arc::new(tensor));
         }
         Ok(Self {


### PR DESCRIPTION
## Description

This PR introduces a reusable scratch buffer mechanism when loading quantized tensors from GGUF files sequentially.

### Motivation
When loading large models via `VarBuilder::from_gguf` or `from_gguf_buffer`, a temporary `Vec<u8>` allocation was created for every single tensor inside `TensorInfo::read` and immediately dropped. Depending on the global memory allocator, this causes heap fragmentation and drives peak memory usage up to the sum of all temporary tensor allocations rather than the size of the largest single tensor.

### Changes
1. **`candle_core::quantized::gguf_file`**:
   - Added `TensorInfo::read_into(&self, reader, tensor_data_offset, device, scratch: &mut Vec<u8>)` which resizes the scratch buffer only when needed.
   - `TensorInfo::read` now delegates to `read_into` (full backward compatibility).
   - Added `Content::tensor_into(&self, reader, name, device, scratch: &mut Vec<u8>)`.
2. **`candle_transformers::quantized_var_builder`**:
   - In `VarBuilder::from_gguf` and `from_gguf_buffer`, pre-calculates the maximum raw tensor byte size across `tensor_infos`, allocates one `scratch` buffer upfront, and passes it into `content.tensor_into`.
3. **Tests**:
   - Added test `read_tensor_into_reuses_scratch` in `candle-core/tests/gguf_tests.rs`.

### Testing
- `cargo test -p candle-core --test gguf_tests` passes (all 11 tests ok).