### PR TITLE
Fix SIMD128 half-precision CPU kernels

### DIFF
--- a/candle-core/src/cpu/mod.rs
+++ b/candle-core/src/cpu/mod.rs
@@ -74,7 +74,7 @@ pub use avx::{CurrentCpu, CurrentCpuBF16, CurrentCpuF16};
 pub mod simd128;
 #[cfg(target_arch = "wasm32")]
 #[cfg(target_feature = "simd128")]
-pub use simd128::CurrentCpu;
+pub use simd128::{CurrentCpu, CurrentCpuBF16, CurrentCpuF16};
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 #[cfg(target_feature = "neon")]

--- a/candle-core/src/cpu/simd128.rs
+++ b/candle-core/src/cpu/simd128.rs
@@ -1,5 +1,6 @@
-use super::Cpu;
+use super::{Cpu, CpuBF16, CpuF16};
 use core::arch::wasm32::*;
+use half::{bf16, f16};
 
 pub struct CurrentCpu {}
 
@@ -57,5 +58,110 @@ impl Cpu for CurrentCpu {
             + f32x4_extract_lane::<1>(x[0])
             + f32x4_extract_lane::<2>(x[0])
             + f32x4_extract_lane::<3>(x[0]);
+    }
+}
+
+// WebAssembly SIMD has no half-precision arithmetic, so widen f16 lanes to
+// f32x4 as the AVX software fallback and the NEON fallback do.
+pub struct CurrentCpuF16 {}
+
+impl CpuF16 for CurrentCpuF16 {
+    type Unit = v128;
+    type Array = [v128; ARR];
+
+    const STEP: usize = STEP;
+    const EPR: usize = EPR;
+    const ARR: usize = ARR;
+
+    unsafe fn zero() -> Self::Unit {
+        <CurrentCpu as Cpu>::zero()
+    }
+
+    unsafe fn zero_array() -> Self::Array {
+        <CurrentCpu as Cpu>::zero_array()
+    }
+
+    unsafe fn from_f32(v: f32) -> Self::Unit {
+        <CurrentCpu as Cpu>::from_f32(v)
+    }
+
+    unsafe fn load(mem_addr: *const f16) -> Self::Unit {
+        let values = [
+            (*mem_addr).to_f32(),
+            (*mem_addr.add(1)).to_f32(),
+            (*mem_addr.add(2)).to_f32(),
+            (*mem_addr.add(3)).to_f32(),
+        ];
+        v128_load(values.as_ptr().cast())
+    }
+
+    unsafe fn vec_add(a: Self::Unit, b: Self::Unit) -> Self::Unit {
+        <CurrentCpu as Cpu>::vec_add(a, b)
+    }
+
+    unsafe fn vec_fma(a: Self::Unit, b: Self::Unit, c: Self::Unit) -> Self::Unit {
+        <CurrentCpu as Cpu>::vec_fma(a, b, c)
+    }
+
+    unsafe fn vec_store(mem_addr: *mut f16, a: Self::Unit) {
+        let mut values = [0f32; EPR];
+        v128_store(values.as_mut_ptr().cast(), a);
+        for (i, value) in values.into_iter().enumerate() {
+            *mem_addr.add(i) = f16::from_f32(value);
+        }
+    }
+
+    unsafe fn vec_reduce(x: Self::Array, y: *mut f32) {
+        <CurrentCpu as Cpu>::vec_reduce(x, y)
+    }
+}
+
+// bf16 is the upper half of an f32. Widen its bits before doing arithmetic in
+// f32x4, then use half's scalar conversion to preserve round-to-even on store.
+pub struct CurrentCpuBF16 {}
+
+impl CpuBF16 for CurrentCpuBF16 {
+    type Unit = v128;
+    type Array = [v128; ARR];
+
+    const STEP: usize = STEP;
+    const EPR: usize = EPR;
+    const ARR: usize = ARR;
+
+    unsafe fn zero() -> Self::Unit {
+        <CurrentCpu as Cpu>::zero()
+    }
+
+    unsafe fn zero_array() -> Self::Array {
+        <CurrentCpu as Cpu>::zero_array()
+    }
+
+    unsafe fn from_f32(v: f32) -> Self::Unit {
+        <CurrentCpu as Cpu>::from_f32(v)
+    }
+
+    unsafe fn load(mem_addr: *const bf16) -> Self::Unit {
+        let values = v128_load64_zero(mem_addr.cast());
+        u32x4_shl(u32x4_extend_low_u16x8(values), 16)
+    }
+
+    unsafe fn vec_add(a: Self::Unit, b: Self::Unit) -> Self::Unit {
+        <CurrentCpu as Cpu>::vec_add(a, b)
+    }
+
+    unsafe fn vec_fma(a: Self::Unit, b: Self::Unit, c: Self::Unit) -> Self::Unit {
+        <CurrentCpu as Cpu>::vec_fma(a, b, c)
+    }
+
+    unsafe fn vec_store(mem_addr: *mut bf16, a: Self::Unit) {
+        let mut values = [0f32; EPR];
+        v128_store(values.as_mut_ptr().cast(), a);
+        for (i, value) in values.into_iter().enumerate() {
+            *mem_addr.add(i) = bf16::from_f32(value);
+        }
+    }
+
+    unsafe fn vec_reduce(x: Self::Array, y: *mut f32) {
+        <CurrentCpu as Cpu>::vec_reduce(x, y)
     }
 }

