### PR TITLE
Metal QMatMul: extend the batch==1 mat-vec fast path to batch<=8

### DIFF
--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -319,22 +319,83 @@ impl QMetalStorage {
             .with_label("qmatmul")
             .build()?;
         let encoder = device.command_encoder()?;
-        // In some cases it would be better to use the mm variant, though it has its drawbacks
-        // around memory alignment.
-        for batch_id in 0..m {
+        // `call_quantized_matmul_mv_t`'s own dispatch grid already supports
+        // multiple rows in one dispatch (`height: ne11`, `ne11 = m`) -- for
+        // the block-quantized dtypes below, every row is read via
+        // `src1 + r1*ne10 + ...` inside the kernel itself (`ne10` is the
+        // contraction dim, a stride that's correct for any contiguous
+        // multi-row `src1` on its own, independent of the wrapper's own
+        // `nb11` field), so one batched call is exactly equivalent to `m`
+        // independent single-row calls -- confirmed against the actual
+        // kernel bodies (`metal_src/quantized.metal`) AND against a real
+        // bit-exact differential test per dtype
+        // (`candle-core/tests/quantized_tests.rs`'s
+        // `qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact`),
+        // not assumed from source reading alone. F16, BF16, F32 index via
+        // `src1 + r1*nb11 + ...` (their own distinct kernel template), and
+        // the wrapper always passes `nb11 = 0` -- every row would silently
+        // read row 0 for those three dtypes at `m > 1`, so they keep the
+        // old, always-correct per-row loop. **`Q2K` and `Q5_1` also stay on
+        // the loop, despite superficially matching the `ne10`-indexed
+        // template**: the differential test suite above found real, silent
+        // per-dtype corruption at `batch > 1` for both -- `Q2K` scattered
+        // zeros within rows at `batch == 2` (this dtype already carries a
+        // known Metal-kernel quirk elsewhere in this file, see the "Fixing
+        // a bug in Metal for GGML" comment in `candle-metal-kernels`' own
+        // tuning table), `Q5_1` an entirely-zeroed row 0 at `batch == 4`
+        // with rows 1-3 correct (a distinct failure shape, root cause not
+        // chased further). Root cause not chased for either -- this list is
+        // deliberately built from "verified correct by a real differential
+        // test," not "looks safe by reading the kernel source," after these
+        // two proved that shortcut wrong twice. `Q8_1` is also absent: its
+        // own mat-vec Metal kernel (`kernel_mul_mv_q8_1_f32`) doesn't exist
+        // anywhere in the vendored `.metal` source at all -- a pre-existing
+        // gap this change neither causes nor fixes (the identical
+        // kernel-load failure already happens at `batch == 1` through the
+        // unchanged loop path).
+        let batched_dispatch_safe = matches!(
+            self.dtype,
+            GgmlDType::Q4_0
+                | GgmlDType::Q4_1
+                | GgmlDType::Q5_0
+                | GgmlDType::Q8_0
+                | GgmlDType::Q3K
+                | GgmlDType::Q4K
+                | GgmlDType::Q5K
+                | GgmlDType::Q6K
+        );
+        if batched_dispatch_safe {
             candle_metal_kernels::call_quantized_matmul_mv_t(
                 device.device(),
                 &encoder,
                 device.kernels(),
                 self.dtype.into(),
-                (1, 1, n, k),
+                (1, m, n, k),
                 storage.buffer(),
-                (layout.start_offset() + batch_id * k) * storage.dtype().size_in_bytes(),
+                layout.start_offset() * storage.dtype().size_in_bytes(),
                 &self.buffer,
-                batch_id * n * DType::F32.size_in_bytes(),
+                0,
                 &dst,
             )
             .map_err(MetalError::from)?;
+        } else {
+            // In some cases it would be better to use the mm variant, though it has its drawbacks
+            // around memory alignment.
+            for batch_id in 0..m {
+                candle_metal_kernels::call_quantized_matmul_mv_t(
+                    device.device(),
+                    &encoder,
+                    device.kernels(),
+                    self.dtype.into(),
+                    (1, 1, n, k),
+                    storage.buffer(),
+                    (layout.start_offset() + batch_id * k) * storage.dtype().size_in_bytes(),
+                    &self.buffer,
+                    batch_id * n * DType::F32.size_in_bytes(),
+                    &dst,
+                )
+                .map_err(MetalError::from)?;
+            }
         }
         let dst_storage =
             crate::MetalStorage::new(dst, device.clone(), dst_shape.elem_count(), DType::F32);
@@ -369,7 +430,50 @@ impl QMetalStorage {
             )
         }
 
-        if src_shape.dim(D::Minus2)? == 1 {
+        // Decode (batch == 1) and small multi-token batches (batch <= 8,
+        // e.g. a speculative-decode verify step) route to `fwd_mv`'s
+        // matrix-vector dispatch. `mv_t`'s own Metal dispatch grid is
+        // `height: ne11` (the row/batch count) -- proportional to real
+        // work -- while `mm_t`'s `width: ne11/32` stays at a fixed 1 for
+        // any batch from 1 to 32, so `mm_t` pays nearly the same dispatch
+        // tax at batch 2 as it would at batch 32: a near-fixed cost poorly
+        // amortized at small batch. `8` is a conservative margin below an
+        // unmeasured-past-that-point crossover, not a proven-optimal
+        // number. `fwd_mv` requires a rank-2 weight and a rank-<=3 src --
+        // routing a rank-3-weight or rank-4-src call into it would trade a
+        // previously-working `mm_t` path for a hard error, so those stay
+        // on `mm_t` regardless of batch size.
+        //
+        // `Q5_1` is excluded from this `m > 1` routing entirely (not just
+        // from `fwd_mv`'s own internal batched-dispatch dtype list): a
+        // real differential test found `fwd_mv`'s pre-existing per-row
+        // *loop* -- unmodified by this change, previously only reachable
+        // at `m > 1` via a rank-3, leading-batch-dim-`b`-greater-than-1
+        // input, never via this rank-2 path -- silently zeroes row 0's
+        // output for this dtype specifically at `m == 4`, rows 1..m
+        // unaffected. Root cause not found (plausibly a Metal hazard-
+        // tracking/encoder-ordering issue specific to this dtype's own
+        // kernel tuning, across repeated same-buffer dispatches); `Q5_1`
+        // keeps its exact prior behavior (`mm_t` for any `m > 1`) rather
+        // than risk exposing the same latent bug through this new code
+        // path.
+        //
+        // `Q2K` is excluded the same way, for the same reason, found the
+        // same way: the pre-existing `qmm_batch` test (`quantized_tests.rs`,
+        // stacks real batches up to `m == 12`) failed once `m > 1` could
+        // reach `fwd_mv`'s loop at all for this dtype -- beyond the `m <= 8`
+        // range this fix's own differential test suite swept, where the
+        // loop looked correct. Root cause not chased (plausibly the same
+        // hazard-tracking family of issue as `Q5_1`, just with a larger
+        // `m` threshold before it manifests); excluded rather than
+        // partially trusted.
+        let m_gt_1_safe_for_fwd_mv = !matches!(self.dtype, GgmlDType::Q5_1 | GgmlDType::Q2K);
+        if src_shape.dim(D::Minus2)? == 1
+            || (src_shape.dim(D::Minus2)? <= 8
+                && self_shape.rank() == 2
+                && src_shape.rank() <= 3
+                && m_gt_1_safe_for_fwd_mv)
+        {
             return self.fwd_mv(self_shape, storage, layout);
         }
 

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -184,12 +184,17 @@ fn quantized_matmul_neg(device: &Device) -> Result<()> {
     let matmul = quantized::QMatMul::from_qtensor(qtensor)?;
     let res = matmul.forward(&lhs)?;
     match device {
+        // `lhs` is (m=3, k=64), Q4_0 -- now routes through `fwd_mv`'s
+        // batched mat-vec dispatch instead of `mm_t` (the `use_mv`-style
+        // `batch <= 8` extension). Different accumulation order than
+        // `mm_t`, still correct -- these golden values were re-captured
+        // against the new path.
         Device::Metal(_) => assert_eq!(
             to_vec2_round(&res, 0)?,
             &[
-                [243659.0, -19716.0, -285444.0, -550439.0],
-                [23779.0, 21653.0, 19404.0, 18349.0],
-                [-196101.0, 63021.0, 324252.0, 587137.0]
+                [243666.0, -19714.0, -285433.0, -550453.0],
+                [23782.0, 21654.0, 19400.0, 18369.0],
+                [-196102.0, 63022.0, 324233.0, 587191.0]
             ]
         ),
         Device::Cuda(_) => assert_eq!(
@@ -261,6 +266,255 @@ fn qmm_batch(dev: &Device) -> Result<()> {
 test_device!(quantized_matmul, qmm_cpu, qmm_cuda, qmm_metal);
 test_device!(quantized_matmul_neg, qmm_n_cpu, qmm_n_cuda, qmm_n_metal);
 test_device!(qmm_batch, qmm_b_cpu, qmm_b_cuda, qmm_b_metal);
+
+/// `QTensor::fwd`'s own small-multi-token-batch dispatch (extends the
+/// existing `batch == 1` mat-vec fast path to `batch <= 8`, routing through
+/// `fwd_mv`'s single batched `call_quantized_matmul_mv_t` dispatch instead
+/// of `mm_t`): compares a real `batch`-row `QMatMul::forward` call against
+/// `batch` independent single-row calls on the same data, which must be
+/// bit-exact -- every row is computed identically either way (the kernel's
+/// own `src1 + r1*ne10 + ...` indexing, confirmed against the actual
+/// `quantized.metal` source for these dtypes, is per-row-independent by
+/// construction), so any difference is a real stride/offset bug in the
+/// batched dispatch's own plumbing, not an accumulation-order artifact.
+#[cfg(feature = "metal")]
+fn qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact(
+    dtype: GgmlDType,
+) -> Result<()> {
+    let device = Device::new_metal(0)?;
+    let (n, k) = (256usize, 512usize); // block-aligned for every dtype under test (min block size 256)
+
+    let weight: Vec<f32> = (0..n * k)
+        .map(|v| ((v * 37 + 11) % 997) as f32 * 0.001)
+        .collect();
+    let weight = Tensor::from_slice(&weight, (n, k), &device)?;
+    let qweight = quantized::QTensor::quantize(&weight, dtype)?;
+    let matmul = quantized::QMatMul::from_qtensor(qweight)?;
+
+    for batch in [2usize, 3, 4, 8] {
+        let x: Vec<f32> = (0..batch * k)
+            .map(|v| ((v * 13 + 5) % 991) as f32 * 0.001)
+            .collect();
+        let x = Tensor::from_slice(&x, (batch, k), &device)?;
+
+        let batched = matmul.forward(&x)?.to_vec2::<f32>()?;
+        let mut sequential = Vec::with_capacity(batch);
+        for row in 0..batch {
+            let x_row = x.narrow(0, row, 1)?;
+            let out_row = matmul.forward(&x_row)?.to_vec2::<f32>()?;
+            sequential.push(out_row[0].clone());
+        }
+
+        assert_eq!(
+            batched, sequential,
+            "dtype={dtype:?} batch={batch}: batched QMatMul::forward diverges from {batch} \
+             independent single-row calls on the same data -- must be bit-exact"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact_q4k() -> Result<()> {
+    qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact(GgmlDType::Q4K)
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact_q6k() -> Result<()> {
+    qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact(GgmlDType::Q6K)
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact_q4_0() -> Result<()> {
+    qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact(GgmlDType::Q4_0)
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact_q5k() -> Result<()> {
+    qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact(GgmlDType::Q5K)
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact_q3k() -> Result<()> {
+    qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact(GgmlDType::Q3K)
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact_q4_1() -> Result<()> {
+    qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact(GgmlDType::Q4_1)
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact_q5_0() -> Result<()> {
+    qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact(GgmlDType::Q5_0)
+}
+
+// Regression guard, not a "safe dtype" test: `Q5_1` is excluded from
+// `fwd()`'s own `m > 1` routing entirely (not just from `fwd_mv`'s internal
+// batched-dispatch dtype list) -- a real differential test found
+// `fwd_mv`'s pre-existing, unmodified per-row loop itself silently zeroes
+// row 0's output for this dtype at `m == 4` (rows 1..m unaffected, a
+// distinct failure shape from `Q2K`'s own scattered-zero pattern). So at
+// `m > 1`, `Q5_1` now always uses `mm_t` -- comparing that against `m`
+// independent `fwd_mv` (`mv_t`) calls is a genuine cross-kernel comparison
+// (different accumulation order), hence tolerance-based here, unlike the
+// bit-exact dtype tests above which compare the *same* kernel batched vs.
+// looped.
+#[cfg(feature = "metal")]
+#[test]
+fn qmatmul_mm_t_matches_sequential_single_row_mv_calls_within_tolerance_q5_1() -> Result<()> {
+    let device = Device::new_metal(0)?;
+    let (n, k) = (256usize, 512usize);
+    let weight: Vec<f32> = (0..n * k)
+        .map(|v| ((v * 37 + 11) % 997) as f32 * 0.001)
+        .collect();
+    let weight = Tensor::from_slice(&weight, (n, k), &device)?;
+    let qweight = quantized::QTensor::quantize(&weight, GgmlDType::Q5_1)?;
+    let matmul = quantized::QMatMul::from_qtensor(qweight)?;
+
+    for batch in [2usize, 4, 8] {
+        let x: Vec<f32> = (0..batch * k)
+            .map(|v| ((v * 13 + 5) % 991) as f32 * 0.001)
+            .collect();
+        let x = Tensor::from_slice(&x, (batch, k), &device)?;
+        let got = matmul.forward(&x)?.to_vec2::<f32>()?; // mm_t (batch > 1 always routes here for Q5_1)
+
+        let mut expected = Vec::with_capacity(batch);
+        for row in 0..batch {
+            let x_row = x.narrow(0, row, 1)?;
+            let out_row = matmul.forward(&x_row)?.to_vec2::<f32>()?; // fwd_mv (m == 1, always safe)
+            expected.push(out_row[0].clone());
+        }
+        for (r, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+            for (c, (gv, ev)) in g.iter().zip(e.iter()).enumerate() {
+                let diff = (gv - ev).abs();
+                assert!(
+                    diff <= 1e-3 + 1e-3 * ev.abs(),
+                    "batch={batch} row={r} col={c}: Q5_1 mm_t vs. sequential mv_t mismatch, \
+                     got={gv} expected={ev} (diff {diff})"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "metal")]
+#[test]
+fn qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact_q8_0() -> Result<()> {
+    qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact(GgmlDType::Q8_0)
+}
+
+// No qmatmul_batched_..._q8_1 test: `kernel_mul_mv_q8_1_f32` does not exist
+// anywhere in the vendored `metal_src/quantized.metal` -- Q8_1's mat-vec
+// Metal path is completely non-functional today, independent of and
+// pre-dating this change (the identical kernel-load failure occurs at
+// `batch == 1` through the untouched loop path too, confirmed while
+// building this test). Not a regression this change introduces, not fixed
+// here.
+
+// Regression guard, not a "safe dtype" test: `Q2K` is excluded from
+// `fwd()`'s own `m > 1` routing entirely (not just `fwd_mv`'s internal
+// batched-dispatch dtype list) -- a real differential test found `Q2K`'s
+// batched `mv_t` dispatch produces scattered zeros/NaN/garbage at m == 2,
+// and separately that its pre-existing, unmodified per-row loop *also*
+// breaks at larger m (the pre-existing `qmm_batch` test, stacking up to
+// m == 12, failed once `Q2K` could reach `fwd_mv` for m > 1 at all). Root
+// cause not chased further. So at `m > 1`, `Q2K` now always uses `mm_t` --
+// comparing that against `m` independent `fwd_mv` (`mv_t`) calls is a
+// genuine cross-kernel comparison (different accumulation order), hence
+// tolerance-based here, same treatment as `Q5_1` above.
+#[cfg(feature = "metal")]
+#[test]
+fn qmatmul_mm_t_matches_sequential_single_row_mv_calls_within_tolerance_q2k() -> Result<()> {
+    let device = Device::new_metal(0)?;
+    let (n, k) = (256usize, 512usize);
+    let weight: Vec<f32> = (0..n * k)
+        .map(|v| ((v * 37 + 11) % 997) as f32 * 0.001)
+        .collect();
+    let weight = Tensor::from_slice(&weight, (n, k), &device)?;
+    let qweight = quantized::QTensor::quantize(&weight, GgmlDType::Q2K)?;
+    let matmul = quantized::QMatMul::from_qtensor(qweight)?;
+
+    for batch in [2usize, 4, 8] {
+        let x: Vec<f32> = (0..batch * k)
+            .map(|v| ((v * 13 + 5) % 991) as f32 * 0.001)
+            .collect();
+        let x = Tensor::from_slice(&x, (batch, k), &device)?;
+        let got = matmul.forward(&x)?.to_vec2::<f32>()?; // mm_t (batch > 1 always routes here for Q2K)
+
+        let mut expected = Vec::with_capacity(batch);
+        for row in 0..batch {
+            let x_row = x.narrow(0, row, 1)?;
+            let out_row = matmul.forward(&x_row)?.to_vec2::<f32>()?; // fwd_mv (m == 1, always safe)
+            expected.push(out_row[0].clone());
+        }
+        for (r, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+            for (c, (gv, ev)) in g.iter().zip(e.iter()).enumerate() {
+                let diff = (gv - ev).abs();
+                assert!(
+                    diff <= 1e-3 + 1e-3 * ev.abs(),
+                    "batch={batch} row={r} col={c}: Q2K mm_t vs. sequential mv_t mismatch, \
+                     got={gv} expected={ev} (diff {diff})"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Regression guard for the batch-size gate's own boundary: `batch == 9`
+/// must fall through to the unchanged `mm_t` path, not `fwd_mv` -- a real
+/// tolerance-based (not bit-exact, different accumulation order) check
+/// that the two dispatch choices still agree, at the exact boundary where
+/// a future threshold change is most likely to introduce an off-by-one.
+#[cfg(feature = "metal")]
+#[test]
+fn qmatmul_mv_and_mm_agree_at_the_batch_size_gate_boundary() -> Result<()> {
+    let device = Device::new_metal(0)?;
+    let (n, k) = (256usize, 512usize);
+    let weight: Vec<f32> = (0..n * k)
+        .map(|v| ((v * 37 + 11) % 997) as f32 * 0.001)
+        .collect();
+    let weight = Tensor::from_slice(&weight, (n, k), &device)?;
+    let qweight = quantized::QTensor::quantize(&weight, GgmlDType::Q4K)?;
+    let matmul = quantized::QMatMul::from_qtensor(qweight)?;
+
+    for batch in [8usize, 9] {
+        let x: Vec<f32> = (0..batch * k)
+            .map(|v| ((v * 13 + 5) % 991) as f32 * 0.001)
+            .collect();
+        let x = Tensor::from_slice(&x, (batch, k), &device)?;
+        let got = matmul.forward(&x)?.to_vec2::<f32>()?;
+
+        // Independent per-row reference, computed via the always-available
+        // batch=1 path (never routes through the new batched dispatch),
+        // so this is a genuine oracle at both sides of the boundary.
+        let mut expected = Vec::with_capacity(batch);
+        for row in 0..batch {
+            let x_row = x.narrow(0, row, 1)?;
+            let out_row = matmul.forward(&x_row)?.to_vec2::<f32>()?;
+            expected.push(out_row[0].clone());
+        }
+        for (r, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+            for (c, (gv, ev)) in g.iter().zip(e.iter()).enumerate() {
+                let diff = (gv - ev).abs();
+                assert!(
+                    diff <= 1e-3 + 1e-3 * ev.abs(),
+                    "batch={batch} row={r} col={c}: mismatch at gate boundary, got={gv} expected={ev} (diff {diff})"
+                );
+            }
+        }
+    }
+    Ok(())
+}
 
 fn embedding_weight(device: &Device) -> Result<Tensor> {
     let values = (0..(8 * 256))


### PR DESCRIPTION
Extends `QTensor::fwd`'s existing decode-only (`batch == 1`) fast path to small multi-token batches (`batch <= 8`), for the generic quantized-matmul dispatch every quantized linear layer uses — not just MoE routing (#3797, a related but independent fix to a different, MoE-specific dispatch).

## What

`fwd()`'s gate previously only routed `batch == 1` to `fwd_mv`'s `mv_t` (matrix-vector) dispatch; every other batch size fell through to `mm_t` (matrix-matrix). Extended the gate to `batch <= 8` for rank-2 weights with a rank-<=3 src (the shapes `fwd_mv` actually supports — a rank-3 weight or rank-4 src stays on `mm_t` regardless of batch, since routing those into `fwd_mv` would trade a working call for a hard error).

Inside `fwd_mv`, replaced the per-row loop (one `call_quantized_matmul_mv_t` dispatch per row) with a single batched dispatch (real `m`, not a loop) for dtypes verified bit-exact against sequential single-row calls by a real differential test: `Q4_0`/`Q4_1`/`Q5_0`/`Q8_0`/`Q3K`/`Q4K`/`Q5K`/`Q6K`.

Two dtypes are excluded from `m > 1` routing entirely, not just from the batched-dispatch list — real, pre-existing bugs found by the same differential testing, neither caused by or fixed in this change:
- `Q2K`: the new batched dispatch corrupts (scattered zeros/NaN) at `m == 2`; separately, the *existing*, unmodified per-row loop itself breaks at larger `m` (the pre-existing `qmm_batch` test, which stacks batches up to `m == 12`, failed once `Q2K` could reach `fwd_mv` for `m > 1` at all — beyond the `m <= 8` range this PR's own differential sweep covers).
- `Q5_1`: the existing per-row loop silently zeroes row 0's output at `m == 4` (rows 1..m unaffected).

`Q8_1` has no working mat-vec Metal kernel at all (`kernel_mul_mv_q8_1_f32` isn't in the vendored `.metal` source) — a pre-existing, unrelated gap, left untouched.

## Why

`mv_t`'s Metal dispatch grid is `height: ne11` (the row count) — proportional to real work. `mm_t`'s is `width: ne11/32`, which stays at a fixed 1 for any batch from 1 to 32 — so `mm_t` pays nearly the same dispatch tax at batch 2 as at batch 32, a near-fixed cost poorly amortized at small batch. This is the same mechanism #3797 already fixes for MoE's routed-expert matmul (`mv_id`/`mm_id`), but here in the generic path every quantized linear layer goes through — dense FFN, attention Q/K/V/O projections, and MoE's own gate/shared-expert projections. Any model doing small-batch multi-token work on Metal (speculative-decode verify steps, batched sampling, short prefill continuations) pays this tax on every quantized layer, not just routed-expert ones.

`8` is chosen the same way #3797 chose its own threshold: a conservative margin below an unmeasured-past-that-point crossover, matching a realistic verify-window range rather than claiming a proven-optimal number.

## Testing

- `candle-core/tests/quantized_tests.rs`: a real differential (`qmatmul_batched_mv_matches_sequential_single_row_calls_bit_exact`) comparing a batched `QMatMul::forward` call against N independent single-row calls on the same data, bit-exact, for every batched-safe dtype at batch ∈ {2,3,4,8}. Tolerance-based cross-kernel comparisons (`mm_t` vs. sequential `mv_t`) for `Q2K`/`Q5_1`, since those now compare genuinely different kernels rather than the same kernel batched-vs-looped. A boundary regression guard at `batch == 8` vs. `batch == 9`. Two existing hardcoded-golden-value tests (`qmm_n_metal`) updated where `Q4_0` now legitimately produces slightly different (equally correct) values via the new path's different accumulation order.
- Full `cargo test --release --features metal -p candle-core` (`--test-threads=1`, avoiding Metal-device-contention false positives under parallel execution) is clean. Two pre-existing, unrelated Metal test failures were confirmed present on a clean checkout of this branch's base, unaffected by this change: `conv2d_grad_noncontiguous_kernel_metal` and `meshgrid_with_empty_axis_metal`.
- `cargo fmt --check` / `cargo clippy` clean on both changed files (pre-existing, unrelated warnings elsewhere in the crate are untouched by this change).

Independent of #3797 (MoE-specific `indexed_moe_forward` dispatch) and #3897 (gated-DeltaNet-specific kernels) — this is the generic `QTensor::fwd`/`fwd_mv` path underneath all three, and can merge in any order relative to either.