### PR TITLE
fix(cuda): add context to kernel lookup errors

### DIFF
--- a/candle-core/src/cuda_backend/device.rs
+++ b/candle-core/src/cuda_backend/device.rs
@@ -254,6 +254,42 @@ pub struct CudaFunc {
     stream: Arc<cudarc::driver::CudaStream>,
 }
 
+fn kernel_load_context(
+    fn_name: &str,
+    module_name: &str,
+    cuda: &cudarc::driver::DriverError,
+) -> String {
+    if cuda.0 == cudarc::driver::sys::CUresult::CUDA_ERROR_NOT_FOUND {
+        format!(
+            "cuda: kernel `{fn_name}` not found in module `{module_name}` \
+             (this kernel may not be compiled for the target architecture)"
+        )
+    } else {
+        format!("cuda: failed to load kernel `{fn_name}` from module `{module_name}`")
+    }
+}
+
+fn kernel_load_error(
+    cuda: cudarc::driver::DriverError,
+    fn_name: &str,
+    mdl: &kernels::Module,
+) -> crate::Error {
+    let module_name = format!("{:?}", kernels::ALL_IDS[mdl.index()]).to_ascii_lowercase();
+    let context = kernel_load_context(fn_name, &module_name, &cuda);
+    let error: crate::Error = CudaError::Load { cuda, module_name }.into();
+    error.context(context)
+}
+
+fn load_kernel_function(
+    module: &Arc<cudarc::driver::CudaModule>,
+    fn_name: &str,
+    mdl: &kernels::Module,
+) -> Result<CudaFunction> {
+    module
+        .load_function(fn_name)
+        .map_err(|cuda| kernel_load_error(cuda, fn_name, mdl))
+}
+
 impl std::ops::Deref for CudaFunc {
     type Target = CudaFunction;
 
@@ -360,8 +396,8 @@ impl CudaDevice {
 
     pub fn get_or_load_func(&self, fn_name: &str, mdl: &kernels::Module) -> Result<CudaFunc> {
         let ms = self.modules.read().unwrap();
-        if let Some(mdl) = ms.mdls[mdl.index()].as_ref() {
-            let func = mdl.load_function(fn_name).w()?;
+        if let Some(cuda_module) = ms.mdls[mdl.index()].as_ref() {
+            let func = load_kernel_function(cuda_module, fn_name, mdl)?;
             return Ok(CudaFunc {
                 func,
                 stream: self.stream.clone(),
@@ -371,7 +407,7 @@ impl CudaDevice {
         let mut ms = self.modules.write().unwrap();
         let cuda_module = self.context.load_module(mdl.ptx().into()).w()?;
         ms.mdls[mdl.index()] = Some(cuda_module.clone());
-        let func = cuda_module.load_function(fn_name).w()?;
+        let func = load_kernel_function(&cuda_module, fn_name, mdl)?;
         Ok(CudaFunc {
             func,
             stream: self.stream.clone(),
@@ -833,5 +869,52 @@ impl BackendDevice for CudaDevice {
     fn synchronize(&self) -> Result<()> {
         self.stream.synchronize().map_err(crate::Error::wrap)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source_chain_contains_driver_error(
+        error: &crate::Error,
+        expected: &cudarc::driver::DriverError,
+    ) -> bool {
+        let mut source = std::error::Error::source(error);
+        while let Some(error) = source {
+            if error.downcast_ref::<cudarc::driver::DriverError>() == Some(expected) {
+                return true;
+            }
+            source = error.source();
+        }
+        false
+    }
+
+    #[test]
+    fn kernel_not_found_error_has_context_and_preserves_source() {
+        let driver_error =
+            cudarc::driver::DriverError(cudarc::driver::sys::CUresult::CUDA_ERROR_NOT_FOUND);
+        let error = kernel_load_error(driver_error, "missing_kernel", &kernels::AFFINE);
+
+        assert_eq!(
+            error.to_string().lines().next(),
+            Some(
+                "cuda: kernel `missing_kernel` not found in module `affine` \
+                 (this kernel may not be compiled for the target architecture)"
+            )
+        );
+        assert!(source_chain_contains_driver_error(&error, &driver_error));
+    }
+
+    #[test]
+    fn other_kernel_load_errors_do_not_include_architecture_hint() {
+        let driver_error =
+            cudarc::driver::DriverError(cudarc::driver::sys::CUresult::CUDA_ERROR_INVALID_CONTEXT);
+        let error = kernel_load_error(driver_error, "missing_kernel", &kernels::AFFINE);
+
+        assert_eq!(
+            error.to_string().lines().next(),
+            Some("cuda: failed to load kernel `missing_kernel` from module `affine`")
+        );
     }
 }

--- a/candle-core/src/cuda_backend/error.rs
+++ b/candle-core/src/cuda_backend/error.rs
@@ -40,6 +40,7 @@ pub enum CudaError {
 
     #[error("{cuda} when loading {module_name}")]
     Load {
+        #[source]
         cuda: cudarc::driver::DriverError,
         module_name: String,
     },

--- a/candle-core/src/error.rs
+++ b/candle-core/src/error.rs
@@ -220,6 +220,7 @@ pub enum Error {
 
     #[error("{context}\n{inner}")]
     Context {
+        #[source]
         inner: Box<Self>,
         context: Box<dyn std::fmt::Display + Send + Sync>,
     },
@@ -233,6 +234,7 @@ pub enum Error {
 
     #[error("{inner}\n{backtrace}")]
     WithBacktrace {
+        #[source]
         inner: Box<Self>,
         backtrace: Box<std::backtrace::Backtrace>,
     },
@@ -390,5 +392,24 @@ impl<T> Context<T, Infallible> for Option<T> {
             Some(v) => Ok(v),
             None => Err(Error::UnwrapNone.context(context()).bt()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn context_and_backtrace_expose_their_inner_errors_as_sources() {
+        let error = Error::Msg("root cause".into());
+        let error = Error::WithBacktrace {
+            inner: Box::new(error),
+            backtrace: Box::new(std::backtrace::Backtrace::force_capture()),
+        }
+        .context("operation failed");
+
+        let backtrace = std::error::Error::source(&error).unwrap();
+        let root_cause = backtrace.source().unwrap();
+        assert_eq!(root_cause.to_string(), "root cause");
     }
 }


### PR DESCRIPTION
## Summary

- include the kernel and module names when a built-in CUDA function lookup fails
- add the architecture hint only for `CUDA_ERROR_NOT_FOUND`, while using neutral context for other driver errors
- preserve the underlying `DriverError` through Candle's CUDA, backtrace, and context wrappers
- route both cached-module and load-then-lookup paths through the same helper
- add tests for the diagnostic text and error source chain

Fixes #3884

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p candle-core`
- `RUST_BACKTRACE=1 cargo test -p candle-core --features cuda --lib cuda_backend::device::tests -- --nocapture`
- `cargo test -p candle-core --features cuda -- --skip conv2d_grad_noncontiguous_kernel_gpu`
- `cargo clippy -p candle-core --features cuda --lib --tests -- -D warnings`

The unfiltered CUDA suite hits the existing
`conv2d_grad_noncontiguous_kernel_gpu` baseline failure, which is unrelated to
this change and is already addressed by #3853. The CUDA suite passes when only
that test is skipped.