### PR TITLE
Add XLMRobertaModel::forward_with_cancel

### DIFF
--- a/candle-transformers/src/models/xlm_roberta.rs
+++ b/candle-transformers/src/models/xlm_roberta.rs
@@ -332,16 +332,24 @@ impl XLMRobertaEncoder {
         Ok(Self { layers })
     }
 
-    fn forward(
+    /// Polls `should_cancel` before every layer. `XLMRobertaModel::forward`
+    /// passes a callback that never fires, so the uncancellable path costs one
+    /// predictable branch per layer and nothing else.
+    #[allow(clippy::too_many_arguments)]
+    fn forward_with_cancel(
         &self,
         hidden_states: &Tensor,
         attention_mask: &Tensor,
         encoder_hidden_states: Option<&Tensor>,
         encoder_attention_mask: Option<&Tensor>,
         past_key_value: Option<(&Tensor, &Tensor)>,
+        should_cancel: &(dyn Fn() -> bool + Sync),
     ) -> Result<Tensor> {
         let mut hidden_states = hidden_states.clone();
         for layer_module in self.layers.iter() {
+            if should_cancel() {
+                candle::bail!("xlm-roberta: forward pass cancelled by caller")
+            }
             let layer_outputs = layer_module.forward(
                 &hidden_states,
                 attention_mask,
@@ -379,15 +387,47 @@ impl XLMRobertaModel {
         encoder_hidden_states: Option<&Tensor>,
         encoder_attention_mask: Option<&Tensor>,
     ) -> Result<Tensor> {
+        self.forward_with_cancel(
+            input_ids,
+            attention_mask,
+            token_type_ids,
+            past_key_value,
+            encoder_hidden_states,
+            encoder_attention_mask,
+            &|| false,
+        )
+    }
+
+    /// Same as [`Self::forward`], but `should_cancel` is polled before every
+    /// encoder layer. When it returns `true` the pass stops early with an
+    /// error instead of running the remaining layers.
+    ///
+    /// This matters for interactive callers that abandon a result mid-flight —
+    /// a cancelled request otherwise keeps a core busy for the whole depth of
+    /// the model. The check sits between layers because that is the only point
+    /// where the pass can be interrupted; a matmul already in flight still runs
+    /// to completion.
+    #[allow(clippy::too_many_arguments)]
+    pub fn forward_with_cancel(
+        &self,
+        input_ids: &Tensor,
+        attention_mask: &Tensor,
+        token_type_ids: &Tensor,
+        past_key_value: Option<(&Tensor, &Tensor)>,
+        encoder_hidden_states: Option<&Tensor>,
+        encoder_attention_mask: Option<&Tensor>,
+        should_cancel: &(dyn Fn() -> bool + Sync),
+    ) -> Result<Tensor> {
         let hidden_states = self.embeddings.forward(input_ids, token_type_ids)?;
         let attention_mask = prepare_4d_attention_mask(attention_mask, DType::F32, None)?
             .to_device(hidden_states.device())?;
-        let hidden_states = self.encoder.forward(
+        let hidden_states = self.encoder.forward_with_cancel(
             &hidden_states,
             &attention_mask,
             encoder_hidden_states,
             encoder_attention_mask,
             past_key_value,
+            should_cancel,
         )?;
         Ok(hidden_states)
     }

--- a/candle-transformers/tests/xlm_roberta_tests.rs
+++ b/candle-transformers/tests/xlm_roberta_tests.rs
@@ -1,0 +1,136 @@
+use candle::{DType, Device, Result, Tensor};
+use candle_nn::{Activation, VarBuilder};
+use candle_transformers::models::xlm_roberta::{Config, XLMRobertaModel};
+
+/// A deliberately tiny config: the test exercises control flow, not numerics,
+/// so the model is kept small enough to build and run in milliseconds on CPU.
+fn tiny_config(num_hidden_layers: usize) -> Config {
+    Config {
+        hidden_size: 8,
+        layer_norm_eps: 1e-5,
+        attention_probs_dropout_prob: 0.0,
+        hidden_dropout_prob: 0.0,
+        num_attention_heads: 2,
+        position_embedding_type: "absolute".to_string(),
+        intermediate_size: 16,
+        hidden_act: Activation::Gelu,
+        num_hidden_layers,
+        vocab_size: 32,
+        max_position_embeddings: 16,
+        type_vocab_size: 1,
+        pad_token_id: 1,
+    }
+}
+
+fn tiny_model(num_hidden_layers: usize) -> Result<(XLMRobertaModel, Tensor, Tensor, Tensor)> {
+    let device = Device::Cpu;
+    let vb = VarBuilder::zeros(DType::F32, &device);
+    let model = XLMRobertaModel::new(&tiny_config(num_hidden_layers), vb)?;
+
+    let input_ids = Tensor::new(&[[2u32, 5, 7, 3]], &device)?;
+    let attention_mask = Tensor::ones((1, 4), DType::F32, &device)?;
+    let token_type_ids = Tensor::zeros((1, 4), DType::U32, &device)?;
+
+    Ok((model, input_ids, attention_mask, token_type_ids))
+}
+
+/// A callback that never cancels must leave the pass untouched — this is the
+/// path `forward` itself takes, so a regression here would break every caller.
+#[test]
+fn forward_with_cancel_runs_to_completion_when_not_cancelled() -> Result<()> {
+    let (model, input_ids, attention_mask, token_type_ids) = tiny_model(2)?;
+
+    let out = model.forward_with_cancel(
+        &input_ids,
+        &attention_mask,
+        &token_type_ids,
+        None,
+        None,
+        None,
+        &|| false,
+    )?;
+
+    assert_eq!(out.dims3()?, (1, 4, 8));
+    Ok(())
+}
+
+/// The point of the API: an already-started pass stops instead of running the
+/// remaining layers.
+#[test]
+fn forward_with_cancel_stops_when_cancelled() -> Result<()> {
+    let (model, input_ids, attention_mask, token_type_ids) = tiny_model(2)?;
+
+    let out = model.forward_with_cancel(
+        &input_ids,
+        &attention_mask,
+        &token_type_ids,
+        None,
+        None,
+        None,
+        &|| true,
+    );
+
+    assert!(out.is_err(), "a cancelled pass must not return a tensor");
+    Ok(())
+}
+
+/// Cancellation is polled *between* layers, so it must be observed once per
+/// layer — not once per call. Counting the polls is what proves the check sits
+/// inside the loop rather than in front of it.
+#[test]
+fn cancellation_is_polled_once_per_layer() -> Result<()> {
+    let layers = 5;
+    let (model, input_ids, attention_mask, token_type_ids) = tiny_model(layers)?;
+
+    let polls = std::sync::atomic::AtomicUsize::new(0);
+    let count = || {
+        polls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        false
+    };
+
+    model.forward_with_cancel(
+        &input_ids,
+        &attention_mask,
+        &token_type_ids,
+        None,
+        None,
+        None,
+        &count,
+    )?;
+
+    assert_eq!(polls.load(std::sync::atomic::Ordering::Relaxed), layers);
+    Ok(())
+}
+
+/// `forward` must keep its exact previous behaviour: same signature, same
+/// result as the cancellable variant with a callback that never fires.
+#[test]
+fn forward_matches_forward_with_cancel_without_cancellation() -> Result<()> {
+    let (model, input_ids, attention_mask, token_type_ids) = tiny_model(2)?;
+
+    let plain = model.forward(
+        &input_ids,
+        &attention_mask,
+        &token_type_ids,
+        None,
+        None,
+        None,
+    )?;
+    let cancellable = model.forward_with_cancel(
+        &input_ids,
+        &attention_mask,
+        &token_type_ids,
+        None,
+        None,
+        None,
+        &|| false,
+    )?;
+
+    assert_eq!(plain.dims(), cancellable.dims());
+    let diff = (plain - cancellable)?
+        .abs()?
+        .max_all()?
+        .to_scalar::<f32>()?;
+    assert_eq!(diff, 0.0);
+    Ok(())
+}


### PR DESCRIPTION
## Problem

`XLMRobertaEncoder` and its layer loop are private, so there is no way to interrupt a forward pass that has already started. A caller that abandons a result mid-flight — an interactive request that was cancelled, a stale job in a worker pool — keeps a core busy for the full depth of the model. On a 12-layer backbone that is seconds to tens of seconds of compute thrown away per abandoned request.

Checking for cancellation *around* `forward` does not help: by then the whole pass is already committed.

## Change

Adds `XLMRobertaModel::forward_with_cancel`, which polls a caller-supplied closure before every encoder layer and returns an error instead of running the remaining ones.

```rust
let out = model.forward_with_cancel(
    &input_ids, &attention_mask, &token_type_ids,
    None, None, None,
    &|| job.is_stale(),
);
```

The check sits between layers because that is the only interruptible point — a matmul already in flight still runs to completion. That is enough to bound wasted work to a fraction of a pass rather than a whole one.

**Purely additive, no breaking change.** `forward` keeps its exact signature and behaviour; it delegates to the new method with a callback that never fires, costing one predictable branch per layer. The private `XLMRobertaEncoder::forward` was renamed rather than duplicated, so no public API was removed.

## Tests

`candle-transformers/tests/xlm_roberta_tests.rs`, four cases on a tiny CPU model:

- the uncancelled path returns the expected shape;
- a callback returning `true` makes the pass fail instead of returning a tensor;
- the callback is polled **once per layer**, not once per call — this is what proves the check is inside the loop rather than in front of it;
- `forward` and `forward_with_cancel` agree bit for bit when nothing cancels.

Verified locally on macOS (aarch64): `cargo test -p candle-transformers --test xlm_roberta_tests` (4 passed), `cargo fmt -p candle-transformers -- --check`, and `cargo clippy -p candle-transformers --all-targets -- -D warnings`, all clean.

## Context

We maintain a local copy of this model purely to add this hook, and would rather depend on upstream. Happy to adjust the naming (`forward_with_cancel` follows the existing `forward_with_mask` / `forward_with_img` convention in this crate) or to generalise the mechanism to other encoders if you would prefer a shared approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
