### PR TITLE
Add the LFM2-MoE model (LFM2.5-8B-A1B)

### DIFF
--- a/candle-examples/examples/lfm2-moe/README.md
+++ b/candle-examples/examples/lfm2-moe/README.md
@@ -1,0 +1,33 @@
+# lfm2-moe
+
+LFM2-MoE is the Mixture-of-Experts variant of [LFM2](../lfm2) from
+[LiquidAI](https://www.liquid.ai/). It keeps the hybrid attention +
+short-convolution backbone of LFM2 and replaces the dense feed-forward of the
+later layers with a sparse MoE block (DeepSeek-V3 style sigmoid routing with a
+per-expert selection bias). Both `LFM2.5-8B-A1B` and `LFM2-8B-A1B` have 8.3B
+total parameters but only ~1.5B active per token (top-4 of 32 experts).
+
+## Running the example
+
+```bash
+$ cargo run --example lfm2-moe --release -- --prompt "The capital of France is"
+```
+
+The default model is `LFM2.5-8B-A1B`; use `--which lfm2-8b-a1b` for the older
+LFM2 checkpoint.
+
+Sample output:
+
+```
+The capital of France is Paris.
+```
+
+A chat-formatted prompt for the instruct usage looks like:
+
+```bash
+$ cargo run --example lfm2-moe --release -- \
+    --prompt "<|im_start|>user\nWhat is the capital of France?<|im_end|>\n<|im_start|>assistant\n"
+```
+
+Use `--model-id <hub-id>` to point at another LFM2-MoE checkpoint, and `--cpu`
+to force CPU execution.

--- a/candle-examples/examples/lfm2-moe/main.rs
+++ b/candle-examples/examples/lfm2-moe/main.rs
@@ -1,0 +1,359 @@
+//! LFM2-MoE (Liquid Foundation Model 2, Mixture-of-Experts) example.
+//!
+//! This example demonstrates text generation using the LFM2-MoE model from LiquidAI.
+//!
+//! ```bash
+//! cargo run --example lfm2-moe --release -- --prompt "The capital of France is"
+//! ```
+
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use anyhow::{Error as E, Result};
+use clap::Parser;
+
+use candle::{DType, Device, Tensor};
+use candle_examples::token_output_stream::TokenOutputStream;
+use candle_nn::VarBuilder;
+use candle_transformers::generation::{LogitsProcessor, Sampling};
+use candle_transformers::models::lfm2_moe::{Cache, LayerType, Lfm2Config, Lfm2MoeConfig, Model};
+use hf_hub::{api::sync::Api, Repo, RepoType};
+use tokenizers::Tokenizer;
+
+struct TextGeneration {
+    model: Model,
+    device: Device,
+    tokenizer: TokenOutputStream,
+    logits_processor: LogitsProcessor,
+    repeat_penalty: f32,
+    repeat_last_n: usize,
+    cache: Cache,
+}
+
+impl TextGeneration {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        model: Model,
+        tokenizer: Tokenizer,
+        seed: u64,
+        temp: Option<f64>,
+        top_p: Option<f64>,
+        top_k: Option<usize>,
+        repeat_penalty: f32,
+        repeat_last_n: usize,
+        device: &Device,
+        cache: Cache,
+    ) -> Self {
+        let logits_processor = {
+            let temperature = temp.unwrap_or(0.);
+            let sampling = if temperature <= 0. {
+                Sampling::ArgMax
+            } else {
+                match (top_k, top_p) {
+                    (None, None) => Sampling::All { temperature },
+                    (Some(k), None) => Sampling::TopK { k, temperature },
+                    (None, Some(p)) => Sampling::TopP { p, temperature },
+                    (Some(k), Some(p)) => Sampling::TopKThenTopP { k, p, temperature },
+                }
+            };
+            LogitsProcessor::from_sampling(seed, sampling)
+        };
+
+        Self {
+            model,
+            tokenizer: TokenOutputStream::new(tokenizer),
+            logits_processor,
+            repeat_penalty,
+            repeat_last_n,
+            device: device.clone(),
+            cache,
+        }
+    }
+
+    fn run(&mut self, prompt: &str, sample_len: usize) -> Result<()> {
+        use std::io::Write;
+        self.tokenizer.clear();
+        self.cache.clear();
+
+        let mut tokens = self
+            .tokenizer
+            .tokenizer()
+            .encode(prompt, true)
+            .map_err(E::msg)?
+            .get_ids()
+            .to_vec();
+
+        for &t in tokens.iter() {
+            if let Some(t) = self.tokenizer.next_token(t)? {
+                print!("{t}")
+            }
+        }
+        std::io::stdout().flush()?;
+
+        let mut generated_tokens = 0usize;
+        let eos_token = match self.tokenizer.get_token("<|im_end|>") {
+            Some(token) => token,
+            None => match self.tokenizer.get_token("</s>") {
+                Some(token) => token,
+                None => {
+                    println!("Warning: cannot find EOS token, using token id 7");
+                    7
+                }
+            },
+        };
+
+        let start_gen = std::time::Instant::now();
+        for index in 0..sample_len {
+            let context_size = if index > 0 { 1 } else { tokens.len() };
+            let start_pos = tokens.len().saturating_sub(context_size);
+            let ctxt = &tokens[start_pos..];
+            let input = Tensor::new(ctxt, &self.device)?.unsqueeze(0)?;
+            let logits = self.model.forward(&input, start_pos, &mut self.cache)?;
+            let logits = logits.squeeze(0)?.to_dtype(DType::F32)?;
+            let logits = if self.repeat_penalty == 1. {
+                logits
+            } else {
+                let start_at = tokens.len().saturating_sub(self.repeat_last_n);
+                candle_transformers::utils::apply_repeat_penalty(
+                    &logits,
+                    self.repeat_penalty,
+                    &tokens[start_at..],
+                )?
+            };
+
+            let next_token = self.logits_processor.sample(&logits)?;
+            tokens.push(next_token);
+            generated_tokens += 1;
+            if next_token == eos_token {
+                break;
+            }
+            if let Some(t) = self.tokenizer.next_token(next_token)? {
+                print!("{t}");
+                std::io::stdout().flush()?;
+            }
+        }
+        let dt = start_gen.elapsed();
+        if let Some(rest) = self.tokenizer.decode_rest().map_err(E::msg)? {
+            print!("{rest}");
+        }
+        std::io::stdout().flush()?;
+        println!(
+            "\n{generated_tokens} tokens generated ({:.2} token/s)",
+            generated_tokens as f64 / dt.as_secs_f64(),
+        );
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[allow(non_camel_case_types)]
+enum Which {
+    #[value(name = "lfm2-8b-a1b")]
+    Lfm2_8B_A1B,
+    #[value(name = "lfm2.5-8b-a1b")]
+    Lfm2_5_8B_A1B,
+}
+
+impl Which {
+    fn model_id(&self) -> &'static str {
+        match self {
+            Which::Lfm2_8B_A1B => "LiquidAI/LFM2-8B-A1B",
+            Which::Lfm2_5_8B_A1B => "LiquidAI/LFM2.5-8B-A1B",
+        }
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Run on CPU rather than on GPU.
+    #[arg(long)]
+    cpu: bool,
+
+    /// Enable tracing (generates a trace-timestamp.json file).
+    #[arg(long)]
+    tracing: bool,
+
+    /// Use flash attention (requires CUDA and flash-attn feature).
+    #[arg(long)]
+    use_flash_attn: bool,
+
+    /// The prompt to use for generation.
+    #[arg(long)]
+    prompt: String,
+
+    /// The temperature used to generate samples.
+    #[arg(long)]
+    temperature: Option<f64>,
+
+    /// Nucleus sampling probability cutoff.
+    #[arg(long)]
+    top_p: Option<f64>,
+
+    /// Only sample among the top K samples.
+    #[arg(long)]
+    top_k: Option<usize>,
+
+    /// The seed to use when generating random samples.
+    #[arg(long, default_value_t = 299792458)]
+    seed: u64,
+
+    /// The length of the sample to generate (in tokens).
+    #[arg(long, short = 'n', default_value_t = 10000)]
+    sample_len: usize,
+
+    /// The model variant to use.
+    #[arg(long, default_value = "lfm2.5-8b-a1b")]
+    which: Which,
+
+    /// Override the model ID from HuggingFace Hub.
+    #[arg(long)]
+    model_id: Option<String>,
+
+    /// Revision to use from HuggingFace Hub.
+    #[arg(long, default_value = "main")]
+    revision: String,
+
+    /// Path to a local tokenizer file.
+    #[arg(long)]
+    tokenizer_file: Option<String>,
+
+    /// Path to a local config file.
+    #[arg(long)]
+    config_file: Option<String>,
+
+    /// Comma-separated paths to weight files.
+    #[arg(long)]
+    weight_files: Option<String>,
+
+    /// Penalty to be applied for repeating tokens, 1. means no penalty.
+    #[arg(long, default_value_t = 1.1)]
+    repeat_penalty: f32,
+
+    /// The context size to consider for the repeat penalty.
+    #[arg(long, default_value_t = 64)]
+    repeat_last_n: usize,
+}
+
+fn main() -> Result<()> {
+    use tracing_chrome::ChromeLayerBuilder;
+    use tracing_subscriber::prelude::*;
+
+    let args = Args::parse();
+
+    let _guard = if args.tracing {
+        let (chrome_layer, guard) = ChromeLayerBuilder::new().build();
+        tracing_subscriber::registry().with(chrome_layer).init();
+        Some(guard)
+    } else {
+        None
+    };
+
+    println!(
+        "avx: {}, neon: {}, simd128: {}, f16c: {}",
+        candle::utils::with_avx(),
+        candle::utils::with_neon(),
+        candle::utils::with_simd128(),
+        candle::utils::with_f16c()
+    );
+    println!(
+        "temp: {:.2} repeat-penalty: {:.2} repeat-last-n: {}",
+        args.temperature.unwrap_or(0.),
+        args.repeat_penalty,
+        args.repeat_last_n
+    );
+
+    let start = std::time::Instant::now();
+    let api = Api::new()?;
+    let model_id = args
+        .model_id
+        .unwrap_or_else(|| args.which.model_id().to_string());
+    let repo = api.repo(Repo::with_revision(
+        model_id.clone(),
+        RepoType::Model,
+        args.revision,
+    ));
+
+    let tokenizer_filename = match args.tokenizer_file {
+        Some(file) => std::path::PathBuf::from(file),
+        None => repo.get("tokenizer.json")?,
+    };
+
+    let filenames = match args.weight_files {
+        Some(files) => files
+            .split(',')
+            .map(std::path::PathBuf::from)
+            .collect::<Vec<_>>(),
+        None => {
+            // Try sharded first, fall back to single file
+            match candle_examples::hub_load_safetensors(&repo, "model.safetensors.index.json") {
+                Ok(files) => files,
+                Err(_) => vec![repo.get("model.safetensors")?],
+            }
+        }
+    };
+
+    println!("retrieved the files in {:?}", start.elapsed());
+    let tokenizer = Tokenizer::from_file(tokenizer_filename).map_err(E::msg)?;
+
+    let start = std::time::Instant::now();
+    let config: Lfm2MoeConfig = match args.config_file {
+        Some(config_file) => serde_json::from_slice(&std::fs::read(config_file)?)?,
+        None => {
+            let config_file = repo.get("config.json")?;
+            serde_json::from_slice(&std::fs::read(config_file)?)?
+        }
+    };
+    let config = config.into_config(args.use_flash_attn);
+
+    let device = candle_examples::device(args.cpu)?;
+    let dtype = if device.is_cuda() {
+        DType::BF16
+    } else {
+        DType::F32
+    };
+
+    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&filenames, dtype, &device)? };
+    let model = Model::new(&config, vb)?;
+    // The RoPE cache is shared with the dense LFM2 model, so build it from the
+    // dense config (bridged via `From<&Config>`).
+    let cache = Cache::new(true, dtype, &Lfm2Config::from(&config), &device)?;
+
+    println!("loaded the model in {:?}", start.elapsed());
+    println!("model: {model_id}");
+    let n_attn = config
+        .layer_types
+        .iter()
+        .filter(|t| **t == LayerType::FullAttention)
+        .count();
+    let n_conv = config
+        .layer_types
+        .iter()
+        .filter(|t| **t == LayerType::Conv)
+        .count();
+    println!(
+        "layers: {} ({n_attn} attention, {n_conv} conv), {} experts (top-{}), {} dense layers",
+        config.num_hidden_layers,
+        config.num_experts,
+        config.num_experts_per_tok,
+        config.num_dense_layers,
+    );
+
+    let mut pipeline = TextGeneration::new(
+        model,
+        tokenizer,
+        args.seed,
+        args.temperature,
+        args.top_p,
+        args.top_k,
+        args.repeat_penalty,
+        args.repeat_last_n,
+        &device,
+        cache,
+    );
+    pipeline.run(&args.prompt, args.sample_len)?;
+    Ok(())
+}

