### PR TITLE
Fix CUDA argsort for large f32 rows

### DIFF
--- a/candle-core/src/sort.rs
+++ b/candle-core/src/sort.rs
@@ -60,10 +60,165 @@ impl ArgSort {
 mod cuda {
     use super::*;
     use crate::cuda_backend::cudarc::driver::{
-        CudaSlice, DeviceRepr, LaunchConfig, ValidAsZeroBits,
+        CudaSlice, DevicePtr, DevicePtrMut, DeviceRepr, LaunchConfig, ValidAsZeroBits,
     };
     use crate::cuda_backend::{kernel_name, kernels, CudaStorageSlice as S, WrapErr};
-    use crate::{CudaDevice, WithDType};
+    use crate::{CudaDevice, DType, WithDType};
+
+    const SHARED_ARGSORT_MAX_ITEMS: usize = 8192;
+    const LARGE_ARGSORT_MAX_BATCH_ROWS: usize = 256;
+    const LARGE_ARGSORT_AUX_BUDGET: usize = 64 * 1024 * 1024;
+
+    fn checked_device_offset(ptr: u64, elements: usize, element_size: usize) -> Result<u64> {
+        let byte_offset = elements
+            .checked_mul(element_size)
+            .ok_or_else(|| crate::Error::msg("CUDA argsort byte offset overflow"))?;
+        ptr.checked_add(byte_offset as u64)
+            .ok_or_else(|| crate::Error::msg("CUDA argsort device pointer overflow"))
+    }
+
+    fn check_runtime_status(status: i32, action: &str) -> Result<()> {
+        if status != 0 {
+            crate::bail!("CUDA argsort {action} failed with runtime error {status}")
+        }
+        Ok(())
+    }
+
+    fn large_f32_workspace_bytes(
+        nrows: usize,
+        ncols: i32,
+        descending: bool,
+        stream: *mut std::ffi::c_void,
+    ) -> Result<usize> {
+        let nrows = i32::try_from(nrows)
+            .map_err(|_| crate::Error::msg("CUDA argsort batch has too many rows"))?;
+        let mut temp_storage_bytes = 0usize;
+        let status = unsafe {
+            candle_kernels::ffi::candle_argsort_f32(
+                std::ptr::null(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut temp_storage_bytes,
+                nrows,
+                ncols,
+                i32::from(descending),
+                stream,
+            )
+        };
+        check_runtime_status(status, "workspace query")?;
+        Ok(temp_storage_bytes)
+    }
+
+    fn large_f32_argsort<T, P>(
+        src: &P,
+        dst: &mut CudaSlice<u32>,
+        dev: &CudaDevice,
+        nrows: usize,
+        ncols: usize,
+        descending: bool,
+    ) -> Result<()>
+    where
+        T: DeviceRepr + WithDType,
+        P: DevicePtr<T>,
+    {
+        if T::DTYPE != DType::F32 {
+            return Err(crate::Error::UnsupportedDTypeForOp(
+                T::DTYPE,
+                "CUDA arg_sort_last_dim with more than 8192 elements",
+            )
+            .bt());
+        }
+        let ncols_i32 =
+            i32::try_from(ncols).map_err(|_| crate::Error::msg("CUDA argsort row is too large"))?;
+        let rows_by_item_count = (i32::MAX as usize / ncols).max(1);
+        let mut max_batch_rows = nrows
+            .min(LARGE_ARGSORT_MAX_BATCH_ROWS)
+            .min(rows_by_item_count);
+
+        let stream = dev.cuda_stream();
+        let stream_ptr = stream.cu_stream() as *mut std::ffi::c_void;
+        let temp_storage_bytes = loop {
+            let max_temp =
+                large_f32_workspace_bytes(max_batch_rows, ncols_i32, descending, stream_ptr)?;
+            let tail_rows = nrows % max_batch_rows;
+            let tail_temp = if tail_rows == 0 {
+                0
+            } else {
+                large_f32_workspace_bytes(tail_rows, ncols_i32, descending, stream_ptr)?
+            };
+            let temp_bytes = max_temp.max(tail_temp);
+            let direct_items = max_batch_rows
+                .checked_mul(ncols)
+                .ok_or_else(|| crate::Error::msg("CUDA argsort item count overflow"))?;
+            let direct_bytes = direct_items
+                .checked_mul(std::mem::size_of::<f32>() + std::mem::size_of::<u32>())
+                .and_then(|bytes| {
+                    bytes.checked_add((max_batch_rows + 1) * std::mem::size_of::<i32>())
+                })
+                .ok_or_else(|| crate::Error::msg("CUDA argsort workspace size overflow"))?;
+            let total_bytes = direct_bytes
+                .checked_add(temp_bytes)
+                .ok_or_else(|| crate::Error::msg("CUDA argsort workspace size overflow"))?;
+            if total_bytes <= LARGE_ARGSORT_AUX_BUDGET || max_batch_rows == 1 {
+                break temp_bytes;
+            }
+            let scaled_rows = ((max_batch_rows as u128 * LARGE_ARGSORT_AUX_BUDGET as u128)
+                / total_bytes as u128) as usize;
+            max_batch_rows = scaled_rows.clamp(1, max_batch_rows - 1);
+        };
+
+        let max_batch_items = max_batch_rows
+            .checked_mul(ncols)
+            .ok_or_else(|| crate::Error::msg("CUDA argsort item count overflow"))?;
+
+        let mut keys_out = unsafe { dev.alloc::<f32>(max_batch_items)? };
+        let mut indices_in = unsafe { dev.alloc::<u32>(max_batch_items)? };
+        let mut offsets = unsafe { dev.alloc::<i32>(max_batch_rows + 1)? };
+        let (src_ptr, _src_guard) = src.device_ptr(&stream);
+        let (dst_ptr, _dst_guard) = dst.device_ptr_mut(&stream);
+        let (keys_out_ptr, _keys_out_guard) = keys_out.device_ptr_mut(&stream);
+        let (indices_in_ptr, _indices_in_guard) = indices_in.device_ptr_mut(&stream);
+        let (offsets_ptr, _offsets_guard) = offsets.device_ptr_mut(&stream);
+
+        let mut temp_storage = unsafe { dev.alloc::<u8>(temp_storage_bytes.max(1))? };
+        let (temp_storage_ptr, _temp_storage_guard) = temp_storage.device_ptr_mut(&stream);
+
+        let mut row_start = 0usize;
+        while row_start < nrows {
+            let batch_rows = (nrows - row_start).min(max_batch_rows);
+            let batch_items = batch_rows * ncols;
+            let item_offset = row_start * ncols;
+            let batch_src_ptr =
+                checked_device_offset(src_ptr, item_offset, std::mem::size_of::<f32>())?;
+            let batch_dst_ptr =
+                checked_device_offset(dst_ptr, item_offset, std::mem::size_of::<u32>())?;
+            let mut launch_temp_storage_bytes = temp_storage_bytes;
+            let status = unsafe {
+                candle_kernels::ffi::candle_argsort_f32(
+                    batch_src_ptr as *const f32,
+                    keys_out_ptr as *mut f32,
+                    indices_in_ptr as *mut u32,
+                    batch_dst_ptr as *mut u32,
+                    offsets_ptr as *mut i32,
+                    temp_storage_ptr as *mut std::ffi::c_void,
+                    &mut launch_temp_storage_bytes,
+                    i32::try_from(batch_rows)
+                        .map_err(|_| crate::Error::msg("CUDA argsort batch has too many rows"))?,
+                    ncols_i32,
+                    i32::from(descending),
+                    stream_ptr,
+                )
+            };
+            check_runtime_status(status, "launch")?;
+            row_start += batch_rows;
+
+            debug_assert!(batch_items <= max_batch_items);
+        }
+        Ok(())
+    }
 
     impl crate::cuda_backend::Map1Any for ArgSort {
         fn f<T: DeviceRepr + WithDType + ValidAsZeroBits, W: Fn(CudaSlice<T>) -> S>(
@@ -80,14 +235,21 @@ mod cuda {
                 Some((o1, o2)) => src.slice(o1..o2),
             };
             let elem_count = layout.shape().elem_count();
-            let dst = unsafe { dev.alloc::<u32>(elem_count)? };
+            let mut dst = unsafe { dev.alloc::<u32>(elem_count)? };
+            let ncols = self.last_dim;
+            if elem_count == 0 {
+                return Ok(S::U32(dst));
+            }
+            let nrows = elem_count / ncols;
+            if ncols > SHARED_ARGSORT_MAX_ITEMS {
+                large_f32_argsort(&slice, &mut dst, dev, nrows, ncols, !self.asc)?;
+                return Ok(S::U32(dst));
+            }
             let func = if self.asc {
                 dev.get_or_load_func(&kernel_name::<T>("asort_asc"), &kernels::SORT)?
             } else {
                 dev.get_or_load_func(&kernel_name::<T>("asort_desc"), &kernels::SORT)?
             };
-            let ncols = self.last_dim;
-            let nrows = elem_count / ncols;
             let ncols_pad = next_power_of_2(ncols);
             // Limit block dim to 1024 threads, which is the maximum on modern CUDA gpus.
             let block_dim = ncols_pad.min(1024);

--- a/candle-core/tests/cuda_graph_tests.rs
+++ b/candle-core/tests/cuda_graph_tests.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "cuda")]
+
+use candle_core::cuda_backend::cudarc::driver::sys::{
+    CUgraphInstantiate_flags, CUstreamCaptureMode,
+};
+use candle_core::{Device, Error, Result, Tensor};
+
+#[test]
+fn asort_large_cuda_graph() -> Result<()> {
+    let device = Device::new_cuda(0)?;
+    let data = (0..8193).rev().map(|v| v as f32).collect::<Vec<_>>();
+    let tensor = Tensor::from_vec(data, 8193, &device)?;
+    tensor.arg_sort_last_dim(true)?;
+    device.synchronize()?;
+
+    let stream = device.as_cuda_device()?.cuda_stream();
+    stream
+        .begin_capture(CUstreamCaptureMode::CU_STREAM_CAPTURE_MODE_THREAD_LOCAL)
+        .map_err(Error::wrap)?;
+    let indexes = tensor.arg_sort_last_dim(true);
+    let graph = stream
+        .end_capture(CUgraphInstantiate_flags::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH)
+        .map_err(Error::wrap)?
+        .ok_or_else(|| Error::msg("CUDA argsort captured an empty graph"))?;
+    let indexes = indexes?;
+
+    for _ in 0..2 {
+        graph.launch().map_err(Error::wrap)?;
+        device.synchronize()?;
+        assert_eq!(
+            indexes.to_vec1::<u32>()?,
+            (0..8193).rev().map(|v| v as u32).collect::<Vec<_>>()
+        );
+    }
+    Ok(())
+}

--- a/candle-core/tests/tensor_tests.rs
+++ b/candle-core/tests/tensor_tests.rs
@@ -248,6 +248,93 @@ fn asort_big(device: &Device) -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "cuda")]
+fn check_large_cuda_asort(device: &Device, nrows: usize, ncols: usize) -> Result<()> {
+    let mut data = Vec::with_capacity(nrows * ncols);
+    for row in 0..nrows {
+        if row % 2 == 0 {
+            data.extend((0..ncols).rev().map(|v| v as f32));
+        } else {
+            data.extend((0..ncols).map(|v| v as f32));
+        }
+    }
+    let tensor = Tensor::from_vec(data.clone(), (nrows, ncols), device)?;
+
+    for asc in [true, false] {
+        let indexes = tensor.arg_sort_last_dim(asc)?.to_vec2::<u32>()?;
+        for (row, indexes) in indexes.iter().enumerate() {
+            let is_input_ascending = row % 2 == 1;
+            let expect_identity = asc == is_input_ascending;
+            for (position, &index) in indexes.iter().enumerate() {
+                let expected = if expect_identity {
+                    position
+                } else {
+                    ncols - position - 1
+                };
+                assert_eq!(index as usize, expected, "row {row}, position {position}");
+            }
+        }
+    }
+
+    assert_eq!(tensor.flatten_all()?.to_vec1::<f32>()?, data);
+    Ok(())
+}
+
+#[cfg(feature = "cuda")]
+#[test]
+fn asort_large_cuda() -> Result<()> {
+    let device = Device::new_cuda(0)?;
+    // 8192 is the largest power-of-two width whose index buffer fits in the
+    // existing 32-KiB shared-memory fast path; 8193 selects the large path.
+    check_large_cuda_asort(&device, 1, 8192)?;
+    check_large_cuda_asort(&device, 1, 8193)?;
+    check_large_cuda_asort(&device, 1, 32_000)?;
+    check_large_cuda_asort(&device, 1, 128_256)?;
+
+    // Exercise both sides of the large-path row batching boundary.
+    check_large_cuda_asort(&device, 256, 8193)?;
+    check_large_cuda_asort(&device, 257, 8193)?;
+    // This shape exceeds the auxiliary-memory budget as one batch and exercises
+    // the adaptive batch planner plus its one-row tail.
+    check_large_cuda_asort(&device, 33, 128_256)?;
+
+    // Match the all-equal 32K-vector reproduction from #2361.
+    let zeros = Tensor::zeros(32_000, DType::F32, &device)?;
+    for asc in [true, false] {
+        let mut indexes = zeros.arg_sort_last_dim(asc)?.to_vec1::<u32>()?;
+        indexes.sort_unstable();
+        assert_eq!(indexes, (0..32_000).collect::<Vec<_>>());
+    }
+
+    let mut offset_data = vec![f32::INFINITY; 8193];
+    offset_data.extend((0..8193).rev().map(|v| v as f32));
+    let offset_view = Tensor::from_vec(offset_data, (2, 8193), &device)?.narrow(0, 1, 1)?;
+    let indexes = offset_view.arg_sort_last_dim(true)?.to_vec2::<u32>()?;
+    assert_eq!(
+        indexes[0],
+        (0..8193).rev().map(|v| v as u32).collect::<Vec<_>>()
+    );
+
+    let mut mixed_data = (0..8193)
+        .map(|v| ((v * 48_271) % 8193) as f32 - 4096.)
+        .collect::<Vec<_>>();
+    mixed_data[..6].copy_from_slice(&[f32::NEG_INFINITY, f32::INFINITY, 0., -0., -7., -7.]);
+    let mixed = Tensor::from_vec(mixed_data, (1, 8193), &device)?;
+    for asc in [true, false] {
+        let (sorted, indexes) = mixed.sort_last_dim(asc)?;
+        let sorted = sorted.to_vec2::<f32>()?;
+        assert!(sorted[0].windows(2).all(|pair| if asc {
+            pair[0] <= pair[1]
+        } else {
+            pair[0] >= pair[1]
+        }));
+        let mut indexes = indexes.to_vec2::<u32>()?.remove(0);
+        indexes.sort_unstable();
+        assert_eq!(indexes, (0..8193).map(|v| v as u32).collect::<Vec<_>>());
+    }
+    Ok(())
+}
+
 fn unary_op(device: &Device) -> Result<()> {
     let data = &[[-3f32, 1., 4., -0.1, 0.5], [2.7, -1.8, -0.28, 1.8, 2.8]];
     let tensor = Tensor::new(data, device)?;

--- a/candle-kernels/build.rs
+++ b/candle-kernels/build.rs
@@ -1,4 +1,4 @@
-use cudaforge::{KernelBuilder, Result};
+use cudaforge::{CudaToolkit, KernelBuilder, Result};
 use std::env;
 use std::path::PathBuf;
 
@@ -15,7 +15,7 @@ fn main() -> Result<()> {
     let ptx_path = out_dir.join("ptx.rs");
     let bindings = KernelBuilder::new()
         .source_dir("src") // Scan src/ for .cu files
-        .exclude(&["moe_*.cu", "mmvq_gguf.cu", "mmq_*.cu"]) // Exclude statically compiled kernels from ptx build
+        .exclude(&["moe_*.cu", "mmvq_gguf.cu", "mmq_*.cu", "sort_cub.cu"]) // Exclude statically compiled kernels from ptx build
         .arg("--expt-relaxed-constexpr")
         .arg("-std=c++17")
         .arg("-O3")
@@ -72,8 +72,25 @@ fn main() -> Result<()> {
     }
 
     moe_builder.build_lib(out_dir.join("libmoe.a"))?;
+    let ptx_cap = CudaToolkit::detect()?
+        .supported_architectures()
+        .into_iter()
+        .min()
+        .unwrap_or(75);
+    let ptx_gencode = format!("-gencode=arch=compute_{ptx_cap},code=compute_{ptx_cap}");
+    let mut sort_builder = KernelBuilder::default()
+        .source_files(["src/sort_cub.cu"])
+        .arg("--expt-relaxed-constexpr")
+        .arg("-std=c++17")
+        .arg("-O3")
+        .arg(&ptx_gencode);
+    if !is_target_msvc {
+        sort_builder = sort_builder.arg("-Xcompiler").arg("-fPIC");
+    }
+    sort_builder.build_lib(out_dir.join("libsort_cub.a"))?;
     println!("cargo:rustc-link-search={}", out_dir.display());
     println!("cargo:rustc-link-lib=moe");
+    println!("cargo:rustc-link-lib=sort_cub");
     println!("cargo:rustc-link-lib=dylib=cudart");
     if !is_target_msvc {
         println!("cargo:rustc-link-lib=stdc++");

--- a/candle-kernels/src/ffi.rs
+++ b/candle-kernels/src/ffi.rs
@@ -2,6 +2,20 @@ use core::ffi::c_void;
 #[allow(dead_code)]
 #[allow(improper_ctypes)]
 extern "C" {
+    pub fn candle_argsort_f32(
+        keys_in: *const f32,
+        keys_out: *mut f32,
+        indices_in: *mut u32,
+        indices_out: *mut u32,
+        offsets: *mut i32,
+        temp_storage: *mut c_void,
+        temp_storage_bytes: *mut usize,
+        nrows: i32,
+        ncols: i32,
+        descending: i32,
+        stream: *mut c_void,
+    ) -> i32;
+
     #[cfg(feature = "cutile")]
     pub fn candle_launch_moe_align(
         topk_ids: *const i32,

--- a/candle-kernels/src/sort_cub.cu
+++ b/candle-kernels/src/sort_cub.cu
@@ -1,0 +1,88 @@
+#include <cub/cub.cuh>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <limits>
+
+namespace {
+
+__global__ void init_argsort_indices(uint32_t *indices, int num_items,
+                                     int ncols) {
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t item = static_cast<int64_t>(blockIdx.x) * blockDim.x +
+                      threadIdx.x;
+       item < static_cast<int64_t>(num_items);
+       item += stride) {
+    indices[item] = static_cast<uint32_t>(item % static_cast<int64_t>(ncols));
+  }
+}
+
+__global__ void init_argsort_offsets(int *offsets, int nrows, int ncols) {
+  const int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  for (int64_t row = static_cast<int64_t>(blockIdx.x) * blockDim.x +
+                     threadIdx.x;
+       row <= static_cast<int64_t>(nrows);
+       row += stride) {
+    offsets[row] = static_cast<int>(row * ncols);
+  }
+}
+
+cudaError_t segmented_argsort_f32(
+    void *temp_storage, size_t &temp_storage_bytes, const float *keys_in,
+    float *keys_out, const uint32_t *indices_in, uint32_t *indices_out,
+    const int *offsets, int num_items, int nrows, bool descending,
+    cudaStream_t stream) {
+  const int *end_offsets = offsets == nullptr ? nullptr : offsets + 1;
+  if (descending) {
+    return cub::DeviceSegmentedRadixSort::SortPairsDescending(
+        temp_storage, temp_storage_bytes, keys_in, keys_out, indices_in,
+        indices_out, num_items, nrows, offsets, end_offsets, 0,
+        static_cast<int>(sizeof(float) * 8), stream);
+  }
+  return cub::DeviceSegmentedRadixSort::SortPairs(
+      temp_storage, temp_storage_bytes, keys_in, keys_out, indices_in,
+      indices_out, num_items, nrows, offsets, end_offsets, 0,
+      static_cast<int>(sizeof(float) * 8), stream);
+}
+
+} // namespace
+
+extern "C" int candle_argsort_f32(
+    const float *keys_in, float *keys_out, uint32_t *indices_in,
+    uint32_t *indices_out, int *offsets, void *temp_storage,
+    size_t *temp_storage_bytes, int nrows, int ncols, int descending,
+    cudaStream_t stream) {
+  if (temp_storage_bytes == nullptr || nrows <= 0 || ncols <= 0 ||
+      nrows > std::numeric_limits<int>::max() / ncols) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+
+  const int num_items = nrows * ncols;
+  if (temp_storage != nullptr) {
+    if (keys_in == nullptr || keys_out == nullptr || indices_in == nullptr ||
+        indices_out == nullptr || offsets == nullptr) {
+      return static_cast<int>(cudaErrorInvalidValue);
+    }
+    constexpr int block_size = 256;
+    const int required_blocks = (num_items - 1) / block_size + 1;
+    const int blocks = required_blocks < 65535 ? required_blocks : 65535;
+    init_argsort_indices<<<blocks, block_size, 0, stream>>>(indices_in,
+                                                            num_items, ncols);
+    const cudaError_t init_status = cudaGetLastError();
+    if (init_status != cudaSuccess) {
+      return static_cast<int>(init_status);
+    }
+    const int required_offset_blocks = nrows / block_size + 1;
+    init_argsort_offsets<<<required_offset_blocks, block_size, 0, stream>>>(
+        offsets, nrows, ncols);
+    const cudaError_t offset_status = cudaGetLastError();
+    if (offset_status != cudaSuccess) {
+      return static_cast<int>(offset_status);
+    }
+  }
+
+  const cudaError_t sort_status = segmented_argsort_f32(
+      temp_storage, *temp_storage_bytes, keys_in, keys_out, indices_in,
+      indices_out, offsets, num_items, nrows, descending != 0, stream);
+  return static_cast<int>(sort_status);
+}


### PR DESCRIPTION
Fixes #2361. Also addresses #2181.

The existing CUDA kernel sizes dynamic shared memory as next_power_of_two(row_width) * sizeof(u32). At width 8193 that jumps to 64 KiB, so the launch fails with CUDA_ERROR_INVALID_VALUE.

This keeps the current shared-memory kernel for rows up to 8192 and uses CUB segmented radix sort for larger F32 rows. It bounds auxiliary memory with adaptive row batching and embeds a PTX fallback alongside native SASS so the static CUDA object is portable across GPU architectures.

Scope: the new large-row path is F32, matching the reported reproduction. Existing dtype behavior is unchanged for rows up to 8192.

Validated on an RTX 4050 with CUDA 12.6:

- candle-core tensor test suite: 91 passed
- large CUDA argsort under CUDA_LAUNCH_BLOCKING=1
- CUDA graph capture and two replays
- widths 8192, 8193, 32000, and 128256
- fixed and memory-driven batch boundaries, non-zero storage offsets, ascending/descending order, duplicate and infinite values, and unchanged input

Local CPU-side checks also pass: cargo fmt, cargo check, cargo clippy -D warnings, and all candle-core integration tests.