### PR TITLE
Add MXFP4 (GGUF dtype 39) to candle-core's quantized backend

### DIFF
--- a/candle-core/src/quantized/ggml_file.rs
+++ b/candle-core/src/quantized/ggml_file.rs
@@ -184,6 +184,9 @@ pub fn qtensor_from_ggml(
         GgmlDType::Q6K => {
             from_raw_data::<k_quants::BlockQ6K>(raw_data, size_in_bytes, dims, device)
         }
+        GgmlDType::Mxfp4 => {
+            from_raw_data::<k_quants::BlockMxfp4>(raw_data, size_in_bytes, dims, device)
+        }
         _ => crate::bail!("quantized type {ggml_dtype:?} is not supported yet"),
     }
 }

--- a/candle-core/src/quantized/k_quants.rs
+++ b/candle-core/src/quantized/k_quants.rs
@@ -18,6 +18,7 @@ pub const QK5_0: usize = 32;
 pub const QK5_1: usize = 32;
 pub const QK8_0: usize = 32;
 pub const QK8_1: usize = 32;
+pub const QK_MXFP4: usize = 32;
 
 pub trait GgmlType: Sized + Clone + Send + Sync {
     const DTYPE: GgmlDType;
@@ -631,11 +632,146 @@ impl GgmlType for BlockQ5_1 {
     }
 }
 
