### PR TITLE
Remove ineffective KV-cache truncation

### DIFF
--- a/candle-examples/examples/llama_multiprocess/model.rs
+++ b/candle-examples/examples/llama_multiprocess/model.rs
@@ -1,5 +1,5 @@
 use candle::backend::BackendStorage;
-use candle::{CpuStorage, CustomOp1, DType, Device, IndexOp, Layout, Result, Shape, Tensor, D};
+use candle::{CpuStorage, CustomOp1, DType, Device, IndexOp, Layout, Result, Shape, Tensor};
 use candle_nn::var_builder::ShardedVarBuilder as VarBuilder;
 use candle_nn::{Embedding, Linear, Module, RmsNorm};
 use cudarc::nccl::safe::{Comm, ReduceOp};
@@ -241,18 +241,6 @@ impl CausalSelfAttention {
         if let Some((cache_k, cache_v)) = &cache[block_idx] {
             k = Tensor::cat(&[cache_k, &k], 2)?.contiguous()?;
             v = Tensor::cat(&[cache_v, &v], 2)?.contiguous()?;
-            let k_seq_len = k.dims()[1];
-            if k_seq_len > MAX_SEQ_LEN {
-                k = k
-                    .narrow(D::Minus1, k_seq_len - MAX_SEQ_LEN, MAX_SEQ_LEN)?
-                    .contiguous()?
-            }
-            let v_seq_len = v.dims()[1];
-            if v_seq_len > 2 * MAX_SEQ_LEN {
-                v = v
-                    .narrow(D::Minus1, v_seq_len - MAX_SEQ_LEN, MAX_SEQ_LEN)?
-                    .contiguous()?
-            }
         }
         cache[block_idx] = Some((k.clone(), v.clone()));
 

--- a/candle-transformers/src/models/granite.rs
+++ b/candle-transformers/src/models/granite.rs
@@ -193,7 +193,6 @@ struct CausalSelfAttention {
     use_flash_attn: bool,
     span: tracing::Span,
     span_rot: tracing::Span,
-    max_position_embeddings: usize,
 }
 
 #[cfg(feature = "flash-attn")]
@@ -253,26 +252,6 @@ impl CausalSelfAttention {
             if let Some((cache_k, cache_v)) = &cache.kvs[block_idx] {
                 k = Tensor::cat(&[cache_k, &k], 2)?.contiguous()?;
                 v = Tensor::cat(&[cache_v, &v], 2)?.contiguous()?;
-                let k_seq_len = k.dims()[1];
-                if k_seq_len > self.max_position_embeddings {
-                    k = k
-                        .narrow(
-                            D::Minus1,
-                            k_seq_len - self.max_position_embeddings,
-                            self.max_position_embeddings,
-                        )?
-                        .contiguous()?
-                }
-                let v_seq_len = v.dims()[1];
-                if v_seq_len > 2 * self.max_position_embeddings {
-                    v = v
-                        .narrow(
-                            D::Minus1,
-                            v_seq_len - self.max_position_embeddings,
-                            self.max_position_embeddings,
-                        )?
-                        .contiguous()?
-                }
             }
             cache.kvs[block_idx] = Some((k.clone(), v.clone()))
         }
@@ -333,7 +312,6 @@ impl CausalSelfAttention {
             use_flash_attn: cfg.use_flash_attn,
             span,
             span_rot,
-            max_position_embeddings: cfg.max_position_embeddings,
         })
     }
 }

--- a/candle-transformers/src/models/granitemoehybrid.rs
+++ b/candle-transformers/src/models/granitemoehybrid.rs
@@ -236,7 +236,6 @@ struct CausalSelfAttention {
     use_flash_attn: bool,
     span: tracing::Span,
     span_rot: tracing::Span,
-    max_position_embeddings: usize,
     attention_multiplier: f32,
 }
 