--- a/candle-wasm-tests/Cargo.toml
+++ b/candle-wasm-tests/Cargo.toml
@@ -9,7 +9,7 @@ categories.workspace = true
 [dependencies]
 candle = { workspace = true }
 rand = { workspace = true }
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.3", features = ["wasm_js"], default-features = false }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"

--- a/candle-wasm-tests/tests/cpu_tests.rs
+++ b/candle-wasm-tests/tests/cpu_tests.rs
@@ -1,0 +1,65 @@
+use candle::{DType, Device, Result, Tensor};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+const LEN: usize = 20;
+
+fn repeat(values: [f32; 4]) -> Vec<f32> {
+    values.into_iter().cycle().take(LEN).collect()
+}
+
+fn as_f32(tensor: &Tensor) -> Result<Vec<f32>> {
+    tensor.to_dtype(DType::F32)?.to_vec1::<f32>()
+}
+
+fn add_vectors_with_simd_block_and_tail(dtype: DType) -> Result<()> {
+    let lhs = repeat([0.1, 0.3, 0.7, -0.2]);
+    let rhs = repeat([0.2, -0.1, 0.05, 1.3]);
+
+    let lhs = Tensor::from_slice(&lhs, LEN, &Device::Cpu)?.to_dtype(dtype)?;
+    let rhs = Tensor::from_slice(&rhs, LEN, &Device::Cpu)?.to_dtype(dtype)?;
+    let expected = lhs
+        .to_dtype(DType::F32)?
+        .add(&rhs.to_dtype(DType::F32)?)?
+        .to_dtype(dtype)?;
+    let sum = lhs.add(&rhs)?;
+    assert_eq!(as_f32(&sum)?, as_f32(&expected)?);
+
+    Ok(())
+}
+
+fn add_scalar_with_simd_block_and_tail(dtype: DType) -> Result<()> {
+    let lhs = repeat([0.1, 0.3, 0.7, -0.2]);
+
+    let lhs = Tensor::from_slice(&lhs, LEN, &Device::Cpu)?.to_dtype(dtype)?;
+    let scalar = Tensor::new(0.2f32, &Device::Cpu)?.to_dtype(dtype)?;
+    let expected = lhs
+        .to_dtype(DType::F32)?
+        .broadcast_add(&scalar.to_dtype(DType::F32)?)?
+        .to_dtype(dtype)?;
+    let sum = lhs.broadcast_add(&scalar)?;
+    assert_eq!(as_f32(&sum)?, as_f32(&expected)?);
+
+    Ok(())
+}
+
+#[wasm_bindgen_test]
+fn add_f16_vectors_with_simd128() -> Result<()> {
+    add_vectors_with_simd_block_and_tail(DType::F16)
+}
+
+#[wasm_bindgen_test]
+fn add_f16_scalar_with_simd128() -> Result<()> {
+    add_scalar_with_simd_block_and_tail(DType::F16)
+}
+
+#[wasm_bindgen_test]
+fn add_bf16_vectors_with_simd128() -> Result<()> {
+    add_vectors_with_simd_block_and_tail(DType::BF16)
+}
+
+#[wasm_bindgen_test]
+fn add_bf16_scalar_with_simd128() -> Result<()> {
+    add_scalar_with_simd_block_and_tail(DType::BF16)
+}


### PR DESCRIPTION
## Summary

- add `CurrentCpuF16` and `CurrentCpuBF16` implementations to the WebAssembly SIMD128 backend
- widen half-precision lanes to `f32x4` for arithmetic, matching the AVX and NEON fallback approach
- add browser tests for F16/BF16 vector and scalar addition across both a SIMD block and a scalar tail
- update the WASM test crate to select the `getrandom` 0.3 `wasm_js` backend

## Motivation

Fixes #3835.

`cpu/mod.rs` selects the SIMD128 vector and scalar-add kernels for F16 and BF16, but the SIMD128 backend previously exported only `CurrentCpu`. Consequently, the repository's configured `wasm32-unknown-unknown +simd128` target failed to compile because `CurrentCpuF16` and `CurrentCpuBF16` did not exist.

This implements the full SIMD128 option proposed in the issue instead of falling back to scalar half operations. WebAssembly SIMD has no native half-precision arithmetic, so values are widened to four F32 lanes. BF16 loads use bit widening; stores use `half` conversions to preserve round-to-nearest-even behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --locked -p candle-wasm-tests --target wasm32-unknown-unknown --tests`
- `cargo test --locked -p candle-wasm-tests --target wasm32-unknown-unknown --test cpu_tests` using `wasm-bindgen-test-runner` and headless Chrome: 4 passed
