### PR TITLE
fix(quantized): QTensor::quantize ignores layout offset on a narrowed-then-contiguous view

### DIFF
--- a/candle-core/src/quantized/mod.rs
+++ b/candle-core/src/quantized/mod.rs
@@ -544,7 +544,11 @@ impl QTensor {
         let shape = src.shape();
         let block_size = dtype.block_size();
         check_shape(shape, block_size)?;
-        let src = src.to_dtype(crate::DType::F32)?.flatten_all()?;
+        // force_contiguous (not contiguous) always copies, so a non-zero layout
+        // offset (e.g. from narrow().contiguous() on an already-contiguous
+        // view) is resolved before the raw storage reaches the quantizer below,
+        // which reads from element 0 with no offset awareness. See #3864.
+        let src = src.to_dtype(crate::DType::F32)?.force_contiguous()?.flatten_all()?;
         let elem_count = shape.elem_count();
         if !elem_count.is_multiple_of(block_size) {
             crate::bail!(
@@ -580,7 +584,10 @@ impl QTensor {
         let shape = src.shape();
         let block_size = dtype.block_size();
         check_shape(shape, block_size)?;
-        let src = src.to_dtype(crate::DType::F32)?.flatten_all()?;
+        // force_contiguous (not contiguous) always copies, resolving a non-zero
+        // layout offset before the raw storage reaches the quantizer, which
+        // reads from element 0 with no offset awareness. See #3864.
+        let src = src.to_dtype(crate::DType::F32)?.force_contiguous()?.flatten_all()?;
         let elem_count = shape.elem_count();
         if !elem_count.is_multiple_of(block_size) {
             crate::bail!(
@@ -623,7 +630,10 @@ impl QTensor {
         let shape = src.shape();
         let block_size = dtype.block_size();
         check_shape(shape, block_size)?;
-        let src = src.to_dtype(crate::DType::F32)?.flatten_all()?;
+        // force_contiguous (not contiguous) always copies, resolving a non-zero
+        // layout offset before the raw storage reaches the quantizer, which
+        // reads from element 0 with no offset awareness. See #3864.
+        let src = src.to_dtype(crate::DType::F32)?.force_contiguous()?.flatten_all()?;
         let elem_count = shape.elem_count();
         if !elem_count.is_multiple_of(block_size) {
             crate::bail!(
@@ -652,7 +662,10 @@ impl QTensor {
         let shape = src.shape();
         let block_size = dtype.block_size();
         check_shape(shape, block_size)?;
-        let src = src.to_dtype(crate::DType::F32)?.flatten_all()?;
+        // force_contiguous (not contiguous) always copies, resolving a non-zero
+        // layout offset before the raw storage reaches the quantizer, which
+        // reads from element 0 with no offset awareness. See #3864.
+        let src = src.to_dtype(crate::DType::F32)?.force_contiguous()?.flatten_all()?;
         let elem_count = shape.elem_count();
         if !elem_count.is_multiple_of(block_size) {
             crate::bail!(

--- a/candle-core/tests/quantized_tests.rs
+++ b/candle-core/tests/quantized_tests.rs
@@ -321,6 +321,38 @@ fn quantized_embedding_cpu() -> Result<()> {
     Ok(())
 }
 
+// #3864: QTensor::quantize on a narrowed-then-contiguous() view ignored the
+// layout offset and quantized the parent's data starting at element 0. A
+// row-narrowed tensor is already contiguous, so `contiguous()` (unlike
+// `force_contiguous()`) does not copy it — the offset survived into the
+// quantizer's raw storage read.
+#[test]
+fn quantize_a_narrowed_view() -> Result<()> {
+    let device = Device::Cpu;
+    // Four rows of 32 f32; row r is filled with the value r + 1.
+    let data: Vec<f32> = (0..4)
+        .flat_map(|r| std::iter::repeat_n((r + 1) as f32, 32))
+        .collect();
+    let t = Tensor::from_slice(&data, (4, 32), &device)?;
+    let narrowed = t.narrow(0, 1, 1)?.contiguous()?;
+    // The view reads correctly through the ordinary tensor API.
+    assert_eq!(narrowed.to_vec2::<f32>()?, vec![vec![2.0f32; 32]]);
+
+    let qtensor = quantized::QTensor::quantize(&narrowed, GgmlDType::Q8_0)?;
+    let dequantized = qtensor.dequantize(&device)?;
+    let got = dequantized.to_vec2::<f32>()?;
+    // Q8_0's round-trip of 2.0 is close but not bit-exact (~1.99988). The
+    // parent's row 0 (value 1.0) would round-trip to ~0.99994 — over 0.5 away
+    // from 2.0 — which is what the bug produced, so a loose tolerance still
+    // distinguishes "read the right row" from "read the parent's row 0".
+    for row in &got {
+        for &v in row {
+            assert!((v - 2.0).abs() < 0.01, "expected ~2.0, got {v}");
+        }
+    }
+    Ok(())
+}
+
 #[cfg(feature = "metal")]
 #[test]
 fn quantized_embedding_metal() -> Result<()> {


### PR DESCRIPTION
## Summary

Fixes #3864 — `QTensor::quantize` on a narrowed-then-`contiguous()` tensor silently quantizes the *parent's* data in release builds, with no error. In debug builds the same code panics on a `debug_assert_eq!` instead.

## Root cause

`QTensor::quantize` (and its `quantize_imatrix`/`quantize_imatrix_onto`/`quantize_onto` siblings) build `src` via `to_dtype(F32)?.flatten_all()?`. Neither operation forces a copy when the tensor is already contiguous:

1. `Tensor::contiguous()` returns `self.clone()` when `is_contiguous()` is true. A row-narrowed tensor **is** contiguous, so `contiguous()` does not copy it — the result keeps the parent's storage and a non-zero `start_offset()`.
2. `quantize()` passes `src.storage()` — the whole parent storage — to the quantizer, sized only by `shape.elem_count()`. The layout offset is never applied.

Composed: `quantize(&t.narrow(..)?.contiguous()?, ..)` reads the parent's first `shape.elem_count()` elements from element 0, not the narrowed rows.

## Fix

Replace `.flatten_all()` with `.force_contiguous()?.flatten_all()?` in all four entry points. `force_contiguous()` (unlike `contiguous()`) always copies, resolving the offset before the raw storage reaches the quantizer — no change to the public API, no change to callers that already pass a fresh/contiguous-from-scratch tensor.

## Testing

Added `quantize_a_narrowed_view` reproducing the issue's exact repro: narrow a 4-row tensor to row 1, `contiguous()`, quantize with Q8_0, dequantize, and assert the result matches the narrowed row (~2.0) rather than the parent's row 0 (~1.0, which is what the bug produced — a >0.5 discrepancy easily distinguished with a loose tolerance since Q8_0 round-trip isn't bit-exact).

Full `quantized_tests` suite: 40 passed, 0 failed, 0 regressions.

```
cargo test -p candle-core --test quantized_tests
test result: ok. 40 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```