+// MXFP4 (microscaling FP4, OCP MX spec): a block of 32 elements stored as one
+// E8M0 exponent byte plus 16 bytes of packed 4-bit E2M1 codes.
+// See https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
+// and ggml's block_mxfp4 (ggml-common.h).
+#[derive(Debug, Clone, PartialEq)]
+#[repr(C)]
+pub struct BlockMxfp4 {
+    pub(crate) e: u8,
+    pub(crate) qs: [u8; QK_MXFP4 / 2],
+}
+const _: () = assert!(std::mem::size_of::<BlockMxfp4>() == 17);
+
+// E2M1 values doubled, shared by MXFP4 and NVFP4 (ggml-common.h kvalues_fp4).
+const KVALUES_MXFP4: [i8; 16] = [0, 1, 2, 3, 4, 6, 8, 12, 0, -1, -2, -3, -4, -6, -8, -12];
+
+// ggml_e8m0_to_fp32_half: 0.5 * 2^(e - 127) = 2^(e - 128), used with the doubled
+// kvalues above so that kvalues[d] * d gives the exact E2M1 * E8M0 product.
+fn e8m0_to_f32_half(e: u8) -> f32 {
+    let bits = if e < 2 {
+        0x0020_0000u32 << e
+    } else {
+        ((e - 1) as u32) << 23
+    };
+    f32::from_bits(bits)
+}
+
+// best_index_mxfp4 from ggml-quants.c: nearest kvalues[i] * e to x.
+fn best_index_mxfp4(x: f32, e: f32) -> u8 {
+    let mut best_index = 0u8;
+    let mut best_err = (KVALUES_MXFP4[0] as f32 * e - x).abs();
+    for (i, &k) in KVALUES_MXFP4.iter().enumerate().skip(1) {
+        let err = (k as f32 * e - x).abs();
+        if err < best_err {
+            best_index = i as u8;
+            best_err = err;
+        }
+    }
+    best_index
+}
+
+impl GgmlType for BlockMxfp4 {
+    const DTYPE: GgmlDType = GgmlDType::Mxfp4;
+    const BLCK_SIZE: usize = QK_MXFP4;
+    // llama.cpp pairs MXFP4 weights with Q8_0-quantized activations
+    // (ggml_vec_dot_mxfp4_q8_0).
+    type VecDotType = BlockQ8_0;
+
+    // dequantize_row_mxfp4 from ggml-quants.c
+    fn to_float(xs: &[Self], ys: &mut [f32]) {
+        let k = ys.len();
+        debug_assert!(
+            k.is_multiple_of(QK_MXFP4),
+            "dequantize_row_mxfp4: {k} is not divisible by {QK_MXFP4}"
+        );
+
+        let nb = k / QK_MXFP4;
+
+        for i in 0..nb {
+            let d = e8m0_to_f32_half(xs[i].e);
+
+            for j in 0..QK_MXFP4 / 2 {
+                ys[i * QK_MXFP4 + j] = KVALUES_MXFP4[(xs[i].qs[j] & 0x0F) as usize] as f32 * d;
+                ys[i * QK_MXFP4 + j + QK_MXFP4 / 2] =
+                    KVALUES_MXFP4[(xs[i].qs[j] >> 4) as usize] as f32 * d;
+            }
+        }
+    }
+
+    // quantize_row_mxfp4_ref from ggml-quants.c
+    fn from_float(xs: &[f32], ys: &mut [Self]) {
+        let k = xs.len();
+        debug_assert!(
+            k.is_multiple_of(Self::BLCK_SIZE),
+            "{k} is not divisible by {}",
+            Self::BLCK_SIZE
+        );
+        debug_assert_eq!(
+            ys.len(),
+            k / Self::BLCK_SIZE,
+            "size mismatch {} {} {}",
+            xs.len(),
+            ys.len(),
+            Self::BLCK_SIZE
+        );
+        for (i, y) in ys.iter_mut().enumerate() {
+            let xs = &xs[i * Self::BLCK_SIZE..(i + 1) * Self::BLCK_SIZE];
+
+            let mut amax = 0f32;
+            for &x in xs.iter() {
+                amax = amax.max(x.abs());
+            }
+
+            let e = if amax > 0.0 {
+                (amax.log2().floor() - 2.0 + 127.0) as u8
+            } else {
+                0
+            };
+            y.e = e;
+
+            let d = e8m0_to_f32_half(e);
+            for j in 0..Self::BLCK_SIZE / 2 {
+                let x0 = best_index_mxfp4(xs[j], d);
+                let x1 = best_index_mxfp4(xs[j + Self::BLCK_SIZE / 2], d);
+                y.qs[j] = x0 | (x1 << 4);
+            }
+        }
+    }
+
+    fn vec_dot(n: usize, xs: &[Self], ys: &[Self::VecDotType]) -> f32 {
+        Self::vec_dot_unopt(n, xs, ys)
+    }
+
+    // ggml_vec_dot_mxfp4_q8_0_generic from ggml-cpu/quants.c
+    fn vec_dot_unopt(n: usize, xs: &[Self], ys: &[Self::VecDotType]) -> f32 {
+        debug_assert!(
+            n.is_multiple_of(QK_MXFP4),
+            "vec_dot_mxfp4_q8_0: {n} is not divisible by {QK_MXFP4}"
+        );
+
+        let mut sumf = 0f32;
+        for (xs, ys) in xs.iter().zip(ys.iter()) {
+            let d = f16::to_f32(ys.d) * e8m0_to_f32_half(xs.e);
+
+            let mut sumi1 = 0i32;
+            let mut sumi2 = 0i32;
+            for j in 0..QK_MXFP4 / 2 {
+                sumi1 += ys.qs[j] as i32 * KVALUES_MXFP4[(xs.qs[j] & 0x0F) as usize] as i32;
+                sumi2 +=
+                    ys.qs[j + QK_MXFP4 / 2] as i32 * KVALUES_MXFP4[(xs.qs[j] >> 4) as usize] as i32;
+            }
+            sumf += d * (sumi1 + sumi2) as f32;
+        }
+        sumf
+    }
+}
+
 impl GgmlType for BlockQ8_0 {
     const DTYPE: GgmlDType = GgmlDType::Q8_0;
     const BLCK_SIZE: usize = QK8_0;
     type VecDotType = BlockQ8_0;
-
     // https://github.com/ggerganov/llama.cpp/blob/468ea24fb4633a0d681f7ac84089566c1c6190cb/ggml.c#L1619
     fn to_float(xs: &[Self], ys: &mut [f32]) {
         let k = ys.len();

--- a/candle-core/src/quantized/metal.rs
+++ b/candle-core/src/quantized/metal.rs
@@ -115,6 +115,10 @@ impl QMetalStorage {
                 let vec: Vec<crate::quantized::BlockQ8K> = read_to_vec(&buffer, block_len);
                 crate::quantized::BlockQ8K::to_float(&vec, &mut out);
             }
+            GgmlDType::Mxfp4 => {
+                let vec: Vec<crate::quantized::BlockMxfp4> = read_to_vec(&buffer, block_len);
+                crate::quantized::BlockMxfp4::to_float(&vec, &mut out);
+            }
         }
 
         let buffer = self
@@ -261,7 +265,7 @@ impl QMetalStorage {
             device.device(),
             &encoder,
             device.kernels(),
-            self.dtype.into(),
+            candle_metal_kernels::GgmlDType::try_from(self.dtype)?,
             hidden,
             hidden * self.dtype.type_size() / self.dtype.block_size(),
             ids_len,
@@ -326,7 +330,7 @@ impl QMetalStorage {
                 device.device(),
                 &encoder,
                 device.kernels(),
-                self.dtype.into(),
+                candle_metal_kernels::GgmlDType::try_from(self.dtype)?,
                 (1, 1, n, k),
                 storage.buffer(),
                 (layout.start_offset() + batch_id * k) * storage.dtype().size_in_bytes(),
@@ -415,7 +419,7 @@ impl QMetalStorage {
             device.device(),
             &encoder,
             device.kernels(),
-            self.dtype.into(),
+            candle_metal_kernels::GgmlDType::try_from(self.dtype)?,
             src0_l.dims(),
             &src0_stride,
             &self.buffer,
@@ -479,24 +483,27 @@ fn read_to_vec<T: Clone>(buffer: &Buffer, n: usize) -> Vec<T> {
     slice.to_vec()
 }
 
-impl From<GgmlDType> for candle_metal_kernels::GgmlDType {
-    fn from(value: GgmlDType) -> Self {
+impl TryFrom<GgmlDType> for candle_metal_kernels::GgmlDType {
+    type Error = crate::Error;
+
+    fn try_from(value: GgmlDType) -> Result<Self> {
         match value {
-            GgmlDType::Q4_0 => candle_metal_kernels::GgmlDType::Q4_0,
-            GgmlDType::Q4_1 => candle_metal_kernels::GgmlDType::Q4_1,
-            GgmlDType::Q5_0 => candle_metal_kernels::GgmlDType::Q5_0,
-            GgmlDType::Q5_1 => candle_metal_kernels::GgmlDType::Q5_1,
-            GgmlDType::Q8_0 => candle_metal_kernels::GgmlDType::Q8_0,
-            GgmlDType::Q8_1 => candle_metal_kernels::GgmlDType::Q8_1,
-            GgmlDType::Q2K => candle_metal_kernels::GgmlDType::Q2K,
-            GgmlDType::Q3K => candle_metal_kernels::GgmlDType::Q3K,
-            GgmlDType::Q4K => candle_metal_kernels::GgmlDType::Q4K,
-            GgmlDType::Q5K => candle_metal_kernels::GgmlDType::Q5K,
-            GgmlDType::Q6K => candle_metal_kernels::GgmlDType::Q6K,
-            GgmlDType::Q8K => candle_metal_kernels::GgmlDType::Q8K,
-            GgmlDType::F16 => candle_metal_kernels::GgmlDType::F16,
-            GgmlDType::F32 => candle_metal_kernels::GgmlDType::F32,
-            GgmlDType::BF16 => candle_metal_kernels::GgmlDType::BF16,
+            GgmlDType::Q4_0 => Ok(candle_metal_kernels::GgmlDType::Q4_0),
+            GgmlDType::Q4_1 => Ok(candle_metal_kernels::GgmlDType::Q4_1),
+            GgmlDType::Q5_0 => Ok(candle_metal_kernels::GgmlDType::Q5_0),
+            GgmlDType::Q5_1 => Ok(candle_metal_kernels::GgmlDType::Q5_1),
+            GgmlDType::Q8_0 => Ok(candle_metal_kernels::GgmlDType::Q8_0),
+            GgmlDType::Q8_1 => Ok(candle_metal_kernels::GgmlDType::Q8_1),
+            GgmlDType::Q2K => Ok(candle_metal_kernels::GgmlDType::Q2K),
+            GgmlDType::Q3K => Ok(candle_metal_kernels::GgmlDType::Q3K),
+            GgmlDType::Q4K => Ok(candle_metal_kernels::GgmlDType::Q4K),
+            GgmlDType::Q5K => Ok(candle_metal_kernels::GgmlDType::Q5K),
+            GgmlDType::Q6K => Ok(candle_metal_kernels::GgmlDType::Q6K),
+            GgmlDType::Q8K => Ok(candle_metal_kernels::GgmlDType::Q8K),
+            GgmlDType::F16 => Ok(candle_metal_kernels::GgmlDType::F16),
+            GgmlDType::F32 => Ok(candle_metal_kernels::GgmlDType::F32),
+            GgmlDType::BF16 => Ok(candle_metal_kernels::GgmlDType::BF16),
+            GgmlDType::Mxfp4 => crate::bail!("MXFP4 is not supported on Metal"),
         }
     }
 }

--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -111,6 +111,7 @@ impl QStorage {
                 GgmlDType::Q6K => metal::load_quantized(d, as_t_slice::<BlockQ6K>(data)),
                 GgmlDType::Q8K => metal::load_quantized(d, as_t_slice::<BlockQ8K>(data)),
                 GgmlDType::BF16 => metal::load_quantized(d, as_t_slice::<bf16>(data)),
+                GgmlDType::Mxfp4 => metal::load_quantized(d, as_t_slice::<BlockMxfp4>(data)),
             },
             Device::Cuda(d) => match dtype {
                 GgmlDType::F32 => cuda::load_quantized(d, as_t_slice::<f32>(data)),
@@ -128,6 +129,7 @@ impl QStorage {
                 GgmlDType::Q6K => cuda::load_quantized(d, as_t_slice::<BlockQ6K>(data)),
                 GgmlDType::Q8K => cuda::load_quantized(d, as_t_slice::<BlockQ8K>(data)),
                 GgmlDType::BF16 => cuda::load_quantized(d, as_t_slice::<bf16>(data)),
+                GgmlDType::Mxfp4 => cuda::load_quantized(d, as_t_slice::<BlockMxfp4>(data)),
             },
         }
     }
@@ -294,6 +296,7 @@ pub enum GgmlDType {
     Q5K,
     Q6K,
     Q8K,
+    Mxfp4,
 }
 
 impl GgmlDType {
@@ -315,6 +318,7 @@ impl GgmlDType {
             15 => Self::Q8K,
             // https://github.com/ggerganov/ggml/blob/29d87fc6676e7ed0cdfdec0804b06001d9c2bb44/include/ggml.h#L389
             30 => Self::BF16,
+            39 => Self::Mxfp4,
             _ => crate::bail!("unknown dtype for tensor {u}"),
         };
         Ok(dtype)
@@ -338,6 +342,7 @@ impl GgmlDType {
             Self::Q8K => 15,
             // https://github.com/ggerganov/ggml/blob/29d87fc6676e7ed0cdfdec0804b06001d9c2bb44/include/ggml.h#L389
             Self::BF16 => 30,
+            Self::Mxfp4 => 39,
         }
     }
 
@@ -359,6 +364,10 @@ impl GgmlDType {
             Self::Q6K => Box::new(vec![BlockQ6K::zeros(); elem_count / BlockQ6K::BLCK_SIZE]),
             Self::Q8K => Box::new(vec![BlockQ8K::zeros(); elem_count / BlockQ8K::BLCK_SIZE]),
             Self::BF16 => Box::new(vec![bf16::zeros(); elem_count]),
+            Self::Mxfp4 => Box::new(vec![
+                BlockMxfp4::zeros();
+                elem_count / BlockMxfp4::BLCK_SIZE
+            ]),
         }
     }
 
@@ -380,6 +389,7 @@ impl GgmlDType {
             Self::Q6K => Box::new(as_t_slice::<BlockQ6K>(data).to_vec()),
             Self::Q8K => Box::new(as_t_slice::<BlockQ8K>(data).to_vec()),
             Self::BF16 => Box::new(as_t_slice::<bf16>(data).to_vec()),
+            Self::Mxfp4 => Box::new(as_t_slice::<BlockMxfp4>(data).to_vec()),
         }
     }
 
@@ -402,6 +412,7 @@ impl GgmlDType {
             Self::Q5K => std::mem::size_of::<BlockQ5K>(),
             Self::Q6K => std::mem::size_of::<BlockQ6K>(),
             Self::Q8K => std::mem::size_of::<BlockQ8K>(),
+            Self::Mxfp4 => std::mem::size_of::<BlockMxfp4>(),
         }
     }
 
@@ -417,6 +428,7 @@ impl GgmlDType {
             Self::Q8_0 => k_quants::QK8_0,
             Self::Q8_1 => k_quants::QK8_1,
             Self::Q2K | Self::Q3K | Self::Q4K | Self::Q5K | Self::Q6K | Self::Q8K => k_quants::QK_K,
+            Self::Mxfp4 => k_quants::QK_MXFP4,
         }
     }
 }

