### PR TITLE
fix(onnx): Tile with a zero repeat must empty the dimension

### DIFF
--- a/candle-onnx/src/eval.rs
+++ b/candle-onnx/src/eval.rs
@@ -1598,11 +1598,12 @@ fn simple_eval_(
 
                 let mut result = input.clone();
                 for (dim, &repeat) in repeats.iter().enumerate() {
-                    if repeat > 1 {
-                        let repeat = repeat as usize;
-                        let tensors: Vec<_> = (0..repeat).map(|_| result.clone()).collect();
-                        result = Tensor::cat(&tensors, dim)?;
-                    }
+                    result = match repeat {
+                        0 => result.narrow(dim, 0, 0)?,
+                        1 => result,
+                        repeat if repeat > 1 => Tensor::cat(&vec![&result; repeat as usize], dim)?,
+                        repeat => bail!("Tile: repeats must be non-negative, got {repeat}"),
+                    };
                 }
                 values.insert(node.output[0].clone(), result);
             }

--- a/candle-onnx/tests/ops.rs
+++ b/candle-onnx/tests/ops.rs
@@ -7344,3 +7344,47 @@ fn test_one_hot() -> Result<()> {
 
     Ok(())
 }
+
+// "Tile"
+#[test]
+fn test_tile() -> Result<()> {
+    let manual_graph = make_graph_helper("Tile", &["data", "repeats"], &["output"], vec![]);
+
+    let data = Tensor::from_vec(vec![1.0f32, 2.0, 3.0, 4.0], (2, 2), &Device::Cpu)?;
+
+    // Basic tiling: np.tile([[1, 2], [3, 4]], (2, 2)).
+    let repeats = Tensor::from_vec(vec![2i64, 2], (2,), &Device::Cpu)?;
+    let inputs = HashMap::from_iter([
+        ("data".to_string(), data.clone()),
+        ("repeats".to_string(), repeats),
+    ]);
+    let result = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let output = result.get("output").expect("Output 'output' not found");
+    assert_eq!(
+        output.to_vec2::<f32>()?,
+        vec![
+            vec![1.0, 2.0, 1.0, 2.0],
+            vec![3.0, 4.0, 3.0, 4.0],
+            vec![1.0, 2.0, 1.0, 2.0],
+            vec![3.0, 4.0, 3.0, 4.0]
+        ]
+    );
+
+    // A zero repeat empties the dimension: np.tile([[1, 2], [3, 4]], (0, 2))
+    // has shape (0, 4), not a copy of the input.
+    let repeats = Tensor::from_vec(vec![0i64, 2], (2,), &Device::Cpu)?;
+    let inputs = HashMap::from_iter([
+        ("data".to_string(), data.clone()),
+        ("repeats".to_string(), repeats),
+    ]);
+    let result = candle_onnx::simple_eval(&manual_graph, inputs)?;
+    let output = result.get("output").expect("Output 'output' not found");
+    assert_eq!(output.dims(), &[0, 4]);
+
+    // Negative repeats are invalid per the ONNX spec and must error out.
+    let repeats = Tensor::from_vec(vec![-1i64, 2], (2,), &Device::Cpu)?;
+    let inputs = HashMap::from_iter([("data".to_string(), data), ("repeats".to_string(), repeats)]);
+    assert!(candle_onnx::simple_eval(&manual_graph, inputs).is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
The Tile arm (candle-onnx/src/eval.rs:1601 on main) only acts when a repeat is greater than 1, so a repeat of 0 silently behaves like 1. With input `[[1, 2], [3, 4]]` and repeats `[0, 2]`, `simple_eval` returned shape `[2, 4]` containing the original data. np.tile semantics, per the spec linked from the comment at line 1594 and implemented by the ONNX reference as literally `np.tile(x, repeats)`, require shape `[0, 4]`. Negative repeats, invalid per the spec, were swallowed by the same guard instead of erroring.

This is the same bug #3877 fixed in `Tensor::repeat` (candle-core/src/tensor.rs:698); the ONNX arm still carried the pre-fix pattern. This ports that fix: 0 narrows the dimension to empty, 1 is identity, greater than 1 concatenates, negative bails.

Adds the first Tile coverage in candle-onnx/tests/ops.rs: basic tiling values, the zero-repeat shape, and the negative-repeat error. Without the source change the new test fails with `left: [2, 4], right: [0, 4]`; with it the suite matches the main baseline (the only failure either way is the pre-existing float mismatch in test_gelu_operation, unrelated).

Not included: validating that `repeats` has length equal to the input rank, which the spec also requires. That is a separate check and this diff stays on the confirmed defect.