### PR TITLE
Specify parquet features to drop redundant deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,15 @@ log = "0.4"
 memmap2 = { version = "0.9.3", features = ["stable_deref_trait"] }
 num_cpus = "1.15.0"
 num-traits = "0.2.15"
-parquet = "59"
+parquet = { version = "59", default-features = false, features = [
+    "snap",
+    "brotli",
+    "flate2-zlib-rs",
+    "lz4",
+    "zstd",
+    "base64",
+    "simdutf8",
+] }
 rand = "0.9.0"
 rand_distr = "0.5.1"
 rayon = "1.7.0"


### PR DESCRIPTION
There is no usage of `parquet`'s `arrow` feature in candle, so it is just bloat.