### PR TITLE
nomic-bert: use fused Metal SDPA in attention

### DIFF
--- a/candle-transformers/src/models/nomic_bert.rs
+++ b/candle-transformers/src/models/nomic_bert.rs
@@ -239,10 +239,15 @@ impl NomicBertAttention {
         let scale = (self.head_dim as f64).sqrt();
         // The fused kernel supports a fixed set of head dims (and rejects
         // F32 at head_dim 512); anything else falls back to the naive path
-        // rather than erroring on non-default configs.
-        let fused_supported = matches!(self.head_dim, 32 | 64 | 72 | 80 | 96 | 128 | 256 | 512)
+        // rather than erroring on non-default configs. `seq_len == 1` is
+        // excluded too: the kernel would route it to its vector variant,
+        // which supports fewer head dims and does not apply the mask.
+        let fused_supported = seq_len > 1
+            && matches!(q.dtype(), DType::F16 | DType::BF16 | DType::F32)
+            && matches!(self.head_dim, 32 | 64 | 72 | 80 | 96 | 128 | 256 | 512)
             && !(self.head_dim == 512 && q.dtype() == DType::F32);
-        // `NOMIC_BERT_NAIVE_ATTN=1` forces the unfused path for A/B timing.
+        // Setting `NOMIC_BERT_NAIVE_ATTN` (to any value) forces the
+        // unfused path, for A/B timing.
         let use_fused = fused_supported
             && q.device().is_metal()
             && std::env::var_os("NOMIC_BERT_NAIVE_ATTN").is_none();

--- a/candle-transformers/src/models/nomic_bert.rs
+++ b/candle-transformers/src/models/nomic_bert.rs
@@ -89,6 +89,7 @@ impl RotaryEmbedding {
         base: f64,
         interleaved: bool,
         device: &Device,
+        dtype: DType,
     ) -> Result<Self> {
         let half_dim = dim / 2;
         let inv_freq: Vec<f32> = (0..half_dim)
@@ -99,8 +100,11 @@ impl RotaryEmbedding {
             .to_dtype(DType::F32)?
             .reshape((max_seq_len, 1))?;
         let freqs = positions.matmul(&inv_freq.unsqueeze(0)?)?;
-        let cos = freqs.cos()?;
-        let sin = freqs.sin()?;
+        // Stored in the model dtype: `apply` runs once per layer per q/k,
+        // and casting the tables there costs four dispatches per layer per
+        // forward for tensors that never change.
+        let cos = freqs.cos()?.to_dtype(dtype)?;
+        let sin = freqs.sin()?.to_dtype(dtype)?;
         Ok(Self {
             cos,
             sin,
@@ -112,12 +116,10 @@ impl RotaryEmbedding {
     /// Dispatches to interleaved (GPT-J) or non-interleaved (GPT-NeoX) style
     /// based on the model config.
     fn apply(&self, x: &Tensor) -> Result<Tensor> {
-        let cos = self.cos.to_dtype(x.dtype())?;
-        let sin = self.sin.to_dtype(x.dtype())?;
         if self.interleaved {
-            candle_nn::rotary_emb::rope_i(x, &cos, &sin)
+            candle_nn::rotary_emb::rope_i(x, &self.cos, &self.sin)
         } else {
-            candle_nn::rotary_emb::rope(x, &cos, &sin)
+            candle_nn::rotary_emb::rope(x, &self.cos, &self.sin)
         }
     }
 }
@@ -397,6 +399,7 @@ impl NomicBertEncoder {
             config.rotary_emb_base,
             config.rotary_emb_interleaved,
             vb.device(),
+            vb.dtype(),
         )?;
         Ok(Self {
             layers,

--- a/candle-transformers/src/models/nomic_bert.rs
+++ b/candle-transformers/src/models/nomic_bert.rs
@@ -237,27 +237,25 @@ impl NomicBertAttention {
         let k = rotary_emb.apply(&k)?;
 
         let scale = (self.head_dim as f64).sqrt();
+        // The fused kernel supports a fixed set of head dims (and rejects
+        // F32 at head_dim 512); anything else falls back to the naive path
+        // rather than erroring on non-default configs.
+        let fused_supported = matches!(self.head_dim, 32 | 64 | 72 | 80 | 96 | 128 | 256 | 512)
+            && !(self.head_dim == 512 && q.dtype() == DType::F32);
         // `NOMIC_BERT_NAIVE_ATTN=1` forces the unfused path for A/B timing.
-        let use_fused =
-            q.device().is_metal() && std::env::var_os("NOMIC_BERT_NAIVE_ATTN").is_none();
+        let use_fused = fused_supported
+            && q.device().is_metal()
+            && std::env::var_os("NOMIC_BERT_NAIVE_ATTN").is_none();
         let attn_output = if use_fused {
             // Fused scaled-dot-product attention: one kernel instead of
             // four dispatches (two matmuls, a broadcast add, a softmax)
             // plus their intermediate (batch, heads, seq, seq) tensors.
-            // The kernel wants the mask at full rank; `broadcast_as` is
-            // free until `contiguous` materializes it once per layer.
-            let mask = attention_mask
-                .broadcast_as((batch_size, self.num_heads, seq_len, seq_len))?
-                .contiguous()?;
-            candle_nn::ops::sdpa(
-                &q,
-                &k,
-                &v.contiguous()?,
-                Some(&mask),
-                false,
-                (1.0 / scale) as f32,
-                1.0,
-            )?
+            // The kernel takes the mask by strides, so the broadcast view
+            // costs nothing — no materialized (batch, heads, seq, seq)
+            // buffer.
+            let mask =
+                attention_mask.broadcast_as((batch_size, self.num_heads, seq_len, seq_len))?;
+            candle_nn::ops::sdpa(&q, &k, &v, Some(&mask), false, (1.0 / scale) as f32, 1.0)?
         } else {
             let attn_scores = (q.matmul(&k.t()?)? / scale)?;
             let attn_scores = attn_scores.broadcast_add(attention_mask)?;

--- a/candle-transformers/src/models/nomic_bert.rs
+++ b/candle-transformers/src/models/nomic_bert.rs
@@ -237,11 +237,33 @@ impl NomicBertAttention {
         let k = rotary_emb.apply(&k)?;
 
         let scale = (self.head_dim as f64).sqrt();
-        let attn_scores = (q.matmul(&k.t()?)? / scale)?;
-        let attn_scores = attn_scores.broadcast_add(attention_mask)?;
-        let attn_probs = candle_nn::ops::softmax_last_dim(&attn_scores)?;
-
-        let attn_output = attn_probs.matmul(&v.contiguous()?)?;
+        // `NOMIC_BERT_NAIVE_ATTN=1` forces the unfused path for A/B timing.
+        let use_fused =
+            q.device().is_metal() && std::env::var_os("NOMIC_BERT_NAIVE_ATTN").is_none();
+        let attn_output = if use_fused {
+            // Fused scaled-dot-product attention: one kernel instead of
+            // four dispatches (two matmuls, a broadcast add, a softmax)
+            // plus their intermediate (batch, heads, seq, seq) tensors.
+            // The kernel wants the mask at full rank; `broadcast_as` is
+            // free until `contiguous` materializes it once per layer.
+            let mask = attention_mask
+                .broadcast_as((batch_size, self.num_heads, seq_len, seq_len))?
+                .contiguous()?;
+            candle_nn::ops::sdpa(
+                &q,
+                &k,
+                &v.contiguous()?,
+                Some(&mask),
+                false,
+                (1.0 / scale) as f32,
+                1.0,
+            )?
+        } else {
+            let attn_scores = (q.matmul(&k.t()?)? / scale)?;
+            let attn_scores = attn_scores.broadcast_add(attention_mask)?;
+            let attn_probs = candle_nn::ops::softmax_last_dim(&attn_scores)?;
+            attn_probs.matmul(&v.contiguous()?)?
+        };
         let attn_output = attn_output.transpose(1, 2)?.contiguous()?;
         let attn_output = attn_output.flatten_from(D::Minus2)?;
 


### PR DESCRIPTION
## What

`nomic_bert.rs` computes attention as separate matmul / mask-add / softmax / matmul dispatches. This switches the Metal path to the fused `candle_nn::ops::sdpa` kernel that already exists in candle-nn, keeping the naive sequence as the fallback for CPU/CUDA and for head dims the kernel does not support.

## Why

Fewer dispatches per layer, no materialized `(batch, heads, seq, seq)` score tensor, and (after review) no mask/value copies — the kernel consumes strides, so the padding mask goes in as a stride-0 broadcast view. Measured end-to-end on `nomic-ai/CodeRankEmbed` (12 layers, 768 hidden, F16, M-series Mac, batch 4, same-session A/B via `NOMIC_BERT_NAIVE_ATTN=1`, best of 5):

| shape | naive | fused |
|---|---|---|
| seq ~510 | 507.5 ms | **297.7 ms (1.70x)** |
| seq ~200 | 147.0 ms | 113.9 ms (1.29x) |
| seq ~92 | 61.7 ms | 52.5 ms (1.18x) |

## Correctness

Worst cosine between fused-Metal and naive-CPU embeddings over mixed-length real-code batches (padding mask exercised): **0.9995**, consistent with F16-vs-F32 drift alone. Non-default configs whose `head_dim` the kernel does not support (or F32 at head_dim 512) fall back to the naive path rather than erroring. `NOMIC_BERT_NAIVE_ATTN=1` toggles the old path for A/B timing; happy to drop that escape hatch if you'd rather not carry the env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Weaz3abR13kLebo8YiAqNX