### PR TITLE
feat(gemma3): add embed_tokens() and forward_embeds()

### DIFF
--- a/candle-transformers/src/models/gemma3.rs
+++ b/candle-transformers/src/models/gemma3.rs
@@ -500,9 +500,24 @@ impl Model {
         Ok((Some(mask), Some(sliding_mask)))
     }
 
+    /// The token embedding table, so callers can embed text themselves.
+    pub fn embed_tokens(&self) -> &candle_nn::Embedding {
+        &self.embed_tokens
+    }
+
     pub fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
-        let (b_size, seq_len) = input_ids.dims2()?;
         let xs = self.embed_tokens.forward(input_ids)?;
+        self.forward_embeds(&xs, seqlen_offset)
+    }
+
+    /// Same as [`Self::forward`], but takes token embeddings rather than token ids.
+    ///
+    /// A multimodal caller builds a mixed sequence - text embeddings from
+    /// [`Self::embed_tokens`] with image embeddings spliced in - which has no
+    /// representation as token ids. `gemma` already exposes the equivalent pair,
+    /// and `paligemma` is built on it.
+    pub fn forward_embeds(&mut self, xs: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
+        let (b_size, seq_len, _) = xs.dims3()?;
         let mut xs = (xs * (self.hidden_size as f64).sqrt())?;
 
         let (attention_mask, sliding_attention_mask) =


### PR DESCRIPTION
`gemma3::Model` only accepts token ids, and keeps `embed_tokens` private. A multimodal caller needs to build a mixed sequence — text embeddings with image embeddings spliced in — which has no representation as token ids, so Gemma 3's vision variants can't be wired up from outside the crate.

`gemma.rs` already exposes both entry points (`embed_tokens()` at line 371, `forward_embeds()` at line 412) and `paligemma.rs` is built on them. This adds the same pair to `gemma3`.

`forward` now delegates to `forward_embeds`, so there's no behaviour change. Unlike `gemma`, `forward_embeds` builds the attention masks itself rather than taking them as an argument, because gemma3 uses two (full and sliding) and picks per layer — having the caller supply them would leak that detail.

Verified the two paths agree exactly (tiny randomly-initialised model, CPU, no downloads):

```rust
let a = model.forward(&ids, 0).unwrap();
model.clear_kv_cache();
let embeds = model.embed_tokens().forward(&ids).unwrap();
let b = model.forward_embeds(&embeds, 0).unwrap();
```

```
logits len              = 64
max |forward - embeds|  = 0.000000000
OK: forward and forward_embeds are identical
```

Note that running that check at all requires #3902 — `gemma3::Model::forward` currently fails for every input with `slice-set only supports contiguous tensors`. This PR compiles and is independent of it, but can't be exercised at runtime until that one lands.
