### PR TITLE
Add fused Metal kernels for gated-DeltaNet decode and preprocessing

### DIFF
--- a/candle-metal-kernels/src/kernel.rs
+++ b/candle-metal-kernels/src/kernel.rs
@@ -1,5 +1,5 @@
 use crate::source::{
-    AFFINE, BINARY, CAST, CONV, FILL, GEMV, INDEXING, MLX_GEMM, MLX_SORT, QUANTIZED, RANDOM,
+    AFFINE, BINARY, CAST, CONV, FILL, GDN, GEMV, INDEXING, MLX_GEMM, MLX_SORT, QUANTIZED, RANDOM,
     REDUCE, SDPA, SORT, TERNARY, UNARY,
 };
 use crate::utils::get_env_bool;
@@ -90,6 +90,7 @@ impl Kernels {
             Source::Cast => CAST,
             Source::Conv => CONV,
             Source::Fill => FILL,
+            Source::Gdn => GDN,
             Source::Gemm => MLX_GEMM,
             Source::Gemv => GEMV,
             Source::Indexing => INDEXING,

--- a/candle-metal-kernels/src/kernels/gdn.rs
+++ b/candle-metal-kernels/src/kernels/gdn.rs
@@ -103,3 +103,286 @@ pub fn call_gdn_decode_step_f32(
     encoder.dispatch_threads(grid_dims, group_dims);
     Ok(())
 }
+
+#[repr(C)]
+struct GdnConv1dArgs {
+    seq_len: u32,
+    hist_len: u32,
+    channels: u32,
+    kernel_size: u32,
+}
+
+impl EncoderParam for GdnConv1dArgs {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+        encoder.set_bytes(position, &data);
+    }
+}
+
+/// Fused causal depthwise conv1d + silu -- the output half. See
+/// `metal_src/gdn.metal`'s own doc comment for the exact math (operates
+/// conceptually on `history ++ x` without ever materializing the
+/// concatenation) and the dispatch-count arithmetic this replaces.
+///
+/// Shapes (all contiguous F32): `x`: `[b, seq_len, channels]`; `history`:
+/// `[b, hist_len, channels]`; `weight`: `[channels, kernel_size]` --
+/// **caller must canonicalize to this exact layout** (a raw checkpoint
+/// tensor can arrive as `[channels, kernel]` or `[kernel, channels]`; do the
+/// transpose once at load time, not per call, and never pass the
+/// non-canonical layout here). `out`: `[b, seq_len, channels]`.
+///
+/// Every read input takes a `BufferOffset`, not a bare `Buffer` -- same
+/// discipline as `call_gdn_decode_step_f32` above, after the real
+/// nonzero-offset bug that kernel found live: `history` in particular is
+/// exactly the kind of tensor (a restored/cloned cache view, or a
+/// `narrow()`'d slice) most likely to carry a real nonzero byte offset in
+/// production, not just in a synthetic test.
+#[allow(clippy::too_many_arguments)]
+pub fn call_gdn_causal_conv1d_output_f32(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    b: usize,
+    seq_len: usize,
+    hist_len: usize,
+    channels: usize,
+    kernel_size: usize,
+    x: &BufferOffset,
+    history: &BufferOffset,
+    weight: &BufferOffset,
+    out: &Buffer,
+) -> Result<(), MetalKernelError> {
+    let pipeline =
+        kernels.load_pipeline(device, Source::Gdn, "kernel_gdn_causal_conv1d_output_f32")?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(encoder, "gdn_causal_conv1d_output b={b} seq_len={seq_len} hist_len={hist_len} channels={channels} kernel_size={kernel_size}");
+
+    let args = GdnConv1dArgs {
+        seq_len: seq_len as u32,
+        hist_len: hist_len as u32,
+        channels: channels as u32,
+        kernel_size: kernel_size as u32,
+    };
+    set_params!(encoder, (x, history, weight, Output::new(out), args));
+
+    let grid_dims = MTLSize {
+        width: channels,
+        height: seq_len,
+        depth: b,
+    };
+    let group_dims = MTLSize {
+        width: channels.min(64),
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_threads(grid_dims, group_dims);
+    Ok(())
+}
+
+/// Fused causal depthwise conv1d -- the next-conv-state half, companion to
+/// `call_gdn_causal_conv1d_output_f32` above (same inputs, no `weight`,
+/// different output). `new_state` is written functionally (a fresh buffer,
+/// `history` read-only and untouched) -- same correctness discipline as
+/// `state_out` in `call_gdn_decode_step_f32`: a prior session-checkpoint
+/// clone of `history` must survive this call unchanged, and the caller must
+/// bind `new_state` via the write path (this function already does) so the
+/// *next* call's read of it gets a barrier under this fork's
+/// `HazardTrackingModeUntracked` convention.
+///
+/// Shapes: `x`: `[b, seq_len, channels]`; `history`: `[b, hist_len,
+/// channels]`; `new_state`: `[b, hist_len, channels]`. Correct (a no-op
+/// grid) when `hist_len == 0`.
+#[allow(clippy::too_many_arguments)]
+pub fn call_gdn_causal_conv1d_state_f32(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    b: usize,
+    seq_len: usize,
+    hist_len: usize,
+    channels: usize,
+    x: &BufferOffset,
+    history: &BufferOffset,
+    new_state: &Buffer,
+) -> Result<(), MetalKernelError> {
+    let pipeline =
+        kernels.load_pipeline(device, Source::Gdn, "kernel_gdn_causal_conv1d_state_f32")?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(
+        encoder,
+        "gdn_causal_conv1d_state b={b} seq_len={seq_len} hist_len={hist_len} channels={channels}"
+    );
+
+    let args = GdnConv1dArgs {
+        seq_len: seq_len as u32,
+        hist_len: hist_len as u32,
+        channels: channels as u32,
+        kernel_size: 0,
+    };
+    set_params!(encoder, (x, history, Output::new(new_state), args));
+
+    let grid_dims = MTLSize {
+        width: channels,
+        height: hist_len,
+        depth: b,
+    };
+    let group_dims = MTLSize {
+        width: channels.min(64),
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_threads(grid_dims, group_dims);
+    Ok(())
+}
+
+#[repr(C)]
+struct GdnL2NormArgs {
+    seq_len: u32,
+    heads: u32,
+    dim: u32,
+    scale: f32,
+    eps: f32,
+}
+
+impl EncoderParam for GdnL2NormArgs {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+        encoder.set_bytes(position, &data);
+    }
+}
+
+/// Fused L2-normalize + scale -- the q/k half of gated-DeltaNet's
+/// preprocessing gating tail. See `metal_src/gdn.metal`'s own doc comment
+/// for the exact math (eps is added to the sum of squares, not the mean --
+/// do not substitute a generic RMS-norm kernel here, the epsilon placement
+/// differs). Called once for q (with a query-side scale factor) and once
+/// for k (`scale = 1.0`).
+///
+/// Shapes (contiguous F32): `x`/`out`: `[b, seq_len, heads, dim]`.
+#[allow(clippy::too_many_arguments)]
+pub fn call_gdn_l2_normalize_scale_f32(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    b: usize,
+    seq_len: usize,
+    heads: usize,
+    dim: usize,
+    scale: f32,
+    eps: f32,
+    x: &BufferOffset,
+    out: &Buffer,
+) -> Result<(), MetalKernelError> {
+    let pipeline =
+        kernels.load_pipeline(device, Source::Gdn, "kernel_gdn_l2_normalize_scale_f32")?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(
+        encoder,
+        "gdn_l2_normalize_scale b={b} seq_len={seq_len} heads={heads} dim={dim} scale={scale}"
+    );
+
+    let args = GdnL2NormArgs {
+        seq_len: seq_len as u32,
+        heads: heads as u32,
+        dim: dim as u32,
+        scale,
+        eps,
+    };
+    set_params!(encoder, (x, Output::new(out), args));
+
+    let grid_dims = MTLSize {
+        width: heads,
+        height: seq_len,
+        depth: b,
+    };
+    let group_dims = MTLSize {
+        width: heads.min(64),
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_threads(grid_dims, group_dims);
+    Ok(())
+}
+
+#[repr(C)]
+struct GdnDecayBetaArgs {
+    seq_len: u32,
+    heads: u32,
+}
+
+impl EncoderParam for GdnDecayBetaArgs {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+        encoder.set_bytes(position, &data);
+    }
+}
+
+/// Fused decay-gate softplus + beta sigmoid -- the gating half of
+/// gated-DeltaNet's preprocessing gating tail. See `metal_src/gdn.metal`'s
+/// own doc comment for the exact math. `dt_bias`/`a` are indexed directly
+/// by head (`[heads]`), not pre-broadcast -- this eliminates the caller's
+/// own broadcast step entirely, not just the elementwise math around it.
+///
+/// Shapes (contiguous F32): `alpha_logits`/`beta_logits`/`g_out`/`beta_out`:
+/// `[b, seq_len, heads]`; `dt_bias`/`a`: `[heads]`.
+#[allow(clippy::too_many_arguments)]
+pub fn call_gdn_decay_beta_gate_f32(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    b: usize,
+    seq_len: usize,
+    heads: usize,
+    alpha_logits: &BufferOffset,
+    dt_bias: &BufferOffset,
+    a: &BufferOffset,
+    beta_logits: &BufferOffset,
+    g_out: &Buffer,
+    beta_out: &Buffer,
+) -> Result<(), MetalKernelError> {
+    let pipeline = kernels.load_pipeline(device, Source::Gdn, "kernel_gdn_decay_beta_gate_f32")?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(
+        encoder,
+        "gdn_decay_beta_gate b={b} seq_len={seq_len} heads={heads}"
+    );
+
+    let args = GdnDecayBetaArgs {
+        seq_len: seq_len as u32,
+        heads: heads as u32,
+    };
+    set_params!(
+        encoder,
+        (
+            alpha_logits,
+            dt_bias,
+            a,
+            beta_logits,
+            Output::new(g_out),
+            Output::new(beta_out),
+            args
+        )
+    );
+
+    let grid_dims = MTLSize {
+        width: heads,
+        height: seq_len,
+        depth: b,
+    };
+    let group_dims = MTLSize {
+        width: heads.min(64),
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_threads(grid_dims, group_dims);
+    Ok(())
+}

--- a/candle-metal-kernels/src/kernels/gdn.rs
+++ b/candle-metal-kernels/src/kernels/gdn.rs
@@ -1,0 +1,104 @@
+use crate::utils::{BufferOffset, EncoderProvider};
+use crate::{
+    debug_group, set_params, Buffer, ComputeCommandEncoder, Device, EncoderParam, Kernels,
+    MetalKernelError, Output, Source,
+};
+use objc2_metal::MTLSize;
+
+/// Fused gated-DeltaNet single-token decode step -- one Metal dispatch
+/// instead of the ~9 serialized elementwise/reduction ops the equivalent
+/// candle-tensor-op sequence would need. See `metal_src/gdn.metal`'s own
+/// doc comment for the exact math and the functional-state-write
+/// correctness argument (`state_out` must be a fresh buffer, `state_in`
+/// is read-only and untouched).
+///
+/// Shapes (all contiguous F32): `q`/`k`: `[b, h, hk]`; `v`: `[b, h, hv]`;
+/// `g`/`beta`: `[b, h]` (`g` already exponentiated -- the actual decay
+/// gate in `(0, 1)`, not its log); `state_in`/`state_out`: `[b, h, hk,
+/// hv]`; `out`: `[b, h, hv]`.
+///
+/// Every read input takes a `BufferOffset`, not a bare `Buffer`: callers
+/// commonly derive `q`/`k`/`v` from slices of a shared QKV-projection
+/// buffer via `narrow`, which can carry a genuine nonzero byte offset
+/// even when the resulting tensor is itself contiguous -- binding at a
+/// fixed offset 0 regardless of the tensor's real layout silently reads
+/// the wrong region of the buffer. Every input takes a real offset, not
+/// just the ones a particular call site happens to need it for, since
+/// which inputs need a nonzero offset is caller-dependent.
+///
+/// Caller must bind `state_out` and `out` via the write path (this
+/// function already does, via `Output::new`) -- binding them read-only
+/// would leave a later dispatch's read of `state_out` without a
+/// hazard-tracking barrier under `HazardTrackingModeUntracked`.
+#[allow(clippy::too_many_arguments)]
+pub fn call_gdn_decode_step_f32(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    b: usize,
+    h: usize,
+    hk: usize,
+    hv: usize,
+    q: &BufferOffset,
+    k: &BufferOffset,
+    v: &BufferOffset,
+    g: &BufferOffset,
+    beta: &BufferOffset,
+    state_in: &BufferOffset,
+    state_out: &Buffer,
+    out: &Buffer,
+) -> Result<(), MetalKernelError> {
+    #[derive(Debug)]
+    #[repr(C)]
+    struct GdnStepArgs {
+        hk: u32,
+        hv: u32,
+        h: u32,
+    }
+
+    impl EncoderParam for GdnStepArgs {
+        fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+            encoder.set_bytes(position, &data);
+        }
+    }
+
+    let pipeline = kernels.load_pipeline(device, Source::Gdn, "kernel_gdn_decode_step_f32")?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(encoder, "gdn_decode_step b={b} h={h} hk={hk} hv={hv}");
+
+    let args = GdnStepArgs {
+        hk: hk as u32,
+        hv: hv as u32,
+        h: h as u32,
+    };
+    set_params!(
+        encoder,
+        (
+            q,
+            k,
+            v,
+            g,
+            beta,
+            state_in,
+            Output::new(state_out),
+            Output::new(out),
+            args
+        )
+    );
+
+    let grid_dims = MTLSize {
+        width: hv,
+        height: h,
+        depth: b,
+    };
+    let group_dims = MTLSize {
+        width: hv.min(64),
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_threads(grid_dims, group_dims);
+    Ok(())
+}

--- a/candle-metal-kernels/src/kernels/gdn.rs
+++ b/candle-metal-kernels/src/kernels/gdn.rs
@@ -13,9 +13,10 @@ use objc2_metal::MTLSize;
 /// is read-only and untouched).
 ///
 /// Shapes (all contiguous F32): `q`/`k`: `[b, h, hk]`; `v`: `[b, h, hv]`;
-/// `g`/`beta`: `[b, h]` (`g` already exponentiated -- the actual decay
-/// gate in `(0, 1)`, not its log); `state_in`/`state_out`: `[b, h, hk,
-/// hv]`; `out`: `[b, h, hv]`.
+/// `g`/`beta`: `[b, h]` (`g` is the raw decay-gate log, **not**
+/// exponentiated -- the kernel exponentiates it internally, one dispatch
+/// fewer than passing the already-`exp`'d gate); `state_in`/`state_out`:
+/// `[b, h, hk, hv]`; `out`: `[b, h, hv]`.
 ///
 /// Every read input takes a `BufferOffset`, not a bare `Buffer`: callers
 /// commonly derive `q`/`k`/`v` from slices of a shared QKV-projection

--- a/candle-metal-kernels/src/kernels/mod.rs
+++ b/candle-metal-kernels/src/kernels/mod.rs
@@ -20,7 +20,10 @@ pub use binary::{call_binary_contiguous, call_binary_strided};
 pub use cast::{call_cast_contiguous, call_cast_strided};
 pub use convolution::*;
 pub use fill::*;
-pub use gdn::call_gdn_decode_step_f32;
+pub use gdn::{
+    call_gdn_causal_conv1d_output_f32, call_gdn_causal_conv1d_state_f32,
+    call_gdn_decay_beta_gate_f32, call_gdn_decode_step_f32, call_gdn_l2_normalize_scale_f32,
+};
 pub use indexing::*;
 pub use mlx_gemm::{call_mlx_gemm, call_mlx_gemv, GemmDType};
 pub use quantized::{

--- a/candle-metal-kernels/src/kernels/mod.rs
+++ b/candle-metal-kernels/src/kernels/mod.rs
@@ -3,6 +3,7 @@ pub mod binary;
 pub mod cast;
 pub mod convolution;
 pub mod fill;
+pub mod gdn;
 pub mod indexing;
 mod macros;
 pub mod mlx_gemm;
@@ -19,6 +20,7 @@ pub use binary::{call_binary_contiguous, call_binary_strided};
 pub use cast::{call_cast_contiguous, call_cast_strided};
 pub use convolution::*;
 pub use fill::*;
+pub use gdn::call_gdn_decode_step_f32;
 pub use indexing::*;
 pub use mlx_gemm::{call_mlx_gemm, call_mlx_gemv, GemmDType};
 pub use quantized::{

--- a/candle-metal-kernels/src/lib.rs
+++ b/candle-metal-kernels/src/lib.rs
@@ -8,9 +8,11 @@ pub mod utils;
 pub use err::MetalKernelError;
 pub use kernel::Kernels;
 pub use kernels::{
-    affine::*, call_binary_contiguous, call_binary_strided, call_gdn_decode_step_f32,
-    call_mlx_gemm, cast::*, convolution::*, fill::*, indexing::*, quantized::*, random::*,
-    reduce::*, sdpa::*, sort::*, ternary::*, unary, unary::*, GemmDType, GgmlDType,
+    affine::*, call_binary_contiguous, call_binary_strided, call_gdn_causal_conv1d_output_f32,
+    call_gdn_causal_conv1d_state_f32, call_gdn_decay_beta_gate_f32, call_gdn_decode_step_f32,
+    call_gdn_l2_normalize_scale_f32, call_mlx_gemm, cast::*, convolution::*, fill::*, indexing::*,
+    quantized::*, random::*, reduce::*, sdpa::*, sort::*, ternary::*, unary, unary::*, GemmDType,
+    GgmlDType,
 };
 use metal::{
     Buffer, CommandQueue, ComputeCommandEncoder, ComputePipeline, ConstantValues, Device, Function,

--- a/candle-metal-kernels/src/lib.rs
+++ b/candle-metal-kernels/src/lib.rs
@@ -8,9 +8,9 @@ pub mod utils;
 pub use err::MetalKernelError;
 pub use kernel::Kernels;
 pub use kernels::{
-    affine::*, call_binary_contiguous, call_binary_strided, call_mlx_gemm, cast::*, convolution::*,
-    fill::*, indexing::*, quantized::*, random::*, reduce::*, sdpa::*, sort::*, ternary::*, unary,
-    unary::*, GemmDType, GgmlDType,
+    affine::*, call_binary_contiguous, call_binary_strided, call_gdn_decode_step_f32,
+    call_mlx_gemm, cast::*, convolution::*, fill::*, indexing::*, quantized::*, random::*,
+    reduce::*, sdpa::*, sort::*, ternary::*, unary, unary::*, GemmDType, GgmlDType,
 };
 use metal::{
     Buffer, CommandQueue, ComputeCommandEncoder, ComputePipeline, ConstantValues, Device, Function,

--- a/candle-metal-kernels/src/metal_src/gdn.metal
+++ b/candle-metal-kernels/src/metal_src/gdn.metal
@@ -80,3 +80,189 @@ kernel void kernel_gdn_decode_step_f32(
     }
     out[bh * hv + j] = acc;
 }
+// Fused causal depthwise conv1d + silu, as used by gated-DeltaNet /
+// gated-linear-attention hybrid architectures (Qwen3.5, Qwen3-Next-style
+// models) ahead of their recurrent scan. A naive implementation processes
+// this as a `for t in 0..seq_len { for k in 0..kernel_size { ... } }` loop
+// over per-tap elementwise multiply-adds -- O(seq_len * kernel_size)
+// separate dispatches at small batch sizes (decode, or a short
+// multi-token forward like a speculative-decode verify step), each paying
+// a full pipeline/bind/encode cycle for a handful of FLOPs. This fuses the
+// whole causal convolution + activation into one dispatch for the output,
+// plus one small dispatch for the next conv state.
+//
+// Conceptually operates on `padded = history ++ x` (concat along time),
+// length `hist_len + seq_len`. For output position t (0 <= t < seq_len):
+//   out[t][c] = silu( sum_k padded[t+k][c] * weight[c][k] )
+// For next-state position s (0 <= s < hist_len) -- the trailing hist_len
+// entries of `padded`, i.e. `padded[seq_len + s]`:
+//   new_state[s][c] = padded[seq_len + s][c]
+// Both are expressed directly against `history`/`x` (never materializing
+// `padded` itself) via the same `idx < hist_len ? history[idx] : x[idx -
+// hist_len]` branch -- one thread per (channel, output-position, batch), no
+// cross-thread communication, no threadgroup memory. `new_state` is written
+// functionally (a fresh buffer, `history` read-only and untouched) --
+// deliberate, not an oversight: callers holding another reference to the
+// input history (e.g. an externally-taken checkpoint) must be unaffected
+// by this call running, same discipline as `kernel_gdn_decode_step_f32`
+// above.
+//
+// weight is `[channels, kernel_size]` -- the caller is expected to
+// canonicalize to this exact layout once (a raw GGUF/checkpoint tensor can
+// arrive as either `[channels, kernel]` or `[kernel, channels]`), not
+// re-derive it every dispatch.
+
+struct gdn_conv1d_args {
+    uint seq_len;
+    uint hist_len;
+    uint channels;
+    uint kernel_size; // only read by the _output kernel; harmless unused field on the _state kernel
+};
+
+kernel void kernel_gdn_causal_conv1d_output_f32(
+        device const float * x        [[buffer(0)]],  // [b, seq_len, channels]
+        device const float * history  [[buffer(1)]],  // [b, hist_len, channels]
+        device const float * weight   [[buffer(2)]],  // [channels, kernel_size]
+        device float       * out      [[buffer(3)]],  // [b, seq_len, channels], silu already applied
+        constant gdn_conv1d_args & args [[buffer(4)]],
+        uint3 gid [[thread_position_in_grid]]) {
+    const uint c = gid.x;
+    const uint t = gid.y;
+    if (c >= args.channels || t >= args.seq_len) {
+        return;
+    }
+    const uint hist_len = args.hist_len;
+    const uint seq_len = args.seq_len;
+    const uint channels = args.channels;
+    const uint kernel_size = args.kernel_size;
+    const uint b = gid.z;
+
+    device const float * xb = x + b * seq_len * channels;
+    device const float * hb = history + b * hist_len * channels;
+    device const float * wc = weight + c * kernel_size;
+
+    float acc = 0.0f;
+    for (uint k = 0; k < kernel_size; ++k) {
+        const uint idx = t + k; // index into conceptual padded = history ++ x
+        const float val = (idx < hist_len)
+            ? hb[idx * channels + c]
+            : xb[(idx - hist_len) * channels + c];
+        acc += val * wc[k];
+    }
+    // silu(x) = x * sigmoid(x) = x / (1 + exp(-x))
+    out[(b * seq_len + t) * channels + c] = acc / (1.0f + exp(-acc));
+}
+
+kernel void kernel_gdn_causal_conv1d_state_f32(
+        device const float * x           [[buffer(0)]],  // [b, seq_len, channels]
+        device const float * history     [[buffer(1)]],  // [b, hist_len, channels]
+        device float       * new_state   [[buffer(2)]],  // [b, hist_len, channels], functional
+        constant gdn_conv1d_args & args [[buffer(3)]],
+        uint3 gid [[thread_position_in_grid]]) {
+    const uint c = gid.x;
+    const uint s = gid.y;
+    if (c >= args.channels || s >= args.hist_len) {
+        return;
+    }
+    const uint hist_len = args.hist_len;
+    const uint seq_len = args.seq_len;
+    const uint channels = args.channels;
+    const uint b = gid.z;
+
+    device const float * xb = x + b * seq_len * channels;
+    device const float * hb = history + b * hist_len * channels;
+
+    const uint idx = seq_len + s; // index into conceptual padded = history ++ x
+    const float val = (idx < hist_len)
+        ? hb[idx * channels + c]
+        : xb[(idx - hist_len) * channels + c];
+    new_state[(b * hist_len + s) * channels + c] = val;
+}
+
+// Fused elementwise "gating tail" for gated-DeltaNet's preprocessing
+// pipeline, two independent sub-kernels replacing what a naive
+// implementation would otherwise dispatch as ~17 separate ops
+// (L2-normalize q and k, scale q, a softplus-style decay gate, a sigmoid
+// beta gate).
+//
+// kernel_gdn_l2_normalize_scale_f32: out[b][t][h][:] = scale *
+// x[b][t][h][:] / sqrt(sum_d x[b][t][h][d]^2 + eps) -- eps is added to the
+// sum of squares, not the mean, so this is *not* interchangeable with a
+// generic RMS-norm kernel; match your own model's exact epsilon placement
+// before reusing this. One thread per (b, t, h), looping over `dim` twice
+// (sum-of-squares, then the normalized write) -- re-reads `x` rather than
+// caching it in a local array, since `dim` is typically small (~64-256) and
+// the extra read is cheap relative to a per-dispatch fixed-overhead
+// avoided. Intended to be called once for q (with a query-side scale
+// factor) and once for k (scale = 1.0) -- two dispatches of the same
+// kernel, not two kernels.
+struct gdn_l2norm_args {
+    uint seq_len;
+    uint heads;
+    uint dim;
+    float scale;
+    float eps;
+};
+
+kernel void kernel_gdn_l2_normalize_scale_f32(
+        device const float * x    [[buffer(0)]],  // [b, seq_len, heads, dim]
+        device float       * out  [[buffer(1)]],  // [b, seq_len, heads, dim]
+        constant gdn_l2norm_args & args [[buffer(2)]],
+        uint3 gid [[thread_position_in_grid]]) {
+    const uint h = gid.x;
+    const uint t = gid.y;
+    if (h >= args.heads || t >= args.seq_len) {
+        return;
+    }
+    const uint dim = args.dim;
+    const uint b = gid.z;
+    const uint row = (b * args.seq_len + t) * args.heads + h;
+    device const float * xr = x + row * dim;
+    device float       * outr = out + row * dim;
+
+    float sum_sq = 0.0f;
+    for (uint d = 0; d < dim; ++d) {
+        const float v = xr[d];
+        sum_sq += v * v;
+    }
+    const float inv_norm = args.scale / sqrt(sum_sq + args.eps);
+    for (uint d = 0; d < dim; ++d) {
+        outr[d] = xr[d] * inv_norm;
+    }
+}
+
+// kernel_gdn_decay_beta_gate_f32: fuses a softplus-style decay-gate chain
+// and a sigmoid beta gate, the two per-head scalar gates this architecture
+// family derives per token before its recurrent scan:
+//   g[b][t][h]    = a[h] * log(exp(alpha_logits[b][t][h] + dt_bias[h]) + 1)
+//   beta[b][t][h] = sigmoid(beta_logits[b][t][h])
+// `dt_bias`/`a` are indexed directly by head (`[heads]`, not pre-broadcast
+// to `[b, seq_len, heads]`) -- this also eliminates the caller's own
+// broadcast step, not just the elementwise math around it. One thread per
+// (b, t, h), no reduction, purely elementwise.
+struct gdn_decay_beta_args {
+    uint seq_len;
+    uint heads;
+};
+
+kernel void kernel_gdn_decay_beta_gate_f32(
+        device const float * alpha_logits [[buffer(0)]],  // [b, seq_len, heads]
+        device const float * dt_bias      [[buffer(1)]],  // [heads]
+        device const float * a            [[buffer(2)]],  // [heads]
+        device const float * beta_logits  [[buffer(3)]],  // [b, seq_len, heads]
+        device float       * g_out        [[buffer(4)]],  // [b, seq_len, heads]
+        device float       * beta_out     [[buffer(5)]],  // [b, seq_len, heads]
+        constant gdn_decay_beta_args & args [[buffer(6)]],
+        uint3 gid [[thread_position_in_grid]]) {
+    const uint h = gid.x;
+    const uint t = gid.y;
+    if (h >= args.heads || t >= args.seq_len) {
+        return;
+    }
+    const uint b = gid.z;
+    const uint idx = (b * args.seq_len + t) * args.heads + h;
+
+    const float softplus = log(exp(alpha_logits[idx] + dt_bias[h]) + 1.0f);
+    g_out[idx] = a[h] * softplus;
+    beta_out[idx] = 1.0f / (1.0f + exp(-beta_logits[idx]));
+}

--- a/candle-metal-kernels/src/metal_src/gdn.metal
+++ b/candle-metal-kernels/src/metal_src/gdn.metal
@@ -1,0 +1,81 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// Fused gated-DeltaNet (gated linear attention) single-token decode step,
+// as used by Qwen3.5 / Qwen3-Next style hybrid architectures. Batch-1,
+// seq-len-1 decode of this recurrence normally costs ~9 serialized,
+// dependency-chained elementwise/reduction ops per layer per token
+// (decay, a key-weighted read, a delta computation, a state write, a
+// query-weighted read) -- cheap in FLOPs but expensive in fixed
+// per-dispatch overhead at this shape, since every op depends on the
+// previous op's output and the tensors involved are small. This kernel
+// fuses the whole step into one dispatch.
+//
+// Per output column j (over the value-head-dim axis), for a fixed
+// (batch, head), and summing over i (the state-size axis):
+//   s_dec[i][j] = g * s_in[i][j]
+//   kv_mem[j]   = sum_i s_dec[i][j] * k[i]
+//   delta[j]    = (v[j] - kv_mem[j]) * beta
+//   s_out[i][j] = s_dec[i][j] + k[i] * delta[j]
+//   out[j]      = sum_i s_out[i][j] * q[i]
+//
+// One thread per (batch, head, j) -- no cross-thread communication, no
+// threadgroup memory. `state_out` is written functionally (a fresh
+// buffer; `state_in` is read-only and left untouched) rather than
+// mutated in place -- callers that keep other live references to the
+// input state tensor (e.g. a checkpoint taken before this step) depend
+// on that not being silently invalidated. Every per-thread write to
+// `state_out`/`out` is to a disjoint element, so the kernel itself has no
+// internal write hazard -- but the caller must bind `state_out` and
+// `out` via the write path (see `Output` in this crate's `utils.rs`),
+// not the read-only path, or a subsequent dispatch's read of `state_out`
+// may run without a hazard-tracking barrier under
+// `HazardTrackingModeUntracked`.
+
+struct gdn_step_args {
+    uint hk; // state_size
+    uint hv; // value_head_dim
+    uint h;  // value_head_count (heads)
+};
+
+kernel void kernel_gdn_decode_step_f32(
+        device const float * q      [[buffer(0)]],  // [b, h, hk]
+        device const float * k      [[buffer(1)]],  // [b, h, hk]
+        device const float * v      [[buffer(2)]],  // [b, h, hv]
+        device const float * g      [[buffer(3)]],  // [b, h], already exp'ed (actual decay gate, not log_g)
+        device const float * beta   [[buffer(4)]],  // [b, h]
+        device const float * s_in   [[buffer(5)]],  // [b, h, hk, hv]
+        device float       * s_out  [[buffer(6)]],  // [b, h, hk, hv], functional -- fresh buffer, s_in untouched
+        device float       * out    [[buffer(7)]],  // [b, h, hv]
+        constant gdn_step_args & args [[buffer(8)]],
+        uint3 gid [[thread_position_in_grid]]) {
+    const uint j = gid.x;
+    if (j >= args.hv) {
+        return;
+    }
+    const uint hk = args.hk;
+    const uint hv = args.hv;
+    const uint bh = gid.z * args.h + gid.y; // flattened (batch, head) index
+
+    device const float * qh = q + bh * hk;
+    device const float * kh = k + bh * hk;
+    device const float * si = s_in  + bh * hk * hv;
+    device float       * so = s_out + bh * hk * hv;
+
+    const float gv = g[bh];
+    const float bv = beta[bh];
+
+    float kv_mem = 0.0f;
+    for (uint i = 0; i < hk; ++i) {
+        kv_mem += (gv * si[i * hv + j]) * kh[i];
+    }
+    const float delta = (v[bh * hv + j] - kv_mem) * bv;
+
+    float acc = 0.0f;
+    for (uint i = 0; i < hk; ++i) {
+        const float s_new = gv * si[i * hv + j] + kh[i] * delta;
+        so[i * hv + j] = s_new;
+        acc += s_new * qh[i];
+    }
+    out[bh * hv + j] = acc;
+}

--- a/candle-metal-kernels/src/metal_src/gdn.metal
+++ b/candle-metal-kernels/src/metal_src/gdn.metal
@@ -13,6 +13,7 @@ using namespace metal;
 //
 // Per output column j (over the value-head-dim axis), for a fixed
 // (batch, head), and summing over i (the state-size axis):
+//   g           = exp(g_log)
 //   s_dec[i][j] = g * s_in[i][j]
 //   kv_mem[j]   = sum_i s_dec[i][j] * k[i]
 //   delta[j]    = (v[j] - kv_mem[j]) * beta
@@ -42,7 +43,7 @@ kernel void kernel_gdn_decode_step_f32(
         device const float * q      [[buffer(0)]],  // [b, h, hk]
         device const float * k      [[buffer(1)]],  // [b, h, hk]
         device const float * v      [[buffer(2)]],  // [b, h, hv]
-        device const float * g      [[buffer(3)]],  // [b, h], already exp'ed (actual decay gate, not log_g)
+        device const float * g_log  [[buffer(3)]],  // [b, h], NOT exp'ed -- the raw decay-gate log; this kernel exponentiates it internally
         device const float * beta   [[buffer(4)]],  // [b, h]
         device const float * s_in   [[buffer(5)]],  // [b, h, hk, hv]
         device float       * s_out  [[buffer(6)]],  // [b, h, hk, hv], functional -- fresh buffer, s_in untouched
@@ -62,7 +63,7 @@ kernel void kernel_gdn_decode_step_f32(
     device const float * si = s_in  + bh * hk * hv;
     device float       * so = s_out + bh * hk * hv;
 
-    const float gv = g[bh];
+    const float gv = exp(g_log[bh]); // one exp() per (batch, head), not a separate caller-side dispatch
     const float bv = beta[bh];
 
     float kv_mem = 0.0f;

--- a/candle-metal-kernels/src/source.rs
+++ b/candle-metal-kernels/src/source.rs
@@ -3,6 +3,7 @@ pub const BINARY: &str = include_str!("metal_src/binary.metal");
 pub const CAST: &str = include_str!("metal_src/cast.metal");
 pub const CONV: &str = include_str!("metal_src/conv.metal");
 pub const FILL: &str = include_str!("metal_src/fill.metal");
+pub const GDN: &str = include_str!("metal_src/gdn.metal");
 pub const INDEXING: &str = include_str!("metal_src/indexing.metal");
 pub const GEMV: &str = include_str!("metal_src/gemv.metal");
 pub const MLX_GEMM: &str = include_str!("metal_src/mlx_gemm.metal");
@@ -22,6 +23,7 @@ pub enum Source {
     Cast,
     Conv,
     Fill,
+    Gdn,
     Gemm,
     Gemv,
     Indexing,

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2514,18 +2514,21 @@ fn kernel_gdn_decode_step_pipeline_loads() {
 //   delta[j]    = (v[j] - kv_mem[j]) * beta
 //   s_out[i][j] = s_dec[i][j] + k[i] * delta[j]
 //   out[j]      = sum_i s_out[i][j] * q[i]
-// Per (batch, head) -- q/k: [hk], v: [hv], g/beta: scalar, state: [hk, hv].
+// Per (batch, head) -- q/k: [hk], v: [hv], g_log/beta: scalar, state: [hk, hv].
+// `g_log` is the raw decay-gate log, NOT pre-exponentiated -- matches the
+// kernel's own convention (it exponentiates internally).
 #[allow(clippy::too_many_arguments)]
 fn gdn_decode_step_reference(
     q: &[f32],
     k: &[f32],
     v: &[f32],
-    g: f32,
+    g_log: f32,
     beta: f32,
     state_in: &[f32],
     hk: usize,
     hv: usize,
 ) -> (Vec<f32>, Vec<f32>) {
+    let g = g_log.exp();
     let mut state_out = vec![0f32; hk * hv];
     let mut out = vec![0f32; hv];
     for j in 0..hv {
@@ -2565,14 +2568,13 @@ fn run_gdn_decode_step_and_check(b: usize, h: usize, hk: usize, hv: usize) {
     let q = randf(&mut rng, b * h * hk, 0.2);
     let k = randf(&mut rng, b * h * hk, 0.2);
     let v = randf(&mut rng, b * h * hv, 2.0);
-    // g in (0,1) (post-exp decay gate, matching sequential_step's own
-    // convention -- the kernel takes g already exp'd, not log_g); beta in
-    // (0,1) too. Include the large_decay-style strong-decay regime
-    // (g close to 0) at least once via the caller's own shape choices --
-    // this helper takes whatever the caller passes.
-    let g_vals: Vec<f32> = (0..b * h)
+    // Sample the actual decay gate in (0,1) (a realistic range, including
+    // the strong-decay end near 0), then take its log -- the kernel and
+    // the reference both take g_log directly now, not the pre-exp'd gate.
+    let g_decay_vals: Vec<f32> = (0..b * h)
         .map(|_| rng.random::<f32>() * 0.9 + 0.05)
         .collect();
+    let g_log_vals: Vec<f32> = g_decay_vals.iter().map(|g| g.ln()).collect();
     let beta_vals: Vec<f32> = (0..b * h)
         .map(|_| rng.random::<f32>() * 0.9 + 0.05)
         .collect();
@@ -2581,7 +2583,7 @@ fn run_gdn_decode_step_and_check(b: usize, h: usize, hk: usize, hv: usize) {
     let q_buf = new_buffer(&device, &q);
     let k_buf = new_buffer(&device, &k);
     let v_buf = new_buffer(&device, &v);
-    let g_buf = new_buffer(&device, &g_vals);
+    let g_buf = new_buffer(&device, &g_log_vals);
     let beta_buf = new_buffer(&device, &beta_vals);
     let state_in_buf = new_buffer(&device, &state_in);
     let state_out_buf = device
@@ -2625,7 +2627,7 @@ fn run_gdn_decode_step_and_check(b: usize, h: usize, hk: usize, hv: usize) {
             &q[bh * hk..(bh + 1) * hk],
             &k[bh * hk..(bh + 1) * hk],
             &v[bh * hv..(bh + 1) * hv],
-            g_vals[bh],
+            g_log_vals[bh],
             beta_vals[bh],
             &state_in[bh * hk * hv..(bh + 1) * hk * hv],
             hk,
@@ -2704,7 +2706,11 @@ fn kernel_gdn_decode_step_respects_nonzero_buffer_offsets() {
     let q = randf(&mut rng, b * h * hk, 0.2);
     let k = randf(&mut rng, b * h * hk, 0.2);
     let v = randf(&mut rng, b * h * hv, 2.0);
-    let g_vals: Vec<f32> = (0..b * h)
+    // Values don't need to be a realistic post-exp decay-gate range here
+    // (unlike run_gdn_decode_step_and_check's own g) -- this test is
+    // about offset correctness, not numeric range, and the kernel
+    // exponentiates internally regardless.
+    let g_log_vals: Vec<f32> = (0..b * h)
         .map(|_| rng.random::<f32>() * 0.9 + 0.05)
         .collect();
     let beta_vals: Vec<f32> = (0..b * h)
@@ -2719,7 +2725,7 @@ fn kernel_gdn_decode_step_respects_nonzero_buffer_offsets() {
         &q[..],
         &k[..],
         &v[..],
-        &g_vals[..],
+        &g_log_vals[..],
         &beta_vals[..],
         &state_in[..],
     ]
@@ -2746,7 +2752,7 @@ fn kernel_gdn_decode_step_respects_nonzero_buffer_offsets() {
         buffer: &packed_buf,
         offset_in_bytes: offset_elems * f32_size,
     };
-    offset_elems += g_vals.len();
+    offset_elems += g_log_vals.len();
     let beta_off = BufferOffset {
         buffer: &packed_buf,
         offset_in_bytes: offset_elems * f32_size,
@@ -2795,7 +2801,7 @@ fn kernel_gdn_decode_step_respects_nonzero_buffer_offsets() {
             &q[bh * hk..(bh + 1) * hk],
             &k[bh * hk..(bh + 1) * hk],
             &v[bh * hv..(bh + 1) * hv],
-            g_vals[bh],
+            g_log_vals[bh],
             beta_vals[bh],
             &state_in[bh * hk * hv..(bh + 1) * hk * hv],
             hk,

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2825,3 +2825,666 @@ fn kernel_gdn_decode_step_respects_nonzero_buffer_offsets() {
         "nonzero-offset state mismatch, max diff = {max_state_diff}"
     );
 }
+// Fused causal depthwise conv1d + silu: same de-risk-spike-before-wiring
+// precedent as the decode-step kernel above.
+#[test]
+fn kernel_gdn_causal_conv1d_pipelines_load() {
+    let device = device();
+    let kernels = Kernels::new();
+    for name in [
+        "kernel_gdn_causal_conv1d_output_f32",
+        "kernel_gdn_causal_conv1d_state_f32",
+    ] {
+        kernels
+            .load_pipeline(&device, Source::Gdn, name)
+            .unwrap_or_else(|e| panic!("{name} should load as a Metal compute pipeline: {e}"));
+    }
+}
+
+/// Scalar Rust reference for the fused conv1d kernels' math (see
+/// gdn.metal's own doc comment for the derivation): both kernels operate
+/// conceptually on `padded = history ++ x` (concat along time, length
+/// `hist_len + seq_len`) without ever materializing it.
+///   out[t][c]       = silu( sum_k padded[t+k][c] * weight[c][k] ),   0 <= t < seq_len
+///   new_state[s][c] = padded[seq_len + s][c],                       0 <= s < hist_len
+/// Operates on one batch row at a time (caller loops over `b`).
+fn gdn_causal_conv1d_reference(
+    x: &[f32],
+    history: &[f32],
+    weight: &[f32],
+    seq_len: usize,
+    hist_len: usize,
+    channels: usize,
+    kernel_size: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    let padded_at = |idx: usize, c: usize| -> f32 {
+        if idx < hist_len {
+            history[idx * channels + c]
+        } else {
+            x[(idx - hist_len) * channels + c]
+        }
+    };
+    let mut out = vec![0f32; seq_len * channels];
+    for t in 0..seq_len {
+        for c in 0..channels {
+            let mut acc = 0f32;
+            for k in 0..kernel_size {
+                acc += padded_at(t + k, c) * weight[c * kernel_size + k];
+            }
+            out[t * channels + c] = acc / (1.0 + (-acc).exp()); // silu(x) = x * sigmoid(x)
+        }
+    }
+    let mut new_state = vec![0f32; hist_len * channels];
+    for s in 0..hist_len {
+        for c in 0..channels {
+            new_state[s * channels + c] = padded_at(seq_len + s, c);
+        }
+    }
+    (out, new_state)
+}
+
+/// Runs both real kernels on random inputs at the given shape and compares
+/// against the scalar reference above, per batch row. `channels`
+/// deliberately not always a multiple of the threadgroup width
+/// (min(channels, 64)) to exercise the kernels' own bounds checks.
+fn run_gdn_causal_conv1d_and_check(
+    b: usize,
+    seq_len: usize,
+    hist_len: usize,
+    channels: usize,
+    kernel_size: usize,
+) {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+    let x = randf(&mut rng, b * seq_len * channels, 1.0);
+    let history = randf(&mut rng, b * hist_len * channels, 1.0);
+    let weight = randf(&mut rng, channels * kernel_size, 0.5);
+
+    let x_buf = new_buffer(&device, &x);
+    // `new_buffer_with_data` can't allocate a genuinely zero-size buffer
+    // (hist_len == 0 is a real, tested case below) -- pad with one unread
+    // dummy element; the kernel's own `idx < hist_len` check never reads
+    // `history` at all when `hist_len == 0`, so its content is irrelevant.
+    let history_buf = new_buffer(
+        &device,
+        if history.is_empty() {
+            &[0f32]
+        } else {
+            &history
+        },
+    );
+    let weight_buf = new_buffer(&device, &weight);
+    let out_buf = device
+        .new_buffer(
+            b * seq_len * channels * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
+        .unwrap();
+    let new_state_buf = device
+        .new_buffer(
+            (b * hist_len * channels).max(1) * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
+        .unwrap();
+
+    call_gdn_causal_conv1d_output_f32(
+        &device,
+        &encoder,
+        &kernels,
+        b,
+        seq_len,
+        hist_len,
+        channels,
+        kernel_size,
+        &BufferOffset::zero_offset(&x_buf),
+        &BufferOffset::zero_offset(&history_buf),
+        &BufferOffset::zero_offset(&weight_buf),
+        &out_buf,
+    )
+    .unwrap();
+    if hist_len > 0 {
+        call_gdn_causal_conv1d_state_f32(
+            &device,
+            &encoder,
+            &kernels,
+            b,
+            seq_len,
+            hist_len,
+            channels,
+            &BufferOffset::zero_offset(&x_buf),
+            &BufferOffset::zero_offset(&history_buf),
+            &new_state_buf,
+        )
+        .unwrap();
+    }
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got_out: Vec<f32> = read_to_vec(&out_buf, b * seq_len * channels);
+    let got_state: Vec<f32> = if hist_len > 0 {
+        read_to_vec(&new_state_buf, b * hist_len * channels)
+    } else {
+        vec![]
+    };
+
+    let mut max_out_diff = 0f32;
+    let mut max_state_diff = 0f32;
+    for row in 0..b {
+        let (expected_out, expected_state) = gdn_causal_conv1d_reference(
+            &x[row * seq_len * channels..(row + 1) * seq_len * channels],
+            &history[row * hist_len * channels..(row + 1) * hist_len * channels],
+            &weight,
+            seq_len,
+            hist_len,
+            channels,
+            kernel_size,
+        );
+        for i in 0..seq_len * channels {
+            max_out_diff =
+                max_out_diff.max((got_out[row * seq_len * channels + i] - expected_out[i]).abs());
+        }
+        for i in 0..hist_len * channels {
+            max_state_diff = max_state_diff
+                .max((got_state[row * hist_len * channels + i] - expected_state[i]).abs());
+        }
+    }
+    println!(
+        "gdn_causal_conv1d b={b} seq_len={seq_len} hist_len={hist_len} channels={channels} \
+         kernel_size={kernel_size}: out_diff={max_out_diff:.8} state_diff={max_state_diff:.8}"
+    );
+    assert!(
+        max_out_diff < 5e-5,
+        "b={b} seq_len={seq_len} hist_len={hist_len}: output mismatch, max diff = {max_out_diff}"
+    );
+    assert!(
+        max_state_diff < 5e-5,
+        "b={b} seq_len={seq_len} hist_len={hist_len}: state mismatch, max diff = {max_state_diff}"
+    );
+}
+
+#[test]
+fn kernel_gdn_causal_conv1d_matches_scalar_reference_every_short_length() {
+    // Covers the whole native-MTP verify-window range (1-8) at a realistic
+    // kernel_size=4 (hist_len=3) -- including the seq_len < hist_len case
+    // (seq_len 1, 2), which is the COMMON case at real decode/short-verify
+    // shapes, not a rare edge case (found during design: hist_len=3 means
+    // seq_len=1 and seq_len=2 both hit the "mixed history+input" branch of
+    // the new-state computation).
+    for seq_len in 1..=8 {
+        run_gdn_causal_conv1d_and_check(2, seq_len, 3, 6, 4);
+    }
+}
+
+#[test]
+fn kernel_gdn_causal_conv1d_matches_scalar_reference_production_shape() {
+    // b=1, channels=1536 (confirmed against the cached qwen36-35b-a3b
+    // GGUF's real mixed-qkv width: group_count*state_size*2 + inner_size),
+    // kernel_size=4 (hist_len=3), at both a decode (seq_len=1) and a
+    // verify-window (seq_len=2) shape.
+    run_gdn_causal_conv1d_and_check(1, 1, 3, 1536, 4);
+    run_gdn_causal_conv1d_and_check(1, 2, 3, 1536, 4);
+}
+
+#[test]
+fn kernel_gdn_causal_conv1d_handles_zero_history_length() {
+    // kernel_size=1 (hist_len=0) is a degenerate but real edge case: no
+    // causal history needed at all, output kernel must never read `history`
+    // out of bounds, and the state kernel must be skippable (a zero-size
+    // grid dimension) without dispatching at all.
+    run_gdn_causal_conv1d_and_check(1, 3, 0, 8, 1);
+}
+
+// Regression-shaped test for the same offset bug class the decode-step
+// kernel found live (kernel_gdn_decode_step_respects_nonzero_buffer_offsets
+// above): packs x/history/weight back-to-back into ONE buffer with a decoy
+// region ahead of each, at real production-realistic offsets, so a wrong or
+// ignored offset reads cross-contaminated data and fails hard.
+#[test]
+fn kernel_gdn_causal_conv1d_respects_nonzero_buffer_offsets() {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+
+    let (b, seq_len, hist_len, channels, kernel_size) = (1usize, 2usize, 3usize, 8usize, 4usize);
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+
+    let x = randf(&mut rng, b * seq_len * channels, 1.0);
+    let history = randf(&mut rng, b * hist_len * channels, 1.0);
+    let weight = randf(&mut rng, channels * kernel_size, 0.5);
+    let decoy = randf(&mut rng, b * seq_len * channels, 999.0);
+
+    let f32_size = std::mem::size_of::<f32>();
+    let packed: Vec<f32> = [&decoy[..], &x[..], &history[..], &weight[..]].concat();
+    let packed_buf = new_buffer(&device, &packed);
+
+    let mut offset_elems = decoy.len();
+    let x_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += x.len();
+    let history_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += history.len();
+    let weight_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+
+    let out_buf = device
+        .new_buffer(b * seq_len * channels * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+    let new_state_buf = device
+        .new_buffer(b * hist_len * channels * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+
+    call_gdn_causal_conv1d_output_f32(
+        &device,
+        &encoder,
+        &kernels,
+        b,
+        seq_len,
+        hist_len,
+        channels,
+        kernel_size,
+        &x_off,
+        &history_off,
+        &weight_off,
+        &out_buf,
+    )
+    .unwrap();
+    call_gdn_causal_conv1d_state_f32(
+        &device,
+        &encoder,
+        &kernels,
+        b,
+        seq_len,
+        hist_len,
+        channels,
+        &x_off,
+        &history_off,
+        &new_state_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got_out: Vec<f32> = read_to_vec(&out_buf, b * seq_len * channels);
+    let got_state: Vec<f32> = read_to_vec(&new_state_buf, b * hist_len * channels);
+    let (expected_out, expected_state) = gdn_causal_conv1d_reference(
+        &x,
+        &history,
+        &weight,
+        seq_len,
+        hist_len,
+        channels,
+        kernel_size,
+    );
+
+    let mut max_out_diff = 0f32;
+    let mut max_state_diff = 0f32;
+    for i in 0..seq_len * channels {
+        max_out_diff = max_out_diff.max((got_out[i] - expected_out[i]).abs());
+    }
+    for i in 0..hist_len * channels {
+        max_state_diff = max_state_diff.max((got_state[i] - expected_state[i]).abs());
+    }
+    println!("gdn_causal_conv1d_nonzero_offsets: out_diff={max_out_diff:.8} state_diff={max_state_diff:.8}");
+    assert!(
+        max_out_diff < 5e-5,
+        "nonzero-offset output mismatch, max diff = {max_out_diff}"
+    );
+    assert!(
+        max_state_diff < 5e-5,
+        "nonzero-offset state mismatch, max diff = {max_state_diff}"
+    );
+}
+
+// Fused elementwise gating-tail kernels: same de-risk-spike-before-wiring
+// precedent as the kernels above.
+#[test]
+fn kernel_gdn_preprocessing_gating_pipelines_load() {
+    let device = device();
+    let kernels = Kernels::new();
+    for name in [
+        "kernel_gdn_l2_normalize_scale_f32",
+        "kernel_gdn_decay_beta_gate_f32",
+    ] {
+        kernels
+            .load_pipeline(&device, Source::Gdn, name)
+            .unwrap_or_else(|e| panic!("{name} should load as a Metal compute pipeline: {e}"));
+    }
+}
+
+/// Scalar Rust reference for `kernel_gdn_l2_normalize_scale_f32`, matching
+/// `SSMWeights::l2_normalize` exactly (eps added to the sum of squares).
+fn gdn_l2_normalize_scale_reference(
+    x: &[f32],
+    b: usize,
+    seq_len: usize,
+    heads: usize,
+    dim: usize,
+    scale: f32,
+    eps: f32,
+) -> Vec<f32> {
+    let mut out = vec![0f32; b * seq_len * heads * dim];
+    for row in 0..b * seq_len * heads {
+        let xr = &x[row * dim..(row + 1) * dim];
+        let sum_sq: f32 = xr.iter().map(|v| v * v).sum();
+        let inv_norm = scale / (sum_sq + eps).sqrt();
+        for d in 0..dim {
+            out[row * dim + d] = xr[d] * inv_norm;
+        }
+    }
+    out
+}
+
+#[test]
+fn kernel_gdn_l2_normalize_scale_matches_scalar_reference() {
+    let device = device();
+    let kernels = Kernels::new();
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+
+    // (b, seq_len, heads, dim, scale) -- heads=5 (not a multiple of the
+    // threadgroup width min(heads,64)) at one shape to exercise the bounds
+    // check; dim=128 matches the real production state_size.
+    for (b, seq_len, heads, dim, scale) in [
+        (1usize, 1usize, 32usize, 128usize, 1f32 / (128f32).sqrt()),
+        (2usize, 8usize, 5usize, 128usize, 1.0f32),
+        (1usize, 2usize, 32usize, 128usize, 1.0f32),
+    ] {
+        let eps = 1e-6f32;
+        let x = randf(&mut rng, b * seq_len * heads * dim, 1.0);
+        let x_buf = new_buffer(&device, &x);
+        let out_buf = device
+            .new_buffer(
+                b * seq_len * heads * dim * std::mem::size_of::<f32>(),
+                RESOURCE_OPTIONS,
+            )
+            .unwrap();
+
+        let commands = commands(&device);
+        let encoder = commands.command_encoder().unwrap();
+        call_gdn_l2_normalize_scale_f32(
+            &device,
+            &encoder,
+            &kernels,
+            b,
+            seq_len,
+            heads,
+            dim,
+            scale,
+            eps,
+            &BufferOffset::zero_offset(&x_buf),
+            &out_buf,
+        )
+        .unwrap();
+        drop(encoder);
+        commands.wait_until_completed().unwrap();
+
+        let got: Vec<f32> = read_to_vec(&out_buf, b * seq_len * heads * dim);
+        let expected = gdn_l2_normalize_scale_reference(&x, b, seq_len, heads, dim, scale, eps);
+        let max_diff = got
+            .iter()
+            .zip(expected.iter())
+            .fold(0f32, |m, (a, e)| m.max((a - e).abs()));
+        println!("gdn_l2_normalize_scale b={b} seq_len={seq_len} heads={heads} dim={dim} scale={scale}: diff={max_diff:.8}");
+        assert!(
+            max_diff < 5e-5,
+            "b={b} seq_len={seq_len} heads={heads}: mismatch, max diff = {max_diff}"
+        );
+    }
+}
+
+/// Scalar Rust reference for `kernel_gdn_decay_beta_gate_f32`, matching
+/// `SSMWeights::forward`'s own `g`/`beta` computation exactly.
+fn gdn_decay_beta_gate_reference(
+    alpha_logits: &[f32],
+    dt_bias: &[f32],
+    ssm_a: &[f32],
+    beta_logits: &[f32],
+    b: usize,
+    seq_len: usize,
+    heads: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    let mut g = vec![0f32; b * seq_len * heads];
+    let mut beta = vec![0f32; b * seq_len * heads];
+    for row in 0..b * seq_len {
+        for h in 0..heads {
+            let idx = row * heads + h;
+            // Naive log(exp(x)+1), deliberately not the more numerically
+            // stable ln_1p(exp(x)) -- matches this kernel's own (and the
+            // original candle code's own) naive formula exactly, so this
+            // reference isn't "more correct" in a way that could show a
+            // spurious diff from different rounding at the same inputs.
+            let softplus = ((alpha_logits[idx] + dt_bias[h]).exp() + 1.0).ln();
+            g[idx] = ssm_a[h] * softplus;
+            beta[idx] = 1.0 / (1.0 + (-beta_logits[idx]).exp());
+        }
+    }
+    (g, beta)
+}
+
+#[test]
+fn kernel_gdn_decay_beta_gate_matches_scalar_reference() {
+    let device = device();
+    let kernels = Kernels::new();
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+
+    for (b, seq_len, heads) in [
+        (1usize, 1usize, 32usize),
+        (2usize, 8usize, 5usize),
+        (1usize, 2usize, 32usize),
+    ] {
+        let alpha_logits = randf(&mut rng, b * seq_len * heads, 2.0);
+        let dt_bias = randf(&mut rng, heads, 1.0);
+        let ssm_a = randf(&mut rng, heads, 1.0);
+        let beta_logits = randf(&mut rng, b * seq_len * heads, 2.0);
+
+        let alpha_buf = new_buffer(&device, &alpha_logits);
+        let dt_bias_buf = new_buffer(&device, &dt_bias);
+        let ssm_a_buf = new_buffer(&device, &ssm_a);
+        let beta_logits_buf = new_buffer(&device, &beta_logits);
+        let g_out_buf = device
+            .new_buffer(
+                b * seq_len * heads * std::mem::size_of::<f32>(),
+                RESOURCE_OPTIONS,
+            )
+            .unwrap();
+        let beta_out_buf = device
+            .new_buffer(
+                b * seq_len * heads * std::mem::size_of::<f32>(),
+                RESOURCE_OPTIONS,
+            )
+            .unwrap();
+
+        let commands = commands(&device);
+        let encoder = commands.command_encoder().unwrap();
+        call_gdn_decay_beta_gate_f32(
+            &device,
+            &encoder,
+            &kernels,
+            b,
+            seq_len,
+            heads,
+            &BufferOffset::zero_offset(&alpha_buf),
+            &BufferOffset::zero_offset(&dt_bias_buf),
+            &BufferOffset::zero_offset(&ssm_a_buf),
+            &BufferOffset::zero_offset(&beta_logits_buf),
+            &g_out_buf,
+            &beta_out_buf,
+        )
+        .unwrap();
+        drop(encoder);
+        commands.wait_until_completed().unwrap();
+
+        let got_g: Vec<f32> = read_to_vec(&g_out_buf, b * seq_len * heads);
+        let got_beta: Vec<f32> = read_to_vec(&beta_out_buf, b * seq_len * heads);
+        let (expected_g, expected_beta) = gdn_decay_beta_gate_reference(
+            &alpha_logits,
+            &dt_bias,
+            &ssm_a,
+            &beta_logits,
+            b,
+            seq_len,
+            heads,
+        );
+
+        let g_diff = got_g
+            .iter()
+            .zip(expected_g.iter())
+            .fold(0f32, |m, (a, e)| m.max((a - e).abs()));
+        let beta_diff = got_beta
+            .iter()
+            .zip(expected_beta.iter())
+            .fold(0f32, |m, (a, e)| m.max((a - e).abs()));
+        println!("gdn_decay_beta_gate b={b} seq_len={seq_len} heads={heads}: g_diff={g_diff:.8} beta_diff={beta_diff:.8}");
+        assert!(
+            g_diff < 5e-5,
+            "b={b} seq_len={seq_len} heads={heads}: g mismatch, max diff = {g_diff}"
+        );
+        assert!(
+            beta_diff < 5e-5,
+            "b={b} seq_len={seq_len} heads={heads}: beta mismatch, max diff = {beta_diff}"
+        );
+    }
+}
+
+// Regression-shaped test for the same offset bug class the earlier fused
+// kernels found live: packs alpha_logits/dt_bias/ssm_a/beta_logits into
+// ONE buffer with a decoy region ahead of each, at real nonzero offsets.
+#[test]
+fn kernel_gdn_decay_beta_gate_respects_nonzero_buffer_offsets() {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+
+    let (b, seq_len, heads) = (1usize, 2usize, 8usize);
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+
+    let alpha_logits = randf(&mut rng, b * seq_len * heads, 2.0);
+    let dt_bias = randf(&mut rng, heads, 1.0);
+    let ssm_a = randf(&mut rng, heads, 1.0);
+    let beta_logits = randf(&mut rng, b * seq_len * heads, 2.0);
+    let decoy = randf(&mut rng, b * seq_len * heads, 999.0);
+
+    let f32_size = std::mem::size_of::<f32>();
+    let packed: Vec<f32> = [
+        &decoy[..],
+        &alpha_logits[..],
+        &dt_bias[..],
+        &ssm_a[..],
+        &beta_logits[..],
+    ]
+    .concat();
+    let packed_buf = new_buffer(&device, &packed);
+
+    let mut offset_elems = decoy.len();
+    let alpha_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += alpha_logits.len();
+    let dt_bias_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += dt_bias.len();
+    let ssm_a_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += ssm_a.len();
+    let beta_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+
+    let g_out_buf = device
+        .new_buffer(b * seq_len * heads * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+    let beta_out_buf = device
+        .new_buffer(b * seq_len * heads * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+
+    call_gdn_decay_beta_gate_f32(
+        &device,
+        &encoder,
+        &kernels,
+        b,
+        seq_len,
+        heads,
+        &alpha_off,
+        &dt_bias_off,
+        &ssm_a_off,
+        &beta_off,
+        &g_out_buf,
+        &beta_out_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got_g: Vec<f32> = read_to_vec(&g_out_buf, b * seq_len * heads);
+    let got_beta: Vec<f32> = read_to_vec(&beta_out_buf, b * seq_len * heads);
+    let (expected_g, expected_beta) = gdn_decay_beta_gate_reference(
+        &alpha_logits,
+        &dt_bias,
+        &ssm_a,
+        &beta_logits,
+        b,
+        seq_len,
+        heads,
+    );
+
+    let g_diff = got_g
+        .iter()
+        .zip(expected_g.iter())
+        .fold(0f32, |m, (a, e)| m.max((a - e).abs()));
+    let beta_diff = got_beta
+        .iter()
+        .zip(expected_beta.iter())
+        .fold(0f32, |m, (a, e)| m.max((a - e).abs()));
+    println!("gdn_decay_beta_gate_nonzero_offsets: g_diff={g_diff:.8} beta_diff={beta_diff:.8}");
+    assert!(
+        g_diff < 5e-5,
+        "nonzero-offset g mismatch, max diff = {g_diff}"
+    );
+    assert!(
+        beta_diff < 5e-5,
+        "nonzero-offset beta mismatch, max diff = {beta_diff}"
+    );
+}

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2491,3 +2491,331 @@ fn residency_set_batch_insert_remove() {
     set.remove_batch(std::iter::empty());
     assert_eq!(raw.allocationCount(), base);
 }
+
+// Fused gated-DeltaNet decode step: confirms the kernel compiles and
+// loads as a real Metal pipeline before any numeric-correctness work is
+// asked to rely on it -- same de-risk-spike-before-wiring precedent as
+// kernel_mul_mv_id_pipelines_load.
+#[test]
+fn kernel_gdn_decode_step_pipeline_loads() {
+    let device = device();
+    let kernels = Kernels::new();
+    kernels
+        .load_pipeline(&device, Source::Gdn, "kernel_gdn_decode_step_f32")
+        .unwrap_or_else(|e| {
+            panic!("kernel_gdn_decode_step_f32 should load as a Metal compute pipeline: {e}")
+        });
+}
+
+// Scalar Rust reference for the fused kernel's math (see gdn.metal's own
+// doc comment for the derivation):
+//   s_dec[i][j] = g * s_in[i][j]
+//   kv_mem[j]   = sum_i s_dec[i][j] * k[i]
+//   delta[j]    = (v[j] - kv_mem[j]) * beta
+//   s_out[i][j] = s_dec[i][j] + k[i] * delta[j]
+//   out[j]      = sum_i s_out[i][j] * q[i]
+// Per (batch, head) -- q/k: [hk], v: [hv], g/beta: scalar, state: [hk, hv].
+#[allow(clippy::too_many_arguments)]
+fn gdn_decode_step_reference(
+    q: &[f32],
+    k: &[f32],
+    v: &[f32],
+    g: f32,
+    beta: f32,
+    state_in: &[f32],
+    hk: usize,
+    hv: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    let mut state_out = vec![0f32; hk * hv];
+    let mut out = vec![0f32; hv];
+    for j in 0..hv {
+        let mut kv_mem = 0f32;
+        for i in 0..hk {
+            kv_mem += (g * state_in[i * hv + j]) * k[i];
+        }
+        let delta = (v[j] - kv_mem) * beta;
+        let mut acc = 0f32;
+        for i in 0..hk {
+            let s_new = g * state_in[i * hv + j] + k[i] * delta;
+            state_out[i * hv + j] = s_new;
+            acc += s_new * q[i];
+        }
+        out[j] = acc;
+    }
+    (out, state_out)
+}
+
+// Runs the real kernel on random inputs at the given shape and compares
+// against the scalar reference above, per (batch, head). `hv` deliberately
+// not always a multiple of the threadgroup width (min(hv, 64) in
+// call_gdn_decode_step_f32) to exercise the kernel's own `j >= args.hv`
+// bounds check, not just the common case.
+fn run_gdn_decode_step_and_check(b: usize, h: usize, hk: usize, hv: usize) {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+    let q = randf(&mut rng, b * h * hk, 0.2);
+    let k = randf(&mut rng, b * h * hk, 0.2);
+    let v = randf(&mut rng, b * h * hv, 2.0);
+    // g in (0,1) (post-exp decay gate, matching sequential_step's own
+    // convention -- the kernel takes g already exp'd, not log_g); beta in
+    // (0,1) too. Include the large_decay-style strong-decay regime
+    // (g close to 0) at least once via the caller's own shape choices --
+    // this helper takes whatever the caller passes.
+    let g_vals: Vec<f32> = (0..b * h)
+        .map(|_| rng.random::<f32>() * 0.9 + 0.05)
+        .collect();
+    let beta_vals: Vec<f32> = (0..b * h)
+        .map(|_| rng.random::<f32>() * 0.9 + 0.05)
+        .collect();
+    let state_in = randf(&mut rng, b * h * hk * hv, 1.0);
+
+    let q_buf = new_buffer(&device, &q);
+    let k_buf = new_buffer(&device, &k);
+    let v_buf = new_buffer(&device, &v);
+    let g_buf = new_buffer(&device, &g_vals);
+    let beta_buf = new_buffer(&device, &beta_vals);
+    let state_in_buf = new_buffer(&device, &state_in);
+    let state_out_buf = device
+        .new_buffer(
+            b * h * hk * hv * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
+        .unwrap();
+    let out_buf = device
+        .new_buffer(b * h * hv * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .unwrap();
+
+    call_gdn_decode_step_f32(
+        &device,
+        &encoder,
+        &kernels,
+        b,
+        h,
+        hk,
+        hv,
+        &BufferOffset::zero_offset(&q_buf),
+        &BufferOffset::zero_offset(&k_buf),
+        &BufferOffset::zero_offset(&v_buf),
+        &BufferOffset::zero_offset(&g_buf),
+        &BufferOffset::zero_offset(&beta_buf),
+        &BufferOffset::zero_offset(&state_in_buf),
+        &state_out_buf,
+        &out_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got_out: Vec<f32> = read_to_vec(&out_buf, b * h * hv);
+    let got_state: Vec<f32> = read_to_vec(&state_out_buf, b * h * hk * hv);
+
+    let mut max_out_diff = 0f32;
+    let mut max_state_diff = 0f32;
+    for bh in 0..b * h {
+        let (expected_out, expected_state) = gdn_decode_step_reference(
+            &q[bh * hk..(bh + 1) * hk],
+            &k[bh * hk..(bh + 1) * hk],
+            &v[bh * hv..(bh + 1) * hv],
+            g_vals[bh],
+            beta_vals[bh],
+            &state_in[bh * hk * hv..(bh + 1) * hk * hv],
+            hk,
+            hv,
+        );
+        for j in 0..hv {
+            let diff = (got_out[bh * hv + j] - expected_out[j]).abs();
+            max_out_diff = max_out_diff.max(diff);
+        }
+        for e in 0..hk * hv {
+            let diff = (got_state[bh * hk * hv + e] - expected_state[e]).abs();
+            max_state_diff = max_state_diff.max(diff);
+        }
+    }
+    println!(
+        "gdn_decode_step b={b} h={h} hk={hk} hv={hv}: out_diff={max_out_diff:.8} state_diff={max_state_diff:.8}"
+    );
+    assert!(
+        max_out_diff < 5e-5,
+        "b={b} h={h} hk={hk} hv={hv}: output mismatch, max diff = {max_out_diff}"
+    );
+    assert!(
+        max_state_diff < 5e-5,
+        "b={b} h={h} hk={hk} hv={hv}: state mismatch, max diff = {max_state_diff}"
+    );
+}
+
+#[test]
+fn kernel_gdn_decode_step_matches_scalar_reference_tiny() {
+    // Small, odd shapes -- hv=5 is not a multiple of min(hv,64)'s
+    // threadgroup width, exercising the bounds check on every thread group
+    // boundary, not just the last one.
+    run_gdn_decode_step_and_check(1, 2, 4, 4);
+    run_gdn_decode_step_and_check(1, 3, 7, 5);
+    run_gdn_decode_step_and_check(2, 2, 6, 6);
+}
+
+#[test]
+fn kernel_gdn_decode_step_matches_scalar_reference_production_shape() {
+    // b=1, h=32, hk=128, hv=128 -- a real production shape from a
+    // Qwen3.5-family hybrid gated-DeltaNet model.
+    run_gdn_decode_step_and_check(1, 32, 128, 128);
+}
+
+// Regression test for a real bug found while integrating this kernel: a
+// caller's `v` was a `narrow()`'d slice of a shared QKV-split buffer with
+// a genuine nonzero byte offset, which an earlier version of
+// call_gdn_decode_step_f32 (bare &Buffer params, no offset) silently
+// ignored -- reading the wrong region of the buffer. This test reproduces
+// that shape directly: q/k/v/g/beta/state_in are all slices into ONE
+// larger packed buffer at different offsets (not six independent
+// zero-offset allocations, which is what every other test here uses and
+// exactly why this bug slipped past them), so a wrong or ignored offset
+// reads cross-contaminated data and fails the numeric check hard, not
+// subtly.
+#[test]
+fn kernel_gdn_decode_step_respects_nonzero_buffer_offsets() {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+
+    let (b, h, hk, hv) = (1usize, 4usize, 8usize, 8usize);
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+
+    // Pack q, k, v, g, beta, state_in back-to-back into one buffer, each
+    // preceded by a "decoy" region of the *next* tensor's own values --
+    // i.e. deliberately construct it so that reading from byte offset 0
+    // instead of the real offset would read a DIFFERENT tensor's data,
+    // not just garbage. Layout: [decoy_q_sized][q][k][v][g][beta][state_in].
+    let q = randf(&mut rng, b * h * hk, 0.2);
+    let k = randf(&mut rng, b * h * hk, 0.2);
+    let v = randf(&mut rng, b * h * hv, 2.0);
+    let g_vals: Vec<f32> = (0..b * h)
+        .map(|_| rng.random::<f32>() * 0.9 + 0.05)
+        .collect();
+    let beta_vals: Vec<f32> = (0..b * h)
+        .map(|_| rng.random::<f32>() * 0.9 + 0.05)
+        .collect();
+    let state_in = randf(&mut rng, b * h * hk * hv, 1.0);
+    let decoy = randf(&mut rng, b * h * hk, 999.0); // same size as q, deliberately huge-magnitude so a wrong-offset read is obviously wrong
+
+    let f32_size = std::mem::size_of::<f32>();
+    let packed: Vec<f32> = [
+        &decoy[..],
+        &q[..],
+        &k[..],
+        &v[..],
+        &g_vals[..],
+        &beta_vals[..],
+        &state_in[..],
+    ]
+    .concat();
+    let packed_buf = new_buffer(&device, &packed);
+
+    let mut offset_elems = decoy.len();
+    let q_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += q.len();
+    let k_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += k.len();
+    let v_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += v.len();
+    let g_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += g_vals.len();
+    let beta_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += beta_vals.len();
+    let state_in_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+
+    let state_out_buf = device
+        .new_buffer(b * h * hk * hv * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+    let out_buf = device
+        .new_buffer(b * h * hv * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+
+    call_gdn_decode_step_f32(
+        &device,
+        &encoder,
+        &kernels,
+        b,
+        h,
+        hk,
+        hv,
+        &q_off,
+        &k_off,
+        &v_off,
+        &g_off,
+        &beta_off,
+        &state_in_off,
+        &state_out_buf,
+        &out_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got_out: Vec<f32> = read_to_vec(&out_buf, b * h * hv);
+    let got_state: Vec<f32> = read_to_vec(&state_out_buf, b * h * hk * hv);
+
+    let mut max_out_diff = 0f32;
+    let mut max_state_diff = 0f32;
+    for bh in 0..b * h {
+        let (expected_out, expected_state) = gdn_decode_step_reference(
+            &q[bh * hk..(bh + 1) * hk],
+            &k[bh * hk..(bh + 1) * hk],
+            &v[bh * hv..(bh + 1) * hv],
+            g_vals[bh],
+            beta_vals[bh],
+            &state_in[bh * hk * hv..(bh + 1) * hk * hv],
+            hk,
+            hv,
+        );
+        for j in 0..hv {
+            max_out_diff = max_out_diff.max((got_out[bh * hv + j] - expected_out[j]).abs());
+        }
+        for e in 0..hk * hv {
+            max_state_diff =
+                max_state_diff.max((got_state[bh * hk * hv + e] - expected_state[e]).abs());
+        }
+    }
+    println!("gdn_decode_step_nonzero_offsets: out_diff={max_out_diff:.8} state_diff={max_state_diff:.8}");
+    assert!(
+        max_out_diff < 5e-5,
+        "nonzero-offset output mismatch, max diff = {max_out_diff}"
+    );
+    assert!(
+        max_state_diff < 5e-5,
+        "nonzero-offset state mismatch, max diff = {max_state_diff}"
+    );
+}


### PR DESCRIPTION
## Summary

Gated-DeltaNet (gated linear attention) decode, as used by Qwen3.5 / Qwen3-Next style hybrid architectures, normally executes as a chain of ~9 serialized, dependency-ordered elementwise/reduction candle ops per layer per decode token (decay multiply, key-weighted read, delta computation, state write, query-weighted read). At batch=1, seq_len=1 the tensors involved are small, so this is cheap in FLOPs but expensive in fixed per-dispatch overhead — every op depends on the previous op's output, so each pays a full pipeline/bind/encode cycle and a hazard-tracking barrier under `HazardTrackingModeUntracked`.

This PR adds `kernel_gdn_decode_step_f32`, fusing the whole step into one dispatch: one thread per `(batch, head, output-column)`, computing the decay/read/delta/write/read chain entirely in registers, no cross-thread communication or threadgroup memory.

- **State is written functionally** — a fresh output buffer; the input state buffer is read-only and untouched — rather than mutated in place, so callers holding other references to the input state tensor (e.g. an externally-taken checkpoint) are unaffected by a decode step running.
- **Every read input takes a `BufferOffset`, not a bare `Buffer`.** Callers commonly derive `q`/`k`/`v` from `narrow()`'d slices of a shared QKV-projection buffer, which can carry a real nonzero byte offset even when the resulting tensor is itself contiguous. Binding at a fixed offset 0 regardless of the tensor's actual layout silently reads the wrong region of the buffer — caught during integration by an end-to-end differential against a real model reference, not by this crate's own unit tests (which used independent, always-offset-0 buffer allocations and so never exercised this). The included regression test packs six tensors into one shared buffer at real nonzero offsets to reproduce that shape directly.

Measured on a real Qwen3.5-family model's decode path (single-token, production shape): replacing the equivalent candle op sequence with this kernel took full end-to-end decode throughput from ~20 to ~43 tok/s (2.1x) on Apple M4 Pro, with the DeltaNet/SSM recurrence's own share of decode time going from the dominant term to roughly on par with the model's MoE FFN.

## Test plan

- [x] `cargo test -p candle-metal-kernels --lib gdn` — pipeline-load, numeric parity against a scalar Rust reference at small/odd shapes and a real production shape (`b=1, h=32, hk=128, hv=128`, max diff 9e-8), and the nonzero-offset regression test
- [x] `cargo test -p candle-metal-kernels --lib` — full crate suite, 65/65
- [x] `cargo fmt --check` and `cargo clippy --tests -- -D warnings` clean on every file this PR touches (some pre-existing clippy warnings remain elsewhere in the crate, unrelated to this change and not touched here)
- [x] Integrated and validated end-to-end against a real cached GGUF model's decode path with a bit-exact/near-bit-exact differential against an independent HF reference implementation (external project, not part of this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwN6xpWjh1aFcNdWmd1mAM