--- a/candle-transformers/src/models/lfm2.rs
+++ b/candle-transformers/src/models/lfm2.rs
@@ -227,7 +227,7 @@ fn flash_attn(_: &Tensor, _: &Tensor, _: &Tensor, _: f32, _: bool) -> Result<Ten
 
 /// MLP layer with SwiGLU activation.
 #[derive(Debug, Clone)]
-struct Mlp {
+pub struct Mlp {
     gate_proj: Linear,
     up_proj: Linear,
     down_proj: Linear,
@@ -235,7 +235,7 @@ struct Mlp {
 }
 
 impl Mlp {
-    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+    pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
         let hidden_size = cfg.hidden_size;
         let intermediate_size = cfg.intermediate_size;
         // LFM2 uses w1 (gate), w3 (up), w2 (down) naming convention
@@ -250,7 +250,7 @@ impl Mlp {
         })
     }
 
-    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
         let _enter = self.span.enter();
         let gate = candle_nn::ops::silu(&self.gate_proj.forward(x)?)?;
         let up = self.up_proj.forward(x)?;
@@ -260,7 +260,7 @@ impl Mlp {
 
 /// Attention layer with per-head QK normalization and RoPE.
 #[derive(Debug, Clone)]
-struct Attention {
+pub struct Attention {
     q_proj: Linear,
     k_proj: Linear,
     v_proj: Linear,
@@ -276,7 +276,7 @@ struct Attention {
 }
 
 impl Attention {
-    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+    pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
         let hidden_size = cfg.hidden_size;
         let num_attention_heads = cfg.num_attention_heads;
         let num_key_value_heads = cfg.num_key_value_heads;
@@ -318,7 +318,7 @@ impl Attention {
         candle_nn::rotary_emb::rope(&x.contiguous()?, &cos, &sin)
     }
 
-    fn forward(
+    pub fn forward(
         &self,
         x: &Tensor,
         index_pos: usize,
@@ -407,7 +407,7 @@ impl Attention {
 
 /// Short convolution layer for efficient sequence processing.
 #[derive(Debug, Clone)]
-struct ShortConv {
+pub struct ShortConv {
     in_proj: Linear,
     out_proj: Linear,
     conv_weight: Tensor,
@@ -417,7 +417,7 @@ struct ShortConv {
 }
 
 impl ShortConv {
-    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+    pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
         let hidden_size = cfg.hidden_size;
         let l_cache = cfg.conv_l_cache;
 
@@ -438,7 +438,7 @@ impl ShortConv {
         })
     }
 
-    fn forward(&self, x: &Tensor, block_idx: usize, cache: &mut Cache) -> Result<Tensor> {
+    pub fn forward(&self, x: &Tensor, block_idx: usize, cache: &mut Cache) -> Result<Tensor> {
         let _enter = self.span.enter();
         let (b_sz, seq_len, _) = x.dims3()?;
 

--- a/candle-transformers/src/models/lfm2_moe.rs
+++ b/candle-transformers/src/models/lfm2_moe.rs
@@ -1,0 +1,646 @@
+//! LFM2-MoE (Liquid Foundation Model 2, Mixture-of-Experts) implementation.
+//!
+//! LFM2-MoE keeps the hybrid attention + short-convolution backbone of LFM2 and
+//! replaces the dense feed-forward of the later layers with a sparse
+//! Mixture-of-Experts block (DeepSeek-V3 style sigmoid routing with an expert bias).
+//!
+//! The first `num_dense_layers` layers keep a regular dense SwiGLU MLP; every
+//! subsequent layer routes each token to `num_experts_per_tok` experts out of
+//! `num_experts`.
+//!
+//! The token-mixing operators (attention, short convolution), the RoPE cache and
+//! the dense MLP are reused as-is from the [`crate::models::lfm2`] module, in the
+//! same spirit as `qwen3_moe` reusing `qwen3`.
+
+use crate::models::lfm2::{Attention, Mlp, ShortConv};
+use crate::models::with_tracing::{linear_no_bias as linear, Embedding, Linear, RmsNorm};
+use candle::{DType, IndexOp, Module, Result, Tensor, D};
+use candle_nn::VarBuilder;
+
+// Reused verbatim from the dense LFM2 model.
+pub use crate::models::lfm2::{Cache, Config as Lfm2Config, LayerType};
+
+/// Nested RoPE parameters introduced by transformers v5 configs (e.g. LFM2.5),
+/// which moved `rope_theta` from the top level into a `rope_parameters` object.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct RopeParameters {
+    pub rope_theta: f32,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct Lfm2MoeConfig {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    #[serde(default = "default_num_key_value_heads")]
+    pub num_key_value_heads: usize,
+    #[serde(default = "default_norm_eps")]
+    pub norm_eps: f64,
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f32,
+    // When present (transformers v5 configs such as LFM2.5), the nested value
+    // takes precedence over the flat `rope_theta` field.
+    #[serde(default)]
+    pub rope_parameters: Option<RopeParameters>,
+    #[serde(default = "default_max_position_embeddings")]
+    pub max_position_embeddings: usize,
+    #[serde(default = "default_conv_l_cache", alias = "conv_L_cache")]
+    pub conv_l_cache: usize,
+    #[serde(default)]
+    pub conv_bias: bool,
+    pub layer_types: Vec<LayerType>,
+    // HF uses `tie_word_embeddings` (defaults to true for LFM2-MoE); the dense
+    // model used `tie_embedding`. Accept either key and default to tied.
+    #[serde(default = "default_tie_embedding", alias = "tie_word_embeddings")]
+    pub tie_embedding: bool,
+    pub bos_token_id: Option<u32>,
+    pub eos_token_id: Option<u32>,
+    // Dense feed-forward dimension (used by the first `num_dense_layers` layers).
+    pub intermediate_size: usize,
+    // --- MoE-specific fields ---
+    // Intermediate size of each expert (smaller than the dense `intermediate_size`).
+    pub moe_intermediate_size: usize,
+    // Total number of experts in each MoE layer.
+    pub num_experts: usize,
+    // Number of experts each token is routed to (top-k).
+    pub num_experts_per_tok: usize,
+    // Number of leading dense layers before MoE layers start.
+    pub num_dense_layers: usize,
+    // Whether the router adds a per-expert bias when selecting the top-k.
+    #[serde(default = "default_use_expert_bias")]
+    pub use_expert_bias: bool,
+    // Whether to renormalize the top-k routing weights so they sum to 1.
+    #[serde(default = "default_norm_topk_prob")]
+    pub norm_topk_prob: bool,
+    // Final scaling factor applied to the routing weights.
+    #[serde(default = "default_routed_scaling_factor")]
+    pub routed_scaling_factor: f64,
+}
+
+fn default_num_key_value_heads() -> usize {
+    8
+}
+
+fn default_norm_eps() -> f64 {
+    1e-5
+}
+
+fn default_rope_theta() -> f32 {
+    1_000_000.0
+}
+
+fn default_max_position_embeddings() -> usize {
+    128000
+}
+
+fn default_conv_l_cache() -> usize {
+    3
+}
+
+fn default_tie_embedding() -> bool {
+    true
+}
+
+fn default_use_expert_bias() -> bool {
+    true
+}
+
+fn default_norm_topk_prob() -> bool {
+    true
+}
+
+fn default_routed_scaling_factor() -> f64 {
+    1.0
+}
+
+impl Lfm2MoeConfig {
+    pub fn head_dim(&self) -> usize {
+        self.hidden_size / self.num_attention_heads
+    }
+
+    pub fn into_config(self, use_flash_attn: bool) -> Config {
+        let rope_theta = self
+            .rope_parameters
+            .as_ref()
+            .map_or(self.rope_theta, |p| p.rope_theta);
+        Config {
+            vocab_size: self.vocab_size,
+            hidden_size: self.hidden_size,
+            intermediate_size: self.intermediate_size,
+            moe_intermediate_size: self.moe_intermediate_size,
+            num_hidden_layers: self.num_hidden_layers,
+            num_attention_heads: self.num_attention_heads,
+            num_key_value_heads: self.num_key_value_heads,
+            norm_eps: self.norm_eps,
+            rope_theta,
+            max_position_embeddings: self.max_position_embeddings,
+            conv_l_cache: self.conv_l_cache,
+            conv_bias: self.conv_bias,
+            layer_types: self.layer_types,
+            tie_embedding: self.tie_embedding,
+            bos_token_id: self.bos_token_id,
+            eos_token_id: self.eos_token_id,
+            num_experts: self.num_experts,
+            num_experts_per_tok: self.num_experts_per_tok,
+            num_dense_layers: self.num_dense_layers,
+            use_expert_bias: self.use_expert_bias,
+            norm_topk_prob: self.norm_topk_prob,
+            routed_scaling_factor: self.routed_scaling_factor,
+            use_flash_attn,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub moe_intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub norm_eps: f64,
+    pub rope_theta: f32,
+    pub max_position_embeddings: usize,
+    pub conv_l_cache: usize,
+    pub conv_bias: bool,
+    pub layer_types: Vec<LayerType>,
+    pub tie_embedding: bool,
+    pub bos_token_id: Option<u32>,
+    pub eos_token_id: Option<u32>,
+    pub num_experts: usize,
+    pub num_experts_per_tok: usize,
+    pub num_dense_layers: usize,
+    pub use_expert_bias: bool,
+    pub norm_topk_prob: bool,
+    pub routed_scaling_factor: f64,
+    pub use_flash_attn: bool,
+}
+
+impl Config {
+    pub fn head_dim(&self) -> usize {
+        self.hidden_size / self.num_attention_heads
+    }
+}
+
+/// Bridge our MoE config to the dense LFM2 config so we can reuse the dense
+/// token-mixing operators (`Attention`, `ShortConv`) and the RoPE `Cache`.
+impl From<&Config> for Lfm2Config {
+    fn from(cfg: &Config) -> Self {
+        Lfm2Config {
+            vocab_size: cfg.vocab_size,
+            hidden_size: cfg.hidden_size,
+            intermediate_size: cfg.intermediate_size,
+            num_hidden_layers: cfg.num_hidden_layers,
+            num_attention_heads: cfg.num_attention_heads,
+            num_key_value_heads: cfg.num_key_value_heads,
+            norm_eps: cfg.norm_eps,
+            rope_theta: cfg.rope_theta,
+            max_position_embeddings: cfg.max_position_embeddings,
+            conv_l_cache: cfg.conv_l_cache,
+            conv_bias: cfg.conv_bias,
+            layer_types: cfg.layer_types.clone(),
+            tie_embedding: cfg.tie_embedding,
+            bos_token_id: cfg.bos_token_id,
+            eos_token_id: cfg.eos_token_id,
+            use_flash_attn: cfg.use_flash_attn,
+        }
+    }
+}
+
+/// Router (gating network) for a sparse MoE layer.
+///
+/// LFM2-MoE uses DeepSeek-V3 style routing: the router logits go through a
+/// `sigmoid` (not a softmax), and an optional per-expert bias is added *only* to
+/// pick which experts win the top-k. The weights that actually scale each
+/// expert's output are read back from the unbiased sigmoid scores.
+#[derive(Debug, Clone)]
+struct MoeGate {
+    gate: Linear,
+    // Per-expert bias of shape (num_experts,). Only used to select the top-k.
+    expert_bias: Option<Tensor>,
+    num_experts_per_tok: usize,
+    norm_topk_prob: bool,
+    routed_scaling_factor: f64,
+    span: tracing::Span,
+}
+
+impl MoeGate {
+    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let gate = linear(cfg.hidden_size, cfg.num_experts, vb.pp("gate"))?;
+        let expert_bias = if cfg.use_expert_bias {
+            Some(vb.get(cfg.num_experts, "expert_bias")?)
+        } else {
+            None
+        };
+        Ok(Self {
+            gate,
+            expert_bias,
+            num_experts_per_tok: cfg.num_experts_per_tok,
+            norm_topk_prob: cfg.norm_topk_prob,
+            routed_scaling_factor: cfg.routed_scaling_factor,
+            span: tracing::span!(tracing::Level::TRACE, "moe-gate"),
+        })
+    }
+
+    /// `xs`: (num_tokens, hidden_size).
+    /// Returns `(selected_experts, routing_weights)`, both of shape (num_tokens, top_k);
+    /// `selected_experts` holds u32 expert indices, `routing_weights` the scaling factors.
+    fn forward(&self, xs: &Tensor) -> Result<(Tensor, Tensor)> {
+        let _enter = self.span.enter();
+        // (num_tokens, num_experts)
+        let router_logits = xs.apply(&self.gate)?;
+        let routing_weights = candle_nn::ops::sigmoid(&router_logits)?;
+
+        // Pick the top-k experts. The bias (if any) influences *selection* only.
+        let selected_experts = match &self.expert_bias {
+            Some(bias) => routing_weights.broadcast_add(bias)?,
+            None => routing_weights.clone(),
+        }
+        .arg_sort_last_dim(false)? // descending: largest scores first
+        .narrow(D::Minus1, 0, self.num_experts_per_tok)?
+        .contiguous()?;
+
+        // Gather the *unbiased* sigmoid weights for the selected experts.
+        let mut routing_weights = routing_weights.gather(&selected_experts, D::Minus1)?;
+
+        if self.norm_topk_prob {
+            let denom = (routing_weights.sum_keepdim(D::Minus1)? + 1e-6)?;
+            routing_weights = routing_weights.broadcast_div(&denom)?;
+        }
+        let routing_weights = (routing_weights * self.routed_scaling_factor)?;
+        Ok((selected_experts, routing_weights))
+    }
+}
+
+/// Sparse Mixture-of-Experts feed-forward block.
+///
+/// Each token is routed to `num_experts_per_tok` experts; every expert is a plain
+/// LFM2 SwiGLU MLP (reused from the dense model) sized to `moe_intermediate_size`.
+#[derive(Debug, Clone)]
+struct SparseMoeBlock {
+    gate: MoeGate,
+    experts: Vec<Mlp>,
+    span: tracing::Span,
+}
+
+impl SparseMoeBlock {
+    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let gate = MoeGate::new(cfg, vb.clone())?;
+
+        // Each expert is structurally identical to the dense MLP (w1/w3/w2),
+        // just narrower. Build a dense config whose intermediate size is the
+        // expert size so we can reuse `lfm2::Mlp` verbatim.
+        let mut expert_cfg: Lfm2Config = cfg.into();
+        expert_cfg.intermediate_size = cfg.moe_intermediate_size;
+
+        let vb_e = vb.pp("experts");
+        let mut experts = Vec::with_capacity(cfg.num_experts);
+        for idx in 0..cfg.num_experts {
+            experts.push(Mlp::new(&expert_cfg, vb_e.pp(idx))?);
+        }
+        Ok(Self {
+            gate,
+            experts,
+            span: tracing::span!(tracing::Level::TRACE, "moe-block"),
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let (b_size, seq_len, hidden_dim) = xs.dims3()?;
+        // Flatten the batch/sequence dims: route each token independently.
+        let xs = xs.reshape(((), hidden_dim))?;
+
+        let (selected_experts, routing_weights) = self.gate.forward(&xs)?;
+
+        // Move routing decisions to the CPU so we can build per-expert token lists.
+        let routing_weights = routing_weights.to_dtype(DType::F32)?.to_vec2::<f32>()?;
+        let selected_experts = selected_experts.to_vec2::<u32>()?;
+
+        // For each expert, collect the row indices routed to it and their weights.
+        let mut token_rows = vec![vec![]; self.experts.len()];
+        let mut token_weights = vec![vec![]; self.experts.len()];
+        for (row_idx, (weights, experts)) in routing_weights
+            .iter()
+            .zip(selected_experts.iter())
+            .enumerate()
+        {
+            for (&weight, &expert_idx) in weights.iter().zip(experts.iter()) {
+                token_rows[expert_idx as usize].push(row_idx as u32);
+                token_weights[expert_idx as usize].push(weight);
+            }
+        }
+
+        // Run each expert once on its batch of tokens, then scatter-add back.
+        let mut ys = xs.zeros_like()?;
+        for (expert_idx, expert) in self.experts.iter().enumerate() {
+            let rows = &token_rows[expert_idx];
+            if rows.is_empty() {
+                continue;
+            }
+            let rows = Tensor::new(rows.as_slice(), xs.device())?;
+            let weights = Tensor::new(token_weights[expert_idx].as_slice(), xs.device())?
+                .reshape(((), 1))?
+                .to_dtype(xs.dtype())?;
+
+            let tokens = xs.index_select(&rows, 0)?;
+            let out = expert.forward(&tokens)?;
+            let out = out.broadcast_mul(&weights)?;
+            ys = ys.index_add(&rows, &out, 0)?;
+        }
+
+        ys.reshape((b_size, seq_len, hidden_dim))
+    }
+}
+
+/// Feed-forward of a decoder layer: either a dense MLP or a sparse MoE block.
+#[derive(Debug, Clone)]
+enum FeedForward {
+    Dense(Mlp),
+    Sparse(SparseMoeBlock),
+}
+
+impl FeedForward {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        match self {
+            FeedForward::Dense(mlp) => mlp.forward(x),
+            FeedForward::Sparse(moe) => moe.forward(x),
+        }
+    }
+}
+
+/// Token-mixing operator of a decoder layer (reused from the dense model).
+#[derive(Debug, Clone)]
+enum LayerKind {
+    Attention(Box<Attention>),
+    ShortConv(ShortConv),
+}
+
+#[derive(Debug, Clone)]
+struct DecoderLayer {
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+    feed_forward: FeedForward,
+    kind: LayerKind,
+    span: tracing::Span,
+}
+
+impl DecoderLayer {
+    fn new(cfg: &Config, layer_idx: usize, vb: VarBuilder) -> Result<Self> {
+        // LFM2 uses operator_norm and ffn_norm naming.
+        let input_layernorm = RmsNorm::new(cfg.hidden_size, cfg.norm_eps, vb.pp("operator_norm"))?;
+        let post_attention_layernorm =
+            RmsNorm::new(cfg.hidden_size, cfg.norm_eps, vb.pp("ffn_norm"))?;
+
+        // The first `num_dense_layers` layers keep a dense SwiGLU MLP; the rest
+        // route tokens through a sparse MoE block. This mirrors the Python:
+        //   feed_forward = Lfm2MoeMLP(...) if layer_idx < num_dense_layers
+        //                  else Lfm2MoeSparseMoeBlock(...)
+        let lfm2_cfg: Lfm2Config = cfg.into();
+        let feed_forward = if layer_idx < cfg.num_dense_layers {
+            FeedForward::Dense(Mlp::new(&lfm2_cfg, vb.pp("feed_forward"))?)
+        } else {
+            FeedForward::Sparse(SparseMoeBlock::new(cfg, vb.pp("feed_forward"))?)
+        };
+
+        let layer_type = cfg
+            .layer_types
+            .get(layer_idx)
+            .copied()
+            .unwrap_or(LayerType::FullAttention);
+        let kind = match layer_type {
+            LayerType::FullAttention => {
+                LayerKind::Attention(Box::new(Attention::new(&lfm2_cfg, vb.pp("self_attn"))?))
+            }
+            LayerType::Conv => LayerKind::ShortConv(ShortConv::new(&lfm2_cfg, vb.pp("conv"))?),
+        };
+
+        Ok(Self {
+            input_layernorm,
+            post_attention_layernorm,
+            feed_forward,
+            kind,
+            span: tracing::span!(tracing::Level::TRACE, "layer"),
+        })
+    }
+
+    fn forward(
+        &self,
+        x: &Tensor,
+        index_pos: usize,
+        block_idx: usize,
+        cache: &mut Cache,
+    ) -> Result<Tensor> {
+        let _enter = self.span.enter();
+        let residual = x;
+        let x = self.input_layernorm.forward(x)?;
+
+        let x = match &self.kind {
+            LayerKind::Attention(attn) => attn.forward(&x, index_pos, block_idx, cache)?,
+            LayerKind::ShortConv(conv) => conv.forward(&x, block_idx, cache)?,
+        };
+
+        let x = (x + residual)?;
+        let residual = &x;
+        let x = self.post_attention_layernorm.forward(&x)?;
+        let x = self.feed_forward.forward(&x)?;
+        x + residual
+    }
+}
+
+/// LFM2-MoE model for causal language modeling.
+#[derive(Debug, Clone)]
+pub struct Model {
+    embed_tokens: Embedding,
+    layers: Vec<DecoderLayer>,
+    embedding_norm: RmsNorm,
+    lm_head: Linear,
+    dtype: DType,
+}
+
+impl Model {
+    pub fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
+        let vb_m = vb.pp("model");
+
+        let embed_tokens =
+            Embedding::new(cfg.vocab_size, cfg.hidden_size, vb_m.pp("embed_tokens"))?;
+
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        let vb_l = vb_m.pp("layers");
+        for layer_idx in 0..cfg.num_hidden_layers {
+            let layer = DecoderLayer::new(cfg, layer_idx, vb_l.pp(layer_idx))?;
+            layers.push(layer);
+        }
+
+        let embedding_norm =
+            RmsNorm::new(cfg.hidden_size, cfg.norm_eps, vb_m.pp("embedding_norm"))?;
+
+        let lm_head = if cfg.tie_embedding {
+            Linear::from_weights(embed_tokens.embeddings().clone(), None)
+        } else {
+            linear(cfg.hidden_size, cfg.vocab_size, vb.pp("lm_head"))?
+        };
+
+        Ok(Self {
+            embed_tokens,
+            layers,
+            embedding_norm,
+            lm_head,
+            dtype: vb.dtype(),
+        })
+    }
+
+    pub fn forward(
+        &self,
+        input_ids: &Tensor,
+        index_pos: usize,
+        cache: &mut Cache,
+    ) -> Result<Tensor> {
+        let (_, seq_len) = input_ids.dims2()?;
+        let mut hidden_states = self.embed_tokens.forward(input_ids)?;
+
+        for (block_idx, layer) in self.layers.iter().enumerate() {
+            hidden_states = layer.forward(&hidden_states, index_pos, block_idx, cache)?;
+        }
+
+        let hidden_states = self.embedding_norm.forward(&hidden_states)?;
+        let hidden_states = hidden_states.i((.., seq_len - 1, ..))?.contiguous()?;
+        let logits = self.lm_head.forward(&hidden_states)?;
+        logits.to_dtype(DType::F32)
+    }
+
+    pub fn dtype(&self) -> DType {
+        self.dtype
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::Device;
+    use candle_nn::{VarBuilder, VarMap};
+
+    /// Build a tiny LFM2-MoE config that exercises every code path:
+    /// dense layers, MoE layers, attention layers and conv layers.
+    fn tiny_config() -> Config {
+        Config {
+            vocab_size: 16,
+            hidden_size: 8,
+            intermediate_size: 16,
+            moe_intermediate_size: 8,
+            num_hidden_layers: 4,
+            num_attention_heads: 2,
+            num_key_value_heads: 1,
+            norm_eps: 1e-5,
+            rope_theta: 10000.0,
+            max_position_embeddings: 64,
+            conv_l_cache: 3,
+            conv_bias: false,
+            // layers 0,1 = dense (and conv); layer 2 = MoE + attention; layer 3 = MoE + conv.
+            layer_types: vec![
+                LayerType::Conv,
+                LayerType::Conv,
+                LayerType::FullAttention,
+                LayerType::Conv,
+            ],
+            tie_embedding: true,
+            bos_token_id: None,
+            eos_token_id: None,
+            num_experts: 4,
+            num_experts_per_tok: 2,
+            num_dense_layers: 2,
+            use_expert_bias: true,
+            norm_topk_prob: true,
+            routed_scaling_factor: 1.0,
+            use_flash_attn: false,
+        }
+    }
+
+    /// LFM2 (transformers v4) exposes `rope_theta` at the top level while LFM2.5
+    /// (transformers v5) nests it inside `rope_parameters`; both must parse to the
+    /// right value.
+    #[test]
+    fn config_rope_theta_formats() {
+        let base = r#"
+            "vocab_size": 128000, "hidden_size": 2048, "num_hidden_layers": 24,
+            "num_attention_heads": 32, "layer_types": ["conv", "full_attention"],
+            "intermediate_size": 7168, "moe_intermediate_size": 1792,
+            "num_experts": 32, "num_experts_per_tok": 4, "num_dense_layers": 2,
+            "bos_token_id": 1, "eos_token_id": 7
+        "#;
+        let flat: Lfm2MoeConfig =
+            serde_json::from_str(&format!("{{ \"rope_theta\": 1000000.0, {base} }}")).unwrap();
+        assert_eq!(flat.into_config(false).rope_theta, 1_000_000.0);
+        let nested: Lfm2MoeConfig = serde_json::from_str(&format!(
+            "{{ \"rope_parameters\": {{ \"rope_theta\": 5000000, \"rope_type\": \"default\" }}, {base} }}"
+        ))
+        .unwrap();
+        assert_eq!(nested.into_config(false).rope_theta, 5_000_000.0);
+    }
+
+    /// Smoke test: build the model with random weights and run a prefill followed
+    /// by a single-token decode step. This checks the full plumbing (routing,
+    /// expert dispatch, dense/MoE wiring, attention + conv caches) without needing
+    /// the real multi-gigabyte checkpoint.
+    #[test]
+    fn forward_shapes() -> Result<()> {
+        let device = Device::Cpu;
+        let cfg = tiny_config();
+
+        let varmap = VarMap::new();
+        let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+        let model = Model::new(&cfg, vb)?;
+
+        let mut cache = Cache::new(true, DType::F32, &Lfm2Config::from(&cfg), &device)?;
+
+        // Prefill three tokens.
+        let input = Tensor::new(&[[1u32, 2u32, 3u32]], &device)?;
+        let logits = model.forward(&input, 0, &mut cache)?;
+        assert_eq!(logits.dims(), &[1, cfg.vocab_size]);
+
+        // Decode one more token, reusing the caches (index_pos = 3).
+        let next = Tensor::new(&[[4u32]], &device)?;
+        let logits = model.forward(&next, 3, &mut cache)?;
+        assert_eq!(logits.dims(), &[1, cfg.vocab_size]);
+
+        Ok(())
+    }
+
+    /// The router must select exactly `num_experts_per_tok` experts per token and
+    /// produce matching, finite routing weights.
+    #[test]
+    fn router_topk_shapes() -> Result<()> {
+        let device = Device::Cpu;
+        let cfg = tiny_config();
+
+        let varmap = VarMap::new();
+        let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+        let gate = MoeGate::new(&cfg, vb)?;
+
+        let n_tokens = 5;
+        let xs = Tensor::randn(0f32, 1f32, (n_tokens, cfg.hidden_size), &device)?;
+        let (selected, weights) = gate.forward(&xs)?;
+
+        assert_eq!(selected.dims(), &[n_tokens, cfg.num_experts_per_tok]);
+        assert_eq!(weights.dims(), &[n_tokens, cfg.num_experts_per_tok]);
+
+        // Every selected index must be a valid expert id.
+        for row in selected.to_vec2::<u32>()? {
+            for idx in row {
+                assert!((idx as usize) < cfg.num_experts);
+            }
+        }
+        // With norm_topk_prob the per-token weights sum to ~1.
+        for row in weights.to_vec2::<f32>()? {
+            let sum: f32 = row.iter().sum();
+            assert!(
+                (sum - 1.0).abs() < 1e-4,
+                "weights should sum to 1, got {sum}"
+            );
+        }
+        Ok(())
+    }
+}

--- a/candle-transformers/src/models/mod.rs
+++ b/candle-transformers/src/models/mod.rs
@@ -54,6 +54,7 @@ pub mod helium;
 pub mod hiera;
 pub mod jina_bert;
 pub mod lfm2;
+pub mod lfm2_moe;
 pub mod llama;
 pub mod llama2_c;
 pub mod llama2_c_weights;


### PR DESCRIPTION
Follow-up to #3400: this adds LFM2-MoE, the Mixture-of-Experts variant of LFM2 from LiquidAI.

LFM2-MoE keeps the hybrid attention + short-convolution backbone of LFM2 and replaces the dense feed-forward of the later layers with a sparse MoE block (DeepSeek-V3 style sigmoid routing with a per-expert selection bias).

- Reuses the dense LFM2 token-mixing operators (`Attention`, `ShortConv`, `Mlp`), in the same spirit as `qwen3_moe` reusing `qwen3`.
- Supports both config formats: flat `rope_theta` (transformers v4) and the nested `rope_parameters` object used by LFM2.5 (transformers v5).
- Adds a text-generation example defaulting to `LiquidAI/LFM2.5-8B-A1B`, plus unit tests (config parsing, router top-k shapes, random-weight prefill + decode smoke test).

Tested on a 24GB CUDA GPU in BF16:

```
model: LiquidAI/LFM2.5-8B-A1B
layers: 24 (6 attention, 18 conv), 32 experts (top-4), 2 dense layers
user
What is the capital of France?
assistant
<think>
The user asks a simple factual question: [...]
</think>
The capital of France is Paris.
81 tokens generated (61.81 token/s)
```