### PR TITLE
fix(kernels): gate __hmax_nan/__hmin_nan shim on toolkit version

### DIFF
--- a/candle-kernels/src/compatibility.cuh
+++ b/candle-kernels/src/compatibility.cuh
@@ -7,7 +7,13 @@
 
 // FIXME: the minimum compute capabilities are just guesses since the table is not specific enough
 
-#if __CUDA_ARCH__ < 800
+// CUDA >= 12.2 defines __hmax_nan/__hmin_nan for every arch (emulating on
+// pre-sm_80 via NV_IF_ELSE_TARGET). CUDA < 12.2 only declare them for
+// __CUDA_ARCH__ >= 800. Shim only when the toolkit genuinely lacks them.
+// Testing arch alone redefines them on 12.2+ (sm_75), testing the minor
+// version alone misfires on 13.0/13.1.
+#define CANDLE_CUDA_VERSION (__CUDACC_VER_MAJOR__ * 1000 + __CUDACC_VER_MINOR__ * 10)
+#if CANDLE_CUDA_VERSION < 12020 && __CUDA_ARCH__ < 800
 __device__ __forceinline__ __half __hmax_nan(__half a, __half b) {
     return __hisnan(a) ? a : (__hisnan(b) ? b : __hmax(a, b));
 }


### PR DESCRIPTION
Since #3558, building `candle-kernels` with `CUDA_COMPUTE_CAP=75` fails on every toolkit >= 12.2 (including CUDA 13). #3558's shim re-enablement was needed only below CUDA 12.2, but it shipped unconditioned on version, so it also fires on 12.2+/13.x where the header already provides the functions.

```sh
src/compatibility.cuh(11): error: function "__hmax_nan(__half, __half)" has already
been defined (previous definition in cuda_fp16.hpp)
```


CUDA >= 12.2 defines `__hmax_nan`/`__hmin_nan` for every arch, so the shim collides.
CUDA <= 12.1 only defines them for sm_80+, so the shim is still needed there (what #3558 fixed). The guard must test both toolkit and arch:

```cuh
#define CANDLE_CUDA_VERSION (__CUDACC_VER_MAJOR__ * 1000 + __CUDACC_VER_MINOR__ * 10)
#if CANDLE_CUDA_VERSION < 12020 && __CUDA_ARCH__ < 800
```

Verified against the real `cuda_fp16.hpp` of 11.8–13.0, including both sides of the boundary.
12.1.105, the final 12.1, is arch-gated, 12.2.0 is not. The shim is on exactly when the header lacks the functions.
Full sm_75 builds in `nvidia/cuda:12.9.1` and `13.0.2` devel containers fail on main and pass with this change.
sm_80+ is unaffected: __CUDA_ARCH__ < 800 is still false under both the old and new guard, and the preprocessed header is byte-identical.