@@ -302,26 +301,6 @@ impl CausalSelfAttention {
             if let Some((cache_k, cache_v)) = &cache.kvs[block_idx] {
                 k = Tensor::cat(&[cache_k, &k], 2)?.contiguous()?;
                 v = Tensor::cat(&[cache_v, &v], 2)?.contiguous()?;
-                let k_seq_len = k.dims()[1];
-                if k_seq_len > self.max_position_embeddings {
-                    k = k
-                        .narrow(
-                            D::Minus1,
-                            k_seq_len - self.max_position_embeddings,
-                            self.max_position_embeddings,
-                        )?
-                        .contiguous()?
-                }
-                let v_seq_len = v.dims()[1];
-                if v_seq_len > 2 * self.max_position_embeddings {
-                    v = v
-                        .narrow(
-                            D::Minus1,
-                            v_seq_len - self.max_position_embeddings,
-                            self.max_position_embeddings,
-                        )?
-                        .contiguous()?
-                }
             }
             cache.kvs[block_idx] = Some((k.clone(), v.clone()))
         }
@@ -383,7 +362,6 @@ impl CausalSelfAttention {
             use_flash_attn: cfg.use_flash_attn,
             span,
             span_rot,
-            max_position_embeddings: cfg.max_position_embeddings,
             attention_multiplier: cfg.attention_multiplier,
         })
     }

--- a/candle-transformers/src/models/llama.rs
+++ b/candle-transformers/src/models/llama.rs
@@ -5,7 +5,7 @@
 //! Implementation based on Hugging Face's [transformers](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py)
 
 use super::with_tracing::{linear_no_bias as linear, Linear, RmsNorm};
-use candle::{DType, Device, IndexOp, Result, Tensor, D};
+use candle::{DType, Device, IndexOp, Result, Tensor};
 use candle_nn::{embedding, Embedding, Module, VarBuilder};
 use std::{collections::HashMap, f32::consts::PI};
 
@@ -239,7 +239,6 @@ struct CausalSelfAttention {
     use_flash_attn: bool,
     span: tracing::Span,
     span_rot: tracing::Span,
-    max_position_embeddings: usize,
 }
 
 #[cfg(feature = "flash-attn")]
@@ -299,26 +298,6 @@ impl CausalSelfAttention {
             if let Some((cache_k, cache_v)) = &cache.kvs[block_idx] {
                 k = Tensor::cat(&[cache_k, &k], 2)?.contiguous()?;
                 v = Tensor::cat(&[cache_v, &v], 2)?.contiguous()?;
-                let k_seq_len = k.dims()[1];
-                if k_seq_len > self.max_position_embeddings {
-                    k = k
-                        .narrow(
-                            D::Minus1,
-                            k_seq_len - self.max_position_embeddings,
-                            self.max_position_embeddings,
-                        )?
-                        .contiguous()?
-                }
-                let v_seq_len = v.dims()[1];
-                if v_seq_len > 2 * self.max_position_embeddings {
-                    v = v
-                        .narrow(
-                            D::Minus1,
-                            v_seq_len - self.max_position_embeddings,
-                            self.max_position_embeddings,
-                        )?
-                        .contiguous()?
-                }
             }
             cache.kvs[block_idx] = Some((k.clone(), v.clone()))
         }
@@ -380,7 +359,6 @@ impl CausalSelfAttention {
             use_flash_attn: cfg.use_flash_attn,
             span,
             span_rot,
-            max_position_embeddings: cfg.max_position_embeddings,
         })
     }
 }

--- a/candle-transformers/src/models/voxtral/voxtral_llama.rs
+++ b/candle-transformers/src/models/voxtral/voxtral_llama.rs
@@ -1,5 +1,5 @@
 use crate::models::with_tracing::{linear_no_bias as linear, Linear, RmsNorm};
