### PR TITLE
Improved in-place functionality. Avoids deadlocking.

### DIFF
--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = { workspace = true }
 yoke = { workspace = true }
 zerocopy = { workspace = true }
 zip = { workspace = true }
+parking_lot = "0.12.5"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokenizers = { workspace = true, features = ["onig"] }
 

--- a/candle-core/src/custom_op.rs
+++ b/candle-core/src/custom_op.rs
@@ -388,13 +388,13 @@ pub enum AccessPattern {
 
 impl AccessPattern {
     fn supports(self, rel: LayoutRelation) -> bool {
-        match (self, rel) {
-            (AccessPattern::Elementwise, LayoutRelation::Identical | LayoutRelation::Disjoint) => {
-                true
-            }
-            (AccessPattern::Arbitrary, LayoutRelation::Disjoint) => true,
-            _ => false,
-        }
+        matches!(
+            (self, rel),
+            (
+                AccessPattern::Elementwise,
+                LayoutRelation::Identical | LayoutRelation::Disjoint
+            ) | (AccessPattern::Arbitrary, LayoutRelation::Disjoint)
+        )
     }
 }
 
@@ -692,8 +692,9 @@ impl Tensor {
             let s = match (&guards[i], rels[i]) {
                 (Some(g), None) => Src::Distinct(&**g),
                 (None, Some(rel)) => Src::Aliased(rel),
-                // `guards[i]` is `Some` exactly when `rels[i]` is `None`.
-                _ => unreachable!("guard presence tracks classification"),
+                _ => unreachable!(
+                    "Source is either distinct or aliased. Other match patterns should be impossible"
+                ),
             };
             (s, srcs[i].layout())
         });

--- a/candle-core/src/custom_op.rs
+++ b/candle-core/src/custom_op.rs
@@ -1,6 +1,7 @@
+use crate::layout::LayoutRelation;
 use crate::op::{BackpropOp, Op};
 use crate::tensor::from_storage;
-use crate::{CpuStorage, CudaStorage, Layout, MetalStorage, Result, Shape, Tensor};
+use crate::{bail, CpuStorage, CudaStorage, Layout, MetalStorage, Result, Shape, Storage, Tensor};
 use std::sync::Arc;
 
 /// Unary ops that can be defined in user-land.
@@ -272,6 +273,200 @@ pub trait InplaceOp1 {
     }
 }
 