--- a/candle-core/tests/mxfp4_tests.rs
+++ b/candle-core/tests/mxfp4_tests.rs
@@ -1,0 +1,189 @@
+//! MXFP4 (GGML_TYPE_MXFP4 = 39) tests.
+//!
+//! The golden bytes in this file were generated with llama.cpp's reference
+//! implementation (`quantize_row_mxfp4_ref` in ggml-quants.c plus
+//! `ggml_e8m0_to_fp32_half` from ggml-impl.h), compiled as a standalone C
+//! program against a fixed LCG input. They pin the quantizer to bit-exact
+//! compatibility with llama.cpp.
+#![allow(clippy::excessive_precision)] // exact f32 literals emitted by the C golden generator
+
+use candle_core::quantized::{gguf_file, GgmlDType, QTensor};
+use candle_core::{Device, Result, Tensor};
+use std::io::Cursor;
+
+const QK: usize = 32;
+
+/// Two input blocks (LCG seed 42 and seed 7, see the module docs) with the
+/// expected quantized bytes: 1 exponent byte + 16 nibble-packed code bytes.
+struct Golden {
+    input: [f32; QK],
+    e: u8,
+    qs: [u8; QK / 2],
+}
+
+fn goldens() -> [Golden; 2] {
+    [
+        Golden {
+            input: [
+                -0.835388184,
+                -0.960388184,
+                -1.0680542,
+                -0.445983887,
+                -1.15429688,
+                -1.93328857,
+                -1.16522217,
+                -0.382568359,
+                -0.77532959,
+                -0.570251465,
+                -1.63549805,
+                -0.967651367,
+                -0.876098633,
+                -1.50268555,
+                -0.160827637,
+                -1.77832031,
+                -0.683288574,
+                -1.34307861,
+                -1.62945557,
+                -0.65802002,
+                -0.162536621,
+                -1.73706055,
+                -1.17883301,
+                -0.301757812,
+                -1.18078613,
+                -1.93463135,
+                -0.867736816,
+                -0.392028809,
+                -1.70367432,
+                -0.194030762,
+                -1.03997803,
+                -1.09802246,
+            ],
+            e: 0x7d,
+            qs: [
+                0xdd, 0xfe, 0xfe, 0xdc, 0x9e, 0xff, 0xee, 0xab, 0xed, 0xfc, 0xdf, 0xbe, 0xfe, 0xaf,
+                0xe9, 0xef,
+            ],
+        },
+        Golden {
+            input: [
+                0.194091797,
+                -0.401489258,
+                -0.336669922,
+                0.383911133,
+                0.985534668,
+                -0.794616699,
+                0.955200195,
+                0.940307617,
+                -0.512634277,
+                -0.33392334,
+                -0.315612793,
+                0.548034668,
+                0.80847168,
+                0.579223633,
+                -0.954284668,
+                -0.98034668,
+                -0.134216309,
+                0.443725586,
+                0.168823242,
+                -0.544677734,
+                -0.984619141,
+                0.12713623,
+                -0.690002441,
+                0.810180664,
+                0.102355957,
+                -0.107421875,
+                0.931091309,
+                0.11529541,
+                0.615844727,
+                -0.0777587891,
+                -0.147155762,
+                -0.212036133,
+            ],
+            e: 0x7c,
+            qs: [
+                0xa3, 0x6d, 0x3d, 0xe5, 0xf7, 0x2f, 0xf7, 0x77, 0x2e, 0xad, 0x7d, 0x26, 0x67, 0x96,
+                0xaf, 0xbf,
+            ],
+        },
+    ]
+}
+
+/// The quantizer must produce byte-identical output to llama.cpp's
+/// `quantize_row_mxfp4_ref` on the golden blocks.
+#[test]
+fn quantize_matches_llamacpp() -> Result<()> {
+    for golden in goldens() {
+        let xs = Tensor::from_slice(&golden.input, QK, &Device::Cpu)?;
+        let qtensor = QTensor::quantize(&xs, GgmlDType::Mxfp4)?;
+        let data = qtensor.data()?;
+        assert_eq!(data.len(), 17, "MXFP4 block must be 17 bytes");
+        assert_eq!(data[0], golden.e, "exponent byte mismatch");
+        assert_eq!(&data[1..], &golden.qs, "nibble-packed codes mismatch");
+    }
+    Ok(())
+}
+
+/// Independent reference decoder: kvalues * 2^(e-128), per OCP MX spec.
+/// Layout matches llama.cpp's dequantize_row_mxfp4: low nibbles decode
+/// elements [0, 16), high nibbles decode elements [16, 32).
+fn reference_decode(data: &[u8]) -> Vec<f32> {
+    const KVALUES: [f32; 16] = [
+        0., 1., 2., 3., 4., 6., 8., 12., 0., -1., -2., -3., -4., -6., -8., -12.,
+    ];
+    let e = data[0];
+    let d = f32::powf(2.0, e as f32 - 128.0);
+    let mut out = vec![0f32; QK];
+    for j in 0..QK / 2 {
+        out[j] = KVALUES[(data[1 + j] & 0x0F) as usize] * d;
+        out[j + QK / 2] = KVALUES[(data[1 + j] >> 4) as usize] * d;
+    }
+    out
+}
+
+/// dequantize must match the independent reference decode.
+#[test]
+fn dequantize_matches_reference() -> Result<()> {
+    for golden in goldens() {
+        let xs = Tensor::from_slice(&golden.input, QK, &Device::Cpu)?;
+        let qtensor = QTensor::quantize(&xs, GgmlDType::Mxfp4)?;
+        let expected = reference_decode(&qtensor.data()?);
+        let dequantized = qtensor.dequantize(&Device::Cpu)?;
+        let got: Vec<f32> = dequantized.to_vec1()?;
+        for (i, (g, e)) in got.iter().zip(expected.iter()).enumerate() {
+            assert_eq!(g, e, "element {i}: {g} != {e}");
+        }
+    }
+    Ok(())
+}
+
+/// Round trip through a GGUF file: write as MXFP4, read back, byte-identical.
+#[test]
+fn gguf_roundtrip() -> Result<()> {
+    let golden = &goldens()[0];
+    let xs = Tensor::from_slice(&golden.input, QK, &Device::Cpu)?;
+    let qtensor = QTensor::quantize(&xs, GgmlDType::Mxfp4)?;
+
+    let mut buf = Cursor::new(Vec::new());
+    gguf_file::write(&mut buf, &[], &[("mxfp4_tensor", &qtensor)])?;
+
+    let mut cursor = Cursor::new(buf.into_inner());
+    let content = gguf_file::Content::read(&mut cursor)?;
+    let tensor_info = content
+        .tensor_infos
+        .get("mxfp4_tensor")
+        .expect("tensor must be in the file");
+    assert_eq!(tensor_info.ggml_dtype, GgmlDType::Mxfp4);
+    let loaded = content.tensor(&mut cursor, "mxfp4_tensor", &Device::Cpu)?;
+    assert_eq!(loaded.data()?, qtensor.data()?);
+    assert_eq!(loaded.shape(), qtensor.shape());
+    Ok(())
+}
+
+/// Dtype plumbing: 17 bytes per 32 elements, and GGUF write/read maps id 39.
+#[test]
+fn dtype_plumbing() -> Result<()> {
+    let dtype = GgmlDType::Mxfp4;
+    assert_eq!(dtype.type_size(), 17);
+    assert_eq!(dtype.block_size(), 32);
+    Ok(())
+}

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -22,7 +22,7 @@ fn test_matmul(
     dtype: GgmlDType,
 ) -> Result<()> {
     if (device.is_cuda() || device.is_metal())
-        && (dtype == GgmlDType::Q8_1 || dtype == GgmlDType::Q8K)
+        && (dtype == GgmlDType::Q8_1 || dtype == GgmlDType::Q8K || dtype == GgmlDType::Mxfp4)
     {
         return Ok(());
     }
@@ -45,8 +45,17 @@ fn test_matmul(
         .sum_all()?
         .to_scalar()?;
     let error = error / (b * m * n) as f32;
+    // MXFP4's E2M1 mantissa is coarser than every other format here (2-bit
+    // mantissa, shared per-block exponent), so its quantization error is
+    // substantially larger. The bound is still tight enough to catch
+    // implementation bugs (wrong kvalues, nibble order, or exponent math).
+    let max_error = if dtype == GgmlDType::Mxfp4 {
+        0.15
+    } else {
+        0.02
+    };
     assert!(
-        error <= 0.02,
+        error <= max_error,
         "Error {error} is too big. \nExpected:\n {mm} \nFound:\n {res}\n for {dtype:?}"
     );
 
@@ -315,6 +324,7 @@ fn quantized_embedding_cpu() -> Result<()> {
         GgmlDType::Q5K,
         GgmlDType::Q6K,
         GgmlDType::Q8K,
+        GgmlDType::Mxfp4,
     ] {
         run_quantized_embedding(&device, dtype, 1e-6)?;
     }
@@ -1117,6 +1127,10 @@ fn ggml_reference_matmul_error(dtype: GgmlDType) -> Result<f32> {
 
         // Not from the ggml repo.
         GgmlDType::Q8K => 0.00065,
+        // Not from the ggml repo (MXFP4 is absent from llama.cpp
+        // test-quantize-fns at the time of writing). Value measured with the
+        // ggml_matmul_error_test harness on x86_64.
+        GgmlDType::Mxfp4 => 0.032,
     };
     Ok(err)
 }
@@ -1325,6 +1339,15 @@ quantized_matmul!(
     quantized_matmul_q8k_cuda,
     quantized_matmul_q8k_metal,
     GgmlDType::Q8K
+);
+
+// Not implemented on cuda/metal.
+quantized_matmul!(
+    quantized_matmul_mxfp4_bis,
+    quantized_matmul_mxfp4_cpu,
+    quantized_matmul_mxfp4_cuda,
+    quantized_matmul_mxfp4_metal,
+    GgmlDType::Mxfp4
 );
 
 #[test]


### PR DESCRIPTION
## Add MXFP4 (GGUF dtype 39) to candle-core's quantized backend

DeepSeek-family GGUF files (e.g. DeepSeek-V4 "reap" repacks, DeepSeek-R1
QK2 remixes) ship weight tensors with GGUF type 39 = MXFP4 (microscaling
FP4, OCP MX spec). Upstream candle-core 0.11/0.12 has no such dtype:
`GgmlDType::from_u32(39)` bails, so these models cannot be loaded at all.

This PR adds MXFP4 as a first-class `GgmlDType`, CPU-only, ported verbatim
from llama.cpp and pinned bit-exact against it.

### Format

A block of 32 elements = one E8M0 exponent byte + 16 bytes of packed 4-bit
E2M1 codes → **17 bytes / block (4.25 bits/element)**. Codes use the
doubled kvalues table `[0,1,2,3,4,6,8,12,0,-1,-2,-3,-4,-6,-8,-12]` with
scale `2^(e-128)` (llama.cpp's `ggml_e8m0_to_fp32_half` factorization).

### Changes

- `k_quants.rs`: `BlockMxfp4` (`#[repr(C)]`, size-checked to 17 bytes) with
  a `GgmlType` impl ported from llama.cpp:
  - `from_float` = `quantize_row_mxfp4_ref` (ggml-quants.c)
  - `to_float` = `dequantize_row_mxfp4` (ggml-quants.c)
  - `vec_dot` = `ggml_vec_dot_mxfp4_q8_0_generic` (ggml-cpu/quants.c);
    `VecDotType = BlockQ8_0` matches llama.cpp's pairing of MXFP4 weights
    with Q8_0-quantized activations.
- `mod.rs`: `GgmlDType::Mxfp4` wired through `from_u32`/`to_u32` (39),
  `cpu_zeros`, `from_data`, `type_size` (17), `block_size` (32), and
  `QStorage::from_data` for all three backends.
- `ggml_file.rs`: load MXFP4 tensors from legacy GGML files.
- `metal.rs`: MXFP4 dequantize arm. The `From<GgmlDType>` impl for
  `candle_metal_kernels::GgmlDType` becomes a `TryFrom` that errors clearly
  for MXFP4 — the kernels crates have no MXFP4 kernels yet.

### Validation

- `tests/mxfp4_tests.rs`: **golden bytes produced by the actual llama.cpp
  reference implementation** (`quantize_row_mxfp4_ref` +
  `ggml_e8m0_to_fp32_half` compiled as standalone C), proving bit-exact
  compatibility; plus an independent reference decode, a GGUF write/read
  round trip (exercises id 39 in both directions), and dtype plumbing.
- `tests/quantized_tests.rs`: MXFP4 in the generic quantized-matmul and
  CPU-embedding coverage. Matmul tolerance relaxed to 0.15 (E2M1's 2-bit
  mantissa carries far more quantization error than any other candle dtype;
  measured 0.09 on the test inputs); `ggml_reference_matmul_error` gains a
  measured constant (0.032, ggml harness, x86_64).
- `cargo test -p candle-core --test quantized_tests --test mxfp4_tests` —
  green on current main.

### Relationship to #3391

#3391 ("Mxfp4 gpt oss implementation", open since March) adds MXFP4 Metal
and CUDA kernels plus the gpt-oss model on top of a core dtype
implementation with the same math (plain kvalues × `2^(e-127)` vs. the
doubled table × `2^(e-128)` — equivalent, same quantized bytes). This PR is
the smaller, reviewable core layer: dtype plumbing + bit-exactness tests,
no kernels, no model code. They compose — #3391's kernels would slot onto
the dtype added here (and its `MXFP4` naming could be reconciled to
`Mxfp4` to match candle's `BF16` casing).

### Out of scope (intentionally)

Metal/CUDA matmul kernels for MXFP4 — `TryFrom` (metal) and the existing
`_` arm (cuda) give explicit errors rather than silent miscompute.
