### PR TITLE
fix(onnx): honour allowzero in Reshape and fix -1 inference past a copied zero

### DIFF
--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -396,20 +396,37 @@ fn simple_eval_(
             "Reshape" => {
                 let input0 = get(&node.input[0])?;
                 let input1 = get(&node.input[1])?.to_vec1::<i64>()?;
-                // TODO: Check that there is at most a single -1 or 0, handle other neg values.
-                let mut other_than_minus1 = 1usize;
-                for &v in input1.iter() {
-                    if v != -1 && v != 0 {
-                        other_than_minus1 *= v as usize
-                    }
+                // A 0 in the target shape copies the corresponding input dimension, unless
+                // allowzero=1, where it means a literal zero-length dimension.
+                let allowzero = get_attr_opt::<i64>(node, "allowzero")?
+                    .copied()
+                    .unwrap_or(0)
+                    == 1;
+                if input1.iter().filter(|&&v| v == -1).count() > 1 {
+                    bail!("Reshape: at most one dimension of the target shape can be -1")
                 }
-                let input1 = input1
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, &v)| match v {
-                        -1 => Ok(input0.elem_count() / other_than_minus1),
-                        0 => input0.dim(idx),
-                        _ => Ok(v as usize),
+                // Resolve everything but -1 first: a copied 0 is part of the volume, so it
+                // has to be in the product that -1 is inferred against.
+                let mut resolved: Vec<Option<usize>> = Vec::with_capacity(input1.len());
+                for (idx, &v) in input1.iter().enumerate() {
+                    resolved.push(match v {
+                        -1 => None,
+                        0 if allowzero => Some(0),
+                        0 => Some(input0.dim(idx)?),
+                        v if v > 0 => Some(v as usize),
+                        v => bail!("Reshape: invalid dimension {v} in target shape"),
+                    });
+                }
+                let known: usize = resolved.iter().flatten().product();
+                let input1 = resolved
+                    .into_iter()
+                    .map(|d| match d {
+                        Some(d) => Ok(d),
+                        // A -1 has no unique value when the rest of the volume is zero.
+                        None if known == 0 => {
+                            bail!("Reshape: -1 cannot be inferred when another dimension is zero")
+                        }
+                        None => Ok(input0.elem_count() / known),
                     })
                     .collect::<Result<Vec<usize>>>()?;
                 let output = input0.reshape(input1)?;

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -451,6 +451,124 @@ fn test_reshape_operation() -> Result<()> {
     Ok(())
 }
 
+// Build a single-node Reshape graph, optionally with an `allowzero` attribute.
+fn reshape_graph(allowzero: Option<i64>) -> ModelProto {
+    let attribute = allowzero
+        .map(|i| AttributeProto {
+            name: "allowzero".to_string(),
+            ref_attr_name: "allowzero".to_string(),
+            i,
+            doc_string: "allowzero".to_string(),
+            r#type: 2,
+            f: 0.0,
+            s: vec![],
+            t: None,
+            g: None,
+            sparse_tensor: None,
+            tp: None,
+            floats: vec![],
+            ints: vec![],
+            strings: vec![],
+            tensors: vec![],
+            graphs: vec![],
+            sparse_tensors: vec![],
+            type_protos: vec![],
+        })
+        .into_iter()
+        .collect();
+
+    create_model_proto_with_graph(Some(GraphProto {
+        node: vec![NodeProto {
+            op_type: "Reshape".to_string(),
+            domain: "".to_string(),
+            attribute,
+            input: vec![INPUT_X.to_string(), INPUT_Y.to_string()],
+            output: vec![OUTPUT_Z.to_string()],
+            name: "".to_string(),
+            doc_string: "".to_string(),
+        }],
+        name: "".to_string(),
+        initializer: vec![],
+        input: vec![
+            ValueInfoProto {
+                name: INPUT_X.to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            },
+            ValueInfoProto {
+                name: INPUT_Y.to_string(),
+                doc_string: "".to_string(),
+                r#type: None,
+            },
+        ],
+        output: vec![ValueInfoProto {
+            name: OUTPUT_Z.to_string(),
+            doc_string: "".to_string(),
+            r#type: None,
+        }],
+        value_info: vec![],
+        doc_string: "".to_string(),
+        sparse_initializer: vec![],
+        quantization_annotation: vec![],
+    }))
+}
+
+fn run_reshape(allowzero: Option<i64>, x: Tensor, shape: Vec<i64>) -> Result<Tensor> {
+    let len = shape.len();
+    let y = Tensor::from_vec(shape, &[len], &Device::Cpu)?;
+    let mut inputs: HashMap<String, Tensor> = HashMap::new();
+    inputs.insert(INPUT_X.to_string(), x);
+    inputs.insert(INPUT_Y.to_string(), y);
+    let eval = candle_onnx::simple_eval(&reshape_graph(allowzero), inputs)?;
+    Ok(eval.get(OUTPUT_Z).expect("Output 'z' not found").clone())
+}
+
+// "Reshape" with allowzero=1: a 0 in the target shape is a literal zero-length dimension,
+// not a copy of the corresponding input dimension.
+// https://onnx.ai/onnx/operators/onnx__Reshape.html
+#[test]
+fn test_reshape_allowzero_keeps_a_literal_zero() -> Result<()> {
+    let x = Tensor::from_vec(Vec::<f32>::new(), &[3, 0], &Device::Cpu)?;
+    let z = run_reshape(Some(1), x, vec![0])?;
+    assert_eq!(z.dims(), &[0]);
+    Ok(())
+}
+
+// The default, allowzero=0: a 0 copies the input dimension, so it is part of the volume and
+// must be included in the product that -1 is inferred against. This is ONNX's own
+// `zero_and_negative_dim` test shape.
+#[test]
+fn test_reshape_infers_minus_one_past_a_copied_zero() -> Result<()> {
+    let x = Tensor::from_vec(
+        (0..24).map(|i| i as f32).collect::<Vec<_>>(),
+        &[2, 3, 4],
+        &Device::Cpu,
+    )?;
+    let z = run_reshape(None, x, vec![2, 0, 1, -1])?;
+    // The 0 copies 3, so the known product is 6 and the -1 is 24 / 6 = 4. Leaving the copied
+    // dimension out of the product would infer 12 instead.
+    assert_eq!(z.dims(), &[2, 3, 1, 4]);
+    Ok(())
+}
+
+// ONNX: "At most one dimension of the new shape can be -1." Without an explicit check the
+// inference divides by the same product twice and can silently accept an invalid shape:
+// a 1-element input with target [-1, -1] would produce [1, 1].
+#[test]
+fn test_reshape_rejects_multiple_minus_one() -> Result<()> {
+    let x = Tensor::from_vec(vec![5.0f32], &[1], &Device::Cpu)?;
+    assert!(run_reshape(None, x, vec![-1, -1]).is_err());
+    Ok(())
+}
+
+// allowzero=1 with both a 0 and a -1 is invalid: the -1 has no unique value.
+#[test]
+fn test_reshape_allowzero_rejects_zero_with_minus_one() -> Result<()> {
+    let x = Tensor::from_vec(Vec::<f32>::new(), &[3, 0], &Device::Cpu)?;
+    assert!(run_reshape(Some(1), x, vec![0, -1]).is_err());
+    Ok(())
+}
+
 // "LogSoftmax"
 #[test]
 fn test_logsoftmax_operation() -> Result<()> {


### PR DESCRIPTION
Fixes #3907.

Two problems in the `Reshape` arm of `candle-onnx/src/eval.rs`, both about a
`0` in the target shape.

`allowzero` was never read, so a `0` was always treated as "copy the
corresponding input dimension". With `allowzero=1` it should mean a literal
zero-length dimension.

Separately, the product that `-1` is inferred against skipped zeros. Under the
default `allowzero=0` a `0` copies an input dimension, so it is part of the
volume and belongs in that product; leaving it out made the inferred `-1` too
large. This one needs no attribute, and ONNX's own `zero_and_negative_dim` test
shape reaches it.

Resolving every non-`-1` dimension first fixes both, because the inference then
divides by the true product. While there I also rejected more than one `-1`,
which the previous shape of the code could silently accept.

Three regression tests using ONNX's own `Reshape` test shapes, plus one for
multiple `-1`s. All fail without the fix.

The `known == 0` guard rejects `-1` inference whenever the rest of the volume is
zero, which is broader than the spec sentence about `allowzero=1`. It also covers
a copied zero under `allowzero=0`, which onnx/onnx#6104 left unsettled. Rejecting
seemed better than dividing by zero, but I am happy to narrow it.

A case still left open: a negative other than `-1`, such as `[-2]`. ONNX specifies
inference for `-1` only; `onnx.reference` accepts any negative because it
delegates to `np.reshape`. This patch rejects them explicitly instead of casting
to `usize`, so behaviour is unchanged and only the message improves.