### PR TITLE
feat(qwen3_vl): add clear_kv_cache

### DIFF
--- a/candle-transformers/src/models/qwen3_vl/mod.rs
+++ b/candle-transformers/src/models/qwen3_vl/mod.rs
@@ -26,6 +26,14 @@ impl Qwen3VLModel {
         Ok(Self { text, vision })
     }
 
+    /// Reset every layer's KV cache so the model can start a new sequence.
+    ///
+    /// Without this a model instance is single-use: a second generation decodes
+    /// against the previous conversation's keys and values.
+    pub fn clear_kv_cache(&self) {
+        self.text.clear_kv_cache();
+    }
+
     fn prepare_decoder_attention_mask(
         &self,
         b_size: usize,

--- a/candle-transformers/src/models/qwen3_vl/text.rs
+++ b/candle-transformers/src/models/qwen3_vl/text.rs
@@ -200,6 +200,13 @@ impl Attention {
 
         self.o_proj.forward(&attn_output)
     }
+
+    fn clear_kv_cache(&self) {
+        self.kv_cache
+            .lock()
+            .expect("kv cache lock poisoned")
+            .reset();
+    }
 }
 
 pub struct DecoderLayer {
@@ -246,6 +253,10 @@ impl DecoderLayer {
             .mlp
             .forward(&xs.apply(&self.post_attention_layernorm)?)?;
         residual + xs
+    }
+
+    fn clear_kv_cache(&self) {
+        self.self_attn.clear_kv_cache();
     }
 }
 
@@ -294,6 +305,13 @@ impl Qwen3VLTextModel {
             dtype: vb.dtype(),
             num_attn_heads: cfg.num_attention_heads,
         })
+    }
+
+    /// Reset every layer's KV cache so the model can start a new sequence.
+    pub fn clear_kv_cache(&self) {
+        for layer in &self.layers {
+            layer.clear_kv_cache();
+        }
     }
 
     pub fn embed_tokens(&self, input_ids: &Tensor) -> Result<Tensor> {


### PR DESCRIPTION
Fixes #3901 — thanks @ivarflakstad for the go-ahead.

Follows the `qwen2.rs` / `qwen3.rs` pattern: `Qwen3VLModel` → `Qwen3VLTextModel` → `DecoderLayer` → `Attention`, resetting each layer's cache.

One deviation worth a look: this takes `&self` rather than `&mut self`. `qwen3_vl` keeps its cache in an `Arc<Mutex<KvCache>>` precisely so `forward` can take `&self`, so requiring exclusive access just to reset would be inconsistent with the rest of the type — a caller holding an `Arc<Qwen3VLModel>` could generate but never reset. Happy to switch to `&mut self` if you'd rather match the other models exactly.

Verified with the repro from #3901, three runs (weights are randomly initialised, so the magnitude varies):

```
relative diff, no clear_kv_cache = 0.791419   relative diff, clear_kv_cache = 0.000000
relative diff, no clear_kv_cache = 0.682957   relative diff, clear_kv_cache = 0.000000
relative diff, no clear_kv_cache = 0.880759   relative diff, clear_kv_cache = 0.000000
```

`cargo clippy -p candle-transformers -- -D warnings` and `cargo fmt` are clean.