-use candle::{DType, Device, IndexOp, Result, Tensor, D};
+use candle::{DType, Device, IndexOp, Result, Tensor};
 use candle_nn::{embedding, Embedding, Module, VarBuilder};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -134,7 +134,6 @@ struct CausalSelfAttention {
     use_flash_attn: bool,
     span: tracing::Span,
     span_rot: tracing::Span,
-    max_position_embeddings: usize,
 }
 
 #[cfg(feature = "flash-attn")]
@@ -213,26 +212,6 @@ impl CausalSelfAttention {
             if let Some((cache_k, cache_v)) = &cache.kvs[block_idx] {
                 k = Tensor::cat(&[cache_k, &k], 2)?.contiguous()?;
                 v = Tensor::cat(&[cache_v, &v], 2)?.contiguous()?;
-                let k_seq_len = k.dims()[1];
-                if k_seq_len > self.max_position_embeddings {
-                    k = k
-                        .narrow(
-                            D::Minus1,
-                            k_seq_len - self.max_position_embeddings,
-                            self.max_position_embeddings,
-                        )?
-                        .contiguous()?
-                }
-                let v_seq_len = v.dims()[1];
-                if v_seq_len > 2 * self.max_position_embeddings {
-                    v = v
-                        .narrow(
-                            D::Minus1,
-                            v_seq_len - self.max_position_embeddings,
-                            self.max_position_embeddings,
-                        )?
-                        .contiguous()?
-                }
             }
             cache.kvs[block_idx] = Some((k.clone(), v.clone()))
         }
@@ -304,7 +283,6 @@ impl CausalSelfAttention {
             use_flash_attn: cfg.use_flash_attn,
             span,
             span_rot,
-            max_position_embeddings: cfg.max_position_embeddings,
         })
     }
 }


### PR DESCRIPTION
# Remove ineffective KV-cache truncation

Remove duplicated KV-cache truncation code from Llama, Granite, GraniteMoeHybrid, Voxtral Llama, and the `llama_multiprocess` example.

Keys and values are first reshaped to `(batch, seq, num_kv_heads, head_dim)`, then passed through `transpose(1, 2)`. At the cache update, their shape is therefore `(batch, num_kv_heads, seq, head_dim)`: dimension 1 counts KV heads, dimension 2 counts cached tokens, and dimension 3 is the size of each head.

The update correctly appends tokens along dimension 2, but then reads dimension 1 as though it were the sequence length:

```rust
k = Tensor::cat(&[cache_k, &k], 2)?.contiguous()?;
v = Tensor::cat(&[cache_v, &v], 2)?.contiguous()?;
let k_seq_len = k.dims()[1];
// The value guard likewise reads v.dims()[1].
```

The key guard therefore compares the KV-head count against `max_position_embeddings`, while the value guard compares it against twice that limit. Whenever `num_kv_heads <= max_position_embeddings`, both conditions are false and their truncation bodies are unreachable. Appending tokens only changes dimension 2; it cannot change the head count or make either guard fire, even if the actual cache length exceeds the limit. The multiprocess implementation has the same issue using `MAX_SEQ_LEN`.

The truncation itself also targets the wrong axis: `narrow(D::Minus1, ...)` selects dimension 3, `head_dim`. Changing the length lookup to `dims()[2]` alone would still slice head features instead of cached history. The slice would fail bounds checks when it exceeds `head_dim`; even if it fits, it would not shorten the sequence. The inconsistent key/value thresholds would also remain.

Removing these branches preserves behavior for configurations satisfying the condition above. With an initially empty cache and `index_pos` matching its sequence length, the fixed RoPE tables already prevent appending beyond the position limit: `apply_rotary_emb` slices those tables before cache concatenation and returns an error if `index_pos + seq_len` exceeds their length. Callers that reuse positions can grow the cache beyond the limit, but these guards never prevented that either.

Instrumented Llama runs confirmed that the branches remain inactive.

Also remove the now-unused private `max_position_embeddings` fields from four attention structs and three unused `D` imports.
