### PR TITLE
docs: Add candle-3d to useful external resources. Inferring 3D models with support for the Vulkan and WGPU backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ And then head over to
   out-of-the-box LoRA support for many models from Candle, which can be found
   [here](https://github.com/EricLBuehler/candle-lora/tree/master/candle-lora-transformers/examples).
 - [`candle-video`](https://github.com/FerrisMind/candle-video): Rust library for text-to-video generation (LTX-Video and related models) built on Candle, focused on fast, Python-free inference.
+- [`candle-3d`](https://github.com/FerrisMind/candle-3d): Clean-room Rust 3D inference toolkit for Pi3, Pi3X, and TripoSR with contract inspection and canonical weight tooling; supports Vulkan and WGPU inference.
 - [`optimisers`](https://github.com/KGrewal1/optimisers): A collection of optimisers
   including SGD with momentum, AdaGrad, AdaDelta, AdaMax, NAdam, RAdam, and RMSprop.
 - [`candle-vllm`](https://github.com/EricLBuehler/candle-vllm): Efficient platform for inference and


### PR DESCRIPTION
Hi! I would like to present to your attention, as far as I am concerned, a rather interesting and useful project. Implementation of inference of some 3D models on the candle fork with inference support on native Vulkan and wgpu

https://github.com/FerrisMind/candle-3d

The development and testing was carried out on a PC with the following characteristics:
CPU: AMD R7 3700x
RAM: 64GB DDR4 3200
GPU: RTX 3060 12GB VRAM

# Performance

https://github.com/FerrisMind/candle-3d#performance

| model | CUDA | Vulkan | WGPU | Vulkan/CUDA | WGPU/CUDA |
|---|---:|---:|---:|---:|---:|
| pi3 (5 frames, 518×518) | **4.82 s** | 7.83 s | 13.96 s | 1.62× | 2.90× |
| pi3x (6 frames, 518×518) | **7.00 s** | 11.10 s | 31.84 s | 1.59× | 4.55× |
| triposr (single image) | **1.23 s** | 3.36 s | 4.89 s | 2.73× | 3.98× |


# Demo

The model in the demo is a normalized TripoSR → https://huggingface.co/oxide-lab/TripoSR

https://github.com/user-attachments/assets/77854b78-dfa3-4c6f-962b-afbc01ac2699

