### PR TITLE
Add fused chunked-scan kernels for gated-DeltaNet prefill

### DIFF
--- a/candle-metal-kernels/src/kernel.rs
+++ b/candle-metal-kernels/src/kernel.rs
@@ -1,5 +1,5 @@
 use crate::source::{
-    AFFINE, BINARY, CAST, CONV, FILL, GEMV, INDEXING, MLX_GEMM, MLX_SORT, QUANTIZED, RANDOM,
+    AFFINE, BINARY, CAST, CONV, FILL, GDN, GEMV, INDEXING, MLX_GEMM, MLX_SORT, QUANTIZED, RANDOM,
     REDUCE, SDPA, SORT, TERNARY, UNARY,
 };
 use crate::utils::get_env_bool;
@@ -90,6 +90,7 @@ impl Kernels {
             Source::Cast => CAST,
             Source::Conv => CONV,
             Source::Fill => FILL,
+            Source::Gdn => GDN,
             Source::Gemm => MLX_GEMM,
             Source::Gemv => GEMV,
             Source::Indexing => INDEXING,

--- a/candle-metal-kernels/src/kernels/gdn.rs
+++ b/candle-metal-kernels/src/kernels/gdn.rs
@@ -103,3 +103,286 @@ pub fn call_gdn_decode_step_f32(
     encoder.dispatch_threads(grid_dims, group_dims);
     Ok(())
 }
+
+#[repr(C)]
+struct GdnConv1dArgs {
+    seq_len: u32,
+    hist_len: u32,
+    channels: u32,
+    kernel_size: u32,
+}
+
+impl EncoderParam for GdnConv1dArgs {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+        encoder.set_bytes(position, &data);
+    }
+}
+
+/// Fused causal depthwise conv1d + silu -- the output half. See
+/// `metal_src/gdn.metal`'s own doc comment for the exact math (operates
+/// conceptually on `history ++ x` without ever materializing the
+/// concatenation) and the dispatch-count arithmetic this replaces.
+///
+/// Shapes (all contiguous F32): `x`: `[b, seq_len, channels]`; `history`:
+/// `[b, hist_len, channels]`; `weight`: `[channels, kernel_size]` --
+/// **caller must canonicalize to this exact layout** (a raw checkpoint
+/// tensor can arrive as `[channels, kernel]` or `[kernel, channels]`; do the
+/// transpose once at load time, not per call, and never pass the
+/// non-canonical layout here). `out`: `[b, seq_len, channels]`.
+///
+/// Every read input takes a `BufferOffset`, not a bare `Buffer` -- same
+/// discipline as `call_gdn_decode_step_f32` above, after the real
+/// nonzero-offset bug that kernel found live: `history` in particular is
+/// exactly the kind of tensor (a restored/cloned cache view, or a
+/// `narrow()`'d slice) most likely to carry a real nonzero byte offset in
+/// production, not just in a synthetic test.
+#[allow(clippy::too_many_arguments)]
+pub fn call_gdn_causal_conv1d_output_f32(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    b: usize,
+    seq_len: usize,
+    hist_len: usize,
+    channels: usize,
+    kernel_size: usize,
+    x: &BufferOffset,
+    history: &BufferOffset,
+    weight: &BufferOffset,
+    out: &Buffer,
+) -> Result<(), MetalKernelError> {
+    let pipeline =
+        kernels.load_pipeline(device, Source::Gdn, "kernel_gdn_causal_conv1d_output_f32")?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(encoder, "gdn_causal_conv1d_output b={b} seq_len={seq_len} hist_len={hist_len} channels={channels} kernel_size={kernel_size}");
+
+    let args = GdnConv1dArgs {
+        seq_len: seq_len as u32,
+        hist_len: hist_len as u32,
+        channels: channels as u32,
+        kernel_size: kernel_size as u32,
+    };
+    set_params!(encoder, (x, history, weight, Output::new(out), args));
+
+    let grid_dims = MTLSize {
+        width: channels,
+        height: seq_len,
+        depth: b,
+    };
+    let group_dims = MTLSize {
+        width: channels.min(64),
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_threads(grid_dims, group_dims);
+    Ok(())
+}
+
+/// Fused causal depthwise conv1d -- the next-conv-state half, companion to
+/// `call_gdn_causal_conv1d_output_f32` above (same inputs, no `weight`,
+/// different output). `new_state` is written functionally (a fresh buffer,
+/// `history` read-only and untouched) -- same correctness discipline as
+/// `state_out` in `call_gdn_decode_step_f32`: a prior session-checkpoint
+/// clone of `history` must survive this call unchanged, and the caller must
+/// bind `new_state` via the write path (this function already does) so the
+/// *next* call's read of it gets a barrier under this fork's
+/// `HazardTrackingModeUntracked` convention.
+///
+/// Shapes: `x`: `[b, seq_len, channels]`; `history`: `[b, hist_len,
+/// channels]`; `new_state`: `[b, hist_len, channels]`. Correct (a no-op
+/// grid) when `hist_len == 0`.
+#[allow(clippy::too_many_arguments)]
+pub fn call_gdn_causal_conv1d_state_f32(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    b: usize,
+    seq_len: usize,
+    hist_len: usize,
+    channels: usize,
+    x: &BufferOffset,
+    history: &BufferOffset,
+    new_state: &Buffer,
+) -> Result<(), MetalKernelError> {
+    let pipeline =
+        kernels.load_pipeline(device, Source::Gdn, "kernel_gdn_causal_conv1d_state_f32")?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(
+        encoder,
+        "gdn_causal_conv1d_state b={b} seq_len={seq_len} hist_len={hist_len} channels={channels}"
+    );
+
+    let args = GdnConv1dArgs {
+        seq_len: seq_len as u32,
+        hist_len: hist_len as u32,
+        channels: channels as u32,
+        kernel_size: 0,
+    };
+    set_params!(encoder, (x, history, Output::new(new_state), args));
+
+    let grid_dims = MTLSize {
+        width: channels,
+        height: hist_len,
+        depth: b,
+    };
+    let group_dims = MTLSize {
+        width: channels.min(64),
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_threads(grid_dims, group_dims);
+    Ok(())
+}
+
+#[repr(C)]
+struct GdnL2NormArgs {
+    seq_len: u32,
+    heads: u32,
+    dim: u32,
+    scale: f32,
+    eps: f32,
+}
+
+impl EncoderParam for GdnL2NormArgs {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+        encoder.set_bytes(position, &data);
+    }
+}
+
+/// Fused L2-normalize + scale -- the q/k half of gated-DeltaNet's
+/// preprocessing gating tail. See `metal_src/gdn.metal`'s own doc comment
+/// for the exact math (eps is added to the sum of squares, not the mean --
+/// do not substitute a generic RMS-norm kernel here, the epsilon placement
+/// differs). Called once for q (with a query-side scale factor) and once
+/// for k (`scale = 1.0`).
+///
+/// Shapes (contiguous F32): `x`/`out`: `[b, seq_len, heads, dim]`.
+#[allow(clippy::too_many_arguments)]
+pub fn call_gdn_l2_normalize_scale_f32(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    b: usize,
+    seq_len: usize,
+    heads: usize,
+    dim: usize,
+    scale: f32,
+    eps: f32,
+    x: &BufferOffset,
+    out: &Buffer,
+) -> Result<(), MetalKernelError> {
+    let pipeline =
+        kernels.load_pipeline(device, Source::Gdn, "kernel_gdn_l2_normalize_scale_f32")?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(
+        encoder,
+        "gdn_l2_normalize_scale b={b} seq_len={seq_len} heads={heads} dim={dim} scale={scale}"
+    );
+
+    let args = GdnL2NormArgs {
+        seq_len: seq_len as u32,
+        heads: heads as u32,
+        dim: dim as u32,
+        scale,
+        eps,
+    };
+    set_params!(encoder, (x, Output::new(out), args));
+
+    let grid_dims = MTLSize {
+        width: heads,
+        height: seq_len,
+        depth: b,
+    };
+    let group_dims = MTLSize {
+        width: heads.min(64),
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_threads(grid_dims, group_dims);
+    Ok(())
+}
+
+#[repr(C)]
+struct GdnDecayBetaArgs {
+    seq_len: u32,
+    heads: u32,
+}
+
+impl EncoderParam for GdnDecayBetaArgs {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+        encoder.set_bytes(position, &data);
+    }
+}
+
+/// Fused decay-gate softplus + beta sigmoid -- the gating half of
+/// gated-DeltaNet's preprocessing gating tail. See `metal_src/gdn.metal`'s
+/// own doc comment for the exact math. `dt_bias`/`a` are indexed directly
+/// by head (`[heads]`), not pre-broadcast -- this eliminates the caller's
+/// own broadcast step entirely, not just the elementwise math around it.
+///
+/// Shapes (contiguous F32): `alpha_logits`/`beta_logits`/`g_out`/`beta_out`:
+/// `[b, seq_len, heads]`; `dt_bias`/`a`: `[heads]`.
+#[allow(clippy::too_many_arguments)]
+pub fn call_gdn_decay_beta_gate_f32(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    b: usize,
+    seq_len: usize,
+    heads: usize,
+    alpha_logits: &BufferOffset,
+    dt_bias: &BufferOffset,
+    a: &BufferOffset,
+    beta_logits: &BufferOffset,
+    g_out: &Buffer,
+    beta_out: &Buffer,
+) -> Result<(), MetalKernelError> {
+    let pipeline = kernels.load_pipeline(device, Source::Gdn, "kernel_gdn_decay_beta_gate_f32")?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(
+        encoder,
+        "gdn_decay_beta_gate b={b} seq_len={seq_len} heads={heads}"
+    );
+
+    let args = GdnDecayBetaArgs {
+        seq_len: seq_len as u32,
+        heads: heads as u32,
+    };
+    set_params!(
+        encoder,
+        (
+            alpha_logits,
+            dt_bias,
+            a,
+            beta_logits,
+            Output::new(g_out),
+            Output::new(beta_out),
+            args
+        )
+    );
+
+    let grid_dims = MTLSize {
+        width: heads,
+        height: seq_len,
+        depth: b,
+    };
+    let group_dims = MTLSize {
+        width: heads.min(64),
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_threads(grid_dims, group_dims);
+    Ok(())
+}

--- a/candle-metal-kernels/src/kernels/gdn.rs
+++ b/candle-metal-kernels/src/kernels/gdn.rs
@@ -442,7 +442,8 @@ pub fn call_gdn_chunked_scan_solve_f32(
     a_mat: &BufferOffset,
     attn: &Buffer,
 ) -> Result<(), MetalKernelError> {
-    let pipeline = kernels.load_pipeline(device, Source::Gdn, "kernel_gdn_chunked_scan_solve_f32")?;
+    let pipeline =
+        kernels.load_pipeline(device, Source::Gdn, "kernel_gdn_chunked_scan_solve_f32")?;
 
     let encoder = ep.encoder();
     let encoder: &ComputeCommandEncoder = encoder.as_ref();
@@ -459,6 +460,80 @@ pub fn call_gdn_chunked_scan_solve_f32(
     };
     let group_dims = MTLSize {
         width: GDN_SCAN_CHUNK.min(64),
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_threads(grid_dims, group_dims);
+    Ok(())
+}
+
+#[repr(C)]
+struct GdnScanBuildSolveArgs {
+    hk: u32, // bhnc is deliberately not a field -- the kernel never reads it, see gdn.metal
+}
+
+impl EncoderParam for GdnScanBuildSolveArgs {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+        encoder.set_bytes(position, &data);
+    }
+}
+
+/// Phase 3.1b: folds `a_mat`'s construction (mask/`kk`/triangle) into
+/// the solve, this fork's first kernel using threadgroup memory and a
+/// barrier. See `metal_src/gdn.metal`'s own doc comment for the full
+/// derivation, the numerics note (this kernel's own running-suffix-sum
+/// `a_mat` differs from the tensor path's two-prefix-sum-subtraction
+/// form by ordinary summation-order drift -- tolerance-close, not
+/// bit-identical, same as every other reassociation in this design),
+/// and why no thread ever needs a bounds-check `return` (dispatch is
+/// sized to exactly `(GDN_SCAN_CHUNK, bhnc)` threads, so every thread
+/// is always in range -- an early return before this kernel's barrier
+/// would be undefined behavior).
+///
+/// Shapes (contiguous F32): `k_c`: `[bhnc, GDN_SCAN_CHUNK, hk]`;
+/// `log_g_c`/`beta_c`: `[bhnc, GDN_SCAN_CHUNK]`; `attn` (output,
+/// functional): `[bhnc, GDN_SCAN_CHUNK, GDN_SCAN_CHUNK]`. `q_c` is not
+/// an input -- `a_mat`'s construction never reads it (verified against
+/// `gated_delta_rule_chunked`'s own steps 3a-3c).
+///
+/// Every read input takes a `BufferOffset`, not a bare `Buffer` --
+/// same discipline as every other kernel in this file.
+#[allow(clippy::too_many_arguments)]
+pub fn call_gdn_chunked_scan_build_and_solve_f32(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    bhnc: usize,
+    hk: usize,
+    k_c: &BufferOffset,
+    log_g_c: &BufferOffset,
+    beta_c: &BufferOffset,
+    attn: &Buffer,
+) -> Result<(), MetalKernelError> {
+    let pipeline = kernels.load_pipeline(
+        device,
+        Source::Gdn,
+        "kernel_gdn_chunked_scan_build_and_solve_f32",
+    )?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(
+        encoder,
+        "gdn_chunked_scan_build_and_solve bhnc={bhnc} hk={hk}"
+    );
+
+    let args = GdnScanBuildSolveArgs { hk: hk as u32 };
+    set_params!(encoder, (k_c, log_g_c, beta_c, Output::new(attn), args));
+
+    let grid_dims = MTLSize {
+        width: GDN_SCAN_CHUNK,
+        height: bhnc,
+        depth: 1,
+    };
+    let group_dims = MTLSize {
+        width: GDN_SCAN_CHUNK,
         height: 1,
         depth: 1,
     };

--- a/candle-metal-kernels/src/kernels/gdn.rs
+++ b/candle-metal-kernels/src/kernels/gdn.rs
@@ -1,0 +1,104 @@
+use crate::utils::{BufferOffset, EncoderProvider};
+use crate::{
+    debug_group, set_params, Buffer, ComputeCommandEncoder, Device, EncoderParam, Kernels,
+    MetalKernelError, Output, Source,
+};
+use objc2_metal::MTLSize;
+
+/// Fused gated-DeltaNet single-token decode step -- one Metal dispatch
+/// instead of the ~9 serialized elementwise/reduction ops the equivalent
+/// candle-tensor-op sequence would need. See `metal_src/gdn.metal`'s own
+/// doc comment for the exact math and the functional-state-write
+/// correctness argument (`state_out` must be a fresh buffer, `state_in`
+/// is read-only and untouched).
+///
+/// Shapes (all contiguous F32): `q`/`k`: `[b, h, hk]`; `v`: `[b, h, hv]`;
+/// `g`/`beta`: `[b, h]` (`g` already exponentiated -- the actual decay
+/// gate in `(0, 1)`, not its log); `state_in`/`state_out`: `[b, h, hk,
+/// hv]`; `out`: `[b, h, hv]`.
+///
+/// Every read input takes a `BufferOffset`, not a bare `Buffer`: callers
+/// commonly derive `q`/`k`/`v` from slices of a shared QKV-projection
+/// buffer via `narrow`, which can carry a genuine nonzero byte offset
+/// even when the resulting tensor is itself contiguous -- binding at a
+/// fixed offset 0 regardless of the tensor's real layout silently reads
+/// the wrong region of the buffer. Every input takes a real offset, not
+/// just the ones a particular call site happens to need it for, since
+/// which inputs need a nonzero offset is caller-dependent.
+///
+/// Caller must bind `state_out` and `out` via the write path (this
+/// function already does, via `Output::new`) -- binding them read-only
+/// would leave a later dispatch's read of `state_out` without a
+/// hazard-tracking barrier under `HazardTrackingModeUntracked`.
+#[allow(clippy::too_many_arguments)]
+pub fn call_gdn_decode_step_f32(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    b: usize,
+    h: usize,
+    hk: usize,
+    hv: usize,
+    q: &BufferOffset,
+    k: &BufferOffset,
+    v: &BufferOffset,
+    g: &BufferOffset,
+    beta: &BufferOffset,
+    state_in: &BufferOffset,
+    state_out: &Buffer,
+    out: &Buffer,
+) -> Result<(), MetalKernelError> {
+    #[derive(Debug)]
+    #[repr(C)]
+    struct GdnStepArgs {
+        hk: u32,
+        hv: u32,
+        h: u32,
+    }
+
+    impl EncoderParam for GdnStepArgs {
+        fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+            encoder.set_bytes(position, &data);
+        }
+    }
+
+    let pipeline = kernels.load_pipeline(device, Source::Gdn, "kernel_gdn_decode_step_f32")?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(encoder, "gdn_decode_step b={b} h={h} hk={hk} hv={hv}");
+
+    let args = GdnStepArgs {
+        hk: hk as u32,
+        hv: hv as u32,
+        h: h as u32,
+    };
+    set_params!(
+        encoder,
+        (
+            q,
+            k,
+            v,
+            g,
+            beta,
+            state_in,
+            Output::new(state_out),
+            Output::new(out),
+            args
+        )
+    );
+
+    let grid_dims = MTLSize {
+        width: hv,
+        height: h,
+        depth: b,
+    };
+    let group_dims = MTLSize {
+        width: hv.min(64),
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_threads(grid_dims, group_dims);
+    Ok(())
+}

--- a/candle-metal-kernels/src/kernels/gdn.rs
+++ b/candle-metal-kernels/src/kernels/gdn.rs
@@ -13,9 +13,10 @@ use objc2_metal::MTLSize;
 /// is read-only and untouched).
 ///
 /// Shapes (all contiguous F32): `q`/`k`: `[b, h, hk]`; `v`: `[b, h, hv]`;
-/// `g`/`beta`: `[b, h]` (`g` already exponentiated -- the actual decay
-/// gate in `(0, 1)`, not its log); `state_in`/`state_out`: `[b, h, hk,
-/// hv]`; `out`: `[b, h, hv]`.
+/// `g`/`beta`: `[b, h]` (`g` is the raw decay-gate log, **not**
+/// exponentiated -- the kernel exponentiates it internally, one dispatch
+/// fewer than passing the already-`exp`'d gate); `state_in`/`state_out`:
+/// `[b, h, hk, hv]`; `out`: `[b, h, hv]`.
 ///
 /// Every read input takes a `BufferOffset`, not a bare `Buffer`: callers
 /// commonly derive `q`/`k`/`v` from slices of a shared QKV-projection

--- a/candle-metal-kernels/src/kernels/gdn.rs
+++ b/candle-metal-kernels/src/kernels/gdn.rs
@@ -386,3 +386,82 @@ pub fn call_gdn_decay_beta_gate_f32(
     encoder.dispatch_threads(grid_dims, group_dims);
     Ok(())
 }
+
+/// Chunk size for `call_gdn_chunked_scan_solve_f32` -- must match
+/// `metal_src/gdn.metal`'s `GDN_SCAN_CHUNK` and ratatoskr's own
+/// `CHUNK_SIZE` (`qwen3_5_linear_attn_scan.rs`) exactly. The kernel
+/// hardcodes this as a compile-time constant for the dispatch-grid/
+/// buffer-stride arithmetic, not for register-array unrolling -- an
+/// earlier version of this kernel *did* hold a compile-time-sized
+/// per-thread array for exactly that reason, and was found to
+/// miscompile at this size (see the kernel's own doc comment for the
+/// real bug and the fix, which deliberately avoids a per-thread array
+/// of this size entirely).
+pub const GDN_SCAN_CHUNK: usize = 64;
+
+#[repr(C)]
+struct GdnScanSolveArgs {
+    bhnc: u32,
+}
+
+impl EncoderParam for GdnScanSolveArgs {
+    fn set_param(encoder: &ComputeCommandEncoder, position: usize, data: Self) {
+        encoder.set_bytes(position, &data);
+    }
+}
+
+/// Column-parallel forward-substitution solve for gated-DeltaNet's chunked
+/// prefill scan (Phase 3.1a). See `metal_src/gdn.metal`'s own doc comment
+/// for the derivation (`(I - A)X = I` decomposed by columns) and why this
+/// layout -- one thread per column, zero threadgroup memory, zero barriers
+/// -- was chosen over an in-place threadgroup-tile solve.
+///
+/// Shapes (contiguous F32): `a_mat`/`attn`: `[bhnc, GDN_SCAN_CHUNK,
+/// GDN_SCAN_CHUNK]`, where `bhnc` is the caller's own flattened `batch *
+/// n_heads * num_chunks` (matching the tensor path's own `bhnc` reshape in
+/// `gated_delta_rule_chunked`). `a_mat` must be strictly lower-triangular
+/// (zero diagonal and above) -- the kernel does not verify this.
+///
+/// `a_mat` takes a `BufferOffset`, not a bare `Buffer` -- same discipline
+/// as every other kernel in this file, after the real nonzero-offset bug
+/// `call_gdn_decode_step_f32` found live: `a_mat` is exactly the kind of
+/// tensor (built via `narrow`/`contiguous` chains in the tensor path) that
+/// could carry a real nonzero byte offset in a future caller.
+///
+/// Caller must bind `attn` via the write path (this function already does,
+/// via `Output::new`) -- binding it read-only would leave any dependent
+/// dispatch (a future 3.1b/c fold, or the tensor-side comparison this
+/// stage is verified against) without a barrier under this fork's
+/// `HazardTrackingModeUntracked` convention, the same bug class as the
+/// mm_id-counts incident.
+pub fn call_gdn_chunked_scan_solve_f32(
+    device: &Device,
+    ep: impl EncoderProvider,
+    kernels: &Kernels,
+    bhnc: usize,
+    a_mat: &BufferOffset,
+    attn: &Buffer,
+) -> Result<(), MetalKernelError> {
+    let pipeline = kernels.load_pipeline(device, Source::Gdn, "kernel_gdn_chunked_scan_solve_f32")?;
+
+    let encoder = ep.encoder();
+    let encoder: &ComputeCommandEncoder = encoder.as_ref();
+    encoder.set_compute_pipeline_state(&pipeline);
+    debug_group!(encoder, "gdn_chunked_scan_solve bhnc={bhnc}");
+
+    let args = GdnScanSolveArgs { bhnc: bhnc as u32 };
+    set_params!(encoder, (a_mat, Output::new(attn), args));
+
+    let grid_dims = MTLSize {
+        width: GDN_SCAN_CHUNK,
+        height: bhnc,
+        depth: 1,
+    };
+    let group_dims = MTLSize {
+        width: GDN_SCAN_CHUNK.min(64),
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_threads(grid_dims, group_dims);
+    Ok(())
+}

--- a/candle-metal-kernels/src/kernels/mod.rs
+++ b/candle-metal-kernels/src/kernels/mod.rs
@@ -21,8 +21,10 @@ pub use cast::{call_cast_contiguous, call_cast_strided};
 pub use convolution::*;
 pub use fill::*;
 pub use gdn::{
-    call_gdn_causal_conv1d_output_f32, call_gdn_causal_conv1d_state_f32, call_gdn_chunked_scan_solve_f32,
-    call_gdn_decay_beta_gate_f32, call_gdn_decode_step_f32, call_gdn_l2_normalize_scale_f32, GDN_SCAN_CHUNK,
+    call_gdn_causal_conv1d_output_f32, call_gdn_causal_conv1d_state_f32,
+    call_gdn_chunked_scan_build_and_solve_f32, call_gdn_chunked_scan_solve_f32,
+    call_gdn_decay_beta_gate_f32, call_gdn_decode_step_f32, call_gdn_l2_normalize_scale_f32,
+    GDN_SCAN_CHUNK,
 };
 pub use indexing::*;
 pub use mlx_gemm::{call_mlx_gemm, call_mlx_gemv, GemmDType};

--- a/candle-metal-kernels/src/kernels/mod.rs
+++ b/candle-metal-kernels/src/kernels/mod.rs
@@ -20,7 +20,10 @@ pub use binary::{call_binary_contiguous, call_binary_strided};
 pub use cast::{call_cast_contiguous, call_cast_strided};
 pub use convolution::*;
 pub use fill::*;
-pub use gdn::call_gdn_decode_step_f32;
+pub use gdn::{
+    call_gdn_causal_conv1d_output_f32, call_gdn_causal_conv1d_state_f32,
+    call_gdn_decay_beta_gate_f32, call_gdn_decode_step_f32, call_gdn_l2_normalize_scale_f32,
+};
 pub use indexing::*;
 pub use mlx_gemm::{call_mlx_gemm, call_mlx_gemv, GemmDType};
 pub use quantized::{

--- a/candle-metal-kernels/src/kernels/mod.rs
+++ b/candle-metal-kernels/src/kernels/mod.rs
@@ -3,6 +3,7 @@ pub mod binary;
 pub mod cast;
 pub mod convolution;
 pub mod fill;
+pub mod gdn;
 pub mod indexing;
 mod macros;
 pub mod mlx_gemm;
@@ -19,6 +20,7 @@ pub use binary::{call_binary_contiguous, call_binary_strided};
 pub use cast::{call_cast_contiguous, call_cast_strided};
 pub use convolution::*;
 pub use fill::*;
+pub use gdn::call_gdn_decode_step_f32;
 pub use indexing::*;
 pub use mlx_gemm::{call_mlx_gemm, call_mlx_gemv, GemmDType};
 pub use quantized::{

--- a/candle-metal-kernels/src/kernels/mod.rs
+++ b/candle-metal-kernels/src/kernels/mod.rs
@@ -21,8 +21,8 @@ pub use cast::{call_cast_contiguous, call_cast_strided};
 pub use convolution::*;
 pub use fill::*;
 pub use gdn::{
-    call_gdn_causal_conv1d_output_f32, call_gdn_causal_conv1d_state_f32,
-    call_gdn_decay_beta_gate_f32, call_gdn_decode_step_f32, call_gdn_l2_normalize_scale_f32,
+    call_gdn_causal_conv1d_output_f32, call_gdn_causal_conv1d_state_f32, call_gdn_chunked_scan_solve_f32,
+    call_gdn_decay_beta_gate_f32, call_gdn_decode_step_f32, call_gdn_l2_normalize_scale_f32, GDN_SCAN_CHUNK,
 };
 pub use indexing::*;
 pub use mlx_gemm::{call_mlx_gemm, call_mlx_gemv, GemmDType};

--- a/candle-metal-kernels/src/lib.rs
+++ b/candle-metal-kernels/src/lib.rs
@@ -8,9 +8,11 @@ pub mod utils;
 pub use err::MetalKernelError;
 pub use kernel::Kernels;
 pub use kernels::{
-    affine::*, call_binary_contiguous, call_binary_strided, call_gdn_decode_step_f32,
-    call_mlx_gemm, cast::*, convolution::*, fill::*, indexing::*, quantized::*, random::*,
-    reduce::*, sdpa::*, sort::*, ternary::*, unary, unary::*, GemmDType, GgmlDType,
+    affine::*, call_binary_contiguous, call_binary_strided, call_gdn_causal_conv1d_output_f32,
+    call_gdn_causal_conv1d_state_f32, call_gdn_decay_beta_gate_f32, call_gdn_decode_step_f32,
+    call_gdn_l2_normalize_scale_f32, call_mlx_gemm, cast::*, convolution::*, fill::*, indexing::*,
+    quantized::*, random::*, reduce::*, sdpa::*, sort::*, ternary::*, unary, unary::*, GemmDType,
+    GgmlDType,
 };
 use metal::{
     Buffer, CommandQueue, ComputeCommandEncoder, ComputePipeline, ConstantValues, Device, Function,

--- a/candle-metal-kernels/src/lib.rs
+++ b/candle-metal-kernels/src/lib.rs
@@ -9,10 +9,10 @@ pub use err::MetalKernelError;
 pub use kernel::Kernels;
 pub use kernels::{
     affine::*, call_binary_contiguous, call_binary_strided, call_gdn_causal_conv1d_output_f32,
-    call_gdn_causal_conv1d_state_f32, call_gdn_decay_beta_gate_f32, call_gdn_decode_step_f32,
-    call_gdn_l2_normalize_scale_f32, call_mlx_gemm, cast::*, convolution::*, fill::*, indexing::*,
-    quantized::*, random::*, reduce::*, sdpa::*, sort::*, ternary::*, unary, unary::*, GemmDType,
-    GgmlDType,
+    call_gdn_causal_conv1d_state_f32, call_gdn_chunked_scan_solve_f32, call_gdn_decay_beta_gate_f32,
+    call_gdn_decode_step_f32, call_gdn_l2_normalize_scale_f32, call_mlx_gemm, cast::*, convolution::*,
+    fill::*, indexing::*, quantized::*, random::*, reduce::*, sdpa::*, sort::*, ternary::*, unary,
+    unary::*, GemmDType, GgmlDType, GDN_SCAN_CHUNK,
 };
 use metal::{
     Buffer, CommandQueue, ComputeCommandEncoder, ComputePipeline, ConstantValues, Device, Function,

--- a/candle-metal-kernels/src/lib.rs
+++ b/candle-metal-kernels/src/lib.rs
@@ -9,10 +9,11 @@ pub use err::MetalKernelError;
 pub use kernel::Kernels;
 pub use kernels::{
     affine::*, call_binary_contiguous, call_binary_strided, call_gdn_causal_conv1d_output_f32,
-    call_gdn_causal_conv1d_state_f32, call_gdn_chunked_scan_solve_f32, call_gdn_decay_beta_gate_f32,
-    call_gdn_decode_step_f32, call_gdn_l2_normalize_scale_f32, call_mlx_gemm, cast::*, convolution::*,
-    fill::*, indexing::*, quantized::*, random::*, reduce::*, sdpa::*, sort::*, ternary::*, unary,
-    unary::*, GemmDType, GgmlDType, GDN_SCAN_CHUNK,
+    call_gdn_causal_conv1d_state_f32, call_gdn_chunked_scan_build_and_solve_f32,
+    call_gdn_chunked_scan_solve_f32, call_gdn_decay_beta_gate_f32, call_gdn_decode_step_f32,
+    call_gdn_l2_normalize_scale_f32, call_mlx_gemm, cast::*, convolution::*, fill::*, indexing::*,
+    quantized::*, random::*, reduce::*, sdpa::*, sort::*, ternary::*, unary, unary::*, GemmDType,
+    GgmlDType, GDN_SCAN_CHUNK,
 };
 use metal::{
     Buffer, CommandQueue, ComputeCommandEncoder, ComputePipeline, ConstantValues, Device, Function,

--- a/candle-metal-kernels/src/lib.rs
+++ b/candle-metal-kernels/src/lib.rs
@@ -8,9 +8,9 @@ pub mod utils;
 pub use err::MetalKernelError;
 pub use kernel::Kernels;
 pub use kernels::{
-    affine::*, call_binary_contiguous, call_binary_strided, call_mlx_gemm, cast::*, convolution::*,
-    fill::*, indexing::*, quantized::*, random::*, reduce::*, sdpa::*, sort::*, ternary::*, unary,
-    unary::*, GemmDType, GgmlDType,
+    affine::*, call_binary_contiguous, call_binary_strided, call_gdn_decode_step_f32,
+    call_mlx_gemm, cast::*, convolution::*, fill::*, indexing::*, quantized::*, random::*,
+    reduce::*, sdpa::*, sort::*, ternary::*, unary, unary::*, GemmDType, GgmlDType,
 };
 use metal::{
     Buffer, CommandQueue, ComputeCommandEncoder, ComputePipeline, ConstantValues, Device, Function,

--- a/candle-metal-kernels/src/metal_src/gdn.metal
+++ b/candle-metal-kernels/src/metal_src/gdn.metal
@@ -80,3 +80,189 @@ kernel void kernel_gdn_decode_step_f32(
     }
     out[bh * hv + j] = acc;
 }
+// Fused causal depthwise conv1d + silu, as used by gated-DeltaNet /
+// gated-linear-attention hybrid architectures (Qwen3.5, Qwen3-Next-style
+// models) ahead of their recurrent scan. A naive implementation processes
+// this as a `for t in 0..seq_len { for k in 0..kernel_size { ... } }` loop
+// over per-tap elementwise multiply-adds -- O(seq_len * kernel_size)
+// separate dispatches at small batch sizes (decode, or a short
+// multi-token forward like a speculative-decode verify step), each paying
+// a full pipeline/bind/encode cycle for a handful of FLOPs. This fuses the
+// whole causal convolution + activation into one dispatch for the output,
+// plus one small dispatch for the next conv state.
+//
+// Conceptually operates on `padded = history ++ x` (concat along time),
+// length `hist_len + seq_len`. For output position t (0 <= t < seq_len):
+//   out[t][c] = silu( sum_k padded[t+k][c] * weight[c][k] )
+// For next-state position s (0 <= s < hist_len) -- the trailing hist_len
+// entries of `padded`, i.e. `padded[seq_len + s]`:
+//   new_state[s][c] = padded[seq_len + s][c]
+// Both are expressed directly against `history`/`x` (never materializing
+// `padded` itself) via the same `idx < hist_len ? history[idx] : x[idx -
+// hist_len]` branch -- one thread per (channel, output-position, batch), no
+// cross-thread communication, no threadgroup memory. `new_state` is written
+// functionally (a fresh buffer, `history` read-only and untouched) --
+// deliberate, not an oversight: callers holding another reference to the
+// input history (e.g. an externally-taken checkpoint) must be unaffected
+// by this call running, same discipline as `kernel_gdn_decode_step_f32`
+// above.
+//
+// weight is `[channels, kernel_size]` -- the caller is expected to
+// canonicalize to this exact layout once (a raw GGUF/checkpoint tensor can
+// arrive as either `[channels, kernel]` or `[kernel, channels]`), not
+// re-derive it every dispatch.
+
+struct gdn_conv1d_args {
+    uint seq_len;
+    uint hist_len;
+    uint channels;
+    uint kernel_size; // only read by the _output kernel; harmless unused field on the _state kernel
+};
+
+kernel void kernel_gdn_causal_conv1d_output_f32(
+        device const float * x        [[buffer(0)]],  // [b, seq_len, channels]
+        device const float * history  [[buffer(1)]],  // [b, hist_len, channels]
+        device const float * weight   [[buffer(2)]],  // [channels, kernel_size]
+        device float       * out      [[buffer(3)]],  // [b, seq_len, channels], silu already applied
+        constant gdn_conv1d_args & args [[buffer(4)]],
+        uint3 gid [[thread_position_in_grid]]) {
+    const uint c = gid.x;
+    const uint t = gid.y;
+    if (c >= args.channels || t >= args.seq_len) {
+        return;
+    }
+    const uint hist_len = args.hist_len;
+    const uint seq_len = args.seq_len;
+    const uint channels = args.channels;
+    const uint kernel_size = args.kernel_size;
+    const uint b = gid.z;
+
+    device const float * xb = x + b * seq_len * channels;
+    device const float * hb = history + b * hist_len * channels;
+    device const float * wc = weight + c * kernel_size;
+
+    float acc = 0.0f;
+    for (uint k = 0; k < kernel_size; ++k) {
+        const uint idx = t + k; // index into conceptual padded = history ++ x
+        const float val = (idx < hist_len)
+            ? hb[idx * channels + c]
+            : xb[(idx - hist_len) * channels + c];
+        acc += val * wc[k];
+    }
+    // silu(x) = x * sigmoid(x) = x / (1 + exp(-x))
+    out[(b * seq_len + t) * channels + c] = acc / (1.0f + exp(-acc));
+}
+
+kernel void kernel_gdn_causal_conv1d_state_f32(
+        device const float * x           [[buffer(0)]],  // [b, seq_len, channels]
+        device const float * history     [[buffer(1)]],  // [b, hist_len, channels]
+        device float       * new_state   [[buffer(2)]],  // [b, hist_len, channels], functional
+        constant gdn_conv1d_args & args [[buffer(3)]],
+        uint3 gid [[thread_position_in_grid]]) {
+    const uint c = gid.x;
+    const uint s = gid.y;
+    if (c >= args.channels || s >= args.hist_len) {
+        return;
+    }
+    const uint hist_len = args.hist_len;
+    const uint seq_len = args.seq_len;
+    const uint channels = args.channels;
+    const uint b = gid.z;
+
+    device const float * xb = x + b * seq_len * channels;
+    device const float * hb = history + b * hist_len * channels;
+
+    const uint idx = seq_len + s; // index into conceptual padded = history ++ x
+    const float val = (idx < hist_len)
+        ? hb[idx * channels + c]
+        : xb[(idx - hist_len) * channels + c];
+    new_state[(b * hist_len + s) * channels + c] = val;
+}
+
+// Fused elementwise "gating tail" for gated-DeltaNet's preprocessing
+// pipeline, two independent sub-kernels replacing what a naive
+// implementation would otherwise dispatch as ~17 separate ops
+// (L2-normalize q and k, scale q, a softplus-style decay gate, a sigmoid
+// beta gate).
+//
+// kernel_gdn_l2_normalize_scale_f32: out[b][t][h][:] = scale *
+// x[b][t][h][:] / sqrt(sum_d x[b][t][h][d]^2 + eps) -- eps is added to the
+// sum of squares, not the mean, so this is *not* interchangeable with a
+// generic RMS-norm kernel; match your own model's exact epsilon placement
+// before reusing this. One thread per (b, t, h), looping over `dim` twice
+// (sum-of-squares, then the normalized write) -- re-reads `x` rather than
+// caching it in a local array, since `dim` is typically small (~64-256) and
+// the extra read is cheap relative to a per-dispatch fixed-overhead
+// avoided. Intended to be called once for q (with a query-side scale
+// factor) and once for k (scale = 1.0) -- two dispatches of the same
+// kernel, not two kernels.
+struct gdn_l2norm_args {
+    uint seq_len;
+    uint heads;
+    uint dim;
+    float scale;
+    float eps;
+};
+
+kernel void kernel_gdn_l2_normalize_scale_f32(
+        device const float * x    [[buffer(0)]],  // [b, seq_len, heads, dim]
+        device float       * out  [[buffer(1)]],  // [b, seq_len, heads, dim]
+        constant gdn_l2norm_args & args [[buffer(2)]],
+        uint3 gid [[thread_position_in_grid]]) {
+    const uint h = gid.x;
+    const uint t = gid.y;
+    if (h >= args.heads || t >= args.seq_len) {
+        return;
+    }
+    const uint dim = args.dim;
+    const uint b = gid.z;
+    const uint row = (b * args.seq_len + t) * args.heads + h;
+    device const float * xr = x + row * dim;
+    device float       * outr = out + row * dim;
+
+    float sum_sq = 0.0f;
+    for (uint d = 0; d < dim; ++d) {
+        const float v = xr[d];
+        sum_sq += v * v;
+    }
+    const float inv_norm = args.scale / sqrt(sum_sq + args.eps);
+    for (uint d = 0; d < dim; ++d) {
+        outr[d] = xr[d] * inv_norm;
+    }
+}
+
+// kernel_gdn_decay_beta_gate_f32: fuses a softplus-style decay-gate chain
+// and a sigmoid beta gate, the two per-head scalar gates this architecture
+// family derives per token before its recurrent scan:
+//   g[b][t][h]    = a[h] * log(exp(alpha_logits[b][t][h] + dt_bias[h]) + 1)
+//   beta[b][t][h] = sigmoid(beta_logits[b][t][h])
+// `dt_bias`/`a` are indexed directly by head (`[heads]`, not pre-broadcast
+// to `[b, seq_len, heads]`) -- this also eliminates the caller's own
+// broadcast step, not just the elementwise math around it. One thread per
+// (b, t, h), no reduction, purely elementwise.
+struct gdn_decay_beta_args {
+    uint seq_len;
+    uint heads;
+};
+
+kernel void kernel_gdn_decay_beta_gate_f32(
+        device const float * alpha_logits [[buffer(0)]],  // [b, seq_len, heads]
+        device const float * dt_bias      [[buffer(1)]],  // [heads]
+        device const float * a            [[buffer(2)]],  // [heads]
+        device const float * beta_logits  [[buffer(3)]],  // [b, seq_len, heads]
+        device float       * g_out        [[buffer(4)]],  // [b, seq_len, heads]
+        device float       * beta_out     [[buffer(5)]],  // [b, seq_len, heads]
+        constant gdn_decay_beta_args & args [[buffer(6)]],
+        uint3 gid [[thread_position_in_grid]]) {
+    const uint h = gid.x;
+    const uint t = gid.y;
+    if (h >= args.heads || t >= args.seq_len) {
+        return;
+    }
+    const uint b = gid.z;
+    const uint idx = (b * args.seq_len + t) * args.heads + h;
+
+    const float softplus = log(exp(alpha_logits[idx] + dt_bias[h]) + 1.0f);
+    g_out[idx] = a[h] * softplus;
+    beta_out[idx] = 1.0f / (1.0f + exp(-beta_logits[idx]));
+}

--- a/candle-metal-kernels/src/metal_src/gdn.metal
+++ b/candle-metal-kernels/src/metal_src/gdn.metal
@@ -266,3 +266,82 @@ kernel void kernel_gdn_decay_beta_gate_f32(
     g_out[idx] = a[h] * softplus;
     beta_out[idx] = 1.0f / (1.0f + exp(-beta_logits[idx]));
 }
+
+// Column-parallel forward-substitution solve for gated-DeltaNet's chunked
+// prefill scan (ratatoskr's `gated_delta_rule_chunked`, Phase 3.1a -- see
+// yggdrasil/ratatoskr/DESIGN.md's "Phase 3 design, revised 2026-08-17"
+// section for the full derivation and why this layout, not an in-place
+// threadgroup tile, was chosen).
+//
+// Solves `(I - a_mat) * attn = I`, i.e. `attn = (I - a_mat)^-1`, for a
+// strictly lower-triangular `a_mat` (`a_mat[i][k] == 0` for `k >= i`),
+// per independent `(batch, head, chunk)` problem. `(I - A)X = I` decomposes
+// by columns: column j of X satisfies
+//   x_i = e_j[i] + sum_{k<i} a_mat[i][k] * x_k        (e_j[i] = 1 iff i==j)
+// and every dependency for column j stays inside column j -- a_mat is
+// read-only throughout, no thread ever reads another thread's output. So:
+// **one thread per column**, zero threadgroup memory, zero barriers --
+// matching every other kernel in this file. The `i == j` select (not a
+// branch) keeps every thread running the identical loop regardless of
+// column, so there is no thread divergence; for `i < j` it correctly
+// yields `x_i = 0` by the same induction the design's own numerical-
+// stability argument relies on (each `x_i` is a final entry of the answer,
+// computed once from already-final `x_k`, `k < i` -- never a
+// repeated-squaring-style intermediate that could blow up, unlike Phase
+// 1a's reverted doubling attempt).
+//
+// **Deliberately does NOT hold `x[CHUNK]` in a local/register array.**
+// The design's own implementation note assumed a 64-entry per-thread
+// array would either stay register-resident or spill to thread-local
+// memory as a benign, perf-only fallback -- verified false during 3.1a's
+// own bring-up (differential against the scalar reference below): at
+// `CHUNK=64` this compiler mis-lowers a dynamically-indexed 64-entry
+// `float` array, silently producing zeros for most rows (confirmed by
+// shrinking `CHUNK` to 4 in isolation, where the identical logic is
+// bit-exact -- a real, size-dependent miscompilation, not a logic bug).
+// Fixed by writing each row directly to `attn` as it's computed and
+// reading prior rows back from `attn` itself (`out[k * CHUNK + j]`)
+// instead of a local array -- safe with zero synchronization because a
+// thread's own prior writes to device memory are always visible to its
+// own later reads with no barrier required (ordering within one thread's
+// instruction stream, not cross-thread visibility, which is the only
+// thing `HazardTrackingModeUntracked` and barriers govern). This costs
+// device-memory read/write traffic instead of register accesses --
+// acceptable here, matching this stage's own documented scaffolding
+// status (column-major writes are already mildly uncoalesced; 3.1b/c are
+// expected to restructure this further, not preserve this exact form).
+//
+// One dispatch per `(batch, head, chunk)` grid of problems (`bhnc` =
+// `b * n_heads * num_chunks`, already flattened by the caller, same
+// convention as the tensor path's own `bhnc` reshape) -- `attn` is written
+// functionally (a fresh buffer): the caller must bind it via the write
+// path (Output) so this fork's HazardTrackingModeUntracked convention
+// gives any dependent dispatch (3.1b/c's later folds) a real barrier.
+#define GDN_SCAN_CHUNK 64u
+
+struct gdn_scan_solve_args {
+    uint bhnc; // number of independent (batch, head, chunk) problems
+};
+
+kernel void kernel_gdn_chunked_scan_solve_f32(
+        device const float * a_mat [[buffer(0)]],  // [bhnc, CHUNK, CHUNK], strictly lower-triangular
+        device float       * attn  [[buffer(1)]],  // [bhnc, CHUNK, CHUNK], functional -- (I - a_mat)^-1
+        constant gdn_scan_solve_args & args [[buffer(2)]],
+        uint2 gid [[thread_position_in_grid]]) {
+    const uint j = gid.x; // column index, 0..CHUNK
+    const uint p = gid.y; // which (batch, head, chunk) problem
+    if (j >= GDN_SCAN_CHUNK || p >= args.bhnc) {
+        return;
+    }
+
+    device const float * a   = a_mat + p * GDN_SCAN_CHUNK * GDN_SCAN_CHUNK;
+    device float       * out = attn  + p * GDN_SCAN_CHUNK * GDN_SCAN_CHUNK;
+
+    for (uint i = 0; i < GDN_SCAN_CHUNK; ++i) {
+        float acc = (i == j) ? 1.0f : 0.0f;
+        for (uint k = 0; k < i; ++k) {
+            acc += a[i * GDN_SCAN_CHUNK + k] * out[k * GDN_SCAN_CHUNK + j];
+        }
+        out[i * GDN_SCAN_CHUNK + j] = acc;
+    }
+}

--- a/candle-metal-kernels/src/metal_src/gdn.metal
+++ b/candle-metal-kernels/src/metal_src/gdn.metal
@@ -1,0 +1,81 @@
+#include <metal_stdlib>
+using namespace metal;
+
+// Fused gated-DeltaNet (gated linear attention) single-token decode step,
+// as used by Qwen3.5 / Qwen3-Next style hybrid architectures. Batch-1,
+// seq-len-1 decode of this recurrence normally costs ~9 serialized,
+// dependency-chained elementwise/reduction ops per layer per token
+// (decay, a key-weighted read, a delta computation, a state write, a
+// query-weighted read) -- cheap in FLOPs but expensive in fixed
+// per-dispatch overhead at this shape, since every op depends on the
+// previous op's output and the tensors involved are small. This kernel
+// fuses the whole step into one dispatch.
+//
+// Per output column j (over the value-head-dim axis), for a fixed
+// (batch, head), and summing over i (the state-size axis):
+//   s_dec[i][j] = g * s_in[i][j]
+//   kv_mem[j]   = sum_i s_dec[i][j] * k[i]
+//   delta[j]    = (v[j] - kv_mem[j]) * beta
+//   s_out[i][j] = s_dec[i][j] + k[i] * delta[j]
+//   out[j]      = sum_i s_out[i][j] * q[i]
+//
+// One thread per (batch, head, j) -- no cross-thread communication, no
+// threadgroup memory. `state_out` is written functionally (a fresh
+// buffer; `state_in` is read-only and left untouched) rather than
+// mutated in place -- callers that keep other live references to the
+// input state tensor (e.g. a checkpoint taken before this step) depend
+// on that not being silently invalidated. Every per-thread write to
+// `state_out`/`out` is to a disjoint element, so the kernel itself has no
+// internal write hazard -- but the caller must bind `state_out` and
+// `out` via the write path (see `Output` in this crate's `utils.rs`),
+// not the read-only path, or a subsequent dispatch's read of `state_out`
+// may run without a hazard-tracking barrier under
+// `HazardTrackingModeUntracked`.
+
+struct gdn_step_args {
+    uint hk; // state_size
+    uint hv; // value_head_dim
+    uint h;  // value_head_count (heads)
+};
+
+kernel void kernel_gdn_decode_step_f32(
+        device const float * q      [[buffer(0)]],  // [b, h, hk]
+        device const float * k      [[buffer(1)]],  // [b, h, hk]
+        device const float * v      [[buffer(2)]],  // [b, h, hv]
+        device const float * g      [[buffer(3)]],  // [b, h], already exp'ed (actual decay gate, not log_g)
+        device const float * beta   [[buffer(4)]],  // [b, h]
+        device const float * s_in   [[buffer(5)]],  // [b, h, hk, hv]
+        device float       * s_out  [[buffer(6)]],  // [b, h, hk, hv], functional -- fresh buffer, s_in untouched
+        device float       * out    [[buffer(7)]],  // [b, h, hv]
+        constant gdn_step_args & args [[buffer(8)]],
+        uint3 gid [[thread_position_in_grid]]) {
+    const uint j = gid.x;
+    if (j >= args.hv) {
+        return;
+    }
+    const uint hk = args.hk;
+    const uint hv = args.hv;
+    const uint bh = gid.z * args.h + gid.y; // flattened (batch, head) index
+
+    device const float * qh = q + bh * hk;
+    device const float * kh = k + bh * hk;
+    device const float * si = s_in  + bh * hk * hv;
+    device float       * so = s_out + bh * hk * hv;
+
+    const float gv = g[bh];
+    const float bv = beta[bh];
+
+    float kv_mem = 0.0f;
+    for (uint i = 0; i < hk; ++i) {
+        kv_mem += (gv * si[i * hv + j]) * kh[i];
+    }
+    const float delta = (v[bh * hv + j] - kv_mem) * bv;
+
+    float acc = 0.0f;
+    for (uint i = 0; i < hk; ++i) {
+        const float s_new = gv * si[i * hv + j] + kh[i] * delta;
+        so[i * hv + j] = s_new;
+        acc += s_new * qh[i];
+    }
+    out[bh * hv + j] = acc;
+}

--- a/candle-metal-kernels/src/metal_src/gdn.metal
+++ b/candle-metal-kernels/src/metal_src/gdn.metal
@@ -13,6 +13,7 @@ using namespace metal;
 //
 // Per output column j (over the value-head-dim axis), for a fixed
 // (batch, head), and summing over i (the state-size axis):
+//   g           = exp(g_log)
 //   s_dec[i][j] = g * s_in[i][j]
 //   kv_mem[j]   = sum_i s_dec[i][j] * k[i]
 //   delta[j]    = (v[j] - kv_mem[j]) * beta
@@ -42,7 +43,7 @@ kernel void kernel_gdn_decode_step_f32(
         device const float * q      [[buffer(0)]],  // [b, h, hk]
         device const float * k      [[buffer(1)]],  // [b, h, hk]
         device const float * v      [[buffer(2)]],  // [b, h, hv]
-        device const float * g      [[buffer(3)]],  // [b, h], already exp'ed (actual decay gate, not log_g)
+        device const float * g_log  [[buffer(3)]],  // [b, h], NOT exp'ed -- the raw decay-gate log; this kernel exponentiates it internally
         device const float * beta   [[buffer(4)]],  // [b, h]
         device const float * s_in   [[buffer(5)]],  // [b, h, hk, hv]
         device float       * s_out  [[buffer(6)]],  // [b, h, hk, hv], functional -- fresh buffer, s_in untouched
@@ -62,7 +63,7 @@ kernel void kernel_gdn_decode_step_f32(
     device const float * si = s_in  + bh * hk * hv;
     device float       * so = s_out + bh * hk * hv;
 
-    const float gv = g[bh];
+    const float gv = exp(g_log[bh]); // one exp() per (batch, head), not a separate caller-side dispatch
     const float bv = beta[bh];
 
     float kv_mem = 0.0f;

--- a/candle-metal-kernels/src/metal_src/gdn.metal
+++ b/candle-metal-kernels/src/metal_src/gdn.metal
@@ -345,3 +345,141 @@ kernel void kernel_gdn_chunked_scan_solve_f32(
         out[i * GDN_SCAN_CHUNK + j] = acc;
     }
 }
+
+// Phase 3.1b: folds a_mat's construction (mask/kk/triangle) into the
+// solve kernel above -- this fork's first kernel using threadgroup
+// memory and a barrier at all. See yggdrasil/ratatoskr/DESIGN.md's
+// "Phase 3 design" section for the design consult this implements
+// (2026-08-17, verified against qwen3_5_linear_attn_scan.rs's steps
+// 3a-3c before being recorded).
+//
+// Per (batch, head, chunk) problem, for j < i (strictly lower
+// triangular, matching a_mat's own definition):
+//   g_cumsum[i] - g_cumsum[j] = sum_{m=j+1..i} log_g[m]   (running
+//     suffix sum, computed directly -- not two independent prefix
+//     sums subtracted, which is what the tensor path does; this is
+//     the *more* numerically accurate grouping, not a shortcut)
+//   kk[i][j]    = beta[i] * dot(k_c[i,:], k_c[j,:])
+//   a_mat[i][j] = -kk[i][j] * exp(g_cumsum[i] - g_cumsum[j])
+// log_g is always <= 0 (ssm_a * softplus(...), confirmed against this
+// crate's own consumer -- quantized_qwen35.rs's own comment states
+// this explicitly), so the running suffix sum is always <= 0 and
+// exp(...) <= 1 always -- no overflow is possible by construction, for
+// any j < i. This is why no separate mask-before-exp step exists here:
+// the tensor path's own guard (this file's own doc, and DESIGN.md's
+// correctness risk (1)) exists because ITS gc_i/gc_j broadcast-and-
+// subtract materializes the *upper* triangle too before masking it
+// away; this kernel's loop bound (i from j+1 upward) means the
+// upper triangle and diagonal are never evaluated at all, structurally,
+// not masked after the fact.
+//
+// **One thread per column j, same as the solve half** -- deliberately,
+// not a separate assignment for build vs. solve. Thread j builds its
+// own column's strictly-lower entries (i = j+1..CHUNK-1) using a
+// single scalar running accumulator (`acc_g`) and a scalar dot-product
+// accumulator -- **no per-thread array anywhere in this kernel**. This
+// is a hard constraint, not a preference: 3.1a's first implementation
+// held a 64-entry `float x[64]` per thread and was found to silently
+// miscompile (produce zeros for most rows) at that exact size on this
+// Metal toolchain -- confirmed size-dependent, not a logic bug, by
+// shrinking to 4 in isolation, where identical logic was correct. See
+// yggdrasil/ratatoskr/DESIGN.md's "standing risk for future kernel
+// work in this fork" paragraph for the full writeup -- any kernel in
+// this crate wanting a per-thread array above roughly 32-64 entries
+// should differential-test at the real target size specifically, the
+// same way this one did, not assume register-residency holds.
+//
+// a_mat lands in a single 16KB threadgroup tile (the only shared state
+// this kernel needs -- k_c/log_g_c/beta_c stay device-resident and are
+// read via uniform/cache-friendly access patterns, not staged).
+// Exactly **one** threadgroup_barrier, after every thread's build loop
+// completes and before any solve read -- dispatch is deliberately
+// sized to exactly (CHUNK, bhnc) threads (grid_dims == group_dims-
+// multiple, see the Rust wrapper), so **no thread ever needs a
+// bounds-check return before the barrier** (an early return before a
+// barrier is undefined behavior -- not every thread would reach it --
+// so this kernel has none, unlike every other kernel in this file,
+// deliberately).
+//
+// **This is a real landmine for anyone extending this kernel, not
+// just an absence to note in passing.** Every OTHER kernel in this
+// file uses `if (idx >= bound) { return; }`, including the literally
+// adjacent kernel_gdn_chunked_scan_solve_f32 just above this one --
+// copying that idiom into a barrier-containing kernel out of habit is
+// undefined behavior, not merely redundant. The two halves of a
+// combined check are not equally dangerous here: with this kernel's
+// own `group_dims.height == 1`, `p` (the problem index) is
+// threadgroup-uniform (every thread in a group has the same `p`), so a
+// `p`-only early return would be legal; `j` (the column) varies within
+// a group, so a `j`-only (or combined) early return before the barrier
+// is the real hazard. If a future variant of this kernel ever needs
+// non-exact dispatch dimensions, do not add the combined check back
+// in -- restructure so any skipped work still falls through to the
+// barrier (skip the work, never `return`).
+//
+// Numerics note for verification: this kernel's a_mat differs from
+// the tensor path's own a_mat by ordinary f32 summation-order drift
+// (running suffix sum vs. two-prefix-sum subtraction) -- expected to
+// be tolerance-close, not bit-identical, in the Phase-1b sense (benign
+// reassociation), not the Phase-1a sense (repeated-squaring blowup).
+// The production-scale differential is the arbiter, same as every
+// other phase in this design.
+struct gdn_scan_build_solve_args {
+    uint hk; // head_k_dim (k_c's last dimension) -- bhnc is NOT a field
+             // here: the kernel never reads it (dispatch is sized to
+             // exactly (CHUNK, bhnc) threads, so there is nothing for a
+             // bhnc bounds check to do -- see the "no bounds-check
+             // return" note above). Keeping an unused field would be
+             // dead GPU-side state with no compiler warning to catch it.
+};
+
+kernel void kernel_gdn_chunked_scan_build_and_solve_f32(
+        device const float * k_c     [[buffer(0)]],  // [bhnc, CHUNK, hk]
+        device const float * log_g_c [[buffer(1)]],  // [bhnc, CHUNK]
+        device const float * beta_c  [[buffer(2)]],  // [bhnc, CHUNK]
+        device float       * attn    [[buffer(3)]],  // [bhnc, CHUNK, CHUNK], functional
+        constant gdn_scan_build_solve_args & args [[buffer(4)]],
+        uint2 gid [[thread_position_in_grid]]) {
+    const uint j = gid.x; // this thread's column, 0..CHUNK -- exact dispatch sizing, no bounds check
+    const uint p = gid.y; // which (batch, head, chunk) problem -- exact dispatch sizing, no bounds check
+
+    // Fixed-size static threadgroup allocation (16KB) -- compile-time
+    // constant, so no host-side setThreadgroupMemoryLength plumbing is
+    // needed; every threadgroup gets its own private copy.
+    threadgroup float a_tile[GDN_SCAN_CHUNK * GDN_SCAN_CHUNK];
+
+    device const float * k_p     = k_c     + p * GDN_SCAN_CHUNK * args.hk;
+    device const float * log_g_p = log_g_c + p * GDN_SCAN_CHUNK;
+    device const float * beta_p  = beta_c  + p * GDN_SCAN_CHUNK;
+
+    // Build: column j, strictly-lower entries only (i > j).
+    float acc_g = 0.0f;
+    for (uint i = j + 1; i < GDN_SCAN_CHUNK; ++i) {
+        acc_g += log_g_p[i]; // always <= 0 -- see doc comment above
+        float dot = 0.0f;
+        for (uint d = 0; d < args.hk; ++d) {
+            dot += k_p[i * args.hk + d] * k_p[j * args.hk + d];
+        }
+        a_tile[i * GDN_SCAN_CHUNK + j] = -beta_p[i] * dot * exp(acc_g);
+    }
+
+    // The one barrier: every thread falls through to here regardless
+    // of its own build-loop trip count (thread CHUNK-1 does zero
+    // build iterations but still reaches this point) -- required
+    // before any thread reads another thread's tile writes.
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Solve: identical math/shape to kernel_gdn_chunked_scan_solve_f32
+    // above, reading a_mat from the threadgroup tile instead of device
+    // memory. attn is still read back from the OUTPUT device buffer
+    // for prior rows (no per-thread array here either, same reasoning
+    // as the solve-only kernel).
+    device float * out = attn + p * GDN_SCAN_CHUNK * GDN_SCAN_CHUNK;
+    for (uint i = 0; i < GDN_SCAN_CHUNK; ++i) {
+        float acc = (i == j) ? 1.0f : 0.0f;
+        for (uint k = 0; k < i; ++k) {
+            acc += a_tile[i * GDN_SCAN_CHUNK + k] * out[k * GDN_SCAN_CHUNK + j];
+        }
+        out[i * GDN_SCAN_CHUNK + j] = acc;
+    }
+}

--- a/candle-metal-kernels/src/source.rs
+++ b/candle-metal-kernels/src/source.rs
@@ -3,6 +3,7 @@ pub const BINARY: &str = include_str!("metal_src/binary.metal");
 pub const CAST: &str = include_str!("metal_src/cast.metal");
 pub const CONV: &str = include_str!("metal_src/conv.metal");
 pub const FILL: &str = include_str!("metal_src/fill.metal");
+pub const GDN: &str = include_str!("metal_src/gdn.metal");
 pub const INDEXING: &str = include_str!("metal_src/indexing.metal");
 pub const GEMV: &str = include_str!("metal_src/gemv.metal");
 pub const MLX_GEMM: &str = include_str!("metal_src/mlx_gemm.metal");
@@ -22,6 +23,7 @@ pub enum Source {
     Cast,
     Conv,
     Fill,
+    Gdn,
     Gemm,
     Gemv,
     Indexing,

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -3499,7 +3499,23 @@ fn kernel_gdn_chunked_scan_solve_pipeline_loads() {
     let kernels = Kernels::new();
     kernels
         .load_pipeline(&device, Source::Gdn, "kernel_gdn_chunked_scan_solve_f32")
-        .unwrap_or_else(|e| panic!("kernel_gdn_chunked_scan_solve_f32 should load as a Metal compute pipeline: {e}"));
+        .unwrap_or_else(|e| {
+            panic!("kernel_gdn_chunked_scan_solve_f32 should load as a Metal compute pipeline: {e}")
+        });
+}
+
+// Phase 3.1b: this fork's first kernel using threadgroup memory and a
+// barrier -- de-risk-spike-before-numeric-work precedent, same as
+// kernel_gdn_chunked_scan_solve_pipeline_loads above.
+#[test]
+fn kernel_gdn_chunked_scan_build_and_solve_pipeline_loads() {
+    let device = device();
+    let kernels = Kernels::new();
+    kernels
+        .load_pipeline(&device, Source::Gdn, "kernel_gdn_chunked_scan_build_and_solve_f32")
+        .unwrap_or_else(|e| {
+            panic!("kernel_gdn_chunked_scan_build_and_solve_f32 should load as a Metal compute pipeline: {e}")
+        });
 }
 
 // Scalar Rust reference: row-by-row forward substitution, matching
@@ -3550,11 +3566,21 @@ fn run_gdn_scan_solve_and_check(bhnc: usize) {
     let a_mat = random_strict_lower_triangular(&mut rng, bhnc, chunk);
     let a_mat_buf = new_buffer(&device, &a_mat);
     let attn_buf = device
-        .new_buffer(bhnc * chunk * chunk * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .new_buffer(
+            bhnc * chunk * chunk * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
         .unwrap();
 
-    call_gdn_chunked_scan_solve_f32(&device, &encoder, &kernels, bhnc, &BufferOffset::zero_offset(&a_mat_buf), &attn_buf)
-        .unwrap();
+    call_gdn_chunked_scan_solve_f32(
+        &device,
+        &encoder,
+        &kernels,
+        bhnc,
+        &BufferOffset::zero_offset(&a_mat_buf),
+        &attn_buf,
+    )
+    .unwrap();
     drop(encoder);
     commands.wait_until_completed().unwrap();
 
@@ -3563,7 +3589,8 @@ fn run_gdn_scan_solve_and_check(bhnc: usize) {
     let mut max_diff = 0f32;
     let mut worst = (0usize, 0usize, 0usize);
     for p in 0..bhnc {
-        let expected = gdn_scan_solve_reference(&a_mat[p * chunk * chunk..(p + 1) * chunk * chunk], chunk);
+        let expected =
+            gdn_scan_solve_reference(&a_mat[p * chunk * chunk..(p + 1) * chunk * chunk], chunk);
         for i in 0..chunk {
             for j in 0..chunk {
                 let d = (got[p * chunk * chunk + i * chunk + j] - expected[i * chunk + j]).abs();
@@ -3575,7 +3602,10 @@ fn run_gdn_scan_solve_and_check(bhnc: usize) {
         }
     }
     println!("gdn_chunked_scan_solve bhnc={bhnc} chunk={chunk}: max_diff={max_diff:.8} worst(p,i,j)={worst:?}");
-    assert!(max_diff < 1e-3, "bhnc={bhnc}: solve mismatch, max diff = {max_diff}");
+    assert!(
+        max_diff < 1e-3,
+        "bhnc={bhnc}: solve mismatch, max diff = {max_diff}"
+    );
 }
 
 #[test]
@@ -3610,31 +3640,41 @@ fn kernel_gdn_chunked_scan_solve_respects_nonzero_buffer_offset() {
     let chunk = GDN_SCAN_CHUNK;
     let bhnc = 2usize;
     let a_mat = random_strict_lower_triangular(&mut rng, bhnc, chunk);
-    let decoy = (0..a_mat.len()).map(|_| (rng.random::<f32>() - 0.5) * 999.0).collect::<Vec<f32>>();
+    let decoy = (0..a_mat.len())
+        .map(|_| (rng.random::<f32>() - 0.5) * 999.0)
+        .collect::<Vec<f32>>();
 
     let f32_size = std::mem::size_of::<f32>();
     let packed: Vec<f32> = [&decoy[..], &a_mat[..]].concat();
     let packed_buf = new_buffer(&device, &packed);
-    let a_mat_off = BufferOffset { buffer: &packed_buf, offset_in_bytes: decoy.len() * f32_size };
+    let a_mat_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: decoy.len() * f32_size,
+    };
 
     let attn_buf = device
         .new_buffer(bhnc * chunk * chunk * f32_size, RESOURCE_OPTIONS)
         .unwrap();
 
-    call_gdn_chunked_scan_solve_f32(&device, &encoder, &kernels, bhnc, &a_mat_off, &attn_buf).unwrap();
+    call_gdn_chunked_scan_solve_f32(&device, &encoder, &kernels, bhnc, &a_mat_off, &attn_buf)
+        .unwrap();
     drop(encoder);
     commands.wait_until_completed().unwrap();
 
     let got: Vec<f32> = read_to_vec(&attn_buf, bhnc * chunk * chunk);
     let mut max_diff = 0f32;
     for p in 0..bhnc {
-        let expected = gdn_scan_solve_reference(&a_mat[p * chunk * chunk..(p + 1) * chunk * chunk], chunk);
+        let expected =
+            gdn_scan_solve_reference(&a_mat[p * chunk * chunk..(p + 1) * chunk * chunk], chunk);
         for e in 0..chunk * chunk {
             max_diff = max_diff.max((got[p * chunk * chunk + e] - expected[e]).abs());
         }
     }
     println!("gdn_chunked_scan_solve_nonzero_offset: max_diff={max_diff:.8}");
-    assert!(max_diff < 1e-3, "nonzero-offset solve mismatch, max diff = {max_diff}");
+    assert!(
+        max_diff < 1e-3,
+        "nonzero-offset solve mismatch, max diff = {max_diff}"
+    );
 }
 
 // Adversarial case matching the design's own correctness-risk (2): beta near
@@ -3658,28 +3698,423 @@ fn kernel_gdn_chunked_scan_solve_matches_scalar_reference_strong_decay() {
     for p in 0..bhnc {
         for i in 0..chunk {
             for k in 0..i {
-                a_mat[p * chunk * chunk + i * chunk + k] = (rng.random::<f32>() - 0.5) * 1.9; // up to ~0.95 magnitude
+                a_mat[p * chunk * chunk + i * chunk + k] = (rng.random::<f32>() - 0.5) * 1.9;
+                // up to ~0.95 magnitude
             }
         }
     }
     let a_mat_buf = new_buffer(&device, &a_mat);
     let attn_buf = device
-        .new_buffer(bhnc * chunk * chunk * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .new_buffer(
+            bhnc * chunk * chunk * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
         .unwrap();
 
-    call_gdn_chunked_scan_solve_f32(&device, &encoder, &kernels, bhnc, &BufferOffset::zero_offset(&a_mat_buf), &attn_buf)
-        .unwrap();
+    call_gdn_chunked_scan_solve_f32(
+        &device,
+        &encoder,
+        &kernels,
+        bhnc,
+        &BufferOffset::zero_offset(&a_mat_buf),
+        &attn_buf,
+    )
+    .unwrap();
     drop(encoder);
     commands.wait_until_completed().unwrap();
 
     let got: Vec<f32> = read_to_vec(&attn_buf, bhnc * chunk * chunk);
     let mut max_diff = 0f32;
     for p in 0..bhnc {
-        let expected = gdn_scan_solve_reference(&a_mat[p * chunk * chunk..(p + 1) * chunk * chunk], chunk);
+        let expected =
+            gdn_scan_solve_reference(&a_mat[p * chunk * chunk..(p + 1) * chunk * chunk], chunk);
         for e in 0..chunk * chunk {
             max_diff = max_diff.max((got[p * chunk * chunk + e] - expected[e]).abs());
         }
     }
     println!("gdn_chunked_scan_solve_strong_decay: max_diff={max_diff:.8}");
-    assert!(max_diff < 1e-2, "strong-decay solve mismatch, max diff = {max_diff}");
+    assert!(
+        max_diff < 1e-2,
+        "strong-decay solve mismatch, max diff = {max_diff}"
+    );
+}
+
+// Phase 3.1b: folds a_mat's construction into the kernel above. Scalar
+// Rust reference builds a_mat via the running-suffix-sum formula
+// (matching the kernel's own math, NOT the tensor path's two-prefix-
+// sum-subtraction form -- this reference and the kernel should agree
+// closely since both use the same summation order; the tensor path's
+// own subtly different order is what the *ratatoskr-level* differential
+// checks separately), then solves via the same row-serial reference as
+// gdn_scan_solve_reference (deliberately independent of the kernel's
+// own column-parallel solve half).
+fn gdn_scan_build_solve_reference(
+    k_c: &[f32],
+    log_g_c: &[f32],
+    beta_c: &[f32],
+    chunk: usize,
+    hk: usize,
+) -> Vec<f32> {
+    let mut a_mat = vec![0f32; chunk * chunk];
+    for j in 0..chunk {
+        let mut acc_g = 0f32;
+        for i in (j + 1)..chunk {
+            acc_g += log_g_c[i];
+            let mut dot = 0f32;
+            for d in 0..hk {
+                dot += k_c[i * hk + d] * k_c[j * hk + d];
+            }
+            a_mat[i * chunk + j] = -beta_c[i] * dot * acc_g.exp();
+        }
+    }
+    gdn_scan_solve_reference(&a_mat, chunk)
+}
+
+fn run_gdn_scan_build_solve_and_check(bhnc: usize, hk: usize) {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    let mut rng = rng();
+
+    let chunk = GDN_SCAN_CHUNK;
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+    let k_c = randf(&mut rng, bhnc * chunk * hk, 0.4);
+    // log_g must be <= 0 everywhere (ssm_a * softplus(...), see the
+    // kernel's own doc comment) -- sampled from a realistic negative
+    // range, not just "happens to be negative by luck of the RNG".
+    let log_g_c: Vec<f32> = (0..bhnc * chunk)
+        .map(|_| -(rng.random::<f32>() * 0.3 + 0.02))
+        .collect();
+    let beta_c: Vec<f32> = (0..bhnc * chunk)
+        .map(|_| rng.random::<f32>() * 0.9 + 0.05)
+        .collect();
+
+    let k_c_buf = new_buffer(&device, &k_c);
+    let log_g_buf = new_buffer(&device, &log_g_c);
+    let beta_buf = new_buffer(&device, &beta_c);
+    let attn_buf = device
+        .new_buffer(
+            bhnc * chunk * chunk * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
+        .unwrap();
+
+    call_gdn_chunked_scan_build_and_solve_f32(
+        &device,
+        &encoder,
+        &kernels,
+        bhnc,
+        hk,
+        &BufferOffset::zero_offset(&k_c_buf),
+        &BufferOffset::zero_offset(&log_g_buf),
+        &BufferOffset::zero_offset(&beta_buf),
+        &attn_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got: Vec<f32> = read_to_vec(&attn_buf, bhnc * chunk * chunk);
+    let mut max_diff = 0f32;
+    let mut worst = (0usize, 0usize, 0usize);
+    for p in 0..bhnc {
+        let expected = gdn_scan_build_solve_reference(
+            &k_c[p * chunk * hk..(p + 1) * chunk * hk],
+            &log_g_c[p * chunk..(p + 1) * chunk],
+            &beta_c[p * chunk..(p + 1) * chunk],
+            chunk,
+            hk,
+        );
+        for i in 0..chunk {
+            for j in 0..chunk {
+                let d = (got[p * chunk * chunk + i * chunk + j] - expected[i * chunk + j]).abs();
+                if d > max_diff {
+                    max_diff = d;
+                    worst = (p, i, j);
+                }
+            }
+        }
+    }
+    println!(
+        "gdn_chunked_scan_build_and_solve bhnc={bhnc} hk={hk}: max_diff={max_diff:.8} worst(p,i,j)={worst:?}"
+    );
+    assert!(
+        max_diff < 1e-3,
+        "bhnc={bhnc} hk={hk}: build+solve mismatch, max diff = {max_diff}"
+    );
+}
+
+#[test]
+fn kernel_gdn_chunked_scan_build_and_solve_matches_scalar_reference_tiny() {
+    run_gdn_scan_build_solve_and_check(1, 8);
+    run_gdn_scan_build_solve_and_check(3, 16);
+}
+
+#[test]
+fn kernel_gdn_chunked_scan_build_and_solve_matches_scalar_reference_production_shape() {
+    // hk=128 (state_size on both checkpoints); bhnc=96 (35B-A3B MoE) /
+    // 144 (27B dense), matching Phase 3.0's own confirmed shapes.
+    run_gdn_scan_build_solve_and_check(96, 128);
+    run_gdn_scan_build_solve_and_check(144, 128);
+}
+
+// Regression test for the same bug class every other kernel in this
+// file guards against: k_c/log_g_c/beta_c are exactly the kind of
+// tensors (narrow/reshape chains in the tensor path) that could carry
+// a real nonzero byte offset in a future caller.
+#[test]
+fn kernel_gdn_chunked_scan_build_and_solve_respects_nonzero_buffer_offsets() {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    let mut rng = rng();
+
+    let (bhnc, hk) = (2usize, 8usize);
+    let chunk = GDN_SCAN_CHUNK;
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+    let k_c = randf(&mut rng, bhnc * chunk * hk, 0.4);
+    let log_g_c: Vec<f32> = (0..bhnc * chunk)
+        .map(|_| -(rng.random::<f32>() * 0.3 + 0.02))
+        .collect();
+    let beta_c: Vec<f32> = (0..bhnc * chunk)
+        .map(|_| rng.random::<f32>() * 0.9 + 0.05)
+        .collect();
+    let decoy_k = randf(&mut rng, bhnc * chunk * hk, 999.0);
+    let decoy_scalar = randf(&mut rng, bhnc * chunk, 999.0);
+
+    let f32_size = std::mem::size_of::<f32>();
+    let k_packed: Vec<f32> = [&decoy_k[..], &k_c[..]].concat();
+    let k_buf = new_buffer(&device, &k_packed);
+    let k_off = BufferOffset {
+        buffer: &k_buf,
+        offset_in_bytes: decoy_k.len() * f32_size,
+    };
+
+    let scalar_packed: Vec<f32> = [&decoy_scalar[..], &log_g_c[..], &beta_c[..]].concat();
+    let scalar_buf = new_buffer(&device, &scalar_packed);
+    let log_g_off = BufferOffset {
+        buffer: &scalar_buf,
+        offset_in_bytes: decoy_scalar.len() * f32_size,
+    };
+    let beta_off = BufferOffset {
+        buffer: &scalar_buf,
+        offset_in_bytes: (decoy_scalar.len() + log_g_c.len()) * f32_size,
+    };
+
+    let attn_buf = device
+        .new_buffer(bhnc * chunk * chunk * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+
+    call_gdn_chunked_scan_build_and_solve_f32(
+        &device, &encoder, &kernels, bhnc, hk, &k_off, &log_g_off, &beta_off, &attn_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got: Vec<f32> = read_to_vec(&attn_buf, bhnc * chunk * chunk);
+    let mut max_diff = 0f32;
+    for p in 0..bhnc {
+        let expected = gdn_scan_build_solve_reference(
+            &k_c[p * chunk * hk..(p + 1) * chunk * hk],
+            &log_g_c[p * chunk..(p + 1) * chunk],
+            &beta_c[p * chunk..(p + 1) * chunk],
+            chunk,
+            hk,
+        );
+        for e in 0..chunk * chunk {
+            max_diff = max_diff.max((got[p * chunk * chunk + e] - expected[e]).abs());
+        }
+    }
+    println!("gdn_chunked_scan_build_and_solve_nonzero_offsets: max_diff={max_diff:.8}");
+    assert!(
+        max_diff < 1e-3,
+        "nonzero-offset build+solve mismatch, max diff = {max_diff}"
+    );
+}
+
+// Adversarial: strong decay (log_g near its most-negative realistic
+// range) -- exercises the running-suffix-sum accumulator across the
+// full 63-entry range for thread 0's column, the longest chain in the
+// kernel, where the design's own numerics note (drift vs. the tensor
+// path's two-prefix-sum form) would show up first if it were more than
+// benign reassociation.
+#[test]
+fn kernel_gdn_chunked_scan_build_and_solve_matches_scalar_reference_strong_decay() {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    let mut rng = rng();
+
+    let (bhnc, hk) = (2usize, 128usize);
+    let chunk = GDN_SCAN_CHUNK;
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+    let k_c = randf(&mut rng, bhnc * chunk * hk, 0.4);
+    // Real large_decay regime (matching qwen3_5_linear_attn_scan.rs's
+    // own run_chunked_large_decay convention): g = exp(-6.72).
+    let log_g_c: Vec<f32> = vec![-6.72f32; bhnc * chunk];
+    let beta_c: Vec<f32> = vec![0.65f32; bhnc * chunk];
+
+    let k_buf = new_buffer(&device, &k_c);
+    let log_g_buf = new_buffer(&device, &log_g_c);
+    let beta_buf = new_buffer(&device, &beta_c);
+    let attn_buf = device
+        .new_buffer(
+            bhnc * chunk * chunk * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
+        .unwrap();
+
+    call_gdn_chunked_scan_build_and_solve_f32(
+        &device,
+        &encoder,
+        &kernels,
+        bhnc,
+        hk,
+        &BufferOffset::zero_offset(&k_buf),
+        &BufferOffset::zero_offset(&log_g_buf),
+        &BufferOffset::zero_offset(&beta_buf),
+        &attn_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got: Vec<f32> = read_to_vec(&attn_buf, bhnc * chunk * chunk);
+    let mut max_diff = 0f32;
+    for p in 0..bhnc {
+        let expected = gdn_scan_build_solve_reference(
+            &k_c[p * chunk * hk..(p + 1) * chunk * hk],
+            &log_g_c[p * chunk..(p + 1) * chunk],
+            &beta_c[p * chunk..(p + 1) * chunk],
+            chunk,
+            hk,
+        );
+        for e in 0..chunk * chunk {
+            max_diff = max_diff.max((got[p * chunk * chunk + e] - expected[e]).abs());
+        }
+    }
+    println!("gdn_chunked_scan_build_and_solve_strong_decay: max_diff={max_diff:.8}");
+    assert!(
+        max_diff < 1e-2,
+        "strong-decay build+solve mismatch, max diff = {max_diff}"
+    );
+}
+
+// Standalone wall-clock microbench at production shape (mirrors
+// sequential_step_standalone_microbench_at_production_shapes's own
+// precedent) -- a standing reference point for this kernel's own
+// absolute cost, for catching a future regression.
+//
+// 2026-08-17 investigation, recorded here rather than left only in
+// conversation: this kernel's build phase re-reads k_c from device
+// memory redundantly (up to 63x per row). Measured directly (an
+// interleaved calibration against a same-address-always variant, 4
+// runs, tight and reproducible at 66.5-67.5%) -- real cost, not noise,
+// contradicting an initial "small working set, cache-absorbed"
+// prediction. A structural fix was designed, implemented, and
+// differential-verified correct (stage k_c into a second threadgroup
+// tile; move a_mat to a device scratch buffer to make room, since the
+// two tiles together exceed this crate's confirmed 32768-byte
+// maxThreadgroupMemoryLength at hk=128) -- then measured and found to
+// be a net REGRESSION: ~4.7-4.9ms/call versus this kernel's own
+// ~2.5ms/call, roughly double. The fix's own cost (a `mem_device`
+// barrier -- device-memory-wide visibility, not just on-chip
+// threadgroup synchronization -- plus a larger per-threadgroup
+// footprint likely reducing how many threadgroups run concurrently)
+// exceeded what it saved. Reverted; this kernel's redundant reads are
+// real but not worth eliminating given the only structurally-correct
+// fix available. Full writeup in yggdrasil/ratatoskr/DESIGN.md.
+#[test]
+fn kernel_gdn_chunked_scan_build_and_solve_standalone_microbench_at_production_shape() {
+    let device = device();
+    let kernels = Kernels::new();
+    let mut rng = rng();
+
+    let (bhnc, hk) = (96usize, 128usize);
+    let chunk = GDN_SCAN_CHUNK;
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+    let k_c = randf(&mut rng, bhnc * chunk * hk, 0.4);
+    let log_g_c: Vec<f32> = (0..bhnc * chunk)
+        .map(|_| -(rng.random::<f32>() * 0.3 + 0.02))
+        .collect();
+    let beta_c: Vec<f32> = (0..bhnc * chunk)
+        .map(|_| rng.random::<f32>() * 0.9 + 0.05)
+        .collect();
+
+    let k_buf = new_buffer(&device, &k_c);
+    let log_g_buf = new_buffer(&device, &log_g_c);
+    let beta_buf = new_buffer(&device, &beta_c);
+    let attn_buf = device
+        .new_buffer(
+            bhnc * chunk * chunk * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
+        .unwrap();
+
+    const WARMUP: usize = 8;
+    const TOTAL_CALLS: usize = 150; // matches 35B's real DeltaNet-layers x windows count
+    for _ in 0..WARMUP {
+        let commands = commands(&device);
+        let encoder = commands.command_encoder().unwrap();
+        call_gdn_chunked_scan_build_and_solve_f32(
+            &device,
+            &encoder,
+            &kernels,
+            bhnc,
+            hk,
+            &BufferOffset::zero_offset(&k_buf),
+            &BufferOffset::zero_offset(&log_g_buf),
+            &BufferOffset::zero_offset(&beta_buf),
+            &attn_buf,
+        )
+        .unwrap();
+        drop(encoder);
+        commands.wait_until_completed().unwrap();
+    }
+
+    let start = std::time::Instant::now();
+    for _ in 0..TOTAL_CALLS {
+        let commands = commands(&device);
+        let encoder = commands.command_encoder().unwrap();
+        call_gdn_chunked_scan_build_and_solve_f32(
+            &device,
+            &encoder,
+            &kernels,
+            bhnc,
+            hk,
+            &BufferOffset::zero_offset(&k_buf),
+            &BufferOffset::zero_offset(&log_g_buf),
+            &BufferOffset::zero_offset(&beta_buf),
+            &attn_buf,
+        )
+        .unwrap();
+        drop(encoder);
+        commands.wait_until_completed().unwrap();
+    }
+    let elapsed = start.elapsed();
+    let per_call = elapsed / TOTAL_CALLS as u32;
+    println!(
+        "kernel_gdn_chunked_scan_build_and_solve_standalone_microbench_at_production_shape: \
+         bhnc={bhnc} hk={hk} {TOTAL_CALLS} calls: total={elapsed:?} per_call={per_call:?}"
+    );
 }

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2514,18 +2514,21 @@ fn kernel_gdn_decode_step_pipeline_loads() {
 //   delta[j]    = (v[j] - kv_mem[j]) * beta
 //   s_out[i][j] = s_dec[i][j] + k[i] * delta[j]
 //   out[j]      = sum_i s_out[i][j] * q[i]
-// Per (batch, head) -- q/k: [hk], v: [hv], g/beta: scalar, state: [hk, hv].
+// Per (batch, head) -- q/k: [hk], v: [hv], g_log/beta: scalar, state: [hk, hv].
+// `g_log` is the raw decay-gate log, NOT pre-exponentiated -- matches the
+// kernel's own convention (it exponentiates internally).
 #[allow(clippy::too_many_arguments)]
 fn gdn_decode_step_reference(
     q: &[f32],
     k: &[f32],
     v: &[f32],
-    g: f32,
+    g_log: f32,
     beta: f32,
     state_in: &[f32],
     hk: usize,
     hv: usize,
 ) -> (Vec<f32>, Vec<f32>) {
+    let g = g_log.exp();
     let mut state_out = vec![0f32; hk * hv];
     let mut out = vec![0f32; hv];
     for j in 0..hv {
@@ -2565,14 +2568,13 @@ fn run_gdn_decode_step_and_check(b: usize, h: usize, hk: usize, hv: usize) {
     let q = randf(&mut rng, b * h * hk, 0.2);
     let k = randf(&mut rng, b * h * hk, 0.2);
     let v = randf(&mut rng, b * h * hv, 2.0);
-    // g in (0,1) (post-exp decay gate, matching sequential_step's own
-    // convention -- the kernel takes g already exp'd, not log_g); beta in
-    // (0,1) too. Include the large_decay-style strong-decay regime
-    // (g close to 0) at least once via the caller's own shape choices --
-    // this helper takes whatever the caller passes.
-    let g_vals: Vec<f32> = (0..b * h)
+    // Sample the actual decay gate in (0,1) (a realistic range, including
+    // the strong-decay end near 0), then take its log -- the kernel and
+    // the reference both take g_log directly now, not the pre-exp'd gate.
+    let g_decay_vals: Vec<f32> = (0..b * h)
         .map(|_| rng.random::<f32>() * 0.9 + 0.05)
         .collect();
+    let g_log_vals: Vec<f32> = g_decay_vals.iter().map(|g| g.ln()).collect();
     let beta_vals: Vec<f32> = (0..b * h)
         .map(|_| rng.random::<f32>() * 0.9 + 0.05)
         .collect();
@@ -2581,7 +2583,7 @@ fn run_gdn_decode_step_and_check(b: usize, h: usize, hk: usize, hv: usize) {
     let q_buf = new_buffer(&device, &q);
     let k_buf = new_buffer(&device, &k);
     let v_buf = new_buffer(&device, &v);
-    let g_buf = new_buffer(&device, &g_vals);
+    let g_buf = new_buffer(&device, &g_log_vals);
     let beta_buf = new_buffer(&device, &beta_vals);
     let state_in_buf = new_buffer(&device, &state_in);
     let state_out_buf = device
@@ -2625,7 +2627,7 @@ fn run_gdn_decode_step_and_check(b: usize, h: usize, hk: usize, hv: usize) {
             &q[bh * hk..(bh + 1) * hk],
             &k[bh * hk..(bh + 1) * hk],
             &v[bh * hv..(bh + 1) * hv],
-            g_vals[bh],
+            g_log_vals[bh],
             beta_vals[bh],
             &state_in[bh * hk * hv..(bh + 1) * hk * hv],
             hk,
@@ -2704,7 +2706,11 @@ fn kernel_gdn_decode_step_respects_nonzero_buffer_offsets() {
     let q = randf(&mut rng, b * h * hk, 0.2);
     let k = randf(&mut rng, b * h * hk, 0.2);
     let v = randf(&mut rng, b * h * hv, 2.0);
-    let g_vals: Vec<f32> = (0..b * h)
+    // Values don't need to be a realistic post-exp decay-gate range here
+    // (unlike run_gdn_decode_step_and_check's own g) -- this test is
+    // about offset correctness, not numeric range, and the kernel
+    // exponentiates internally regardless.
+    let g_log_vals: Vec<f32> = (0..b * h)
         .map(|_| rng.random::<f32>() * 0.9 + 0.05)
         .collect();
     let beta_vals: Vec<f32> = (0..b * h)
@@ -2719,7 +2725,7 @@ fn kernel_gdn_decode_step_respects_nonzero_buffer_offsets() {
         &q[..],
         &k[..],
         &v[..],
-        &g_vals[..],
+        &g_log_vals[..],
         &beta_vals[..],
         &state_in[..],
     ]
@@ -2746,7 +2752,7 @@ fn kernel_gdn_decode_step_respects_nonzero_buffer_offsets() {
         buffer: &packed_buf,
         offset_in_bytes: offset_elems * f32_size,
     };
-    offset_elems += g_vals.len();
+    offset_elems += g_log_vals.len();
     let beta_off = BufferOffset {
         buffer: &packed_buf,
         offset_in_bytes: offset_elems * f32_size,
@@ -2795,7 +2801,7 @@ fn kernel_gdn_decode_step_respects_nonzero_buffer_offsets() {
             &q[bh * hk..(bh + 1) * hk],
             &k[bh * hk..(bh + 1) * hk],
             &v[bh * hv..(bh + 1) * hv],
-            g_vals[bh],
+            g_log_vals[bh],
             beta_vals[bh],
             &state_in[bh * hk * hv..(bh + 1) * hk * hv],
             hk,

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2825,3 +2825,666 @@ fn kernel_gdn_decode_step_respects_nonzero_buffer_offsets() {
         "nonzero-offset state mismatch, max diff = {max_state_diff}"
     );
 }
+// Fused causal depthwise conv1d + silu: same de-risk-spike-before-wiring
+// precedent as the decode-step kernel above.
+#[test]
+fn kernel_gdn_causal_conv1d_pipelines_load() {
+    let device = device();
+    let kernels = Kernels::new();
+    for name in [
+        "kernel_gdn_causal_conv1d_output_f32",
+        "kernel_gdn_causal_conv1d_state_f32",
+    ] {
+        kernels
+            .load_pipeline(&device, Source::Gdn, name)
+            .unwrap_or_else(|e| panic!("{name} should load as a Metal compute pipeline: {e}"));
+    }
+}
+
+/// Scalar Rust reference for the fused conv1d kernels' math (see
+/// gdn.metal's own doc comment for the derivation): both kernels operate
+/// conceptually on `padded = history ++ x` (concat along time, length
+/// `hist_len + seq_len`) without ever materializing it.
+///   out[t][c]       = silu( sum_k padded[t+k][c] * weight[c][k] ),   0 <= t < seq_len
+///   new_state[s][c] = padded[seq_len + s][c],                       0 <= s < hist_len
+/// Operates on one batch row at a time (caller loops over `b`).
+fn gdn_causal_conv1d_reference(
+    x: &[f32],
+    history: &[f32],
+    weight: &[f32],
+    seq_len: usize,
+    hist_len: usize,
+    channels: usize,
+    kernel_size: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    let padded_at = |idx: usize, c: usize| -> f32 {
+        if idx < hist_len {
+            history[idx * channels + c]
+        } else {
+            x[(idx - hist_len) * channels + c]
+        }
+    };
+    let mut out = vec![0f32; seq_len * channels];
+    for t in 0..seq_len {
+        for c in 0..channels {
+            let mut acc = 0f32;
+            for k in 0..kernel_size {
+                acc += padded_at(t + k, c) * weight[c * kernel_size + k];
+            }
+            out[t * channels + c] = acc / (1.0 + (-acc).exp()); // silu(x) = x * sigmoid(x)
+        }
+    }
+    let mut new_state = vec![0f32; hist_len * channels];
+    for s in 0..hist_len {
+        for c in 0..channels {
+            new_state[s * channels + c] = padded_at(seq_len + s, c);
+        }
+    }
+    (out, new_state)
+}
+
+/// Runs both real kernels on random inputs at the given shape and compares
+/// against the scalar reference above, per batch row. `channels`
+/// deliberately not always a multiple of the threadgroup width
+/// (min(channels, 64)) to exercise the kernels' own bounds checks.
+fn run_gdn_causal_conv1d_and_check(
+    b: usize,
+    seq_len: usize,
+    hist_len: usize,
+    channels: usize,
+    kernel_size: usize,
+) {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+    let x = randf(&mut rng, b * seq_len * channels, 1.0);
+    let history = randf(&mut rng, b * hist_len * channels, 1.0);
+    let weight = randf(&mut rng, channels * kernel_size, 0.5);
+
+    let x_buf = new_buffer(&device, &x);
+    // `new_buffer_with_data` can't allocate a genuinely zero-size buffer
+    // (hist_len == 0 is a real, tested case below) -- pad with one unread
+    // dummy element; the kernel's own `idx < hist_len` check never reads
+    // `history` at all when `hist_len == 0`, so its content is irrelevant.
+    let history_buf = new_buffer(
+        &device,
+        if history.is_empty() {
+            &[0f32]
+        } else {
+            &history
+        },
+    );
+    let weight_buf = new_buffer(&device, &weight);
+    let out_buf = device
+        .new_buffer(
+            b * seq_len * channels * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
+        .unwrap();
+    let new_state_buf = device
+        .new_buffer(
+            (b * hist_len * channels).max(1) * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
+        .unwrap();
+
+    call_gdn_causal_conv1d_output_f32(
+        &device,
+        &encoder,
+        &kernels,
+        b,
+        seq_len,
+        hist_len,
+        channels,
+        kernel_size,
+        &BufferOffset::zero_offset(&x_buf),
+        &BufferOffset::zero_offset(&history_buf),
+        &BufferOffset::zero_offset(&weight_buf),
+        &out_buf,
+    )
+    .unwrap();
+    if hist_len > 0 {
+        call_gdn_causal_conv1d_state_f32(
+            &device,
+            &encoder,
+            &kernels,
+            b,
+            seq_len,
+            hist_len,
+            channels,
+            &BufferOffset::zero_offset(&x_buf),
+            &BufferOffset::zero_offset(&history_buf),
+            &new_state_buf,
+        )
+        .unwrap();
+    }
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got_out: Vec<f32> = read_to_vec(&out_buf, b * seq_len * channels);
+    let got_state: Vec<f32> = if hist_len > 0 {
+        read_to_vec(&new_state_buf, b * hist_len * channels)
+    } else {
+        vec![]
+    };
+
+    let mut max_out_diff = 0f32;
+    let mut max_state_diff = 0f32;
+    for row in 0..b {
+        let (expected_out, expected_state) = gdn_causal_conv1d_reference(
+            &x[row * seq_len * channels..(row + 1) * seq_len * channels],
+            &history[row * hist_len * channels..(row + 1) * hist_len * channels],
+            &weight,
+            seq_len,
+            hist_len,
+            channels,
+            kernel_size,
+        );
+        for i in 0..seq_len * channels {
+            max_out_diff =
+                max_out_diff.max((got_out[row * seq_len * channels + i] - expected_out[i]).abs());
+        }
+        for i in 0..hist_len * channels {
+            max_state_diff = max_state_diff
+                .max((got_state[row * hist_len * channels + i] - expected_state[i]).abs());
+        }
+    }
+    println!(
+        "gdn_causal_conv1d b={b} seq_len={seq_len} hist_len={hist_len} channels={channels} \
+         kernel_size={kernel_size}: out_diff={max_out_diff:.8} state_diff={max_state_diff:.8}"
+    );
+    assert!(
+        max_out_diff < 5e-5,
+        "b={b} seq_len={seq_len} hist_len={hist_len}: output mismatch, max diff = {max_out_diff}"
+    );
+    assert!(
+        max_state_diff < 5e-5,
+        "b={b} seq_len={seq_len} hist_len={hist_len}: state mismatch, max diff = {max_state_diff}"
+    );
+}
+
+#[test]
+fn kernel_gdn_causal_conv1d_matches_scalar_reference_every_short_length() {
+    // Covers the whole native-MTP verify-window range (1-8) at a realistic
+    // kernel_size=4 (hist_len=3) -- including the seq_len < hist_len case
+    // (seq_len 1, 2), which is the COMMON case at real decode/short-verify
+    // shapes, not a rare edge case (found during design: hist_len=3 means
+    // seq_len=1 and seq_len=2 both hit the "mixed history+input" branch of
+    // the new-state computation).
+    for seq_len in 1..=8 {
+        run_gdn_causal_conv1d_and_check(2, seq_len, 3, 6, 4);
+    }
+}
+
+#[test]
+fn kernel_gdn_causal_conv1d_matches_scalar_reference_production_shape() {
+    // b=1, channels=1536 (confirmed against the cached qwen36-35b-a3b
+    // GGUF's real mixed-qkv width: group_count*state_size*2 + inner_size),
+    // kernel_size=4 (hist_len=3), at both a decode (seq_len=1) and a
+    // verify-window (seq_len=2) shape.
+    run_gdn_causal_conv1d_and_check(1, 1, 3, 1536, 4);
+    run_gdn_causal_conv1d_and_check(1, 2, 3, 1536, 4);
+}
+
+#[test]
+fn kernel_gdn_causal_conv1d_handles_zero_history_length() {
+    // kernel_size=1 (hist_len=0) is a degenerate but real edge case: no
+    // causal history needed at all, output kernel must never read `history`
+    // out of bounds, and the state kernel must be skippable (a zero-size
+    // grid dimension) without dispatching at all.
+    run_gdn_causal_conv1d_and_check(1, 3, 0, 8, 1);
+}
+
+// Regression-shaped test for the same offset bug class the decode-step
+// kernel found live (kernel_gdn_decode_step_respects_nonzero_buffer_offsets
+// above): packs x/history/weight back-to-back into ONE buffer with a decoy
+// region ahead of each, at real production-realistic offsets, so a wrong or
+// ignored offset reads cross-contaminated data and fails hard.
+#[test]
+fn kernel_gdn_causal_conv1d_respects_nonzero_buffer_offsets() {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+
+    let (b, seq_len, hist_len, channels, kernel_size) = (1usize, 2usize, 3usize, 8usize, 4usize);
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+
+    let x = randf(&mut rng, b * seq_len * channels, 1.0);
+    let history = randf(&mut rng, b * hist_len * channels, 1.0);
+    let weight = randf(&mut rng, channels * kernel_size, 0.5);
+    let decoy = randf(&mut rng, b * seq_len * channels, 999.0);
+
+    let f32_size = std::mem::size_of::<f32>();
+    let packed: Vec<f32> = [&decoy[..], &x[..], &history[..], &weight[..]].concat();
+    let packed_buf = new_buffer(&device, &packed);
+
+    let mut offset_elems = decoy.len();
+    let x_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += x.len();
+    let history_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += history.len();
+    let weight_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+
+    let out_buf = device
+        .new_buffer(b * seq_len * channels * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+    let new_state_buf = device
+        .new_buffer(b * hist_len * channels * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+
+    call_gdn_causal_conv1d_output_f32(
+        &device,
+        &encoder,
+        &kernels,
+        b,
+        seq_len,
+        hist_len,
+        channels,
+        kernel_size,
+        &x_off,
+        &history_off,
+        &weight_off,
+        &out_buf,
+    )
+    .unwrap();
+    call_gdn_causal_conv1d_state_f32(
+        &device,
+        &encoder,
+        &kernels,
+        b,
+        seq_len,
+        hist_len,
+        channels,
+        &x_off,
+        &history_off,
+        &new_state_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got_out: Vec<f32> = read_to_vec(&out_buf, b * seq_len * channels);
+    let got_state: Vec<f32> = read_to_vec(&new_state_buf, b * hist_len * channels);
+    let (expected_out, expected_state) = gdn_causal_conv1d_reference(
+        &x,
+        &history,
+        &weight,
+        seq_len,
+        hist_len,
+        channels,
+        kernel_size,
+    );
+
+    let mut max_out_diff = 0f32;
+    let mut max_state_diff = 0f32;
+    for i in 0..seq_len * channels {
+        max_out_diff = max_out_diff.max((got_out[i] - expected_out[i]).abs());
+    }
+    for i in 0..hist_len * channels {
+        max_state_diff = max_state_diff.max((got_state[i] - expected_state[i]).abs());
+    }
+    println!("gdn_causal_conv1d_nonzero_offsets: out_diff={max_out_diff:.8} state_diff={max_state_diff:.8}");
+    assert!(
+        max_out_diff < 5e-5,
+        "nonzero-offset output mismatch, max diff = {max_out_diff}"
+    );
+    assert!(
+        max_state_diff < 5e-5,
+        "nonzero-offset state mismatch, max diff = {max_state_diff}"
+    );
+}
+
+// Fused elementwise gating-tail kernels: same de-risk-spike-before-wiring
+// precedent as the kernels above.
+#[test]
+fn kernel_gdn_preprocessing_gating_pipelines_load() {
+    let device = device();
+    let kernels = Kernels::new();
+    for name in [
+        "kernel_gdn_l2_normalize_scale_f32",
+        "kernel_gdn_decay_beta_gate_f32",
+    ] {
+        kernels
+            .load_pipeline(&device, Source::Gdn, name)
+            .unwrap_or_else(|e| panic!("{name} should load as a Metal compute pipeline: {e}"));
+    }
+}
+
+/// Scalar Rust reference for `kernel_gdn_l2_normalize_scale_f32`, matching
+/// `SSMWeights::l2_normalize` exactly (eps added to the sum of squares).
+fn gdn_l2_normalize_scale_reference(
+    x: &[f32],
+    b: usize,
+    seq_len: usize,
+    heads: usize,
+    dim: usize,
+    scale: f32,
+    eps: f32,
+) -> Vec<f32> {
+    let mut out = vec![0f32; b * seq_len * heads * dim];
+    for row in 0..b * seq_len * heads {
+        let xr = &x[row * dim..(row + 1) * dim];
+        let sum_sq: f32 = xr.iter().map(|v| v * v).sum();
+        let inv_norm = scale / (sum_sq + eps).sqrt();
+        for d in 0..dim {
+            out[row * dim + d] = xr[d] * inv_norm;
+        }
+    }
+    out
+}
+
+#[test]
+fn kernel_gdn_l2_normalize_scale_matches_scalar_reference() {
+    let device = device();
+    let kernels = Kernels::new();
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+
+    // (b, seq_len, heads, dim, scale) -- heads=5 (not a multiple of the
+    // threadgroup width min(heads,64)) at one shape to exercise the bounds
+    // check; dim=128 matches the real production state_size.
+    for (b, seq_len, heads, dim, scale) in [
+        (1usize, 1usize, 32usize, 128usize, 1f32 / (128f32).sqrt()),
+        (2usize, 8usize, 5usize, 128usize, 1.0f32),
+        (1usize, 2usize, 32usize, 128usize, 1.0f32),
+    ] {
+        let eps = 1e-6f32;
+        let x = randf(&mut rng, b * seq_len * heads * dim, 1.0);
+        let x_buf = new_buffer(&device, &x);
+        let out_buf = device
+            .new_buffer(
+                b * seq_len * heads * dim * std::mem::size_of::<f32>(),
+                RESOURCE_OPTIONS,
+            )
+            .unwrap();
+
+        let commands = commands(&device);
+        let encoder = commands.command_encoder().unwrap();
+        call_gdn_l2_normalize_scale_f32(
+            &device,
+            &encoder,
+            &kernels,
+            b,
+            seq_len,
+            heads,
+            dim,
+            scale,
+            eps,
+            &BufferOffset::zero_offset(&x_buf),
+            &out_buf,
+        )
+        .unwrap();
+        drop(encoder);
+        commands.wait_until_completed().unwrap();
+
+        let got: Vec<f32> = read_to_vec(&out_buf, b * seq_len * heads * dim);
+        let expected = gdn_l2_normalize_scale_reference(&x, b, seq_len, heads, dim, scale, eps);
+        let max_diff = got
+            .iter()
+            .zip(expected.iter())
+            .fold(0f32, |m, (a, e)| m.max((a - e).abs()));
+        println!("gdn_l2_normalize_scale b={b} seq_len={seq_len} heads={heads} dim={dim} scale={scale}: diff={max_diff:.8}");
+        assert!(
+            max_diff < 5e-5,
+            "b={b} seq_len={seq_len} heads={heads}: mismatch, max diff = {max_diff}"
+        );
+    }
+}
+
+/// Scalar Rust reference for `kernel_gdn_decay_beta_gate_f32`, matching
+/// `SSMWeights::forward`'s own `g`/`beta` computation exactly.
+fn gdn_decay_beta_gate_reference(
+    alpha_logits: &[f32],
+    dt_bias: &[f32],
+    ssm_a: &[f32],
+    beta_logits: &[f32],
+    b: usize,
+    seq_len: usize,
+    heads: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    let mut g = vec![0f32; b * seq_len * heads];
+    let mut beta = vec![0f32; b * seq_len * heads];
+    for row in 0..b * seq_len {
+        for h in 0..heads {
+            let idx = row * heads + h;
+            // Naive log(exp(x)+1), deliberately not the more numerically
+            // stable ln_1p(exp(x)) -- matches this kernel's own (and the
+            // original candle code's own) naive formula exactly, so this
+            // reference isn't "more correct" in a way that could show a
+            // spurious diff from different rounding at the same inputs.
+            let softplus = ((alpha_logits[idx] + dt_bias[h]).exp() + 1.0).ln();
+            g[idx] = ssm_a[h] * softplus;
+            beta[idx] = 1.0 / (1.0 + (-beta_logits[idx]).exp());
+        }
+    }
+    (g, beta)
+}
+
+#[test]
+fn kernel_gdn_decay_beta_gate_matches_scalar_reference() {
+    let device = device();
+    let kernels = Kernels::new();
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+
+    for (b, seq_len, heads) in [
+        (1usize, 1usize, 32usize),
+        (2usize, 8usize, 5usize),
+        (1usize, 2usize, 32usize),
+    ] {
+        let alpha_logits = randf(&mut rng, b * seq_len * heads, 2.0);
+        let dt_bias = randf(&mut rng, heads, 1.0);
+        let ssm_a = randf(&mut rng, heads, 1.0);
+        let beta_logits = randf(&mut rng, b * seq_len * heads, 2.0);
+
+        let alpha_buf = new_buffer(&device, &alpha_logits);
+        let dt_bias_buf = new_buffer(&device, &dt_bias);
+        let ssm_a_buf = new_buffer(&device, &ssm_a);
+        let beta_logits_buf = new_buffer(&device, &beta_logits);
+        let g_out_buf = device
+            .new_buffer(
+                b * seq_len * heads * std::mem::size_of::<f32>(),
+                RESOURCE_OPTIONS,
+            )
+            .unwrap();
+        let beta_out_buf = device
+            .new_buffer(
+                b * seq_len * heads * std::mem::size_of::<f32>(),
+                RESOURCE_OPTIONS,
+            )
+            .unwrap();
+
+        let commands = commands(&device);
+        let encoder = commands.command_encoder().unwrap();
+        call_gdn_decay_beta_gate_f32(
+            &device,
+            &encoder,
+            &kernels,
+            b,
+            seq_len,
+            heads,
+            &BufferOffset::zero_offset(&alpha_buf),
+            &BufferOffset::zero_offset(&dt_bias_buf),
+            &BufferOffset::zero_offset(&ssm_a_buf),
+            &BufferOffset::zero_offset(&beta_logits_buf),
+            &g_out_buf,
+            &beta_out_buf,
+        )
+        .unwrap();
+        drop(encoder);
+        commands.wait_until_completed().unwrap();
+
+        let got_g: Vec<f32> = read_to_vec(&g_out_buf, b * seq_len * heads);
+        let got_beta: Vec<f32> = read_to_vec(&beta_out_buf, b * seq_len * heads);
+        let (expected_g, expected_beta) = gdn_decay_beta_gate_reference(
+            &alpha_logits,
+            &dt_bias,
+            &ssm_a,
+            &beta_logits,
+            b,
+            seq_len,
+            heads,
+        );
+
+        let g_diff = got_g
+            .iter()
+            .zip(expected_g.iter())
+            .fold(0f32, |m, (a, e)| m.max((a - e).abs()));
+        let beta_diff = got_beta
+            .iter()
+            .zip(expected_beta.iter())
+            .fold(0f32, |m, (a, e)| m.max((a - e).abs()));
+        println!("gdn_decay_beta_gate b={b} seq_len={seq_len} heads={heads}: g_diff={g_diff:.8} beta_diff={beta_diff:.8}");
+        assert!(
+            g_diff < 5e-5,
+            "b={b} seq_len={seq_len} heads={heads}: g mismatch, max diff = {g_diff}"
+        );
+        assert!(
+            beta_diff < 5e-5,
+            "b={b} seq_len={seq_len} heads={heads}: beta mismatch, max diff = {beta_diff}"
+        );
+    }
+}
+
+// Regression-shaped test for the same offset bug class the earlier fused
+// kernels found live: packs alpha_logits/dt_bias/ssm_a/beta_logits into
+// ONE buffer with a decoy region ahead of each, at real nonzero offsets.
+#[test]
+fn kernel_gdn_decay_beta_gate_respects_nonzero_buffer_offsets() {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+
+    let (b, seq_len, heads) = (1usize, 2usize, 8usize);
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+
+    let alpha_logits = randf(&mut rng, b * seq_len * heads, 2.0);
+    let dt_bias = randf(&mut rng, heads, 1.0);
+    let ssm_a = randf(&mut rng, heads, 1.0);
+    let beta_logits = randf(&mut rng, b * seq_len * heads, 2.0);
+    let decoy = randf(&mut rng, b * seq_len * heads, 999.0);
+
+    let f32_size = std::mem::size_of::<f32>();
+    let packed: Vec<f32> = [
+        &decoy[..],
+        &alpha_logits[..],
+        &dt_bias[..],
+        &ssm_a[..],
+        &beta_logits[..],
+    ]
+    .concat();
+    let packed_buf = new_buffer(&device, &packed);
+
+    let mut offset_elems = decoy.len();
+    let alpha_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += alpha_logits.len();
+    let dt_bias_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += dt_bias.len();
+    let ssm_a_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += ssm_a.len();
+    let beta_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+
+    let g_out_buf = device
+        .new_buffer(b * seq_len * heads * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+    let beta_out_buf = device
+        .new_buffer(b * seq_len * heads * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+
+    call_gdn_decay_beta_gate_f32(
+        &device,
+        &encoder,
+        &kernels,
+        b,
+        seq_len,
+        heads,
+        &alpha_off,
+        &dt_bias_off,
+        &ssm_a_off,
+        &beta_off,
+        &g_out_buf,
+        &beta_out_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got_g: Vec<f32> = read_to_vec(&g_out_buf, b * seq_len * heads);
+    let got_beta: Vec<f32> = read_to_vec(&beta_out_buf, b * seq_len * heads);
+    let (expected_g, expected_beta) = gdn_decay_beta_gate_reference(
+        &alpha_logits,
+        &dt_bias,
+        &ssm_a,
+        &beta_logits,
+        b,
+        seq_len,
+        heads,
+    );
+
+    let g_diff = got_g
+        .iter()
+        .zip(expected_g.iter())
+        .fold(0f32, |m, (a, e)| m.max((a - e).abs()));
+    let beta_diff = got_beta
+        .iter()
+        .zip(expected_beta.iter())
+        .fold(0f32, |m, (a, e)| m.max((a - e).abs()));
+    println!("gdn_decay_beta_gate_nonzero_offsets: g_diff={g_diff:.8} beta_diff={beta_diff:.8}");
+    assert!(
+        g_diff < 5e-5,
+        "nonzero-offset g mismatch, max diff = {g_diff}"
+    );
+    assert!(
+        beta_diff < 5e-5,
+        "nonzero-offset beta mismatch, max diff = {beta_diff}"
+    );
+}

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -2491,3 +2491,331 @@ fn residency_set_batch_insert_remove() {
     set.remove_batch(std::iter::empty());
     assert_eq!(raw.allocationCount(), base);
 }
+
+// Fused gated-DeltaNet decode step: confirms the kernel compiles and
+// loads as a real Metal pipeline before any numeric-correctness work is
+// asked to rely on it -- same de-risk-spike-before-wiring precedent as
+// kernel_mul_mv_id_pipelines_load.
+#[test]
+fn kernel_gdn_decode_step_pipeline_loads() {
+    let device = device();
+    let kernels = Kernels::new();
+    kernels
+        .load_pipeline(&device, Source::Gdn, "kernel_gdn_decode_step_f32")
+        .unwrap_or_else(|e| {
+            panic!("kernel_gdn_decode_step_f32 should load as a Metal compute pipeline: {e}")
+        });
+}
+
+// Scalar Rust reference for the fused kernel's math (see gdn.metal's own
+// doc comment for the derivation):
+//   s_dec[i][j] = g * s_in[i][j]
+//   kv_mem[j]   = sum_i s_dec[i][j] * k[i]
+//   delta[j]    = (v[j] - kv_mem[j]) * beta
+//   s_out[i][j] = s_dec[i][j] + k[i] * delta[j]
+//   out[j]      = sum_i s_out[i][j] * q[i]
+// Per (batch, head) -- q/k: [hk], v: [hv], g/beta: scalar, state: [hk, hv].
+#[allow(clippy::too_many_arguments)]
+fn gdn_decode_step_reference(
+    q: &[f32],
+    k: &[f32],
+    v: &[f32],
+    g: f32,
+    beta: f32,
+    state_in: &[f32],
+    hk: usize,
+    hv: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    let mut state_out = vec![0f32; hk * hv];
+    let mut out = vec![0f32; hv];
+    for j in 0..hv {
+        let mut kv_mem = 0f32;
+        for i in 0..hk {
+            kv_mem += (g * state_in[i * hv + j]) * k[i];
+        }
+        let delta = (v[j] - kv_mem) * beta;
+        let mut acc = 0f32;
+        for i in 0..hk {
+            let s_new = g * state_in[i * hv + j] + k[i] * delta;
+            state_out[i * hv + j] = s_new;
+            acc += s_new * q[i];
+        }
+        out[j] = acc;
+    }
+    (out, state_out)
+}
+
+// Runs the real kernel on random inputs at the given shape and compares
+// against the scalar reference above, per (batch, head). `hv` deliberately
+// not always a multiple of the threadgroup width (min(hv, 64) in
+// call_gdn_decode_step_f32) to exercise the kernel's own `j >= args.hv`
+// bounds check, not just the common case.
+fn run_gdn_decode_step_and_check(b: usize, h: usize, hk: usize, hv: usize) {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+    let q = randf(&mut rng, b * h * hk, 0.2);
+    let k = randf(&mut rng, b * h * hk, 0.2);
+    let v = randf(&mut rng, b * h * hv, 2.0);
+    // g in (0,1) (post-exp decay gate, matching sequential_step's own
+    // convention -- the kernel takes g already exp'd, not log_g); beta in
+    // (0,1) too. Include the large_decay-style strong-decay regime
+    // (g close to 0) at least once via the caller's own shape choices --
+    // this helper takes whatever the caller passes.
+    let g_vals: Vec<f32> = (0..b * h)
+        .map(|_| rng.random::<f32>() * 0.9 + 0.05)
+        .collect();
+    let beta_vals: Vec<f32> = (0..b * h)
+        .map(|_| rng.random::<f32>() * 0.9 + 0.05)
+        .collect();
+    let state_in = randf(&mut rng, b * h * hk * hv, 1.0);
+
+    let q_buf = new_buffer(&device, &q);
+    let k_buf = new_buffer(&device, &k);
+    let v_buf = new_buffer(&device, &v);
+    let g_buf = new_buffer(&device, &g_vals);
+    let beta_buf = new_buffer(&device, &beta_vals);
+    let state_in_buf = new_buffer(&device, &state_in);
+    let state_out_buf = device
+        .new_buffer(
+            b * h * hk * hv * std::mem::size_of::<f32>(),
+            RESOURCE_OPTIONS,
+        )
+        .unwrap();
+    let out_buf = device
+        .new_buffer(b * h * hv * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .unwrap();
+
+    call_gdn_decode_step_f32(
+        &device,
+        &encoder,
+        &kernels,
+        b,
+        h,
+        hk,
+        hv,
+        &BufferOffset::zero_offset(&q_buf),
+        &BufferOffset::zero_offset(&k_buf),
+        &BufferOffset::zero_offset(&v_buf),
+        &BufferOffset::zero_offset(&g_buf),
+        &BufferOffset::zero_offset(&beta_buf),
+        &BufferOffset::zero_offset(&state_in_buf),
+        &state_out_buf,
+        &out_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got_out: Vec<f32> = read_to_vec(&out_buf, b * h * hv);
+    let got_state: Vec<f32> = read_to_vec(&state_out_buf, b * h * hk * hv);
+
+    let mut max_out_diff = 0f32;
+    let mut max_state_diff = 0f32;
+    for bh in 0..b * h {
+        let (expected_out, expected_state) = gdn_decode_step_reference(
+            &q[bh * hk..(bh + 1) * hk],
+            &k[bh * hk..(bh + 1) * hk],
+            &v[bh * hv..(bh + 1) * hv],
+            g_vals[bh],
+            beta_vals[bh],
+            &state_in[bh * hk * hv..(bh + 1) * hk * hv],
+            hk,
+            hv,
+        );
+        for j in 0..hv {
+            let diff = (got_out[bh * hv + j] - expected_out[j]).abs();
+            max_out_diff = max_out_diff.max(diff);
+        }
+        for e in 0..hk * hv {
+            let diff = (got_state[bh * hk * hv + e] - expected_state[e]).abs();
+            max_state_diff = max_state_diff.max(diff);
+        }
+    }
+    println!(
+        "gdn_decode_step b={b} h={h} hk={hk} hv={hv}: out_diff={max_out_diff:.8} state_diff={max_state_diff:.8}"
+    );
+    assert!(
+        max_out_diff < 5e-5,
+        "b={b} h={h} hk={hk} hv={hv}: output mismatch, max diff = {max_out_diff}"
+    );
+    assert!(
+        max_state_diff < 5e-5,
+        "b={b} h={h} hk={hk} hv={hv}: state mismatch, max diff = {max_state_diff}"
+    );
+}
+
+#[test]
+fn kernel_gdn_decode_step_matches_scalar_reference_tiny() {
+    // Small, odd shapes -- hv=5 is not a multiple of min(hv,64)'s
+    // threadgroup width, exercising the bounds check on every thread group
+    // boundary, not just the last one.
+    run_gdn_decode_step_and_check(1, 2, 4, 4);
+    run_gdn_decode_step_and_check(1, 3, 7, 5);
+    run_gdn_decode_step_and_check(2, 2, 6, 6);
+}
+
+#[test]
+fn kernel_gdn_decode_step_matches_scalar_reference_production_shape() {
+    // b=1, h=32, hk=128, hv=128 -- a real production shape from a
+    // Qwen3.5-family hybrid gated-DeltaNet model.
+    run_gdn_decode_step_and_check(1, 32, 128, 128);
+}
+
+// Regression test for a real bug found while integrating this kernel: a
+// caller's `v` was a `narrow()`'d slice of a shared QKV-split buffer with
+// a genuine nonzero byte offset, which an earlier version of
+// call_gdn_decode_step_f32 (bare &Buffer params, no offset) silently
+// ignored -- reading the wrong region of the buffer. This test reproduces
+// that shape directly: q/k/v/g/beta/state_in are all slices into ONE
+// larger packed buffer at different offsets (not six independent
+// zero-offset allocations, which is what every other test here uses and
+// exactly why this bug slipped past them), so a wrong or ignored offset
+// reads cross-contaminated data and fails the numeric check hard, not
+// subtly.
+#[test]
+fn kernel_gdn_decode_step_respects_nonzero_buffer_offsets() {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+
+    let (b, h, hk, hv) = (1usize, 4usize, 8usize, 8usize);
+    let mut rng = rng();
+    fn randf(rng: &mut impl Rng, n: usize, scale: f32) -> Vec<f32> {
+        (0..n)
+            .map(|_| (rng.random::<f32>() - 0.5) * scale)
+            .collect()
+    }
+
+    // Pack q, k, v, g, beta, state_in back-to-back into one buffer, each
+    // preceded by a "decoy" region of the *next* tensor's own values --
+    // i.e. deliberately construct it so that reading from byte offset 0
+    // instead of the real offset would read a DIFFERENT tensor's data,
+    // not just garbage. Layout: [decoy_q_sized][q][k][v][g][beta][state_in].
+    let q = randf(&mut rng, b * h * hk, 0.2);
+    let k = randf(&mut rng, b * h * hk, 0.2);
+    let v = randf(&mut rng, b * h * hv, 2.0);
+    let g_vals: Vec<f32> = (0..b * h)
+        .map(|_| rng.random::<f32>() * 0.9 + 0.05)
+        .collect();
+    let beta_vals: Vec<f32> = (0..b * h)
+        .map(|_| rng.random::<f32>() * 0.9 + 0.05)
+        .collect();
+    let state_in = randf(&mut rng, b * h * hk * hv, 1.0);
+    let decoy = randf(&mut rng, b * h * hk, 999.0); // same size as q, deliberately huge-magnitude so a wrong-offset read is obviously wrong
+
+    let f32_size = std::mem::size_of::<f32>();
+    let packed: Vec<f32> = [
+        &decoy[..],
+        &q[..],
+        &k[..],
+        &v[..],
+        &g_vals[..],
+        &beta_vals[..],
+        &state_in[..],
+    ]
+    .concat();
+    let packed_buf = new_buffer(&device, &packed);
+
+    let mut offset_elems = decoy.len();
+    let q_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += q.len();
+    let k_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += k.len();
+    let v_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += v.len();
+    let g_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += g_vals.len();
+    let beta_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+    offset_elems += beta_vals.len();
+    let state_in_off = BufferOffset {
+        buffer: &packed_buf,
+        offset_in_bytes: offset_elems * f32_size,
+    };
+
+    let state_out_buf = device
+        .new_buffer(b * h * hk * hv * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+    let out_buf = device
+        .new_buffer(b * h * hv * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+
+    call_gdn_decode_step_f32(
+        &device,
+        &encoder,
+        &kernels,
+        b,
+        h,
+        hk,
+        hv,
+        &q_off,
+        &k_off,
+        &v_off,
+        &g_off,
+        &beta_off,
+        &state_in_off,
+        &state_out_buf,
+        &out_buf,
+    )
+    .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got_out: Vec<f32> = read_to_vec(&out_buf, b * h * hv);
+    let got_state: Vec<f32> = read_to_vec(&state_out_buf, b * h * hk * hv);
+
+    let mut max_out_diff = 0f32;
+    let mut max_state_diff = 0f32;
+    for bh in 0..b * h {
+        let (expected_out, expected_state) = gdn_decode_step_reference(
+            &q[bh * hk..(bh + 1) * hk],
+            &k[bh * hk..(bh + 1) * hk],
+            &v[bh * hv..(bh + 1) * hv],
+            g_vals[bh],
+            beta_vals[bh],
+            &state_in[bh * hk * hv..(bh + 1) * hk * hv],
+            hk,
+            hv,
+        );
+        for j in 0..hv {
+            max_out_diff = max_out_diff.max((got_out[bh * hv + j] - expected_out[j]).abs());
+        }
+        for e in 0..hk * hv {
+            max_state_diff =
+                max_state_diff.max((got_state[bh * hk * hv + e] - expected_state[e]).abs());
+        }
+    }
+    println!("gdn_decode_step_nonzero_offsets: out_diff={max_out_diff:.8} state_diff={max_state_diff:.8}");
+    assert!(
+        max_out_diff < 5e-5,
+        "nonzero-offset output mismatch, max diff = {max_out_diff}"
+    );
+    assert!(
+        max_state_diff < 5e-5,
+        "nonzero-offset state mismatch, max diff = {max_state_diff}"
+    );
+}

--- a/candle-metal-kernels/src/tests.rs
+++ b/candle-metal-kernels/src/tests.rs
@@ -3488,3 +3488,198 @@ fn kernel_gdn_decay_beta_gate_respects_nonzero_buffer_offsets() {
         "nonzero-offset beta mismatch, max diff = {beta_diff}"
     );
 }
+
+// Column-parallel chunked-scan forward-substitution solve (Phase 3.1a,
+// yggdrasil/ratatoskr/DESIGN.md's "Phase 3 design, revised 2026-08-17"
+// section): same de-risk-spike-before-wiring precedent as
+// kernel_mul_mv_id_pipelines_load / kernel_gdn_decode_step_pipeline_loads.
+#[test]
+fn kernel_gdn_chunked_scan_solve_pipeline_loads() {
+    let device = device();
+    let kernels = Kernels::new();
+    kernels
+        .load_pipeline(&device, Source::Gdn, "kernel_gdn_chunked_scan_solve_f32")
+        .unwrap_or_else(|e| panic!("kernel_gdn_chunked_scan_solve_f32 should load as a Metal compute pipeline: {e}"));
+}
+
+// Scalar Rust reference: row-by-row forward substitution, matching
+// ratatoskr::qwen3_5_linear_attn_scan::gated_delta_rule_chunked's own
+// tensor-path loop line-by-line (`attn[i,:] = e_i + sum_{k<i} a_mat[i,k] *
+// attn[k,:]`) -- deliberately the row-serial form, not the kernel's own
+// column-parallel one, so this reference doesn't just re-derive the same
+// algorithm the kernel uses and risk sharing a bug with it.
+fn gdn_scan_solve_reference(a_mat: &[f32], chunk: usize) -> Vec<f32> {
+    let mut attn = vec![0f32; chunk * chunk];
+    // Row 0 is already e_0 (a_mat's row 0 is all zero, strictly lower triangular).
+    attn[0] = 1.0;
+    for i in 1..chunk {
+        for j in 0..chunk {
+            let mut acc = if i == j { 1.0f32 } else { 0.0f32 };
+            for k in 0..i {
+                acc += a_mat[i * chunk + k] * attn[k * chunk + j];
+            }
+            attn[i * chunk + j] = acc;
+        }
+    }
+    attn
+}
+
+// Builds a random strictly-lower-triangular a_mat (entries scaled small, matching
+// the tensor path's own real magnitude: k_beta @ k^T-derived, decay-masked,
+// bounded by L2-normalized-key inner products times beta<=1 times decay<=1).
+fn random_strict_lower_triangular(rng: &mut impl Rng, bhnc: usize, chunk: usize) -> Vec<f32> {
+    let mut a = vec![0f32; bhnc * chunk * chunk];
+    for p in 0..bhnc {
+        for i in 0..chunk {
+            for k in 0..i {
+                a[p * chunk * chunk + i * chunk + k] = (rng.random::<f32>() - 0.5) * 0.6;
+            }
+        }
+    }
+    a
+}
+
+fn run_gdn_scan_solve_and_check(bhnc: usize) {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    let mut rng = rng();
+
+    let chunk = GDN_SCAN_CHUNK;
+    let a_mat = random_strict_lower_triangular(&mut rng, bhnc, chunk);
+    let a_mat_buf = new_buffer(&device, &a_mat);
+    let attn_buf = device
+        .new_buffer(bhnc * chunk * chunk * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .unwrap();
+
+    call_gdn_chunked_scan_solve_f32(&device, &encoder, &kernels, bhnc, &BufferOffset::zero_offset(&a_mat_buf), &attn_buf)
+        .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got: Vec<f32> = read_to_vec(&attn_buf, bhnc * chunk * chunk);
+
+    let mut max_diff = 0f32;
+    let mut worst = (0usize, 0usize, 0usize);
+    for p in 0..bhnc {
+        let expected = gdn_scan_solve_reference(&a_mat[p * chunk * chunk..(p + 1) * chunk * chunk], chunk);
+        for i in 0..chunk {
+            for j in 0..chunk {
+                let d = (got[p * chunk * chunk + i * chunk + j] - expected[i * chunk + j]).abs();
+                if d > max_diff {
+                    max_diff = d;
+                    worst = (p, i, j);
+                }
+            }
+        }
+    }
+    println!("gdn_chunked_scan_solve bhnc={bhnc} chunk={chunk}: max_diff={max_diff:.8} worst(p,i,j)={worst:?}");
+    assert!(max_diff < 1e-3, "bhnc={bhnc}: solve mismatch, max diff = {max_diff}");
+}
+
+#[test]
+fn kernel_gdn_chunked_scan_solve_matches_scalar_reference_tiny() {
+    run_gdn_scan_solve_and_check(1);
+    run_gdn_scan_solve_and_check(3);
+}
+
+#[test]
+fn kernel_gdn_chunked_scan_solve_matches_scalar_reference_production_shape() {
+    // bhnc=96 (35B-A3B MoE: n_h=32, num_chunks=3) and bhnc=144 (27B dense:
+    // n_h=48, num_chunks=3) -- both real per-checkpoint shapes confirmed in
+    // ratatoskr/DESIGN.md's Phase 3.0 calibration writeup.
+    run_gdn_scan_solve_and_check(96);
+    run_gdn_scan_solve_and_check(144);
+}
+
+// Regression test for the exact bug class kernel_gdn_decode_step_respects_
+// nonzero_buffer_offsets was written for: a_mat is exactly the kind of
+// tensor (built via narrow/contiguous chains in the tensor path) that could
+// carry a real nonzero byte offset in a future caller. Packs a_mat behind a
+// large-magnitude decoy region so a wrong or ignored offset reads
+// cross-contaminated data and fails the numeric check hard, not subtly.
+#[test]
+fn kernel_gdn_chunked_scan_solve_respects_nonzero_buffer_offset() {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    let mut rng = rng();
+
+    let chunk = GDN_SCAN_CHUNK;
+    let bhnc = 2usize;
+    let a_mat = random_strict_lower_triangular(&mut rng, bhnc, chunk);
+    let decoy = (0..a_mat.len()).map(|_| (rng.random::<f32>() - 0.5) * 999.0).collect::<Vec<f32>>();
+
+    let f32_size = std::mem::size_of::<f32>();
+    let packed: Vec<f32> = [&decoy[..], &a_mat[..]].concat();
+    let packed_buf = new_buffer(&device, &packed);
+    let a_mat_off = BufferOffset { buffer: &packed_buf, offset_in_bytes: decoy.len() * f32_size };
+
+    let attn_buf = device
+        .new_buffer(bhnc * chunk * chunk * f32_size, RESOURCE_OPTIONS)
+        .unwrap();
+
+    call_gdn_chunked_scan_solve_f32(&device, &encoder, &kernels, bhnc, &a_mat_off, &attn_buf).unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got: Vec<f32> = read_to_vec(&attn_buf, bhnc * chunk * chunk);
+    let mut max_diff = 0f32;
+    for p in 0..bhnc {
+        let expected = gdn_scan_solve_reference(&a_mat[p * chunk * chunk..(p + 1) * chunk * chunk], chunk);
+        for e in 0..chunk * chunk {
+            max_diff = max_diff.max((got[p * chunk * chunk + e] - expected[e]).abs());
+        }
+    }
+    println!("gdn_chunked_scan_solve_nonzero_offset: max_diff={max_diff:.8}");
+    assert!(max_diff < 1e-3, "nonzero-offset solve mismatch, max diff = {max_diff}");
+}
+
+// Adversarial case matching the design's own correctness-risk (2): beta near
+// 1, strong (near-1-magnitude) decay entries -- the diagonal/near-diagonal
+// terms are load-bearing here, unlike the small random-scale a_mat used
+// above, which could pass this kernel even with a subtly wrong solve order
+// (the mm_id "any permutation is equivalent" trap this design explicitly
+// calls out). Uses larger-magnitude entries (up to ~0.95) than the other
+// tests' 0.6 cap.
+#[test]
+fn kernel_gdn_chunked_scan_solve_matches_scalar_reference_strong_decay() {
+    let device = device();
+    let kernels = Kernels::new();
+    let commands = commands(&device);
+    let encoder = commands.command_encoder().unwrap();
+    let mut rng = rng();
+
+    let chunk = GDN_SCAN_CHUNK;
+    let bhnc = 2usize;
+    let mut a_mat = vec![0f32; bhnc * chunk * chunk];
+    for p in 0..bhnc {
+        for i in 0..chunk {
+            for k in 0..i {
+                a_mat[p * chunk * chunk + i * chunk + k] = (rng.random::<f32>() - 0.5) * 1.9; // up to ~0.95 magnitude
+            }
+        }
+    }
+    let a_mat_buf = new_buffer(&device, &a_mat);
+    let attn_buf = device
+        .new_buffer(bhnc * chunk * chunk * std::mem::size_of::<f32>(), RESOURCE_OPTIONS)
+        .unwrap();
+
+    call_gdn_chunked_scan_solve_f32(&device, &encoder, &kernels, bhnc, &BufferOffset::zero_offset(&a_mat_buf), &attn_buf)
+        .unwrap();
+    drop(encoder);
+    commands.wait_until_completed().unwrap();
+
+    let got: Vec<f32> = read_to_vec(&attn_buf, bhnc * chunk * chunk);
+    let mut max_diff = 0f32;
+    for p in 0..bhnc {
+        let expected = gdn_scan_solve_reference(&a_mat[p * chunk * chunk..(p + 1) * chunk * chunk], chunk);
+        for e in 0..chunk * chunk {
+            max_diff = max_diff.max((got[p * chunk * chunk + e] - expected[e]).abs());
+        }
+    }
+    println!("gdn_chunked_scan_solve_strong_decay: max_diff={max_diff:.8}");
+    assert!(max_diff < 1e-2, "strong-decay solve mismatch, max diff = {max_diff}");
+}


### PR DESCRIPTION
## Summary

Gated-DeltaNet (gated linear attention) prefill, as used by Qwen3.5 / Qwen3-Next style hybrid architectures, processes long sequences via a chunked WY-representation scan: within each chunk (64 tokens), a lower-triangular linear system `(I - A)X = I` is solved to build an intra-chunk attention matrix, then applied to produce chunk outputs before the running state is carried to the next chunk. Solving that system via forward substitution costs one op dispatch per row of the triangle (63 dispatches at chunk=64) — each paying a full pipeline/bind/encode cycle for what's a small amount of real per-row compute, on top of the several device-memory-materializing ops (`decay_mask`, `k_beta @ k^T`, their masked product) that build `A` itself beforehand.

This PR adds two fused kernels, built and measured incrementally on a real production model:

- **`kernel_gdn_chunked_scan_solve_f32`** — fuses the forward-substitution solve into one dispatch: one thread per output column. The system `(I - A)X = I` decomposes by columns, so this needs zero threadgroup memory and zero barriers — no cross-thread synchronization at all, matching this file's other kernels' preferred risk profile.
- **`kernel_gdn_chunked_scan_build_and_solve_f32`** — additionally folds `A`'s own construction (the decay mask, `k_beta @ k^T`, and their masked product) into the same dispatch, reading `k_c`/`log_g_c`/`beta_c` directly instead of five separate device-memory-materializing ops beforehand. This is the first kernel in this file needing intra-threadgroup synchronization: `A` is built into a single 16KB threadgroup tile, with one `mem_threadgroup` barrier separating the build phase from the column-parallel solve phase that consumes it.

One correctness note worth flagging for reviewers: an earlier version of the solve kernel held a compile-time-sized per-thread register array (to enable full loop unrolling at the chunk size). At the production chunk size (64) this **silently miscompiled to wrong zeros** — caught by a differential test, and isolated by shrinking the constant to 4, where identical logic produced correct output. The shipped kernel avoids any per-thread array of that size entirely (same-thread device write-then-read instead); the constant's own doc comment records the real reason it exists (dispatch-grid/buffer-stride arithmetic) so a future reader doesn't reintroduce the same array under a plausible-sounding "for unrolling" rationale.

Measured end-to-end on two real cached GGUF models' prefill paths (external project, not part of this repo) after wiring both kernels in: **35B-A3B MoE 159.8 → 196.5 tok/s (+23.0%); 27B dense 58.9 → 70.7 tok/s (+20.0%)** prefill throughput, both against an on-record pre-kernel baseline, both verified via a token-identical differential against a llama.cpp-verified reference.

Note for reviewers: this branch is built on top of #3897 (still open at time of writing) since it extends the same `gdn.rs`/`gdn.metal` files that PR introduces — the diff below will include #3897's commits until that one merges.

## Test plan

- `cargo test -p candle-metal-kernels --lib gdn` — pipeline load, numeric parity against a scalar Rust reference at tiny/strong-decay shapes and a real production shape, nonzero-buffer-offset regression tests, and a standalone per-call microbench for the build-and-solve kernel (24/24 passing)
- `cargo test -p candle-metal-kernels --lib` — full crate suite, 85/85 passing
- `cargo fmt --check` and `cargo clippy --tests -- -D warnings` clean on every file this PR touches (some pre-existing clippy warnings remain elsewhere in the crate, unrelated to this change and not touched here, matching #3897's own disclosure)
- Integrated and validated end-to-end against two real cached GGUF models' prefill paths with a token-identical differential against a verified reference, and measured the real throughput win reported above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwN6xpWjh1aFcNdWmd1mAM