### PR TITLE
Fix rotary embedding convention in MiMi transformer

### DIFF
--- a/candle-transformers/src/models/mimi/transformer.rs
+++ b/candle-transformers/src/models/mimi/transformer.rs
@@ -79,7 +79,9 @@ impl RotaryEmbedding {
         let qk_dtype = qk.dtype();
         let c = self.cos.narrow(0, seqlen_offset, seqlen)?;
         let s = self.sin.narrow(0, seqlen_offset, seqlen)?;
-        candle_nn::rotary_emb::rope_i(&qk.to_dtype(DType::F32)?, &c, &s)?.to_dtype(qk_dtype)
+        // The checkpoints are stored in the transformers layout, which rotates the two halves
+        // of the head dimension rather than adjacent pairs.
+        candle_nn::rotary_emb::rope(&qk.to_dtype(DType::F32)?, &c, &s)?.to_dtype(qk_dtype)
     }
 }
 


### PR DESCRIPTION
fixes #3948

`RotaryEmbedding::apply_rotary_emb` in the mimi transformer applies the interleaved (GPT-J
style) rotary embedding, but the checkpoints are stored in the `transformers` layout, which
rotates the two halves of the head dimension (NeoX style). Attention is computed against the
wrong frequency pairing at every position but the first, so the encoder and the decoder both
drift away from the reference implementation as the sequence grows.

This switches that one call to `candle_nn::rotary_emb::rope`, which is what `rotate_half` in
`transformers` implements.

## Verification

Against `MimiModel` from `transformers` 4.57.3 on `kyutai/mimi`, a 5.04 s mono clip at 24 kHz,
63 frames, f32 on CPU. Encoding the same audio through `cargo run --example mimi`:

| | codes matching `transformers` | frames matching in full |
|---|---|---|
| before | 359 of 1008 | 0 of 63 |
| after | 1008 of 1008 | 63 of 63 |

Decoding the `transformers` codes with `Model::decode` and comparing samples with
`MimiModel.decode`:

| quantizers | max abs sample difference | correlation |
|---|---|---|
| 16, before | 1.2e-01 | 0.9959 |
| 16, after | 7.9e-07 | 1.000000 |
| 32 as used by `csm`, before | 5.1e-02 | 0.9978 |
| 32 as used by `csm`, after | 1.2e-06 | 1.000000 |

Both consumers of the module still build and run. The `mimi` example round trips audio to codes
and back, including streaming with frame sized chunks. The `csm` example builds; its weights are
gated on the hub, so instead of an end to end run I exercised the 32 quantizer decode path it
uses, which is the last two rows above.