+/// In-place ops that can be defined in user-land.
+/// These ops work in-place and as such back-propagation is unsupported.
+pub trait InplaceOpN<const N: usize> {
+    fn name(&self) -> &'static str;
+
+    /// Defines the source access pattern of this in-place op.
+    /// Defaults to `None`, which rejects all in-place source aliasing.
+    fn src_access_pattern(&self) -> Option<AccessPattern> {
+        None
+    }
+
+    fn cpu_fwd(
+        &self,
+        dst: &mut CpuStorage,
+        dst_l: &Layout,
+        srcs: [(&CpuStorage, &Layout); N],
+    ) -> Result<()> {
+        let _ = (dst, dst_l, srcs);
+        bail!("no cpu implementation for {}", self.name())
+    }
+
+    fn cpu_fwd_aliased(
+        &self,
+        dst: &mut CpuStorage,
+        dst_l: &Layout,
+        srcs: [(Src<'_, CpuStorage>, &Layout); N],
+    ) -> Result<()> {
+        let _ = (dst, dst_l, srcs);
+        bail!("no aliased cpu implementation for {}", self.name())
+    }
+
+    fn cuda_fwd(
+        &self,
+        dst: &mut CudaStorage,
+        dst_l: &Layout,
+        srcs: [(&CudaStorage, &Layout); N],
+    ) -> Result<()> {
+        let _ = (dst, dst_l, srcs);
+        bail!("no cuda implementation for {}", self.name())
+    }
+
+    fn cuda_fwd_aliased(
+        &self,
+        dst: &mut CudaStorage,
+        dst_l: &Layout,
+        srcs: [(Src<'_, CudaStorage>, &Layout); N],
+    ) -> Result<()> {
+        let _ = (dst, dst_l, srcs);
+        bail!("no aliased cpu implementation for {}", self.name())
+    }
+
+    fn metal_fwd(
+        &self,
+        dst: &mut MetalStorage,
+        dst_l: &Layout,
+        srcs: [(&MetalStorage, &Layout); N],
+    ) -> Result<()> {
+        let _ = (dst, dst_l, srcs);
+        bail!("no metal implementation for {}", self.name())
+    }
+
+    fn metal_fwd_aliased(
+        &self,
+        dst: &mut MetalStorage,
+        dst_l: &Layout,
+        srcs: [(Src<'_, MetalStorage>, &Layout); N],
+    ) -> Result<()> {
+        let _ = (dst, dst_l, srcs);
+        bail!("no aliased metal implementation for {}", self.name())
+    }
+}
+
+#[derive(Debug)]
+pub enum Src<'a, S> {
+    Distinct(&'a S),
+    Aliased(LayoutRelation),
+}
+
+impl<S> Copy for Src<'_, S> {}
+
+impl<S> Clone for Src<'_, S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+// If all sources are distinct we return the entire array of tensors without the `Src` wrapper.
+pub(crate) fn all_distinct<'a, B, const N: usize>(
+    srcs: &[(Src<'a, B>, &'a Layout); N],
+) -> Option<[(&'a B, &'a Layout); N]> {
+    srcs.iter()
+        .all(|(s, _)| matches!(s, Src::Distinct(_)))
+        .then(|| {
+            std::array::from_fn(|i| match srcs[i] {
+                (Src::Distinct(s), l) => (s, l),
+                _ => unreachable!("checked immediately above"),
+            })
+        })
+}
+
+/// Indicates which indices a kernel reads, relative to the destination indices it writes.
+///
+/// When used with [`crate::LayoutRelation`] we can describe safe access patterns.
+/// For example `Elementwise` is safe to use with both `LayoutRelation::Identical` and `LayoutRelation::Disjoint`,
+/// while `Arbitrary` is only guaranteed to be safe with `LayoutRelation::Disjoint`.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum AccessPattern {
+    /// Reads only source index `i` when writing destination index `i`.
+    Elementwise,
+    /// Reads arbitrary source indices.
+    Arbitrary,
+}
+
+impl AccessPattern {
+    fn supports(self, rel: LayoutRelation) -> bool {
+        match (self, rel) {
+            (AccessPattern::Elementwise, LayoutRelation::Identical | LayoutRelation::Disjoint) => {
+                true
+            }
+            (AccessPattern::Arbitrary, LayoutRelation::Disjoint) => true,
+            _ => false,
+        }
+    }
+}
+
+macro_rules! forward_op1 {
+    ($fwd:ident, $fwd_aliased:ident, $storage:ty) => {
+        fn $fwd(
+            &self,
+            dst: &mut $storage,
+            dl: &Layout,
+            _: [(&$storage, &Layout); 0],
+        ) -> Result<()> {
+            InplaceOp1::$fwd(self, dst, dl)
+        }
+
+        fn $fwd_aliased(
+            &self,
+            dst: &mut $storage,
+            dl: &Layout,
+            _: [(Src<'_, $storage>, &Layout); 0],
+        ) -> Result<()> {
+            InplaceOp1::$fwd(self, dst, dl)
+        }
+    };
+}
+
+impl<C: InplaceOp1> InplaceOpN<0> for C {
+    fn name(&self) -> &'static str {
+        InplaceOp1::name(self)
+    }
+
+    forward_op1!(cpu_fwd, cpu_fwd_aliased, CpuStorage);
+    forward_op1!(cuda_fwd, cuda_fwd_aliased, CudaStorage);
+    forward_op1!(metal_fwd, metal_fwd_aliased, MetalStorage);
+}
+
+macro_rules! forward_op2 {
+    ($fwd:ident, $fwd_aliased:ident, $storage:ty) => {
+        fn $fwd(
+            &self,
+            dst: &mut $storage,
+            dl: &Layout,
+            srcs: [(&$storage, &Layout); 1],
+        ) -> Result<()> {
+            let [(s, sl)] = srcs;
+            InplaceOp2::$fwd(self, dst, dl, s, sl)
+        }
+
+        fn $fwd_aliased(
+            &self,
+            dst: &mut $storage,
+            dl: &Layout,
+            srcs: [(Src<'_, $storage>, &Layout); 1],
+        ) -> Result<()> {
+            let [(s, sl)] = srcs;
+            match s {
+                Src::Distinct(s) => InplaceOp2::$fwd(self, dst, dl, s, sl),
+                Src::Aliased(ref rel) => InplaceOp2::$fwd_aliased(self, dst, dl, sl, rel),
+            }
+        }
+    };
+}
+
+impl<C: InplaceOp2> InplaceOpN<1> for C {
+    fn name(&self) -> &'static str {
+        InplaceOp2::name(self)
+    }
+
+    forward_op2!(cpu_fwd, cpu_fwd_aliased, CpuStorage);
+    forward_op2!(cuda_fwd, cuda_fwd_aliased, CudaStorage);
+    forward_op2!(metal_fwd, metal_fwd_aliased, MetalStorage);
+}
+
 pub trait InplaceOp2 {
     fn name(&self) -> &'static str;
 
@@ -280,27 +475,109 @@ pub trait InplaceOp2 {
     fn cpu_fwd(&self, s1: &mut CpuStorage, l1: &Layout, s2: &CpuStorage, l2: &Layout)
         -> Result<()>;
 
+    fn cpu_fwd_aliased(
+        &self,
+        s: &mut CpuStorage,
+        l1: &Layout,
+        l2: &Layout,
+        rel: &LayoutRelation,
+    ) -> Result<()> {
+        _ = (s, l1, l2, rel);
+        bail!("{} does not support aliased operands on cpu", self.name())
+    }
+
     /// The forward pass, as run on a gpu device. Note that the storage can use arbitrary strides,
     /// offsets etc so the associated layout should be used to access it.
-    fn cuda_fwd(&self, _: &mut CudaStorage, _: &Layout, _: &CudaStorage, _: &Layout) -> Result<()> {
+    fn cuda_fwd(
+        &self,
+        s1: &mut CudaStorage,
+        l1: &Layout,
+        s2: &CudaStorage,
+        l2: &Layout,
+    ) -> Result<()> {
+        _ = (s1, l1, s2, l2);
         Err(crate::Error::Cuda(
             format!("no cuda implementation for {}", self.name()).into(),
         ))
+    }
+
+    fn cuda_fwd_aliased(
+        &self,
+        s: &mut CudaStorage,
+        l1: &Layout,
+        l2: &Layout,
+        rel: &LayoutRelation,
+    ) -> Result<()> {
+        _ = (s, l1, l2, rel);
+        bail!("{} does not support aliased operands on cuda", self.name())
     }
 
     /// The forward pass, as run on a metal gpu device. Note that the storage can use arbitrary strides,
     /// offsets etc so the associated layout should be used to access it.
     fn metal_fwd(
         &self,
-        _: &mut MetalStorage,
-        _: &Layout,
-        _: &MetalStorage,
-        _: &Layout,
+        s1: &mut MetalStorage,
+        l1: &Layout,
+        s2: &MetalStorage,
+        l2: &Layout,
     ) -> Result<()> {
+        _ = (s1, l1, s2, l2);
         Err(crate::Error::Metal(
             format!("no metal implementation for {}", self.name()).into(),
         ))
     }
+
+    fn metal_fwd_aliased(
+        &self,
+        s: &mut MetalStorage,
+        l1: &Layout,
+        l2: &Layout,
+        rel: &LayoutRelation,
+    ) -> Result<()> {
+        _ = (s, l1, l2, rel);
+        bail!("{} does not support aliased operands on cuda", self.name())
+    }
+}
+
+macro_rules! forward_op3 {
+    ($fwd:ident, $fwd_aliased:ident, $storage:ty) => {
+        fn $fwd(
+            &self,
+            dst: &mut $storage,
+            dl: &Layout,
+            srcs: [(&$storage, &Layout); 2],
+        ) -> Result<()> {
+            let [(s1, l1), (s2, l2)] = srcs;
+            InplaceOp3::$fwd(self, dst, dl, s1, l1, s2, l2)
+        }
+
+        fn $fwd_aliased(
+            &self,
+            dst: &mut $storage,
+            dl: &Layout,
+            srcs: [(Src<'_, $storage>, &Layout); 2],
+        ) -> Result<()> {
+            match srcs {
+                [(Src::Distinct(s1), l1), (Src::Distinct(s2), l2)] => {
+                    InplaceOp3::$fwd(self, dst, dl, s1, l1, s2, l2)
+                }
+                _ => bail!(
+                    "{}: aliased input requires migrating to InplaceOpN",
+                    self.name()
+                ),
+            }
+        }
+    };
+}
+
+impl<C: InplaceOp3> InplaceOpN<2> for C {
+    fn name(&self) -> &'static str {
+        InplaceOp3::name(self)
+    }
+
+    forward_op3!(cpu_fwd, cpu_fwd_aliased, CpuStorage);
+    forward_op3!(cuda_fwd, cuda_fwd_aliased, CudaStorage);
+    forward_op3!(metal_fwd, metal_fwd_aliased, MetalStorage);
 }
 
 pub trait InplaceOp3 {
@@ -352,27 +629,91 @@ pub trait InplaceOp3 {
 }
 
 impl Tensor {
-    /// Applies a unary custom op in place.
-    pub fn inplace_op1<C: InplaceOp1>(&self, c: &C) -> Result<()> {
-        self.storage_mut().inplace_op1(self.layout(), c)
+    /// Applies a custom op in-place for the `self` tensor.
+    ///
+    /// Tensors sharing underlying storage with `self` are classified and passed as [`Src::Aliased`].
+    /// Separate tensors are locked and passed as [`Src::Distinct`].
+    fn inplace_op<const N: usize, C: InplaceOpN<N>>(&self, srcs: [&Self; N], c: &C) -> Result<()> {
+        let name = c.name();
+
+        // Ensure writes cannot collide with themselves
+        if self.layout().has_internal_overlap() {
+            bail!("{name}: dst has repeated elements (zero-stride). Can not write in-place")
+        }
+
+        // Classify srcs wrt dst
+        let access = c.src_access_pattern();
+        let mut rels: [Option<LayoutRelation>; N] = [None; N];
+        for i in 0..N {
+            if !self.same_storage(srcs[i]) {
+                continue;
+            }
+            let rel = Layout::relation(self.layout(), srcs[i].layout());
+            match access {
+                Some(a) if a.supports(rel) => rels[i] = Some(rel),
+                Some(a) => bail!(
+                    "src {i} shares storage with dst ({rel:?}), which is not supported for the access pattern of `{name}` ({a:?})."
+                ),
+                None => bail!(
+                    "src {i} shares storage with dst, and `{name}` does not support aliased operands."
+                ),
+            }
+        }
+
+        // Acquire locks in order sorted by `Tensor::storage_key`.
+        // Avoids deadlock from cycle of waiting locks.
+        let dst_key = self.storage_key();
+
+        let mut order: [usize; N] = std::array::from_fn(|i| i);
+        order.sort_unstable_by_key(|&i| srcs[i].storage_key());
+
+        let mut guards: [Option<_>; N] = std::array::from_fn(|_| None);
+        let mut dst: Option<_> = None;
+
+        for &i in order.iter() {
+            if rels[i].is_some() {
+                continue; // Aliased. Read through `dst`
+            }
+            let key = srcs[i].storage_key();
+            if key > dst_key && dst.is_none() {
+                dst = Some(self.storage_mut());
+            }
+            // Two sources sharing the same allocation, but distinct from dst.
+            // `read_recursive` allows for shared read access
+            guards[i] = Some(srcs[i].storage());
+        }
+        // If `dst` is not yet set we acquire it from `self` now.
+        let mut dst = match dst {
+            Some(g) => g,
+            None => self.storage_mut(),
+        };
+
+        let operands: [(Src<'_, Storage>, &Layout); N] = std::array::from_fn(|i| {
+            let s = match (&guards[i], rels[i]) {
+                (Some(g), None) => Src::Distinct(&**g),
+                (None, Some(rel)) => Src::Aliased(rel),
+                // `guards[i]` is `Some` exactly when `rels[i]` is `None`.
+                _ => unreachable!("guard presence tracks classification"),
+            };
+            (s, srcs[i].layout())
+        });
+
+        dst.inplace_op(self.layout(), operands, c)
     }
 
-    /// Applies a unary custom op in place (for the first tensor).
-    pub fn inplace_op2<C: InplaceOp2>(&self, rhs: &Self, c: &C) -> Result<()> {
-        self.storage_mut()
-            .inplace_op2(self.layout(), &rhs.storage(), rhs.layout(), c)
+    /// Applies a unary custom op in place.
+    pub fn inplace_op1<C: InplaceOp1>(&self, c: &C) -> Result<()> {
+        self.inplace_op([], c)
+    }
+
+    /// Applies a binary custom op in place (for the first tensor).
+    pub fn inplace_op2<C: InplaceOpN<1>>(&self, rhs: &Self, c: &C) -> Result<()> {
+        self.inplace_op([rhs], c)
     }
 
     /// Applies a ternary custom op in place (for the first tensor).
-    pub fn inplace_op3<C: InplaceOp3>(&self, t2: &Self, t3: &Self, c: &C) -> Result<()> {
-        self.storage_mut().inplace_op3(
-            self.layout(),
-            &t2.storage(),
-            t2.layout(),
-            &t3.storage(),
-            t3.layout(),
-            c,
-        )
+    pub fn inplace_op3<C: InplaceOpN<2>>(&self, t2: &Self, t3: &Self, c: &C) -> Result<()> {
+        self.inplace_op([t2, t3], c)
     }
 }
 

--- a/candle-core/src/custom_op.rs
+++ b/candle-core/src/custom_op.rs
@@ -448,10 +448,12 @@ macro_rules! forward_op2 {
             dl: &Layout,
             srcs: [(Src<'_, $storage>, &Layout); 1],
         ) -> Result<()> {
-            let [(s, sl)] = srcs;
-            match s {
-                Src::Distinct(s) => InplaceOp2::$fwd(self, dst, dl, s, sl),
-                Src::Aliased(ref rel) => InplaceOp2::$fwd_aliased(self, dst, dl, sl, rel),
+            match srcs {
+                [(Src::Distinct(s), sl)] => InplaceOp2::$fwd(self, dst, dl, s, sl),
+                _ => bail!(
+                    "{}: aliased input requires migrating to InplaceOpN",
+                    self.name()
+                ),
             }
         }
     };
@@ -475,17 +477,6 @@ pub trait InplaceOp2 {
     fn cpu_fwd(&self, s1: &mut CpuStorage, l1: &Layout, s2: &CpuStorage, l2: &Layout)
         -> Result<()>;
 
-    fn cpu_fwd_aliased(
-        &self,
-        s: &mut CpuStorage,
-        l1: &Layout,
-        l2: &Layout,
-        rel: &LayoutRelation,
-    ) -> Result<()> {
-        _ = (s, l1, l2, rel);
-        bail!("{} does not support aliased operands on cpu", self.name())
-    }
-
     /// The forward pass, as run on a gpu device. Note that the storage can use arbitrary strides,
     /// offsets etc so the associated layout should be used to access it.
     fn cuda_fwd(
@@ -501,17 +492,6 @@ pub trait InplaceOp2 {
         ))
     }
 
-    fn cuda_fwd_aliased(
-        &self,
-        s: &mut CudaStorage,
-        l1: &Layout,
-        l2: &Layout,
-        rel: &LayoutRelation,
-    ) -> Result<()> {
-        _ = (s, l1, l2, rel);
-        bail!("{} does not support aliased operands on cuda", self.name())
-    }
-
     /// The forward pass, as run on a metal gpu device. Note that the storage can use arbitrary strides,
     /// offsets etc so the associated layout should be used to access it.
     fn metal_fwd(
@@ -525,17 +505,6 @@ pub trait InplaceOp2 {
         Err(crate::Error::Metal(
             format!("no metal implementation for {}", self.name()).into(),
         ))
-    }
-
-    fn metal_fwd_aliased(
-        &self,
-        s: &mut MetalStorage,
-        l1: &Layout,
-        l2: &Layout,
-        rel: &LayoutRelation,
-    ) -> Result<()> {
-        _ = (s, l1, l2, rel);
-        bail!("{} does not support aliased operands on cuda", self.name())
     }
 }
 

--- a/candle-core/src/layout.rs
+++ b/candle-core/src/layout.rs
@@ -95,24 +95,36 @@ impl Layout {
         Some(outer_stride)
     }
 
-    /// Checks if more than one logical index lands on the same cell (a stride is 0 over a dim > 1).
+    /// Checks if more than one logical index lands on the same cell (or when we can't prove it does not)
     pub fn has_internal_overlap(&self) -> bool {
-        self.dims()
-            .iter()
-            .zip(self.stride())
-            .any(|(&d, &s)| d > 1 && s == 0)
+        !self.range().is_some_and(|f| f.injective)
     }
 
     /// Returns range of cells this layout can reach, and wether it reaches all of them.
     /// Returns `None` on arithmetic overflow.
     fn range(&self) -> Option<LayoutRange> {
-        let numel = self.shape().elem_count();
-        let mut span: usize = 0;
-        let mut injective = true;
+        // Filter out dims <= 1 as their strides are irrelevant.
+        let mut axes: Vec<(usize, usize)> = self
+            .dims()
+            .iter()
+            .zip(self.stride())
+            .filter(|(&d, _)| d > 1)
+            .map(|(&d, &s)| (d, s))
+            .collect();
+        axes.sort_unstable_by_key(|&(_, s)| s);
 
-        for (&d, &s) in self.dims().iter().zip(self.stride()) {
-            if d > 1 && s == 0 {
+        let mut span = 0usize;
+        let mut injective = true;
+        let mut dense = true;
+
+        for (d, s) in axes {
+            if s <= span {
+                // This dim can land on a cell another dim already reaches.
                 injective = false;
+                dense = false;
+            } else if s - span != 1 {
+                // Has a gap
+                dense = false;
             }
             span = span.checked_add((d - 1).checked_mul(s)?)?;
         }
@@ -121,10 +133,8 @@ impl Layout {
         Some(LayoutRange {
             lo,
             hi: lo.checked_add(span)?,
-            // injective means exactly `numel` distinct cells.
-            // if `span == numel - 1` as well then we have as many cells as elements,
-            // meaning the range is dense.
-            dense: injective && span == numel - 1,
+            injective,
+            dense,
         })
     }
 
@@ -360,6 +370,8 @@ struct LayoutRange {
     lo: usize,
     /// Highest reachable cell (inclusive).
     hi: usize,
+    /// Proven to map distinct logical indices to distinct cells.
+    injective: bool,
     /// Indicates that layout occupies every cell in `lo..=hi`.
     /// Does not necessarily mean that layout is contiguous.
     dense: bool,

--- a/candle-core/src/layout.rs
+++ b/candle-core/src/layout.rs
@@ -95,6 +95,71 @@ impl Layout {
         Some(outer_stride)
     }
 
+    /// Checks if more than one logical index lands on the same cell (a stride is 0 over a dim > 1).
+    pub fn has_internal_overlap(&self) -> bool {
+        self.dims()
+            .iter()
+            .zip(self.stride())
+            .any(|(&d, &s)| d > 1 && s == 0)
+    }
+
+    /// Returns range of cells this layout can reach, and wether it reaches all of them.
+    /// Returns `None` on arithmetic overflow.
+    fn range(&self) -> Option<LayoutRange> {
+        let numel = self.shape().elem_count();
+        let mut span: usize = 0;
+        let mut injective = true;
+
+        for (&d, &s) in self.dims().iter().zip(self.stride()) {
+            if d > 1 && s == 0 {
+                injective = false;
+            }
+            span = span.checked_add((d - 1).checked_mul(s)?)?;
+        }
+
+        let lo = self.start_offset();
+        Some(LayoutRange {
+            lo,
+            hi: lo.checked_add(span)?,
+            // injective means exactly `numel` distinct cells.
+            // if `span == numel - 1` as well then we have as many cells as elements,
+            // meaning the range is dense.
+            dense: injective && span == numel - 1,
+        })
+    }
+
+    /// Relation between this layout and another
+    pub fn relation(&self, other: &Self) -> LayoutRelation {
+        if self == other {
+            return LayoutRelation::Identical;
+        }
+
+        if self.shape().elem_count() == 0 || other.shape().elem_count() == 0 {
+            return LayoutRelation::Disjoint;
+        }
+
+        // Extract [`LayoutRange`] from layout.
+        let (a, b) = match (self.range(), other.range()) {
+            (Some(a), Some(b)) => (a, b),
+            _ => return LayoutRelation::Unknown, // address arithmetic overflowed
+        };
+
+        if a.separated_from(&b) {
+            return LayoutRelation::Disjoint;
+        }
+
+        if a.densely_contains(&b) || b.densely_contains(&a) {
+            return LayoutRelation::Overlapping;
+        }
+
+        // We end up here when layouts ranges overlap and neither is dense, such as disjoint
+        // column slices. Figuring out these cases is a bounded integer feasibility problem
+        // over the strides. This is NP-hard in general. Cheap at common tensor ranks.
+        // If we want to move more cases out of unknown into disjoint/overlapping it can be done using the
+        // same approach as numpy: https://github.com/numpy/numpy/blob/main/numpy/_core/src/common/mem_overlap.c
+        LayoutRelation::Unknown
+    }
+
     /// Returns the appropriate start and stop offset if the data is stored in a C
     /// contiguous (aka row major) way.
     pub fn contiguous_offsets(&self) -> Option<(usize, usize)> {
@@ -286,4 +351,41 @@ impl Layout {
             }
         }
     }
+}
+
+/// Describes the range of cells a [`Layout`] can reach within its allocation,
+/// and whether it reaches all of them.
+struct LayoutRange {
+    /// Lowest reachable cell. Equal to layout `start_offset`.
+    lo: usize,
+    /// Highest reachable cell (inclusive).
+    hi: usize,
+    /// Indicates that layout occupies every cell in `lo..=hi`.
+    /// Does not necessarily mean that layout is contiguous.
+    dense: bool,
+}
+
+impl LayoutRange {
+    /// Bounding intervals cannot meet, which means these layouts are seperate.
+    fn separated_from(&self, other: &Self) -> bool {
+        self.hi < other.lo || other.hi < self.lo
+    }
+
+    /// If a dense layout contains another's `lo` there is overlap.
+    fn densely_contains(&self, other: &Self) -> bool {
+        self.dense && other.lo >= self.lo && other.lo <= self.hi
+    }
+}
+
+/// How two layouts over the same allocation relate.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum LayoutRelation {
+    /// Simple assignment. x[i] += x[i]
+    Identical,
+    /// Completely distinct layouts.
+    Disjoint,
+    /// Any kind of overlap.
+    Overlapping,
+    /// Could not prove relation.
+    Unknown,
 }

--- a/candle-core/src/lib.rs
+++ b/candle-core/src/lib.rs
@@ -104,7 +104,7 @@ pub use indexer::{IndexOp, TensorIndexer};
 pub use layout::Layout;
 pub use nditer::NdIter;
 pub use shape::{Shape, D};
-pub use storage::Storage;
+pub use storage::{Storage, StorageMutRef, StorageRef};
 pub use streaming::{StreamTensor, StreamingBinOp, StreamingModule};
 pub use strided_index::{StridedBlocks, StridedIndex};
 pub use tensor::{Tensor, TensorId};

--- a/candle-core/src/metal_backend/mod.rs
+++ b/candle-core/src/metal_backend/mod.rs
@@ -4,7 +4,6 @@ use crate::backend::{BackendDevice, BackendStorage};
 use crate::conv::{ParamsConv1D, ParamsConv2D, ParamsConvTranspose1D, ParamsConvTranspose2D};
 use crate::op::{BinaryOpT, CmpOp, ReduceOp, UnaryOpT};
 use crate::{CpuStorage, CpuStorageRef, DType, Error, Layout, Result, Shape};
-use candle_metal_kernels::kernels::binary::contiguous;
 use candle_metal_kernels::{
     metal::{Buffer, Commands, Device, ResidencySet},
     BufferOffset, CallConvTranspose2dCfg, Kernels, RESOURCE_OPTIONS,

--- a/candle-core/src/storage.rs
+++ b/candle-core/src/storage.rs
@@ -1,8 +1,10 @@
 use crate::backend::BackendStorage;
+use crate::custom_op::{all_distinct, InplaceOpN, Src};
 use crate::op::{self, CmpOp, ReduceOp};
 use crate::scalar::Scalar;
 use crate::{CpuStorage, CudaStorage, DType, Device, Error, Layout, MetalStorage, Result, Shape};
-use crate::{CustomOp1, CustomOp2, CustomOp3, InplaceOp1, InplaceOp2, InplaceOp3};
+use crate::{CustomOp1, CustomOp2, CustomOp3};
+use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 
 // We do not want to implement Clone on Storage as cloning may fail because of
 // out of memory. Instead try_clone should be used.
@@ -12,6 +14,9 @@ pub enum Storage {
     Cuda(CudaStorage),
     Metal(MetalStorage),
 }
+
+pub type StorageRef<'a> = RwLockReadGuard<'a, Storage>;
+pub type StorageMutRef<'a> = RwLockWriteGuard<'a, Storage>;
 
 impl Storage {
     pub fn try_clone(&self, layout: &Layout) -> Result<Self> {
@@ -272,48 +277,49 @@ impl Storage {
         }
     }
 
-    pub(crate) fn inplace_op1(&mut self, l: &Layout, c: &dyn InplaceOp1) -> Result<()> {
-        match self {
-            Self::Cpu(storage) => c.cpu_fwd(storage, l),
-            Self::Cuda(storage) => c.cuda_fwd(storage, l),
-            Self::Metal(storage) => c.metal_fwd(storage, l),
-        }
-    }
-
-    pub(crate) fn inplace_op2(
+    /// Applies an custom in-place op for the `self` tensor.
+    ///
+    /// [`Src::Aliased`] use the same underlying storage as `self`, while [`Src::Distinct`] does not.
+    /// If there are aliases present the aliased forward function on `InplaceOpN` is called. Otherwise
+    /// the normal forward function can be used.
+    pub(crate) fn inplace_op<const N: usize, C: InplaceOpN<N>>(
         &mut self,
-        l1: &Layout,
-        t2: &Self,
-        l2: &Layout,
-        c: &dyn InplaceOp2,
+        dst_l: &Layout,
+        srcs: [(Src<'_, Storage>, &Layout); N],
+        c: &C,
     ) -> Result<()> {
-        self.same_device(t2, c.name())?;
-        match (self, t2) {
-            (Self::Cpu(s1), Self::Cpu(s2)) => c.cpu_fwd(s1, l1, s2, l2),
-            (Self::Cuda(s1), Self::Cuda(s2)) => c.cuda_fwd(s1, l1, s2, l2),
-            (Self::Metal(s1), Self::Metal(s2)) => c.metal_fwd(s1, l1, s2, l2),
-            _ => unreachable!(),
-        }
-    }
-
-    pub(crate) fn inplace_op3(
-        &mut self,
-        l1: &Layout,
-        t2: &Self,
-        l2: &Layout,
-        t3: &Self,
-        l3: &Layout,
-        c: &dyn InplaceOp3,
-    ) -> Result<()> {
-        self.same_device(t2, c.name())?;
-        self.same_device(t3, c.name())?;
-        match (self, t2, t3) {
-            (Self::Cpu(s1), Self::Cpu(s2), Self::Cpu(s3)) => c.cpu_fwd(s1, l1, s2, l2, s3, l3),
-            (Self::Cuda(s1), Self::Cuda(s2), Self::Cuda(s3)) => c.cuda_fwd(s1, l1, s2, l2, s3, l3),
-            (Self::Metal(s1), Self::Metal(s2), Self::Metal(s3)) => {
-                c.metal_fwd(s1, l1, s2, l2, s3, l3)
+        // Aliased sources are `self`. Only distinct needs checking.
+        for (s, _) in srcs.iter() {
+            if let Src::Distinct(s) = s {
+                self.same_device(s, c.name())?;
             }
-            _ => unreachable!(),
+        }
+        macro_rules! inplace_dispatch {
+            ($dst:expr, $variant:ident, $fwd:ident, $fwd_aliased:ident) => {{
+                // Extract underlying storage variant on same device
+                let operands: [(Src<'_, _>, &Layout); N] = std::array::from_fn(|i| {
+                    let (s, l) = srcs[i];
+                    let s = match s {
+                        Src::Distinct(Storage::$variant(s)) => Src::Distinct(s),
+                        Src::Aliased(rel) => Src::Aliased(rel),
+                        Src::Distinct(_) => {
+                            unreachable!("same_device above rejects mismatched backends")
+                        }
+                    };
+                    (s, l)
+                });
+
+                match all_distinct(&operands) {
+                    Some(distinct) => c.$fwd($dst, dst_l, distinct),
+                    None => c.$fwd_aliased($dst, dst_l, operands),
+                }
+            }};
+        }
+
+        match self {
+            Storage::Cpu(dst) => inplace_dispatch!(dst, Cpu, cpu_fwd, cpu_fwd_aliased),
+            Storage::Cuda(dst) => inplace_dispatch!(dst, Cuda, cuda_fwd, cuda_fwd_aliased),
+            Storage::Metal(dst) => inplace_dispatch!(dst, Metal, metal_fwd, metal_fwd_aliased),
         }
     }
 

--- a/candle-core/src/tensor.rs
+++ b/candle-core/src/tensor.rs
@@ -4,8 +4,10 @@ use crate::backend::{BackendDevice, BackendStorage};
 use crate::op::{BackpropOp, BinaryOp, CmpOp, Op, ReduceOp, UnaryOp};
 use crate::scalar::TensorOrScalar;
 use crate::shape::{Dim, Dims, ShapeWithOneHole};
+use crate::storage::{StorageMutRef, StorageRef};
 use crate::{bail, storage::Storage, DType, Device, Error, Layout, Result, Shape};
-use std::sync::{Arc, RwLock};
+use parking_lot::RwLock;
+use std::sync::Arc;
 
 /// Unique identifier for tensors.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -1228,7 +1230,7 @@ impl Tensor {
     /// # Arguments
     ///
     /// * `target_h` - Target height
-    /// * `target_w` - Target width  
+    /// * `target_w` - Target width
     /// * `align_corners` - If true, corner pixels are aligned. If false (default),
     ///   pixels are treated as areas (matches PyTorch default behavior).
     ///
@@ -2755,33 +2757,41 @@ impl Tensor {
         m.forward_t(self, train)
     }
 
-    pub(crate) fn storage(&self) -> std::sync::RwLockReadGuard<'_, Storage> {
-        self.storage.read().unwrap()
+    /// Acquire read lock on storage and returns guard.
+    /// `read_recursive` allows for shared read access.
+    pub(crate) fn storage(&self) -> StorageRef<'_> {
+        self.storage.read_recursive()
     }
 
-    pub(crate) fn storage_mut(&self) -> std::sync::RwLockWriteGuard<'_, Storage> {
-        self.storage.write().unwrap()
+    /// Acquire write lock on storage and returns guard.
+    pub(crate) fn storage_mut(&self) -> StorageMutRef<'_> {
+        self.storage.write()
     }
 
     // If we extend the visibility of this function to be usable outside of this crate, we should
     // make it unsafe.
-    pub(crate) fn storage_mut_and_layout(
-        &self,
-    ) -> (std::sync::RwLockWriteGuard<'_, Storage>, &Layout) {
-        let storage = self.storage.write().unwrap();
+    pub(crate) fn storage_mut_and_layout(&self) -> (StorageMutRef<'_>, &Layout) {
+        let storage = self.storage.write();
         (storage, &self.layout)
     }
 
     /// The storage used by this tensor, together with the layout to use to access it safely.
-    pub fn storage_and_layout(&self) -> (std::sync::RwLockReadGuard<'_, Storage>, &Layout) {
-        let storage = self.storage.read().unwrap();
+    pub fn storage_and_layout(&self) -> (StorageRef<'_>, &Layout) {
+        let storage = self.storage.read();
         (storage, &self.layout)
     }
 
+    /// Unique key for this tensor's storage. Equal keys mean the tensors share the same allocation.
+    #[inline]
+    pub(crate) fn storage_key(&self) -> usize {
+        let lock: &RwLock<Storage> = self.storage.as_ref();
+        std::ptr::from_ref(lock).addr()
+    }
+
+    /// Check if two tensors share the same underlying allocation.
+    #[inline]
     pub(crate) fn same_storage(&self, rhs: &Self) -> bool {
-        let lhs: &RwLock<Storage> = self.storage.as_ref();
-        let rhs: &RwLock<Storage> = rhs.storage.as_ref();
-        std::ptr::eq(lhs, rhs)
+        self.storage_key() == rhs.storage_key()
     }
 
     /// Normalize a 'relative' axis value: positive values are kept, negative

--- a/candle-core/tests/custom_op_tests.rs
+++ b/candle-core/tests/custom_op_tests.rs
@@ -180,3 +180,67 @@ fn ug_op() -> Result<()> {
     );
     Ok(())
 }
+
+struct InplaceAdd;
+
+impl candle_core::InplaceOp2 for InplaceAdd {
+    fn name(&self) -> &'static str {
+        "inplace-add"
+    }
+
+    fn cpu_fwd(
+        &self,
+        s1: &mut CpuStorage,
+        l1: &Layout,
+        s2: &CpuStorage,
+        l2: &Layout,
+    ) -> Result<()> {
+        let elems = l1.shape().elem_count();
+        let start1 = l1.start_offset();
+        let start2 = l2.start_offset();
+        let (CpuStorage::F32(d1), CpuStorage::F32(d2)) = (s1, s2) else {
+            candle_core::bail!("unsupported dtype for inplace-add")
+        };
+        let rhs: Vec<f32> = d2[start2..start2 + elems].to_vec();
+        for (v, r) in d1[start1..start1 + elems].iter_mut().zip(rhs) {
+            *v += r;
+        }
+        Ok(())
+    }
+}
+
+impl candle_core::InplaceOp3 for InplaceAdd {
+    fn name(&self) -> &'static str {
+        "inplace-add3"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _: &mut CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn inplace_op_shared_storage_errors_instead_of_deadlocking() -> Result<()> {
+    let cpu = &Device::Cpu;
+    let t = Tensor::from_vec(vec![1f32, 2., 3., 4.], 4, cpu)?;
+    let dst = t.narrow(0, 0, 2)?;
+    let src = t.narrow(0, 2, 2)?;
+    let res = dst.inplace_op2(&src, &InplaceAdd);
+    assert!(res.is_err(), "shared-storage inplace_op2 must error");
+    let res = dst.inplace_op3(&src, &src, &InplaceAdd);
+    let _ = res.expect_err("shared-storage inplace_op3 must error");
+    // Distinct storages keep working.
+    let a = Tensor::from_vec(vec![1f32, 2.], 2, cpu)?;
+    let b = Tensor::from_vec(vec![10f32, 20.], 2, cpu)?;
+    a.inplace_op2(&b, &InplaceAdd)?;
+    assert_eq!(a.to_vec1::<f32>()?, [11., 22.]);
+    Ok(())
+}

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -2203,7 +2203,7 @@ fn transfers_cuda_to_device() -> Result<()> {
 fn allocates_twice_when_transferring_to_same_device() -> Result<()> {
     use std::{ops::Deref, sync::RwLockReadGuard};
 
-    use candle_core::Storage;
+    use candle_core::{Storage, StorageRef};
     use rand::seq::SliceRandom;
 
     let first = Device::new_cuda(0)?;
@@ -2218,7 +2218,7 @@ fn allocates_twice_when_transferring_to_same_device() -> Result<()> {
 
     let (storage1, _) = t1.storage_and_layout();
     let (storage2, _) = t2.storage_and_layout();
-    let extract = |s: RwLockReadGuard<'_, Storage>| match &s.deref() {
+    let extract = |s: StorageRef| match &s.deref() {
         Storage::Cuda(c) => {
             use cudarc::driver::DevicePtr;
             let slice = c.as_cuda_slice::<u32>().unwrap();

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -2201,7 +2201,7 @@ fn transfers_cuda_to_device() -> Result<()> {
 #[cfg(feature = "cuda")]
 #[test]
 fn allocates_twice_when_transferring_to_same_device() -> Result<()> {
-    use std::{ops::Deref, sync::RwLockReadGuard};
+    use std::ops::Deref;
 
     use candle_core::{Storage, StorageRef};
     use rand::seq::SliceRandom;


### PR DESCRIPTION
In-place ops now check if input tensors share underlying allocation, and apply correct locking mechanisms to avoid deadlocks. Unsupported access patterns are rejected.

We use `parking_lot::RwLock::read_recursive` when reading tensor storage, allowing shared read access without acquiring several read locks.

All in-place ops now call through the new `Tensor::inplace_op` using the new `InplaceOpN<const N: usize>` trait - including ops defined through the old `InplaceOp1/2/3` trait.

`Tensor::inplace_op` checks the validity of the in-place op access pattern wrt `N` tensor operands.
If valid then all (distinct) tensors are locked in order of `Tensor::storage_key` to access the underlying storage. This avoids deadlock by cycle.

Then `Storage::inplace_op` is called, which either delegates to the backend specific `*_fwd` or `*_fwd_aliased`. `*_fwd_aliased` is for when one or more of the input tensors shares storage with the destination tensor.